### PR TITLE
Enhance deployment planner

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleEvents.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleEvents.cs
@@ -108,6 +108,7 @@ public sealed record StepCompletedEvent(DeploymentEventContext Context) : Deploy
 public sealed record ActionManuallyExcludedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record ActionSkippedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record ActionNoHandlerEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
+public sealed record ActionCapabilityFilteredEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record ActionRunningEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record ActionPreparationFailedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record ActionPreparationWarningEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);

--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleHandlerBase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleHandlerBase.cs
@@ -35,6 +35,7 @@ public abstract class DeploymentLifecycleHandlerBase : IDeploymentLifecycleHandl
         ActionManuallyExcludedEvent e => OnActionManuallyExcludedAsync(e.Context, ct),
         ActionSkippedEvent e => OnActionSkippedAsync(e.Context, ct),
         ActionNoHandlerEvent e => OnActionNoHandlerAsync(e.Context, ct),
+        ActionCapabilityFilteredEvent e => OnActionCapabilityFilteredAsync(e.Context, ct),
         ActionRunningEvent e => OnActionRunningAsync(e.Context, ct),
         ActionPreparationFailedEvent e => OnActionPreparationFailedAsync(e.Context, ct),
         ActionPreparationWarningEvent e => OnActionPreparationWarningAsync(e.Context, ct),
@@ -90,6 +91,7 @@ public abstract class DeploymentLifecycleHandlerBase : IDeploymentLifecycleHandl
     protected virtual Task OnActionManuallyExcludedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnActionSkippedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnActionNoHandlerAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
+    protected virtual Task OnActionCapabilityFilteredAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnActionRunningAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnActionPreparationFailedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnActionPreparationWarningAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;

--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentActivityLogger.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentActivityLogger.cs
@@ -313,6 +313,13 @@ public sealed class DeploymentActivityLogger : DeploymentLifecycleHandlerBase
         return LogWarningAsync($"No handler found for action type \"{ctx.ActionType}\", skipping", SystemSource, ct, stepNodeId);
     }
 
+    protected override Task OnActionCapabilityFilteredAsync(DeploymentEventContext ctx, CancellationToken ct)
+    {
+        var stepNodeId = LookupStepNode(ctx.StepDisplayOrder);
+
+        return LogWarningAsync($"Action \"{ctx.ActionName}\" skipped on target \"{ctx.MachineName}\": {ctx.Message}", SystemSource, ct, stepNodeId);
+    }
+
     protected override Task OnActionRunningAsync(DeploymentEventContext ctx, CancellationToken ct)
     {
         var stepNodeId = LookupStepNode(ctx.StepDisplayOrder);

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
@@ -1,6 +1,7 @@
 using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Filtering;
 using Squid.Core.Services.DeploymentExecution.Packages;
+using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.VariableSubstitution;
 using Squid.Message.Enums.Deployments;
 using Squid.Message.Models.Deployments.Process;
@@ -31,11 +32,18 @@ public sealed partial class ExecuteStepsPhase
         CancellationToken ct)
     {
         var stepResults = new List<PreparedAction>();
+        var planned = LookupPlannedStep(step);
 
         foreach (var action in eligibleActions)
         {
             if (actionHandlerRegistry.ResolveScope(action) == ExecutionScope.StepLevel)
                 continue;
+
+            if (IsDispatchBlockedByCapability(planned, action.Id, tc.Machine.Id))
+            {
+                await EmitCapabilityFilteredAsync(planned, action, tc, stepDisplayOrder, ct).ConfigureAwait(false);
+                continue;
+            }
 
             var handler = actionHandlerRegistry.Resolve(action);
 
@@ -109,6 +117,42 @@ public sealed partial class ExecuteStepsPhase
             return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         return DeploymentTargetFinder.ParseCsvRoles(rolesProp.PropertyValue);
+    }
+
+    private static bool IsDispatchBlockedByCapability(PlannedStep? planned, int actionId, int machineId)
+    {
+        if (planned == null) return false;
+
+        var dispatch = planned.Actions
+            .FirstOrDefault(a => a.ActionId == actionId)
+            ?.Dispatches
+            .FirstOrDefault(d => d.Target.MachineId == machineId);
+
+        return dispatch is { Validation.IsValid: false };
+    }
+
+    private async Task EmitCapabilityFilteredAsync(PlannedStep planned, DeploymentActionDto action, DeploymentTargetContext tc, int stepDisplayOrder, CancellationToken ct)
+    {
+        var dispatch = planned.Actions
+            .FirstOrDefault(a => a.ActionId == action.Id)
+            ?.Dispatches
+            .FirstOrDefault(d => d.Target.MachineId == tc.Machine.Id);
+
+        var message = dispatch != null
+            ? string.Join("; ", dispatch.Validation.Violations.Select(v => v.Message))
+            : "dispatch blocked by capability validation";
+
+        Log.Warning("[Deploy] Action {ActionName} skipped on {MachineName}: {Message}", action.Name, tc.Machine.Name, message);
+
+        await lifecycle.EmitAsync(new ActionCapabilityFilteredEvent(new DeploymentEventContext
+        {
+            StepDisplayOrder = stepDisplayOrder,
+            ActionName = action.Name,
+            ActionType = action.ActionType,
+            MachineName = tc.Machine.Name,
+            CommunicationStyle = tc.CommunicationStyle,
+            Message = message
+        }), ct).ConfigureAwait(false);
     }
 
     private async Task EmitPreparationWarningsAsync(List<string> warnings, int stepDisplayOrder, string actionName, string machineName, CancellationToken ct)

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6a_PlanDeploymentPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6a_PlanDeploymentPhase.cs
@@ -15,11 +15,23 @@ namespace Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
 ///
 /// <para>
 /// Phase 6c-i (shadow mode): the planner is invoked in <see cref="PlanMode.Preview"/> so it
-/// never throws on blockers. The plan is observed but not consumed — existing execute-time
-/// filtering continues to be the source of truth for behavior. Phase 6c-iii will rewire
-/// <see cref="ExecuteStepsPhase"/> to consume <c>ctx.Plan.Steps</c> directly and switch this
-/// phase to <see cref="PlanMode.Execute"/> so blocker detection short-circuits the deployment
-/// before any action runs.
+/// never throws on blockers. The plan is stashed on <see cref="DeploymentTaskContext.Plan"/>
+/// for consumption by later phases.
+/// </para>
+///
+/// <para>
+/// Phase 6c-iii Tier 2 (per-dispatch filtering): <see cref="ExecuteStepsPhase"/> now reads
+/// <c>ctx.Plan.Steps</c> and skips any (action × target) dispatch whose
+/// <c>PlannedTargetDispatch.Validation.IsValid</c> is <c>false</c>, emitting an
+/// <c>ActionCapabilityFilteredEvent</c> instead of letting the renderer crash. This is a
+/// non-breaking, graceful skip — unsupported dispatches are silently filtered rather than
+/// causing deployment failure.
+/// </para>
+///
+/// <para>
+/// Tier 1 (future): switch this phase to <see cref="PlanMode.Execute"/> so blocker
+/// detection short-circuits the deployment <em>before</em> any action runs. This changes
+/// deployment success/failure semantics and requires its own rollout strategy.
 /// </para>
 ///
 /// <para>

--- a/src/Squid.Core/Squid.Core.csproj
+++ b/src/Squid.Core/Squid.Core.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.0" />
     <PackageReference Include="Hangfire.Pro.Redis" Version="3.0.0" />
     <PackageReference Include="Hangfire.Throttling" Version="1.0.0-beta1" />
-    <PackageReference Include="Mediator.Net" Version="4.9.1" />
-    <PackageReference Include="Mediator.Net.Autofac" Version="4.9.1" />
+    <PackageReference Include="Mediator.Net" Version="4.9.0" />
+    <PackageReference Include="Mediator.Net.Autofac" Version="4.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.6" />

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhaseCapabilityFilterTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhaseCapabilityFilterTests.cs
@@ -1,0 +1,484 @@
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.DeploymentExecution.Packages;
+using Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
+using Squid.Core.Services.DeploymentExecution.Planning;
+using Squid.Core.Services.DeploymentExecution.Rendering;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.DeploymentExecution.Script.ServiceMessages;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Core.Services.Deployments.Checkpoints;
+using Squid.Core.Services.Deployments.ExternalFeeds;
+using Squid.Core.Services.Deployments.Interruptions;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.Deployments.Execution;
+
+/// <summary>
+/// Phase 6c-iii — proves the executor's <c>PrepareStepActionsAsync</c> skips actions
+/// whose <see cref="PlannedTargetDispatch.Validation"/> is invalid, preventing
+/// unsupported (action × target) pairs from reaching the renderer/strategy. The
+/// lifecycle emits <see cref="ActionCapabilityFilteredEvent"/> for each skip.
+/// </summary>
+public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
+{
+    private readonly Mock<IDeploymentLifecycle> _lifecycleMock;
+    private readonly Mock<IExternalFeedDataProvider> _feedProviderMock;
+    private readonly Mock<IPackageAcquisitionService> _acquisitionMock;
+    private readonly Mock<IActionHandlerRegistry> _handlerRegistryMock;
+    private readonly Mock<IDeploymentInterruptionService> _interruptionMock;
+    private readonly Mock<IDeploymentCheckpointService> _checkpointMock;
+    private readonly Mock<IServerTaskService> _taskServiceMock;
+    private readonly Mock<ITransportRegistry> _transportRegistryMock;
+    private readonly Mock<IExecutionStrategy> _strategyMock;
+    private readonly Mock<IDeploymentTransport> _transportMock;
+    private readonly ExecuteStepsPhase _phase;
+    private readonly DeploymentTaskContext _ctx;
+    private readonly CapturingProbeRenderer _sshRenderer;
+    private readonly CapturingProbeRenderer _k8sRenderer;
+    private readonly List<DeploymentLifecycleEvent> _emittedEvents;
+
+    public ExecuteStepsPhaseCapabilityFilterTests()
+    {
+        _emittedEvents = new List<DeploymentLifecycleEvent>();
+        _sshRenderer = new CapturingProbeRenderer(CommunicationStyle.Ssh);
+        _k8sRenderer = new CapturingProbeRenderer(CommunicationStyle.KubernetesApi);
+
+        _lifecycleMock = new Mock<IDeploymentLifecycle>();
+        _lifecycleMock
+            .Setup(l => l.EmitAsync(It.IsAny<DeploymentLifecycleEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<DeploymentLifecycleEvent, CancellationToken>((e, _) => _emittedEvents.Add(e))
+            .Returns(Task.CompletedTask);
+
+        _feedProviderMock = new Mock<IExternalFeedDataProvider>();
+        _acquisitionMock = new Mock<IPackageAcquisitionService>();
+        _handlerRegistryMock = new Mock<IActionHandlerRegistry>();
+        _interruptionMock = new Mock<IDeploymentInterruptionService>();
+        _checkpointMock = new Mock<IDeploymentCheckpointService>();
+        _taskServiceMock = new Mock<IServerTaskService>();
+        _transportRegistryMock = new Mock<ITransportRegistry>();
+        _strategyMock = new Mock<IExecutionStrategy>();
+        _transportMock = new Mock<IDeploymentTransport>();
+
+        _strategyMock
+            .Setup(s => s.ExecuteScriptAsync(It.IsAny<ScriptExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScriptExecutionResult { Success = true, ExitCode = 0, LogLines = new List<string>() });
+
+        _transportMock.Setup(t => t.Strategy).Returns(_strategyMock.Object);
+        _transportRegistryMock.Setup(r => r.Resolve(It.IsAny<CommunicationStyle>())).Returns(_transportMock.Object);
+
+        var rendererRegistry = new IntentRendererRegistry(new IIntentRenderer[] { _sshRenderer, _k8sRenderer });
+
+        _phase = new ExecuteStepsPhase(
+            _handlerRegistryMock.Object,
+            _lifecycleMock.Object,
+            _interruptionMock.Object,
+            _checkpointMock.Object,
+            _taskServiceMock.Object,
+            _transportRegistryMock.Object,
+            _feedProviderMock.Object,
+            _acquisitionMock.Object,
+            new ServiceMessageParser(),
+            rendererRegistry);
+
+        _ctx = new DeploymentTaskContext
+        {
+            ServerTaskId = 1,
+            Deployment = new Deployment { Id = 1, EnvironmentId = 1, ChannelId = 1 },
+            SelectedPackages = new List<ReleaseSelectedPackage>(),
+            Steps = new List<DeploymentStepDto>(),
+            Variables = new List<VariableDto>(),
+            AcquiredPackages = new Dictionary<string, PackageAcquisitionResult>(),
+            AllTargetsContext = new List<DeploymentTargetContext>()
+        };
+    }
+
+    public void Dispose() { }
+
+    // ------------------------------------------------------------------
+    // Shared fakes
+    // ------------------------------------------------------------------
+
+    private sealed class TrackingHandler : IActionHandler
+    {
+        public string ActionType { get; init; }
+        public int DescribeIntentCallCount { get; private set; }
+
+        public Task<ExecutionIntent> DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
+        {
+            DescribeIntentCallCount++;
+            return Task.FromResult<ExecutionIntent>(new RunScriptIntent
+            {
+                Name = "test-intent",
+                StepName = ctx.Step?.Name ?? string.Empty,
+                ActionName = ctx.Action?.Name ?? string.Empty,
+                ScriptBody = "echo test",
+                Syntax = ScriptSyntax.Bash,
+                InjectRuntimeBundle = false
+            });
+        }
+    }
+
+    private sealed class CapturingProbeRenderer : IIntentRenderer
+    {
+        public CapturingProbeRenderer(CommunicationStyle style) => CommunicationStyle = style;
+
+        public CommunicationStyle CommunicationStyle { get; }
+        public List<ExecutionIntent> CapturedIntents { get; } = new();
+
+        public bool CanRender(ExecutionIntent intent) => intent is not null;
+
+        public Task<ScriptExecutionRequest> RenderAsync(ExecutionIntent intent, IntentRenderContext context, CancellationToken ct)
+        {
+            CapturedIntents.Add(intent);
+            return Task.FromResult(new ScriptExecutionRequest
+            {
+                ScriptBody = intent is RunScriptIntent rs ? rs.ScriptBody : "rendered",
+                Variables = context.EffectiveVariables.ToList(),
+                Machine = context.Target.Machine,
+                EndpointContext = context.Target.EndpointContext
+            });
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private TrackingHandler InstallHandler(string actionType = null)
+    {
+        var handler = new TrackingHandler { ActionType = actionType ?? SpecialVariables.ActionTypes.Script };
+        _handlerRegistryMock.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>())).Returns(ExecutionScope.TargetLevel);
+        _handlerRegistryMock.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>())).Returns(handler);
+        return handler;
+    }
+
+    private static DeploymentStepDto BuildStep(int id, string name, params DeploymentActionDto[] actions) => new()
+    {
+        Id = id,
+        StepOrder = 1,
+        Name = name,
+        StepType = "Action",
+        Condition = "Success",
+        StartTrigger = "StartAfterPrevious",
+        Properties = new List<DeploymentStepPropertyDto>(),
+        Actions = actions.ToList()
+    };
+
+    private static DeploymentActionDto BuildAction(int id, string name, string actionType) => new()
+    {
+        Id = id,
+        ActionOrder = id,
+        Name = name,
+        ActionType = actionType,
+        IsDisabled = false,
+        Properties = new List<DeploymentActionPropertyDto>()
+    };
+
+    private DeploymentTargetContext BuildTarget(int machineId, string name, CommunicationStyle style = CommunicationStyle.Ssh) => new()
+    {
+        Machine = new Machine { Id = machineId, Name = name, Roles = string.Empty },
+        CommunicationStyle = style,
+        Transport = _transportMock.Object,
+        EndpointContext = new EndpointContext()
+    };
+
+    private static PlannedStep BuildPlannedStep(int stepId, params PlannedAction[] actions) => new()
+    {
+        StepId = stepId,
+        StepName = "planned",
+        StepOrder = 1,
+        Status = PlannedStepStatus.Applicable,
+        Actions = actions,
+        MatchedTargets = actions.SelectMany(a => a.Dispatches).Select(d => d.Target).Distinct().ToArray()
+    };
+
+    private static PlannedAction BuildPlannedAction(int actionId, string actionType, params PlannedTargetDispatch[] dispatches) => new()
+    {
+        ActionId = actionId,
+        ActionName = "test-action",
+        ActionType = actionType,
+        Dispatches = dispatches
+    };
+
+    private static PlannedTargetDispatch BuildDispatch(int machineId, string machineName, bool isValid, string violationMessage = null) => new()
+    {
+        Target = new PlannedTarget { MachineId = machineId, MachineName = machineName },
+        Intent = new RunScriptIntent { Name = "test", ScriptBody = "echo 1", Syntax = ScriptSyntax.Bash },
+        Validation = isValid
+            ? CapabilityValidationResult.Supported
+            : new CapabilityValidationResult
+            {
+                Violations = new[]
+                {
+                    new CapabilityViolation
+                    {
+                        Code = ViolationCodes.UnsupportedActionType,
+                        Message = violationMessage ?? "transport does not support this action type"
+                    }
+                }
+            }
+    };
+
+    private void SeedPlan(params PlannedStep[] steps)
+    {
+        _ctx.Plan = new DeploymentPlan
+        {
+            Mode = PlanMode.Preview,
+            ReleaseId = 1,
+            EnvironmentId = 1,
+            DeploymentProcessSnapshotId = 1,
+            Steps = steps
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Action_SkippedWhenDispatchValidationFails()
+    {
+        var handler = InstallHandler();
+        var action = BuildAction(1, "Helm Upgrade", "Squid.HelmChartUpgrade");
+        var target = BuildTarget(1, "ssh-target");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, "Squid.HelmChartUpgrade",
+                BuildDispatch(1, "ssh-target", isValid: false, "transport does not support action type 'Squid.HelmChartUpgrade'"))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        handler.DescribeIntentCallCount.ShouldBe(0);
+        _sshRenderer.CapturedIntents.ShouldBeEmpty();
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().Count().ShouldBe(1);
+
+        var evt = _emittedEvents.OfType<ActionCapabilityFilteredEvent>().Single();
+        evt.Context.ActionName.ShouldBe("Helm Upgrade");
+        evt.Context.MachineName.ShouldBe("ssh-target");
+        evt.Context.Message.ShouldContain("Squid.HelmChartUpgrade");
+    }
+
+    [Fact]
+    public async Task Action_ExecutedWhenDispatchValidationPasses()
+    {
+        var handler = InstallHandler();
+        var action = BuildAction(1, "Run Script", SpecialVariables.ActionTypes.Script);
+        var target = BuildTarget(1, "ssh-target");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, SpecialVariables.ActionTypes.Script,
+                BuildDispatch(1, "ssh-target", isValid: true))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        handler.DescribeIntentCallCount.ShouldBe(1);
+        _sshRenderer.CapturedIntents.Count.ShouldBe(1);
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task MultipleActions_OnlyUnsupportedSkipped()
+    {
+        var scriptHandler = new TrackingHandler { ActionType = SpecialVariables.ActionTypes.Script };
+        var helmHandler = new TrackingHandler { ActionType = "Squid.HelmChartUpgrade" };
+
+        _handlerRegistryMock.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>())).Returns(ExecutionScope.TargetLevel);
+        _handlerRegistryMock.Setup(r => r.Resolve(It.Is<DeploymentActionDto>(a => a.ActionType == SpecialVariables.ActionTypes.Script))).Returns(scriptHandler);
+        _handlerRegistryMock.Setup(r => r.Resolve(It.Is<DeploymentActionDto>(a => a.ActionType == "Squid.HelmChartUpgrade"))).Returns(helmHandler);
+
+        var scriptAction = BuildAction(1, "Run Script", SpecialVariables.ActionTypes.Script);
+        var helmAction = BuildAction(2, "Helm Upgrade", "Squid.HelmChartUpgrade");
+        var target = BuildTarget(1, "ssh-target");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Mixed Step", scriptAction, helmAction) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, SpecialVariables.ActionTypes.Script,
+                BuildDispatch(1, "ssh-target", isValid: true)),
+            BuildPlannedAction(2, "Squid.HelmChartUpgrade",
+                BuildDispatch(1, "ssh-target", isValid: false, "unsupported action type"))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        scriptHandler.DescribeIntentCallCount.ShouldBe(1);
+        helmHandler.DescribeIntentCallCount.ShouldBe(0);
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().Count().ShouldBe(1);
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().Single().Context.ActionName.ShouldBe("Helm Upgrade");
+    }
+
+    [Fact]
+    public async Task MultipleTargets_OnlyUnsupportedTargetSkipped()
+    {
+        var handler = InstallHandler();
+        var helmAction = BuildAction(1, "Helm Upgrade", "Squid.HelmChartUpgrade");
+
+        var k8sTarget = BuildTarget(1, "k8s-target", CommunicationStyle.KubernetesApi);
+        var sshTarget = BuildTarget(2, "ssh-target", CommunicationStyle.Ssh);
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy Helm", helmAction) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { k8sTarget, sshTarget };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, "Squid.HelmChartUpgrade",
+                BuildDispatch(1, "k8s-target", isValid: true),
+                BuildDispatch(2, "ssh-target", isValid: false, "unsupported"))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        // Handler called once (for k8s target only)
+        handler.DescribeIntentCallCount.ShouldBe(1);
+        _k8sRenderer.CapturedIntents.Count.ShouldBe(1);
+
+        // One capability filtered event for SSH target
+        var filtered = _emittedEvents.OfType<ActionCapabilityFilteredEvent>().ToList();
+        filtered.Count.ShouldBe(1);
+        filtered[0].Context.MachineName.ShouldBe("ssh-target");
+    }
+
+    [Fact]
+    public async Task NoPlanPresent_FallbackPathUnchanged()
+    {
+        var handler = InstallHandler();
+        var action = BuildAction(1, "Run Script", SpecialVariables.ActionTypes.Script);
+        var target = BuildTarget(1, "target-1");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+        _ctx.Plan = null;
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        handler.DescribeIntentCallCount.ShouldBe(1);
+        _sshRenderer.CapturedIntents.Count.ShouldBe(1);
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task AllDispatchesInvalid_StepEmitsStartAndComplete_NotFailed()
+    {
+        InstallHandler();
+        var action = BuildAction(1, "Helm Upgrade", "Squid.HelmChartUpgrade");
+        var target = BuildTarget(1, "ssh-target");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, "Squid.HelmChartUpgrade",
+                BuildDispatch(1, "ssh-target", isValid: false))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        // Step lifecycle: started and completed
+        _emittedEvents.OfType<StepStartingEvent>().Count().ShouldBe(1);
+        _emittedEvents.OfType<StepCompletedEvent>().Count().ShouldBe(1);
+
+        // Step did not fail
+        var completed = _emittedEvents.OfType<StepCompletedEvent>().Single();
+        completed.Context.Failed.ShouldBeFalse();
+
+        // FailureEncountered should NOT have been set
+        _ctx.FailureEncountered.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RunOnServerStep_NoCapabilityFiltering()
+    {
+        var handler = InstallHandler();
+        var action = BuildAction(1, "Run Script", SpecialVariables.ActionTypes.Script);
+
+        var step = BuildStep(10, "Server Step", action);
+        step.Properties.Add(new DeploymentStepPropertyDto
+        {
+            PropertyName = SpecialVariables.Step.RunOnServer,
+            PropertyValue = "true"
+        });
+
+        _ctx.Steps = new List<DeploymentStepDto> { step };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext>();
+
+        // Plan marks it as RunOnServer with no dispatches
+        SeedPlan(new PlannedStep
+        {
+            StepId = 10,
+            StepName = "Server Step",
+            StepOrder = 1,
+            Status = PlannedStepStatus.RunOnServer,
+            Actions = new[]
+            {
+                new PlannedAction
+                {
+                    ActionId = 1,
+                    ActionName = "Run Script",
+                    ActionType = SpecialVariables.ActionTypes.Script,
+                    Dispatches = Array.Empty<PlannedTargetDispatch>()
+                }
+            }
+        });
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        // Handler should have been called (RunOnServer uses PrepareStepActionsAsync too)
+        handler.DescribeIntentCallCount.ShouldBe(1);
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DispatchMissingForAction_FallbackToNoFilter()
+    {
+        var handler = InstallHandler();
+        var action = BuildAction(1, "Run Script", SpecialVariables.ActionTypes.Script);
+        var target = BuildTarget(1, "target-1");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        // Plan has the action but dispatch targets a *different* machine — (action=1, machine=1) has no dispatch.
+        // Manually include machine 1 in MatchedTargets (as if another action routed it there).
+        SeedPlan(new PlannedStep
+        {
+            StepId = 10,
+            StepName = "Deploy",
+            StepOrder = 1,
+            Status = PlannedStepStatus.Applicable,
+            MatchedTargets = new[] { new PlannedTarget { MachineId = 1, MachineName = "target-1" } },
+            Actions = new[]
+            {
+                new PlannedAction
+                {
+                    ActionId = 1,
+                    ActionName = "Run Script",
+                    ActionType = SpecialVariables.ActionTypes.Script,
+                    Dispatches = new[]
+                    {
+                        BuildDispatch(99, "other-target", isValid: false) // dispatch for machine 99, not machine 1
+                    }
+                }
+            }
+        });
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        // Action proceeds because dispatch lookup returns null for machine 1 → no filtering
+        handler.DescribeIntentCallCount.ShouldBe(1);
+        _emittedEvents.OfType<ActionCapabilityFilteredEvent>().ShouldBeEmpty();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerTests.cs
@@ -11,6 +11,7 @@ using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Process;
 using Squid.Message.Models.Deployments.Variable;
+using Squid.Core.Services.DeploymentExecution.Ssh;
 
 namespace Squid.UnitTests.Services.Deployments.Execution.Planning;
 
@@ -347,6 +348,83 @@ public class DeploymentPlannerTests
 
         plan.CandidateTargets.Select(t => t.MachineName).ShouldBe(new[] { "aaa", "zzz" });
         plan.CandidateTargets[0].Roles.ShouldBe(new[] { "db", "web" });
+    }
+
+    // ---------- SSH transport capability scenarios -----------------------
+
+    [Fact]
+    public async Task PlanAsync_SshTargetWithHelmAction_EmitsUnsupportedActionTypeViolation()
+    {
+        var step = BuildStep(id: 10, order: 1, name: "Deploy");
+        step.Actions.Add(BuildAction(id: 100, order: 1, actionType: "Squid.HelmChartUpgrade", name: "Helm Upgrade"));
+
+        var targets = new[] { BuildTargetContext(1, "ssh-prod-1", "web", CommunicationStyle.Ssh, SshTransport.Capability) };
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(PlanMode.Preview, [step], targets), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+        dispatch.Validation.IsValid.ShouldBeFalse();
+        dispatch.Validation.Violations.ShouldContain(v => v.Code == ViolationCodes.UnsupportedActionType);
+
+        plan.BlockingReasons.ShouldContain(r =>
+            r.Code == PlanBlockingReasonCodes.CapabilityViolation
+            && r.Detail == ViolationCodes.UnsupportedActionType);
+    }
+
+    [Fact]
+    public async Task PlanAsync_MixedTargets_OnlySshTargetHasViolation()
+    {
+        var step = BuildStep(id: 10, order: 1, name: "Deploy");
+        step.Actions.Add(BuildAction(id: 100, order: 1, actionType: "Squid.HelmChartUpgrade", name: "Helm Upgrade"));
+
+        var targets = new[]
+        {
+            BuildTargetContext(1, "k8s-web-1", "web", CommunicationStyle.KubernetesApi),
+            BuildTargetContext(2, "ssh-web-1", "web", CommunicationStyle.Ssh, SshTransport.Capability)
+        };
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(PlanMode.Preview, [step], targets), CancellationToken.None);
+
+        var dispatches = plan.Steps.Single().Actions.Single().Dispatches;
+        dispatches.Count.ShouldBe(2);
+
+        var k8sDispatch = dispatches.Single(d => d.Target.MachineId == 1);
+        var sshDispatch = dispatches.Single(d => d.Target.MachineId == 2);
+
+        k8sDispatch.Validation.IsValid.ShouldBeTrue();
+        sshDispatch.Validation.IsValid.ShouldBeFalse();
+        sshDispatch.Validation.Violations.ShouldContain(v => v.Code == ViolationCodes.UnsupportedActionType);
+    }
+
+    [Fact]
+    public async Task PlanAsync_SshTargetWithScriptAction_NoViolation()
+    {
+        var step = BuildStep(id: 10, order: 1, name: "Deploy");
+        step.Actions.Add(BuildAction(id: 100, order: 1, actionType: SpecialVariables.ActionTypes.Script, name: "Run Script"));
+
+        var targets = new[] { BuildTargetContext(1, "ssh-prod-1", "web", CommunicationStyle.Ssh, SshTransport.Capability) };
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(PlanMode.Preview, [step], targets), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+        dispatch.Validation.IsValid.ShouldBeTrue();
+
+        plan.BlockingReasons.Where(r => r.Code == PlanBlockingReasonCodes.CapabilityViolation).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PlanAsync_ExecuteModeWithSshCapabilityViolation_Throws()
+    {
+        var step = BuildStep(id: 10, order: 1, name: "Deploy");
+        step.Actions.Add(BuildAction(id: 100, order: 1, actionType: "Squid.HelmChartUpgrade", name: "Helm Upgrade"));
+
+        var targets = new[] { BuildTargetContext(1, "ssh-prod-1", "web", CommunicationStyle.Ssh, SshTransport.Capability) };
+
+        var ex = await Should.ThrowAsync<DeploymentPlanValidationException>(() =>
+            BuildPlanner().PlanAsync(BuildRequest(PlanMode.Execute, [step], targets), CancellationToken.None));
+
+        ex.Plan.Mode.ShouldBe(PlanMode.Execute);
+        ex.Reasons.ShouldContain(r => r.Code == PlanBlockingReasonCodes.CapabilityViolation);
     }
 
     // ---------- helpers ------------------------------------------------

--- a/tests/Squid.UnitTests/Services/Deployments/Preview/DeploymentPreviewCapabilityTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Preview/DeploymentPreviewCapabilityTests.cs
@@ -1,0 +1,149 @@
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Planning;
+using Squid.Core.Services.DeploymentExecution.Ssh;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.Deployments.Preview;
+
+/// <summary>
+/// Phase 6c-iii — verifies that capability violations detected by the planner surface
+/// as <see cref="PlanBlockingReason"/> entries in the <see cref="DeploymentPlan"/>,
+/// which the preview UI translates into <c>BlockingReasons</c> for the user.
+/// </summary>
+public class DeploymentPreviewCapabilityTests
+{
+    private readonly CapabilityValidator _validator = new();
+    private readonly Mock<IActionHandlerRegistry> _registry = new();
+
+    public DeploymentPreviewCapabilityTests()
+    {
+        _registry.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>()))
+            .Returns(ExecutionScope.TargetLevel);
+    }
+
+    private DeploymentPlanner BuildPlanner() => new(_registry.Object, _validator);
+
+    [Fact]
+    public async Task Preview_SshTargetWithUnsupportedAction_BlockingReasonsContainViolation()
+    {
+        var step = BuildStep(10, "Deploy", roles: "web");
+        step.Actions.Add(BuildAction(100, "Helm Upgrade", "Squid.HelmChartUpgrade"));
+
+        var targets = new[]
+        {
+            BuildTargetContext(1, "ssh-web-1", "web", CommunicationStyle.Ssh, SshTransport.Capability)
+        };
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(PlanMode.Preview, step, targets), CancellationToken.None);
+
+        plan.CanProceed.ShouldBeFalse();
+        plan.BlockingReasons.ShouldContain(r =>
+            r.Code == PlanBlockingReasonCodes.CapabilityViolation
+            && r.Detail == ViolationCodes.UnsupportedActionType
+            && r.MachineId == 1);
+    }
+
+    [Fact]
+    public async Task Preview_AllTargetsSupportAction_NoBlockingReasons()
+    {
+        var step = BuildStep(10, "Deploy", roles: "web");
+        step.Actions.Add(BuildAction(100, "Run Script", SpecialVariables.ActionTypes.Script));
+
+        var targets = new[]
+        {
+            BuildTargetContext(1, "k8s-web-1", "web", CommunicationStyle.KubernetesApi),
+            BuildTargetContext(2, "ssh-web-1", "web", CommunicationStyle.Ssh, SshTransport.Capability)
+        };
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(PlanMode.Preview, step, targets), CancellationToken.None);
+
+        plan.CanProceed.ShouldBeTrue();
+        plan.BlockingReasons.Where(r => r.Code == PlanBlockingReasonCodes.CapabilityViolation).ShouldBeEmpty();
+    }
+
+    // ---------- helpers --------------------------------------------------
+
+    private static DeploymentPlanRequest BuildRequest(
+        PlanMode mode,
+        DeploymentStepDto step,
+        IReadOnlyList<DeploymentTargetContext> targets) => new()
+    {
+        Mode = mode,
+        ReleaseId = 1,
+        EnvironmentId = 100,
+        ChannelId = 200,
+        DeploymentProcessSnapshotId = 999,
+        Steps = new[] { step },
+        Variables = Array.Empty<VariableDto>(),
+        TargetContexts = targets
+    };
+
+    private static DeploymentStepDto BuildStep(int id, string name, string roles = null)
+    {
+        var step = new DeploymentStepDto
+        {
+            Id = id,
+            StepOrder = 1,
+            Name = name,
+            Properties = new List<DeploymentStepPropertyDto>(),
+            Actions = new List<DeploymentActionDto>()
+        };
+
+        if (!string.IsNullOrEmpty(roles))
+        {
+            step.Properties.Add(new DeploymentStepPropertyDto
+            {
+                PropertyName = SpecialVariables.Step.TargetRoles,
+                PropertyValue = roles
+            });
+        }
+
+        return step;
+    }
+
+    private static DeploymentActionDto BuildAction(int id, string name, string actionType) => new()
+    {
+        Id = id,
+        ActionOrder = 1,
+        ActionType = actionType,
+        Name = name
+    };
+
+    private static DeploymentTargetContext BuildTargetContext(
+        int machineId,
+        string machineName,
+        string roles,
+        CommunicationStyle style,
+        ITransportCapabilities capabilities = null)
+    {
+        var caps = capabilities ?? new TransportCapabilities
+        {
+            SupportedSyntaxes = TransportCapabilities.Syntaxes(ScriptSyntax.Bash)
+        };
+
+        var transport = new Mock<IDeploymentTransport>();
+        transport.SetupGet(t => t.CommunicationStyle).Returns(style);
+        transport.SetupGet(t => t.Capabilities).Returns(caps);
+
+        return new DeploymentTargetContext
+        {
+            Machine = new Machine
+            {
+                Id = machineId,
+                Name = machineName,
+                Roles = $"[{string.Join(",", roles.Split(',').Select(r => $"\"{r.Trim()}\""))}]"
+            },
+            CommunicationStyle = style,
+            Transport = transport.Object
+        };
+    }
+}


### PR DESCRIPTION
…se 6c-iii Tier 2)

The DeploymentPlanner (Phase 6a) validates every (action × target) pair against ITransportCapabilities.SupportedActionTypes and records violations in PlannedTargetDispatch.Validation. However, ExecuteStepsPhase never checked these validations, causing unsupported dispatches to reach the renderer and crash with IntentRenderingException at runtime.

This change adds a graceful per-dispatch capability filter in PrepareStepActionsAsync that skips invalid dispatches before handler resolution, emitting a new ActionCapabilityFilteredEvent lifecycle event instead of letting the renderer crash.

Changes:
- Add IsDispatchBlockedByCapability() + EmitCapabilityFilteredAsync() to 6_ExecuteStepsPhase.Prepare.cs
- Add ActionCapabilityFilteredEvent lifecycle event
- Add DeploymentLifecycleHandlerBase switch arm + virtual method
- Add DeploymentActivityLogger warning log for filtered actions
- Update PlanDeploymentPhase XML docs to reflect Tier 2 is now active

Tests (14 new test cases):
- 8 executor unit tests covering skip/execute/mixed/multi-target/null-plan/ all-invalid/run-on-server/dispatch-missing scenarios
- 4 planner tests for SSH+Helm violation, mixed targets, SSH+Script pass, Execute-mode throw
- 2 preview tests for blocking reasons surfacing

All 3971 existing tests continue to pass with zero regressions.