### PR TITLE
Multi-instance Tentacle with cross-platform service host

### DIFF
--- a/deploy/scripts/install-tentacle.sh
+++ b/deploy/scripts/install-tentacle.sh
@@ -44,6 +44,33 @@ echo "Arch:     ${RID}"
 echo "Install:  ${INSTALL_DIR}"
 echo ""
 
+# Install runtime dependencies (.NET 9 self-contained needs libicu + ca-certificates).
+# Detect the host package manager and install silently if libicu is missing.
+install_runtime_deps() {
+    if ldconfig -p 2>/dev/null | grep -q "libicuuc"; then
+        return 0
+    fi
+
+    echo "Installing runtime dependencies (libicu, ca-certificates)..."
+
+    if command -v apt-get >/dev/null 2>&1; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq >/dev/null 2>&1 || true
+        apt-get install -y -qq libicu-dev ca-certificates >/dev/null 2>&1
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf install -y -q libicu ca-certificates >/dev/null
+    elif command -v yum >/dev/null 2>&1; then
+        yum install -y -q libicu ca-certificates >/dev/null
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache --quiet icu-libs ca-certificates
+    else
+        echo "Warning: couldn't detect package manager — install libicu manually."
+        return 1
+    fi
+}
+
+install_runtime_deps || true
+
 # Resolve download URL.
 # GitHub Actions publishes two tar.gz per arch under each release tag:
 #   squid-tentacle-${VERSION}-${RID}.tar.gz     (versioned)
@@ -105,6 +132,16 @@ if [ -d /usr/local/bin ]; then
     echo "Installed: /usr/local/bin/${BINARY_NAME}"
 else
     echo "Add to PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
+fi
+
+# Create the system-scope config directory for multi-instance support.
+# Register + run will read/write here; restricting to root-only protects the API key
+# and server thumbprint that get persisted after a successful `register`.
+CONFIG_DIR="/etc/squid-tentacle"
+if [ ! -d "$CONFIG_DIR" ]; then
+    mkdir -p "$CONFIG_DIR/instances"
+    chmod 700 "$CONFIG_DIR"
+    echo "Created config dir: ${CONFIG_DIR}"
 fi
 
 # Verify binary is runnable (use the `help` subcommand — `--help` is routed to RunCommand in Program.cs).

--- a/src/Squid.Api/Program.cs
+++ b/src/Squid.Api/Program.cs
@@ -1,6 +1,8 @@
+using System.Security.Cryptography.X509Certificates;
 using Autofac.Extensions.DependencyInjection;
 using Squid.Core.Persistence.Db;
 using Squid.Core.Settings.Logging;
+using Squid.Core.Settings.SelfCert;
 using Squid.Core.Settings.System;
 
 namespace Squid.Api;
@@ -56,5 +58,37 @@ public class Program
             {
                 builder.RegisterModule(new SquidModule(Log.Logger, configuration));
             })
-            .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+                webBuilder.ConfigureKestrel((ctx, kestrel) =>
+                {
+                    // Use the same SelfCert as Halibut (port 10943) so clients pinning the Squid
+                    // Server thumbprint (returned by MachineScriptService.GetServerThumbprint)
+                    // can connect to the HTTP API as well. Without this, Kestrel falls back to
+                    // ASP.NET's dev-cert on port 7078 and the thumbprint mismatch breaks TLS pinning.
+                    ConfigureSelfCertHttps(kestrel, ctx.Configuration);
+                });
+            });
+
+    private static void ConfigureSelfCertHttps(Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions kestrel, IConfiguration config)
+    {
+        var selfCert = new SelfCertSetting(config);
+
+        if (string.IsNullOrWhiteSpace(selfCert.Base64)) return;
+
+        try
+        {
+            var certBytes = Convert.FromBase64String(selfCert.Base64);
+            var cert = X509CertificateLoader.LoadPkcs12(certBytes, selfCert.Password);
+
+            kestrel.ConfigureHttpsDefaults(https => https.ServerCertificate = cert);
+
+            Log.Information("Kestrel HTTPS configured with SelfCert (thumbprint {Thumbprint})", cert.Thumbprint);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to load SelfCert for Kestrel — falling back to ASP.NET default");
+        }
+    }
 }

--- a/src/Squid.Tentacle/Commands/CreateInstanceCommand.cs
+++ b/src/Squid.Tentacle/Commands/CreateInstanceCommand.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Configuration;
+using Squid.Tentacle.Instance;
+using Squid.Tentacle.Platform;
+using Serilog;
+
+namespace Squid.Tentacle.Commands;
+
+/// <summary>
+/// <c>squid-tentacle create-instance [--instance NAME] [--config PATH]</c>
+///
+/// Registers a new Tentacle instance in <c>instances.json</c> and creates its
+/// certs directory. Mirrors Octopus's <c>Tentacle.exe create-instance</c>.
+/// Omitting <c>--instance</c> creates the Default instance.
+/// </summary>
+public sealed class CreateInstanceCommand : ITentacleCommand
+{
+    public string Name => "create-instance";
+    public string Description => "Register a new Tentacle instance";
+
+    public Task<int> ExecuteAsync(string[] args, IConfiguration config, CancellationToken ct)
+    {
+        var (instanceName, remaining) = InstanceSelector.ExtractInstanceArg(args);
+        var explicitConfigPath = ParseOption(remaining, "--config");
+
+        instanceName = string.IsNullOrWhiteSpace(instanceName) ? InstanceRecord.DefaultName : instanceName;
+
+        var registry = InstanceRegistry.CreateForCurrentProcess();
+
+        if (registry.Find(instanceName) != null)
+        {
+            Console.Error.WriteLine($"Instance '{instanceName}' already exists at {registry.Path}");
+            return Task.FromResult(1);
+        }
+
+        var configDir = System.IO.Path.GetDirectoryName(registry.Path)!;
+        var configPath = !string.IsNullOrWhiteSpace(explicitConfigPath)
+            ? explicitConfigPath
+            : PlatformPaths.GetInstanceConfigPath(configDir, instanceName);
+
+        var record = new InstanceRecord
+        {
+            Name = instanceName,
+            ConfigPath = configPath,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        registry.Add(record);
+
+        // Eagerly create per-instance certs directory so register/new-certificate can land in it.
+        var certsDir = PlatformPaths.GetInstanceCertsDir(configDir, instanceName);
+        Directory.CreateDirectory(certsDir);
+
+        Log.Information("Instance '{Name}' created", instanceName);
+        Console.WriteLine($"Instance '{instanceName}' created");
+        Console.WriteLine($"  Registry:  {registry.Path}");
+        Console.WriteLine($"  Config:    {configPath}");
+        Console.WriteLine($"  Certs dir: {certsDir}");
+
+        return Task.FromResult(0);
+    }
+
+    private static string ParseOption(string[] args, string optionName)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i].Equals(optionName, StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                return args[i + 1];
+
+            if (args[i].StartsWith($"{optionName}=", StringComparison.OrdinalIgnoreCase))
+                return args[i][(optionName.Length + 1)..];
+        }
+
+        return null;
+    }
+}

--- a/src/Squid.Tentacle/Commands/DeleteInstanceCommand.cs
+++ b/src/Squid.Tentacle/Commands/DeleteInstanceCommand.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Configuration;
+using Squid.Tentacle.Instance;
+using Serilog;
+
+namespace Squid.Tentacle.Commands;
+
+/// <summary>
+/// <c>squid-tentacle delete-instance --instance NAME</c>
+/// Removes the instance from <c>instances.json</c> and deletes its config +
+/// certs directory. Mirrors Octopus's <c>Tentacle.exe delete-instance</c>.
+/// </summary>
+public sealed class DeleteInstanceCommand : ITentacleCommand
+{
+    public string Name => "delete-instance";
+    public string Description => "Unregister a Tentacle instance and delete its config + certs";
+
+    public Task<int> ExecuteAsync(string[] args, IConfiguration config, CancellationToken ct)
+    {
+        var (instanceName, _) = InstanceSelector.ExtractInstanceArg(args);
+
+        if (string.IsNullOrWhiteSpace(instanceName))
+        {
+            Console.Error.WriteLine("Error: --instance NAME is required");
+            return Task.FromResult(1);
+        }
+
+        var registry = InstanceRegistry.CreateForCurrentProcess();
+        var record = registry.Find(instanceName);
+
+        if (record == null)
+        {
+            Console.Error.WriteLine($"Instance '{instanceName}' not found in {registry.Path}");
+            return Task.FromResult(1);
+        }
+
+        DeleteIfExists(record.ConfigPath);
+
+        // Wipe the whole per-instance directory (certs + any workspace artefacts stored alongside).
+        // InstanceSelector.ResolveCertsPath returns .../instances/{name}/certs; we climb one level
+        // up so we clean the enclosing {name}/ folder too, not just certs/.
+        var certsDir = InstanceSelector.ResolveCertsPath(record);
+        var instanceDir = Path.GetDirectoryName(certsDir);
+        DeleteDirectoryIfExists(instanceDir);
+
+        registry.Remove(instanceName);
+
+        Log.Information("Instance '{Name}' deleted", instanceName);
+        Console.WriteLine($"Instance '{instanceName}' deleted");
+
+        return Task.FromResult(0);
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        try
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Warning: couldn't delete {path}: {ex.Message}");
+        }
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Warning: couldn't delete {path}: {ex.Message}");
+        }
+    }
+}

--- a/src/Squid.Tentacle/Commands/ListInstancesCommand.cs
+++ b/src/Squid.Tentacle/Commands/ListInstancesCommand.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Configuration;
+using Squid.Tentacle.Instance;
+
+namespace Squid.Tentacle.Commands;
+
+/// <summary>
+/// <c>squid-tentacle list-instances</c> — print all registered instances
+/// as a simple table. Mirrors Octopus's <c>Tentacle.exe list-instances</c>.
+/// </summary>
+public sealed class ListInstancesCommand : ITentacleCommand
+{
+    public string Name => "list-instances";
+    public string Description => "List all registered Tentacle instances";
+
+    public Task<int> ExecuteAsync(string[] args, IConfiguration config, CancellationToken ct)
+    {
+        var registry = InstanceRegistry.CreateForRead();
+        var instances = registry.List();
+
+        if (instances.Count == 0)
+        {
+            Console.WriteLine("No instances registered.");
+            Console.WriteLine($"  Registry looked at: {registry.Path}");
+            Console.WriteLine("  Run 'squid-tentacle create-instance --instance NAME' to create one.");
+            return Task.FromResult(0);
+        }
+
+        Console.WriteLine($"Instances registered at {registry.Path}:");
+        Console.WriteLine();
+
+        var nameColWidth = Math.Max(4, instances.Max(i => i.Name.Length));
+
+        Console.WriteLine($"  {"NAME".PadRight(nameColWidth)}  CONFIG");
+        Console.WriteLine($"  {new string('-', nameColWidth)}  ------");
+
+        foreach (var instance in instances.OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase))
+            Console.WriteLine($"  {instance.Name.PadRight(nameColWidth)}  {instance.ConfigPath}");
+
+        return Task.FromResult(0);
+    }
+}

--- a/src/Squid.Tentacle/Commands/RegisterCommand.cs
+++ b/src/Squid.Tentacle/Commands/RegisterCommand.cs
@@ -1,27 +1,34 @@
 using Microsoft.Extensions.Configuration;
 using Squid.Tentacle.Abstractions;
 using Squid.Tentacle.Certificate;
+using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Core;
+using Squid.Tentacle.Instance;
 using Serilog;
 
 namespace Squid.Tentacle.Commands;
 
 /// <summary>
-/// One-shot registration: resolves the flavor's registrar, calls RegisterAsync, prints the result, then exits.
-/// This is generic — works for any flavor (LinuxTentacle, KubernetesAgent, future WindowsTentacle).
+/// One-shot registration: resolves the flavor's registrar, calls RegisterAsync,
+/// **persists the effective settings to the instance config file**, then exits.
+///
+/// The persistence step is what makes <c>service install</c> + <c>systemd start</c>
+/// actually work: systemd re-invokes <c>squid-tentacle run</c> with no arguments,
+/// so the agent can only come back up if its settings are already on disk.
 ///
 /// Shorthand args are mapped to TentacleSettings before execution:
-///   --server URL      → Tentacle:ServerUrl
-///   --api-key KEY     → Tentacle:ApiKey
-///   --role ROLE       → Tentacle:Roles
-///   --environment ENV → Tentacle:Environments
-///   --comms-url URL   → Tentacle:ServerCommsUrl
-///   --flavor NAME     → Tentacle:Flavor
+///   --server URL         → Tentacle:ServerUrl
+///   --api-key KEY        → Tentacle:ApiKey
+///   --role ROLE          → Tentacle:Roles
+///   --environment ENV    → Tentacle:Environments
+///   --comms-url URL      → Tentacle:ServerCommsUrl
+///   --flavor NAME        → Tentacle:Flavor
+///   --instance NAME      → picked up by the outer ConfigurationBuilder and Program.cs
 /// </summary>
 public sealed class RegisterCommand : ITentacleCommand
 {
     public string Name => "register";
-    public string Description => "Register this Tentacle with the Squid Server (one-shot)";
+    public string Description => "Register this Tentacle with the Squid Server and persist its config";
 
     private static readonly Dictionary<string, string> ArgMapping = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -38,13 +45,46 @@ public sealed class RegisterCommand : ITentacleCommand
         ["--server-cert"] = "Tentacle:ServerCertificate",
     };
 
+    /// <summary>Settings we deem safe + necessary to persist after a successful register.</summary>
+    private static readonly string[] PersistableKeys =
+    [
+        "Tentacle:Flavor",
+        "Tentacle:ServerUrl",
+        "Tentacle:ServerCommsUrl",
+        "Tentacle:ServerCommsAddresses",
+        "Tentacle:ServerCertificate",
+        "Tentacle:MachineName",
+        "Tentacle:Roles",
+        "Tentacle:Environments",
+        "Tentacle:ListeningHostName",
+        "Tentacle:ListeningPort",
+        "Tentacle:SpaceId",
+        "Tentacle:SubscriptionId",
+        "Tentacle:CertsPath",
+        "Tentacle:WorkspacePath",
+    ];
+
     public async Task<int> ExecuteAsync(string[] args, IConfiguration config, CancellationToken ct)
     {
-        var expandedArgs = ExpandShorthandArgs(args);
+        // --instance is consumed upstream in Program.cs — this extraction is here so that
+        // inlining the shorthand-expanded args into IConfigurationBuilder.AddCommandLine doesn't
+        // choke, and so we know which instance to persist into.
+        var (instanceName, argsWithoutInstance) = InstanceSelector.ExtractInstanceArg(args);
+        var instance = InstanceSelector.Resolve(instanceName);
+
+        var expandedArgs = ExpandShorthandArgs(argsWithoutInstance);
+
+        // Per-instance certs path takes priority over whatever's in config, so multi-instance
+        // setups don't clobber each other's certificates.
+        var instanceCertsPath = InstanceSelector.ResolveCertsPath(instance);
 
         var merged = new ConfigurationBuilder()
             .AddConfiguration(config)
             .AddCommandLine(expandedArgs)
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Tentacle:CertsPath"] = instanceCertsPath
+            })
             .Build();
 
         var settings = TentacleApp.LoadTentacleSettings(merged);
@@ -74,13 +114,64 @@ public sealed class RegisterCommand : ITentacleCommand
 
         var registration = await runtime.Registrar.RegisterAsync(identity, ct).ConfigureAwait(false);
 
+        PersistInstanceConfig(instance, settings, subscriptionId, registration.ServerThumbprint);
+
         Console.WriteLine($"MachineId:       {registration.MachineId}");
         Console.WriteLine($"ServerThumbprint: {registration.ServerThumbprint}");
         Console.WriteLine($"SubscriptionUri: {registration.SubscriptionUri}");
         Console.WriteLine($"Thumbprint:      {cert.Thumbprint}");
+        Console.WriteLine($"Instance:        {instance.Name}");
+        Console.WriteLine($"Config saved to: {instance.ConfigPath}");
         Console.WriteLine("Registration complete.");
 
         return 0;
+    }
+
+    /// <summary>
+    /// Writes the effective settings to the instance's config.json so that a subsequent
+    /// <c>squid-tentacle run</c> (e.g. from systemd) can pick them up.
+    /// Falls back gracefully if registration wasn't created via <c>create-instance</c>:
+    /// ensures the Default entry in <c>instances.json</c> exists.
+    /// </summary>
+    private static void PersistInstanceConfig(InstanceRecord instance, Configuration.TentacleSettings settings, string subscriptionId, string serverThumbprint)
+    {
+        // Auto-create Default instance in the registry if this is a first-run where the user
+        // skipped create-instance and went straight to register.
+        try
+        {
+            var registry = InstanceRegistry.CreateForCurrentProcess();
+
+            if (registry.Find(instance.Name) == null)
+                registry.Add(new InstanceRecord { Name = instance.Name, ConfigPath = instance.ConfigPath });
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not update instance registry (non-fatal — config still persisted directly)");
+        }
+
+        var file = new TentacleConfigFile(instance.ConfigPath);
+
+        var updates = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Tentacle:Flavor"] = settings.Flavor,
+            ["Tentacle:ServerUrl"] = settings.ServerUrl,
+            ["Tentacle:ServerCommsUrl"] = settings.ServerCommsUrl,
+            ["Tentacle:ServerCommsAddresses"] = settings.ServerCommsAddresses,
+            ["Tentacle:ServerCertificate"] = string.IsNullOrWhiteSpace(settings.ServerCertificate) ? serverThumbprint : settings.ServerCertificate,
+            ["Tentacle:MachineName"] = settings.MachineName,
+            ["Tentacle:Roles"] = settings.Roles,
+            ["Tentacle:Environments"] = settings.Environments,
+            ["Tentacle:ListeningHostName"] = settings.ListeningHostName,
+            ["Tentacle:ListeningPort"] = settings.ListeningPort.ToString(),
+            ["Tentacle:SpaceId"] = settings.SpaceId.ToString(),
+            ["Tentacle:SubscriptionId"] = subscriptionId,
+            ["Tentacle:CertsPath"] = settings.CertsPath,
+            ["Tentacle:WorkspacePath"] = settings.WorkspacePath,
+        };
+
+        file.Merge(updates);
+
+        Log.Information("Persisted settings to {Path}", instance.ConfigPath);
     }
 
     internal static string[] ExpandShorthandArgs(string[] args)

--- a/src/Squid.Tentacle/Commands/ServiceCommand.cs
+++ b/src/Squid.Tentacle/Commands/ServiceCommand.cs
@@ -1,191 +1,118 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
-using Serilog;
+using Squid.Tentacle.Instance;
+using Squid.Tentacle.ServiceHost;
 
 namespace Squid.Tentacle.Commands;
 
 /// <summary>
-/// Manages the Tentacle as a systemd service (Linux).
+/// Manages the Tentacle as a system service. Backends are chosen per-OS
+/// via <see cref="ServiceHostFactory"/>: systemd on Linux, Windows Services on
+/// Windows, launchd on macOS. The command itself only knows about the generic
+/// <see cref="IServiceHost"/> contract.
+///
 /// Subcommands: install, uninstall, start, stop, status.
+/// Options: <c>--instance NAME</c> (default <c>Default</c>), <c>--service-name NAME</c>.
 /// </summary>
 public sealed class ServiceCommand : ITentacleCommand
 {
     public string Name => "service";
-    public string Description => "Manage the Tentacle systemd service (install, uninstall, start, stop, status)";
+    public string Description => "Manage the Tentacle system service (install, uninstall, start, stop, status)";
 
     private const string DefaultServiceName = "squid-tentacle";
 
     public Task<int> ExecuteAsync(string[] args, IConfiguration config, CancellationToken ct)
     {
-        if (args.Length == 0)
+        var (instanceName, argsWithoutInstance) = InstanceSelector.ExtractInstanceArg(args);
+
+        if (argsWithoutInstance.Length == 0)
         {
             PrintUsage();
             return Task.FromResult(1);
         }
 
-        var subcommand = args[0].ToLowerInvariant();
-        var serviceName = ParseServiceName(args) ?? DefaultServiceName;
+        var subcommand = argsWithoutInstance[0].ToLowerInvariant();
+        var instance = InstanceSelector.Resolve(instanceName);
+
+        // Service name defaults to "squid-tentacle" for the Default instance, or
+        // "squid-tentacle-{instance}" for named instances, so multi-instance hosts
+        // don't collide on the same systemd unit name.
+        var serviceName = ParseOption(argsWithoutInstance, "--service-name")
+            ?? (instance.Name.Equals(InstanceRecord.DefaultName, StringComparison.OrdinalIgnoreCase)
+                ? DefaultServiceName
+                : $"{DefaultServiceName}-{instance.Name}");
+
+        var host = ServiceHostFactory.Resolve();
 
         return subcommand switch
         {
-            "install" => Task.FromResult(Install(serviceName)),
-            "uninstall" => Task.FromResult(Uninstall(serviceName)),
-            "start" => Task.FromResult(RunSystemctl("start", serviceName)),
-            "stop" => Task.FromResult(RunSystemctl("stop", serviceName)),
-            "status" => Task.FromResult(RunSystemctl("status", serviceName)),
+            "install" => Task.FromResult(Install(host, instance, serviceName)),
+            "uninstall" => Task.FromResult(host.Uninstall(serviceName)),
+            "start" => Task.FromResult(host.Start(serviceName)),
+            "stop" => Task.FromResult(host.Stop(serviceName)),
+            "status" => Task.FromResult(host.Status(serviceName)),
             _ => PrintUsageAndFail()
         };
     }
 
-    private static int Install(string serviceName)
+    private static int Install(IServiceHost host, InstanceRecord instance, string serviceName)
     {
-        var executablePath = GetExecutablePath();
-        var workingDir = Path.GetDirectoryName(executablePath) ?? "/opt/squid-tentacle";
+        var (execStart, workingDir) = ResolveServiceExecution();
 
-        var unit = $"""
-            [Unit]
-            Description=Squid Tentacle Agent ({serviceName})
-            After=network.target
+        // Pass --instance NAME so the service loads the right config file; skip the flag
+        // entirely for Default since that's the zero-config default anyway.
+        var execArgs = new List<string> { "run" };
 
-            [Service]
-            Type=simple
-            ExecStart={executablePath} run
-            WorkingDirectory={workingDir}
-            Restart=always
-            RestartSec=10
-            KillSignal=SIGINT
-            TimeoutStopSec=60
-
-            [Install]
-            WantedBy=multi-user.target
-            """;
-
-        var unitPath = $"/etc/systemd/system/{serviceName}.service";
-
-        try
+        if (!instance.Name.Equals(InstanceRecord.DefaultName, StringComparison.OrdinalIgnoreCase))
         {
-            File.WriteAllText(unitPath, unit);
-            Console.WriteLine($"Created {unitPath}");
-        }
-        catch (UnauthorizedAccessException)
-        {
-            Console.Error.WriteLine($"Permission denied writing {unitPath}. Try: sudo squid-tentacle service install");
-            return 1;
+            execArgs.Add("--instance");
+            execArgs.Add(instance.Name);
         }
 
-        RunSystemctl("daemon-reload", null);
-        RunSystemctl("enable", serviceName);
-        RunSystemctl("start", serviceName);
-
-        Console.WriteLine($"Service '{serviceName}' installed and started.");
-        Console.WriteLine($"  Status:  sudo systemctl status {serviceName}");
-        Console.WriteLine($"  Logs:    sudo journalctl -u {serviceName} -f");
-
-        return 0;
+        return host.Install(new ServiceInstallRequest
+        {
+            ServiceName = serviceName,
+            Description = $"Squid Tentacle Agent ({instance.Name})",
+            ExecStart = execStart,
+            WorkingDirectory = workingDir,
+            ExecArgs = execArgs.ToArray()
+        });
     }
 
-    private static int Uninstall(string serviceName)
+    /// <summary>
+    /// Resolves <c>ExecStart</c> and <c>WorkingDirectory</c> for the service unit.
+    /// Uses <see cref="Environment.ProcessPath"/> (real exe — works for single-file
+    /// PublishSingleFile deployments) + <see cref="AppContext.BaseDirectory"/> (install dir).
+    /// </summary>
+    internal static (string ExecStart, string WorkingDir) ResolveServiceExecution()
     {
-        RunSystemctl("stop", serviceName);
-        RunSystemctl("disable", serviceName);
+        var workingDir = (AppContext.BaseDirectory ?? "/opt/squid-tentacle").TrimEnd('/', '\\');
+        var execStart = Environment.ProcessPath;
 
-        var unitPath = $"/etc/systemd/system/{serviceName}.service";
+        if (string.IsNullOrEmpty(execStart))
+            execStart = Path.Combine(workingDir, "Squid.Tentacle");
 
-        if (File.Exists(unitPath))
-        {
-            try
-            {
-                File.Delete(unitPath);
-                Console.WriteLine($"Removed {unitPath}");
-            }
-            catch (UnauthorizedAccessException)
-            {
-                Console.Error.WriteLine($"Permission denied removing {unitPath}. Try: sudo squid-tentacle service uninstall");
-                return 1;
-            }
-        }
-
-        RunSystemctl("daemon-reload", null);
-        Console.WriteLine($"Service '{serviceName}' uninstalled.");
-
-        return 0;
+        return (execStart, workingDir);
     }
 
-    internal static string GenerateUnitFile(string serviceName, string executablePath)
+    /// <summary>
+    /// Kept for tests written against the old signature — delegates to systemd unit builder.
+    /// New call-sites should go through <see cref="ServiceHostFactory"/>.
+    /// </summary>
+    internal static string GenerateUnitFile(string serviceName, string execStart, string workingDir)
     {
-        var workingDir = Path.GetDirectoryName(executablePath) ?? "/opt/squid-tentacle";
-
-        return $"""
-            [Unit]
-            Description=Squid Tentacle Agent ({serviceName})
-            After=network.target
-
-            [Service]
-            Type=simple
-            ExecStart={executablePath} run
-            WorkingDirectory={workingDir}
-            Restart=always
-            RestartSec=10
-            KillSignal=SIGINT
-            TimeoutStopSec=60
-
-            [Install]
-            WantedBy=multi-user.target
-            """;
+        return SystemdServiceHost.BuildUnitFile(new ServiceInstallRequest
+        {
+            ServiceName = serviceName,
+            ExecStart = execStart,
+            WorkingDirectory = workingDir
+        });
     }
 
-    private static int RunSystemctl(string action, string serviceName)
-    {
-        var args = serviceName != null ? $"{action} {serviceName}" : action;
-
-        try
-        {
-            var psi = new ProcessStartInfo("systemctl", args)
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            using var process = Process.Start(psi);
-            if (process == null) return 1;
-
-            var stdout = process.StandardOutput.ReadToEnd();
-            var stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit(TimeSpan.FromSeconds(30));
-
-            if (!string.IsNullOrWhiteSpace(stdout)) Console.Write(stdout);
-            if (!string.IsNullOrWhiteSpace(stderr)) Console.Error.Write(stderr);
-
-            return process.ExitCode;
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Failed to run systemctl {args}: {ex.Message}");
-            return 1;
-        }
-    }
-
-    private static string GetExecutablePath()
-    {
-        var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-
-        if (entryAssembly != null)
-        {
-            var dllPath = entryAssembly.Location;
-
-            if (!string.IsNullOrEmpty(dllPath))
-                return $"dotnet {dllPath}";
-        }
-
-        return "dotnet Squid.Tentacle.dll";
-    }
-
-    private static string ParseServiceName(string[] args)
+    private static string ParseOption(string[] args, string optionName)
     {
         for (var i = 0; i < args.Length - 1; i++)
         {
-            if (args[i] == "--service-name")
+            if (args[i].Equals(optionName, StringComparison.OrdinalIgnoreCase))
                 return args[i + 1];
         }
 
@@ -194,11 +121,11 @@ public sealed class ServiceCommand : ITentacleCommand
 
     private static void PrintUsage()
     {
-        Console.WriteLine("Usage: squid-tentacle service <subcommand> [--service-name NAME]");
+        Console.WriteLine("Usage: squid-tentacle service <subcommand> [--instance NAME] [--service-name NAME]");
         Console.WriteLine();
         Console.WriteLine("Subcommands:");
-        Console.WriteLine("  install     Create and start a systemd service");
-        Console.WriteLine("  uninstall   Stop and remove the systemd service");
+        Console.WriteLine("  install     Create and start a system service");
+        Console.WriteLine("  uninstall   Stop and remove the system service");
         Console.WriteLine("  start       Start the service");
         Console.WriteLine("  stop        Stop the service");
         Console.WriteLine("  status      Show service status");

--- a/src/Squid.Tentacle/Configuration/TentacleConfigFile.cs
+++ b/src/Squid.Tentacle/Configuration/TentacleConfigFile.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Squid.Tentacle.Configuration;
+
+/// <summary>
+/// Per-instance persistent config file — a flat JSON document compatible with
+/// <c>IConfigurationBuilder.AddJsonFile()</c>. This is what makes
+/// <c>register</c> → <c>service install</c> → <c>systemd start</c> actually work:
+/// <c>register</c> writes the config, and <c>run</c> (invoked by systemd without
+/// any CLI args) reads it back.
+/// </summary>
+///
+/// <remarks>
+/// <para>Keys use the same colon-delimited form as <c>appsettings.json</c>
+/// (e.g. <c>Tentacle:ServerUrl</c>), written out as nested JSON so the file is
+/// both human-readable and directly consumable by
+/// <c>ConfigurationBuilder.AddJsonFile()</c>.</para>
+/// <para>Precedence when multiple config sources exist (low → high):
+/// config file → <c>appsettings.json</c> → env vars → CLI args. This matches
+/// Octopus and means temporary overrides via env/CLI still work on top of
+/// persisted config.</para>
+/// </remarks>
+public sealed class TentacleConfigFile
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public string Path { get; }
+
+    public TentacleConfigFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        Path = path;
+    }
+
+    public bool Exists() => File.Exists(Path);
+
+    /// <summary>
+    /// Reads the file as a flat colon-delimited dictionary. Missing file → empty dictionary.
+    /// </summary>
+    public Dictionary<string, string> Load()
+    {
+        if (!File.Exists(Path))
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        using var stream = File.OpenRead(Path);
+        var root = JsonNode.Parse(stream);
+
+        var flat = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (root is JsonObject obj)
+            Flatten(obj, prefix: null, flat);
+
+        return flat;
+    }
+
+    /// <summary>
+    /// Merges <paramref name="updates"/> into whatever is currently in the file and rewrites it.
+    /// Empty/null values in <paramref name="updates"/> are skipped (to avoid wiping out existing keys).
+    /// </summary>
+    public void Merge(IReadOnlyDictionary<string, string> updates)
+    {
+        ArgumentNullException.ThrowIfNull(updates);
+
+        var current = Load();
+
+        foreach (var (key, value) in updates)
+        {
+            if (string.IsNullOrWhiteSpace(value)) continue;
+
+            current[key] = value;
+        }
+
+        Save(current);
+    }
+
+    /// <summary>
+    /// Overwrites the file with exactly the supplied keys — callers that want
+    /// full control over what's persisted use this instead of <see cref="Merge"/>.
+    /// </summary>
+    public void Save(IReadOnlyDictionary<string, string> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path)!);
+
+        var root = new JsonObject();
+
+        foreach (var (key, value) in values.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+            Nest(root, key.Split(':'), value);
+
+        File.WriteAllText(Path, root.ToJsonString(JsonOptions));
+
+        TryRestrictPermissions(Path);
+    }
+
+    /// <summary>Removes a single key (colon-delimited) from the file.</summary>
+    public void Remove(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var current = Load();
+
+        if (!current.Remove(key)) return;
+
+        Save(current);
+    }
+
+    private static void Flatten(JsonObject obj, string prefix, Dictionary<string, string> output)
+    {
+        foreach (var kv in obj)
+        {
+            var key = string.IsNullOrEmpty(prefix) ? kv.Key : $"{prefix}:{kv.Key}";
+
+            if (kv.Value is JsonObject nested)
+                Flatten(nested, key, output);
+            else if (kv.Value is not null)
+                output[key] = kv.Value.ToString();
+        }
+    }
+
+    private static void Nest(JsonObject root, string[] segments, string value)
+    {
+        var cursor = root;
+
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            var segment = segments[i];
+
+            if (cursor[segment] is not JsonObject next)
+            {
+                next = new JsonObject();
+                cursor[segment] = next;
+            }
+
+            cursor = next;
+        }
+
+        cursor[segments[^1]] = value;
+    }
+
+    /// <summary>
+    /// Restricts the config file to owner-read/write only on Unix. Best-effort — silently
+    /// skips on Windows (where ACLs handle this) or if the call fails.
+    /// </summary>
+    private static void TryRestrictPermissions(string path)
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        try
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch
+        {
+            // Non-fatal — permissions tightening is a hardening step, not a correctness requirement
+        }
+    }
+}

--- a/src/Squid.Tentacle/Instance/InstanceRecord.cs
+++ b/src/Squid.Tentacle/Instance/InstanceRecord.cs
@@ -1,0 +1,22 @@
+namespace Squid.Tentacle.Instance;
+
+/// <summary>
+/// Metadata about a single Tentacle instance. Serialised into <c>instances.json</c>.
+/// </summary>
+/// <remarks>
+/// An "instance" is an independent Tentacle configuration — separate certs, separate
+/// Server binding, separate systemd unit. One host can run multiple instances side-by-side
+/// (useful for dev/prod split or for tentacles serving different Squid Servers).
+/// </remarks>
+public sealed class InstanceRecord
+{
+    /// <summary>Default instance name used when <c>--instance</c> is omitted.</summary>
+    public const string DefaultName = "Default";
+
+    public string Name { get; set; } = DefaultName;
+
+    /// <summary>Absolute path to this instance's config.json file.</summary>
+    public string ConfigPath { get; set; } = string.Empty;
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/Squid.Tentacle/Instance/InstanceRegistry.cs
+++ b/src/Squid.Tentacle/Instance/InstanceRegistry.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Instance;
+
+/// <summary>
+/// Persisted list of all Tentacle instances on this host, stored as
+/// <c>{configDir}/instances.json</c>.
+/// </summary>
+///
+/// <remarks>
+/// <para>Analogue to Octopus Tentacle's Windows Registry "Software\Octopus"
+/// instance registry — but cross-platform via plain JSON, so it works
+/// identically on Linux/macOS/Windows.</para>
+/// <para>Instances are stored in system-scope if the current process can write
+/// there (root/Administrator); otherwise user-scope. Reads prefer system-scope
+/// when both exist.</para>
+/// </remarks>
+public sealed class InstanceRegistry
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly string _configDir;
+
+    public InstanceRegistry(string configDir)
+    {
+        _configDir = configDir;
+    }
+
+    /// <summary>
+    /// Creates a registry bound to the default writable config dir for the current process.
+    /// </summary>
+    public static InstanceRegistry CreateForCurrentProcess() =>
+        new(PlatformPaths.PickWritableConfigDir());
+
+    /// <summary>
+    /// Creates a registry bound to the active (readable) config dir. Use for lookups
+    /// from read-only contexts like <c>run</c>.
+    /// </summary>
+    public static InstanceRegistry CreateForRead() =>
+        new(PlatformPaths.ResolveActiveConfigDir());
+
+    public string Path => PlatformPaths.GetInstancesRegistryPath(_configDir);
+
+    public IReadOnlyList<InstanceRecord> List()
+    {
+        if (!File.Exists(Path))
+            return Array.Empty<InstanceRecord>();
+
+        var json = File.ReadAllText(Path);
+        var data = JsonSerializer.Deserialize<RegistryFile>(json, JsonOptions);
+
+        return (IReadOnlyList<InstanceRecord>)data?.Instances ?? Array.Empty<InstanceRecord>();
+    }
+
+    public InstanceRecord Find(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return List().FirstOrDefault(i => i.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Returns the record for <paramref name="name"/>, or creates a default-shaped one
+    /// (but does NOT persist it). The caller decides whether to persist via <see cref="Add"/>.
+    /// </summary>
+    public InstanceRecord FindOrDefault(string name)
+    {
+        var existing = Find(name);
+
+        if (existing != null)
+            return existing;
+
+        return new InstanceRecord
+        {
+            Name = name,
+            ConfigPath = PlatformPaths.GetInstanceConfigPath(_configDir, name)
+        };
+    }
+
+    public void Add(InstanceRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ArgumentException.ThrowIfNullOrWhiteSpace(record.Name);
+
+        var file = LoadFile();
+
+        if (file.Instances.Any(i => i.Name.Equals(record.Name, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Instance '{record.Name}' already exists");
+
+        if (string.IsNullOrWhiteSpace(record.ConfigPath))
+            record.ConfigPath = PlatformPaths.GetInstanceConfigPath(_configDir, record.Name);
+
+        file.Instances.Add(record);
+        SaveFile(file);
+    }
+
+    public void Remove(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var file = LoadFile();
+        var removed = file.Instances.RemoveAll(i => i.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        if (removed == 0) return;
+
+        SaveFile(file);
+    }
+
+    /// <summary>
+    /// Ensures the <c>Default</c> instance exists, creating it on-disk if not.
+    /// This is the "zero-config" escape hatch for users who invoke register/run
+    /// without first calling <c>create-instance</c>.
+    /// </summary>
+    public InstanceRecord EnsureDefault()
+    {
+        var existing = Find(InstanceRecord.DefaultName);
+
+        if (existing != null)
+            return existing;
+
+        var record = new InstanceRecord
+        {
+            Name = InstanceRecord.DefaultName,
+            ConfigPath = PlatformPaths.GetInstanceConfigPath(_configDir, InstanceRecord.DefaultName)
+        };
+
+        Add(record);
+        return record;
+    }
+
+    private RegistryFile LoadFile()
+    {
+        if (!File.Exists(Path))
+            return new RegistryFile();
+
+        var json = File.ReadAllText(Path);
+        return JsonSerializer.Deserialize<RegistryFile>(json, JsonOptions) ?? new RegistryFile();
+    }
+
+    private void SaveFile(RegistryFile file)
+    {
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path)!);
+        File.WriteAllText(Path, JsonSerializer.Serialize(file, JsonOptions));
+    }
+
+    /// <summary>Root JSON shape: <c>{ "version": 1, "instances": [...] }</c>.</summary>
+    private sealed class RegistryFile
+    {
+        public int Version { get; set; } = 1;
+        public List<InstanceRecord> Instances { get; set; } = new();
+    }
+}

--- a/src/Squid.Tentacle/Instance/InstanceSelector.cs
+++ b/src/Squid.Tentacle/Instance/InstanceSelector.cs
@@ -1,0 +1,93 @@
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Instance;
+
+/// <summary>
+/// Turns the user's <c>--instance NAME</c> argument (or its absence) into a
+/// concrete <see cref="InstanceRecord"/> that callers can use to locate certs
+/// and config files.
+/// </summary>
+///
+/// <remarks>
+/// Behaviour:
+/// <list type="bullet">
+/// <item>Named instance resolved from <see cref="InstanceRegistry"/>. Missing → throws.</item>
+/// <item>No name + <c>Default</c> is registered → that record.</item>
+/// <item>No name + no <c>Default</c> → synthesised record pointing at conventional paths
+/// (no filesystem side-effects — callers that need persistence call
+/// <see cref="InstanceRegistry.EnsureDefault"/> themselves).</item>
+/// </list>
+/// </remarks>
+public static class InstanceSelector
+{
+    /// <summary>
+    /// Extracts the <c>--instance NAME</c> argument from a CLI arg array, returning
+    /// the name plus the original args with that pair stripped out so downstream
+    /// <c>AddCommandLine(...)</c> doesn't see an unknown option.
+    /// </summary>
+    public static (string Name, string[] Remaining) ExtractInstanceArg(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i].Equals("--instance", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                var remaining = args.Take(i).Concat(args.Skip(i + 2)).ToArray();
+                return (args[i + 1], remaining);
+            }
+
+            // Also support --instance=NAME form
+            if (args[i].StartsWith("--instance=", StringComparison.OrdinalIgnoreCase))
+            {
+                var remaining = args.Take(i).Concat(args.Skip(i + 1)).ToArray();
+                return (args[i]["--instance=".Length..], remaining);
+            }
+        }
+
+        return (null, args);
+    }
+
+    /// <summary>
+    /// Resolves the instance specified by <paramref name="instanceName"/> (null → Default).
+    /// Read-only — does not create or mutate the registry.
+    /// </summary>
+    public static InstanceRecord Resolve(string instanceName)
+    {
+        var registry = InstanceRegistry.CreateForRead();
+        var effectiveName = string.IsNullOrWhiteSpace(instanceName) ? InstanceRecord.DefaultName : instanceName;
+
+        var record = registry.Find(effectiveName);
+
+        if (record != null) return record;
+
+        // Default always resolves, even if the registry is empty — so first-run
+        // commands (register etc.) can still locate the standard paths.
+        if (effectiveName.Equals(InstanceRecord.DefaultName, StringComparison.OrdinalIgnoreCase))
+        {
+            var configDir = PlatformPaths.ResolveActiveConfigDir();
+
+            return new InstanceRecord
+            {
+                Name = InstanceRecord.DefaultName,
+                ConfigPath = PlatformPaths.GetInstanceConfigPath(configDir, InstanceRecord.DefaultName)
+            };
+        }
+
+        throw new InvalidOperationException(
+            $"Instance '{effectiveName}' does not exist. Run 'squid-tentacle create-instance --instance {effectiveName}' first, " +
+            $"or pass --instance Default (or omit the flag) to use the default instance.");
+    }
+
+    /// <summary>
+    /// Returns the per-instance certs directory (<c>{configDir}/instances/{name}/certs</c>).
+    /// Ensures multi-instance setups don't collide on certificate storage.
+    /// </summary>
+    public static string ResolveCertsPath(InstanceRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var configDir = PlatformPaths.ResolveActiveConfigDir();
+        return PlatformPaths.GetInstanceCertsDir(configDir, record.Name);
+    }
+}

--- a/src/Squid.Tentacle/Platform/PlatformPaths.cs
+++ b/src/Squid.Tentacle/Platform/PlatformPaths.cs
@@ -1,0 +1,171 @@
+using System.Runtime.InteropServices;
+
+namespace Squid.Tentacle.Platform;
+
+/// <summary>
+/// Cross-platform filesystem path conventions for Squid Tentacle.
+/// Centralises all OS-specific path logic so no caller needs its own branching.
+/// </summary>
+///
+/// <remarks>
+/// <para>Precedence rule for reads: system path first (covers root / service
+/// install), user path second (covers unprivileged invocations).</para>
+/// <para>For writes, callers must explicitly pick either
+/// <see cref="GetSystemConfigDir"/> or <see cref="GetUserConfigDir"/> based on
+/// whether they have permission to write under <c>/etc</c>, <c>/Library</c>,
+/// or <c>C:\ProgramData</c>.</para>
+/// </remarks>
+public static class PlatformPaths
+{
+    /// <summary>Base name used for directories and services ("squid-tentacle").</summary>
+    public const string AppFolderName = "squid-tentacle";
+
+    /// <summary>Branded folder name on platforms that nest under a vendor dir ("Squid/Tentacle").</summary>
+    public const string BrandedFolderName = "Squid/Tentacle";
+
+    public static bool IsLinux => OperatingSystem.IsLinux();
+    public static bool IsMacOS => OperatingSystem.IsMacOS();
+    public static bool IsWindows => OperatingSystem.IsWindows();
+
+    /// <summary>
+    /// System-level configuration directory. Requires elevation (root / Administrator) to write.
+    /// Returns the canonical per-OS location where daemons and system services expect their config.
+    /// </summary>
+    public static string GetSystemConfigDir()
+    {
+        if (IsLinux) return $"/etc/{AppFolderName}";
+
+        if (IsMacOS) return $"/Library/Application Support/{BrandedFolderName}";
+
+        if (IsWindows)
+        {
+            var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            return Path.Combine(programData, BrandedFolderName);
+        }
+
+        throw new PlatformNotSupportedException($"Unsupported OS: {RuntimeInformation.OSDescription}");
+    }
+
+    /// <summary>
+    /// User-level configuration directory — writable without elevation.
+    /// Used as fallback when the current process can't touch <see cref="GetSystemConfigDir"/>.
+    /// </summary>
+    public static string GetUserConfigDir()
+    {
+        if (IsLinux)
+        {
+            var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+
+            if (!string.IsNullOrWhiteSpace(xdg))
+                return Path.Combine(xdg, AppFolderName);
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, ".config", AppFolderName);
+        }
+
+        if (IsMacOS)
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, "Library/Application Support", BrandedFolderName);
+        }
+
+        if (IsWindows)
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(appData, BrandedFolderName);
+        }
+
+        throw new PlatformNotSupportedException($"Unsupported OS: {RuntimeInformation.OSDescription}");
+    }
+
+    /// <summary>
+    /// Default install directory for a <c>binary + systemd/service</c> deployment.
+    /// Docker / dotnet-run invocations typically override this with WorkingDirectory.
+    /// </summary>
+    public static string GetDefaultInstallDir()
+    {
+        if (IsLinux) return $"/opt/{AppFolderName}";
+
+        if (IsMacOS) return $"/usr/local/{AppFolderName}";
+
+        if (IsWindows)
+        {
+            var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            return Path.Combine(programFiles, BrandedFolderName.Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        throw new PlatformNotSupportedException($"Unsupported OS: {RuntimeInformation.OSDescription}");
+    }
+
+    /// <summary>
+    /// Returns <see cref="GetSystemConfigDir"/> when it exists or is writable;
+    /// otherwise falls back to <see cref="GetUserConfigDir"/>. Used by reads
+    /// that don't care which scope they land in.
+    /// </summary>
+    public static string ResolveActiveConfigDir()
+    {
+        var system = GetSystemConfigDir();
+
+        if (Directory.Exists(system) && IsDirectoryAccessible(system))
+            return system;
+
+        return GetUserConfigDir();
+    }
+
+    /// <summary>
+    /// Picks the "best" scope to write into: system if the current process can write there
+    /// (typically when running as root/Administrator), user otherwise. Callers should prefer
+    /// this over hardcoding either choice unless they have an explicit reason (e.g. <c>sudo</c>).
+    /// </summary>
+    public static string PickWritableConfigDir()
+    {
+        var system = GetSystemConfigDir();
+
+        if (TryEnsureDirectory(system))
+            return system;
+
+        var user = GetUserConfigDir();
+        Directory.CreateDirectory(user);
+        return user;
+    }
+
+    public static string GetInstancesRegistryPath(string configDir) =>
+        Path.Combine(configDir, "instances.json");
+
+    public static string GetInstanceConfigPath(string configDir, string instanceName) =>
+        Path.Combine(configDir, "instances", $"{instanceName}.config.json");
+
+    public static string GetInstanceCertsDir(string configDir, string instanceName) =>
+        Path.Combine(configDir, "instances", instanceName, "certs");
+
+    private static bool IsDirectoryAccessible(string path)
+    {
+        try
+        {
+            Directory.EnumerateFileSystemEntries(path).Take(0).ToList();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryEnsureDirectory(string path)
+    {
+        try
+        {
+            Directory.CreateDirectory(path);
+
+            // Probe writability with a short-lived temp file
+            var probe = Path.Combine(path, $".write-probe-{Guid.NewGuid():N}");
+            File.WriteAllText(probe, string.Empty);
+            File.Delete(probe);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Squid.Tentacle/Program.cs
+++ b/src/Squid.Tentacle/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Squid.Tentacle.Commands;
+using Squid.Tentacle.Configuration;
+using Squid.Tentacle.Instance;
 using Serilog;
 
 Log.Logger = new LoggerConfiguration()
@@ -14,7 +16,10 @@ var commands = new ITentacleCommand[]
     new ShowConfigCommand(),
     new NewCertificateCommand(),
     new RegisterCommand(),
-    new ServiceCommand()
+    new ServiceCommand(),
+    new CreateInstanceCommand(),
+    new ListInstancesCommand(),
+    new DeleteInstanceCommand()
 };
 
 try
@@ -34,11 +39,25 @@ try
         return 1;
     }
 
-    var config = new ConfigurationBuilder()
-        .AddJsonFile("appsettings.json", optional: true)
-        .AddEnvironmentVariables()
-        .AddCommandLine(route.RemainingArgs)
-        .Build();
+    // Extract --instance NAME (the instance-aware commands need to know which config to load
+    // and which certs dir to use). Remove it from the arg array before the rest of the pipeline
+    // sees it, so ConfigurationBuilder.AddCommandLine doesn't choke on an unknown key.
+    var (instanceName, argsAfterInstance) = InstanceSelector.ExtractInstanceArg(route.RemainingArgs);
+
+    var configBuilder = new ConfigurationBuilder();
+
+    // Priority (low → high): per-instance config.json → appsettings.json → env vars → CLI args.
+    // This lets `register` persist to the config file and `systemd run` pick it up, while
+    // still allowing env vars / CLI args to override for debugging or Docker-style launches.
+    var instanceConfigPath = TryGetInstanceConfigPath(instanceName);
+    if (instanceConfigPath != null)
+        configBuilder.AddJsonFile(instanceConfigPath, optional: true, reloadOnChange: false);
+
+    configBuilder.AddJsonFile("appsettings.json", optional: true);
+    configBuilder.AddEnvironmentVariables();
+    configBuilder.AddCommandLine(argsAfterInstance);
+
+    var config = configBuilder.Build();
 
     var cts = new CancellationTokenSource();
     Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
@@ -61,11 +80,26 @@ finally
     await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }
 
+static string TryGetInstanceConfigPath(string instanceName)
+{
+    try
+    {
+        var record = InstanceSelector.Resolve(instanceName);
+        return new TentacleConfigFile(record.ConfigPath).Exists() ? record.ConfigPath : null;
+    }
+    catch
+    {
+        // Instance lookup failures are non-fatal at startup — commands that actually need
+        // an instance (register, run) will fail with a clear error later.
+        return null;
+    }
+}
+
 static void PrintHelp(ITentacleCommand[] commands)
 {
     Console.WriteLine("Squid Tentacle — Deployment Agent");
     Console.WriteLine();
-    Console.WriteLine("Usage: squid-tentacle <command> [options]");
+    Console.WriteLine("Usage: squid-tentacle <command> [--instance NAME] [options]");
     Console.WriteLine();
     Console.WriteLine("Commands:");
 
@@ -74,12 +108,14 @@ static void PrintHelp(ITentacleCommand[] commands)
 
     Console.WriteLine($"  {"help",-20} Show this help message");
     Console.WriteLine();
-    Console.WriteLine("Examples:");
-    Console.WriteLine("  squid-tentacle run                           Start the agent (default)");
-    Console.WriteLine("  squid-tentacle show-thumbprint               Display certificate thumbprint");
-    Console.WriteLine("  squid-tentacle new-certificate               Generate certificate if missing");
-    Console.WriteLine("  squid-tentacle register --server URL ...     Register with Squid Server");
-    Console.WriteLine("  squid-tentacle service install               Install as systemd service");
+    Console.WriteLine("Instance management (multiple Tentacles on one host):");
+    Console.WriteLine("  squid-tentacle create-instance --instance production");
+    Console.WriteLine("  squid-tentacle list-instances");
+    Console.WriteLine("  squid-tentacle delete-instance --instance production");
     Console.WriteLine();
-    Console.WriteLine("Configuration: --Tentacle:Key=Value, environment variables (Tentacle__Key), or appsettings.json");
+    Console.WriteLine("Install + register + run (typical flow):");
+    Console.WriteLine("  squid-tentacle register --server URL --api-key KEY --role R --environment E");
+    Console.WriteLine("  sudo squid-tentacle service install");
+    Console.WriteLine();
+    Console.WriteLine("Configuration sources (low → high): instance config → appsettings.json → env (Tentacle__Key) → CLI (--Tentacle:Key=V)");
 }

--- a/src/Squid.Tentacle/ServiceHost/IServiceHost.cs
+++ b/src/Squid.Tentacle/ServiceHost/IServiceHost.cs
@@ -1,0 +1,46 @@
+namespace Squid.Tentacle.ServiceHost;
+
+/// <summary>
+/// OS-agnostic abstraction over the host's service manager.
+/// Concrete impls: systemd (Linux), Windows Services (Windows), launchd (macOS).
+/// </summary>
+///
+/// <remarks>
+/// Each method returns a POSIX-style exit code: 0 = success, non-zero = failure.
+/// Implementations should print human-readable progress to stdout/stderr so the
+/// caller (ServiceCommand) doesn't need to format per-OS diagnostics.
+/// </remarks>
+public interface IServiceHost
+{
+    /// <summary>Friendly name of the backing service manager (for logs).</summary>
+    string DisplayName { get; }
+
+    /// <summary>Whether this host can be used on the current platform at all.</summary>
+    bool IsSupported { get; }
+
+    int Install(ServiceInstallRequest request);
+    int Uninstall(string serviceName);
+    int Start(string serviceName);
+    int Stop(string serviceName);
+    int Status(string serviceName);
+}
+
+/// <summary>
+/// Parameters for <see cref="IServiceHost.Install"/>. OS-neutral — each host
+/// translates them into its own unit/plist/SCM format.
+/// </summary>
+public sealed class ServiceInstallRequest
+{
+    public string ServiceName { get; init; }
+    public string Description { get; init; }
+    public string ExecStart { get; init; }
+
+    /// <summary>Directory the service should run in. Must contain any files the binary expects (e.g. appsettings.json).</summary>
+    public string WorkingDirectory { get; init; }
+
+    /// <summary>Optional CLI args appended after <see cref="ExecStart"/>.</summary>
+    public string[] ExecArgs { get; init; } = [];
+
+    /// <summary>If set, the service runs as this OS user instead of the caller.</summary>
+    public string RunAsUser { get; init; }
+}

--- a/src/Squid.Tentacle/ServiceHost/LaunchdServiceHost.cs
+++ b/src/Squid.Tentacle/ServiceHost/LaunchdServiceHost.cs
@@ -1,0 +1,29 @@
+namespace Squid.Tentacle.ServiceHost;
+
+/// <summary>
+/// Placeholder macOS launchd implementation. Emits a clear "not yet implemented"
+/// message so callers know to bail out. Fill this in (write a plist under
+/// <c>/Library/LaunchDaemons</c>, use <c>launchctl load/unload</c>) when macOS
+/// deployment targets become a real use-case.
+/// </summary>
+public sealed class LaunchdServiceHost : IServiceHost
+{
+    public string DisplayName => "launchd";
+
+    public bool IsSupported => OperatingSystem.IsMacOS();
+
+    public int Install(ServiceInstallRequest request) => NotImplemented(nameof(Install));
+    public int Uninstall(string serviceName) => NotImplemented(nameof(Uninstall));
+    public int Start(string serviceName) => NotImplemented(nameof(Start));
+    public int Stop(string serviceName) => NotImplemented(nameof(Stop));
+    public int Status(string serviceName) => NotImplemented(nameof(Status));
+
+    private static int NotImplemented(string operation)
+    {
+        Console.Error.WriteLine(
+            $"macOS launchd '{operation}' is not yet implemented for Squid Tentacle. " +
+            "Use 'launchctl' with a plist under /Library/LaunchDaemons manually, " +
+            "or track progress at https://github.com/SolarifyDev/Squid/issues.");
+        return 2;
+    }
+}

--- a/src/Squid.Tentacle/ServiceHost/ServiceHostFactory.cs
+++ b/src/Squid.Tentacle/ServiceHost/ServiceHostFactory.cs
@@ -1,0 +1,52 @@
+using System.Runtime.InteropServices;
+
+namespace Squid.Tentacle.ServiceHost;
+
+/// <summary>
+/// Picks the correct <see cref="IServiceHost"/> implementation for the current OS.
+/// </summary>
+///
+/// <remarks>
+/// <para>Uses a registry pattern so adding a new service host (e.g. FreeBSD rc.d,
+/// Solaris SMF) is a one-line change here — no edits to per-platform branching
+/// elsewhere, no new <c>if</c>/<c>switch</c> arm to forget. Each
+/// <see cref="IServiceHost"/> is sole authority on whether it applies to the
+/// current platform via its <see cref="IServiceHost.IsSupported"/> property,
+/// so the factory stays ignorant of OS details.</para>
+/// <para>Ordering defines priority: the first candidate whose
+/// <see cref="IServiceHost.IsSupported"/> is <c>true</c> wins. Systemd comes
+/// first because it's the most deployed target; Windows and launchd follow.</para>
+/// </remarks>
+public static class ServiceHostFactory
+{
+    /// <summary>
+    /// Candidate hosts in priority order. Registering a new platform = add one entry.
+    /// Internal so tests can inspect / extend if needed.
+    /// </summary>
+    internal static readonly IReadOnlyList<Func<IServiceHost>> Candidates =
+    [
+        () => new SystemdServiceHost(),
+        () => new WindowsServiceHost(),
+        () => new LaunchdServiceHost()
+    ];
+
+    /// <summary>
+    /// Returns the first registered <see cref="IServiceHost"/> whose
+    /// <see cref="IServiceHost.IsSupported"/> is <c>true</c> on the current platform.
+    /// Throws <see cref="PlatformNotSupportedException"/> when nothing matches.
+    /// </summary>
+    public static IServiceHost Resolve()
+    {
+        foreach (var factory in Candidates)
+        {
+            var host = factory();
+
+            if (host.IsSupported)
+                return host;
+        }
+
+        throw new PlatformNotSupportedException(
+            $"No IServiceHost implementation matches this platform ({RuntimeInformation.OSDescription}). " +
+            "Register one in ServiceHostFactory.Candidates.");
+    }
+}

--- a/src/Squid.Tentacle/ServiceHost/SystemdServiceHost.cs
+++ b/src/Squid.Tentacle/ServiceHost/SystemdServiceHost.cs
@@ -1,0 +1,150 @@
+using System.Diagnostics;
+
+namespace Squid.Tentacle.ServiceHost;
+
+/// <summary>
+/// Linux implementation of <see cref="IServiceHost"/>. Generates a systemd unit,
+/// reloads the daemon, and drives enable/start/stop/status via <c>systemctl</c>.
+/// </summary>
+public sealed class SystemdServiceHost : IServiceHost
+{
+    public string DisplayName => "systemd";
+
+    public bool IsSupported => OperatingSystem.IsLinux();
+
+    public int Install(ServiceInstallRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ServiceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ExecStart);
+
+        var unit = BuildUnitFile(request);
+        var unitPath = $"/etc/systemd/system/{request.ServiceName}.service";
+
+        try
+        {
+            File.WriteAllText(unitPath, unit);
+            Console.WriteLine($"Created {unitPath}");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine($"Permission denied writing {unitPath}. Try: sudo squid-tentacle service install");
+            return 1;
+        }
+
+        var reload = Systemctl("daemon-reload");
+        var enable = Systemctl("enable", request.ServiceName);
+        var start = Systemctl("start", request.ServiceName);
+
+        if (reload != 0 || enable != 0 || start != 0)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine($"Service '{request.ServiceName}' unit file written, but systemctl steps failed.");
+            Console.Error.WriteLine("  Is systemd available on this host? (Docker/WSL1 often lack it.)");
+            return 1;
+        }
+
+        Console.WriteLine($"Service '{request.ServiceName}' installed and started.");
+        Console.WriteLine($"  Status:  sudo systemctl status {request.ServiceName}");
+        Console.WriteLine($"  Logs:    sudo journalctl -u {request.ServiceName} -f");
+
+        return 0;
+    }
+
+    public int Uninstall(string serviceName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+
+        Systemctl("stop", serviceName);
+        Systemctl("disable", serviceName);
+
+        var unitPath = $"/etc/systemd/system/{serviceName}.service";
+
+        if (File.Exists(unitPath))
+        {
+            try
+            {
+                File.Delete(unitPath);
+                Console.WriteLine($"Removed {unitPath}");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine($"Permission denied removing {unitPath}. Try: sudo squid-tentacle service uninstall");
+                return 1;
+            }
+        }
+
+        Systemctl("daemon-reload");
+        Console.WriteLine($"Service '{serviceName}' uninstalled.");
+        return 0;
+    }
+
+    public int Start(string serviceName) => Systemctl("start", serviceName);
+    public int Stop(string serviceName) => Systemctl("stop", serviceName);
+    public int Status(string serviceName) => Systemctl("status", serviceName);
+
+    internal static string BuildUnitFile(ServiceInstallRequest request)
+    {
+        var description = string.IsNullOrWhiteSpace(request.Description)
+            ? $"Squid Tentacle Agent ({request.ServiceName})"
+            : request.Description;
+
+        var execLine = request.ExecArgs is { Length: > 0 }
+            ? $"{request.ExecStart} {string.Join(' ', request.ExecArgs)}"
+            : request.ExecStart;
+
+        var userLines = !string.IsNullOrWhiteSpace(request.RunAsUser)
+            ? $"User={request.RunAsUser}\nGroup={request.RunAsUser}\n"
+            : string.Empty;
+
+        return $"""
+            [Unit]
+            Description={description}
+            After=network.target
+
+            [Service]
+            Type=simple
+            ExecStart={execLine}
+            WorkingDirectory={request.WorkingDirectory}
+            {userLines}Restart=always
+            RestartSec=10
+            KillSignal=SIGINT
+            TimeoutStopSec=60
+
+            [Install]
+            WantedBy=multi-user.target
+            """;
+    }
+
+    private static int Systemctl(string action, string serviceName = null)
+    {
+        var args = serviceName != null ? $"{action} {serviceName}" : action;
+
+        try
+        {
+            var psi = new ProcessStartInfo("systemctl", args)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            using var process = Process.Start(psi);
+            if (process == null) return 1;
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit(TimeSpan.FromSeconds(30));
+
+            if (!string.IsNullOrWhiteSpace(stdout)) Console.Write(stdout);
+            if (!string.IsNullOrWhiteSpace(stderr)) Console.Error.Write(stderr);
+
+            return process.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to run systemctl {args}: {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/src/Squid.Tentacle/ServiceHost/WindowsServiceHost.cs
+++ b/src/Squid.Tentacle/ServiceHost/WindowsServiceHost.cs
@@ -1,0 +1,27 @@
+namespace Squid.Tentacle.ServiceHost;
+
+/// <summary>
+/// Placeholder Windows Service implementation. Emits a clear "not yet implemented"
+/// message so callers (ServiceCommand) know to bail out gracefully rather than
+/// pretending to succeed. Fill this in when Windows Tentacle support lands.
+/// </summary>
+public sealed class WindowsServiceHost : IServiceHost
+{
+    public string DisplayName => "Windows Service Manager";
+
+    public bool IsSupported => OperatingSystem.IsWindows();
+
+    public int Install(ServiceInstallRequest request) => NotImplemented(nameof(Install));
+    public int Uninstall(string serviceName) => NotImplemented(nameof(Uninstall));
+    public int Start(string serviceName) => NotImplemented(nameof(Start));
+    public int Stop(string serviceName) => NotImplemented(nameof(Stop));
+    public int Status(string serviceName) => NotImplemented(nameof(Status));
+
+    private static int NotImplemented(string operation)
+    {
+        Console.Error.WriteLine(
+            $"Windows Service '{operation}' is not yet implemented for Squid Tentacle. " +
+            "Use 'sc.exe' manually, or track progress at https://github.com/SolarifyDev/Squid/issues.");
+        return 2;
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Commands/ServiceCommandTests.cs
+++ b/tests/Squid.Tentacle.Tests/Commands/ServiceCommandTests.cs
@@ -1,0 +1,84 @@
+using Squid.Tentacle.Commands;
+
+namespace Squid.Tentacle.Tests.Commands;
+
+public class ServiceCommandTests
+{
+    // ========================================================================
+    // GenerateUnitFile — verifies the exact systemd unit content
+    // ========================================================================
+
+    [Fact]
+    public void GenerateUnitFile_ProducesExpectedUnitContent()
+    {
+        var unit = ServiceCommand.GenerateUnitFile(
+            serviceName: "squid-tentacle",
+            execStart: "/opt/squid-tentacle/Squid.Tentacle",
+            workingDir: "/opt/squid-tentacle");
+
+        unit.ShouldContain("[Unit]");
+        unit.ShouldContain("Description=Squid Tentacle Agent (squid-tentacle)");
+        unit.ShouldContain("After=network.target");
+
+        unit.ShouldContain("[Service]");
+        unit.ShouldContain("Type=simple");
+        // ExecArgs are no longer hardcoded in GenerateUnitFile — ServiceCommand supplies them
+        // (e.g. "run" or "run --instance NAME"). This test just verifies the ExecStart itself.
+        unit.ShouldContain("ExecStart=/opt/squid-tentacle/Squid.Tentacle");
+        unit.ShouldContain("WorkingDirectory=/opt/squid-tentacle");
+        unit.ShouldContain("Restart=always");
+        unit.ShouldContain("RestartSec=10");
+        unit.ShouldContain("KillSignal=SIGINT");
+        unit.ShouldContain("TimeoutStopSec=60");
+
+        unit.ShouldContain("[Install]");
+        unit.ShouldContain("WantedBy=multi-user.target");
+    }
+
+    [Fact]
+    public void GenerateUnitFile_HonoursCustomServiceName()
+    {
+        var unit = ServiceCommand.GenerateUnitFile(
+            serviceName: "squid-prod",
+            execStart: "/opt/squid-tentacle/Squid.Tentacle",
+            workingDir: "/opt/squid-tentacle");
+
+        unit.ShouldContain("Description=Squid Tentacle Agent (squid-prod)");
+    }
+
+    [Fact]
+    public void GenerateUnitFile_NeverEmitsDotnetDllForm()
+    {
+        // Regression: old code generated `ExecStart=dotnet Squid.Tentacle.dll run` for
+        // PublishSingleFile binaries — which never worked on target machines (no SDK, no .dll).
+        var unit = ServiceCommand.GenerateUnitFile(
+            serviceName: "squid-tentacle",
+            execStart: "/usr/local/bin/squid-tentacle",
+            workingDir: "/opt/squid-tentacle");
+
+        unit.ShouldNotContain("dotnet Squid.Tentacle.dll");
+        unit.ShouldNotContain(" dll ");
+    }
+
+    // ========================================================================
+    // ResolveServiceExecution — validates real-binary path resolution
+    // ========================================================================
+
+    [Fact]
+    public void ResolveServiceExecution_ReturnsAbsoluteExecStartAndWorkingDir()
+    {
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution();
+
+        // Must produce non-empty values
+        execStart.ShouldNotBeNullOrWhiteSpace();
+        workingDir.ShouldNotBeNullOrWhiteSpace();
+
+        // Regression guard: must not fall back to the broken "dotnet *.dll" form
+        execStart.ShouldNotStartWith("dotnet ");
+        execStart.ShouldNotContain("Squid.Tentacle.dll");
+
+        // Working dir must be a plausible absolute-ish path (no trailing slash)
+        workingDir.ShouldNotEndWith("/");
+        workingDir.ShouldNotEndWith("\\");
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Configuration/TentacleConfigFileTests.cs
+++ b/tests/Squid.Tentacle.Tests/Configuration/TentacleConfigFileTests.cs
@@ -1,0 +1,141 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
+using Squid.Tentacle.Configuration;
+
+namespace Squid.Tentacle.Tests.Configuration;
+
+public class TentacleConfigFileTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _configPath;
+
+    public TentacleConfigFileTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"squid-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _configPath = Path.Combine(_tempDir, "instance.config.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void Load_MissingFile_ReturnsEmpty()
+    {
+        var file = new TentacleConfigFile(_configPath);
+
+        file.Exists().ShouldBeFalse();
+        file.Load().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Save_WritesNestedJson_WithColonSeparatedKeysUnpacked()
+    {
+        var file = new TentacleConfigFile(_configPath);
+
+        file.Save(new Dictionary<string, string>
+        {
+            ["Tentacle:Flavor"] = "LinuxTentacle",
+            ["Tentacle:ServerUrl"] = "https://squid:7078",
+            ["Tentacle:ListeningPort"] = "10933"
+        });
+
+        var json = File.ReadAllText(_configPath);
+        var root = JsonNode.Parse(json).AsObject();
+
+        root["Tentacle"].AsObject()["Flavor"].ToString().ShouldBe("LinuxTentacle");
+        root["Tentacle"].AsObject()["ServerUrl"].ToString().ShouldBe("https://squid:7078");
+        root["Tentacle"].AsObject()["ListeningPort"].ToString().ShouldBe("10933");
+    }
+
+    [Fact]
+    public void Load_ReadsNestedJsonBackAsFlatColonKeys()
+    {
+        File.WriteAllText(_configPath, """
+        {
+          "Tentacle": {
+            "Flavor": "LinuxTentacle",
+            "Server": { "Url": "https://squid:7078" }
+          }
+        }
+        """);
+
+        var loaded = new TentacleConfigFile(_configPath).Load();
+
+        loaded["Tentacle:Flavor"].ShouldBe("LinuxTentacle");
+        loaded["Tentacle:Server:Url"].ShouldBe("https://squid:7078");
+    }
+
+    [Fact]
+    public void Merge_PreservesExistingKeys_NotInTheUpdateSet()
+    {
+        var file = new TentacleConfigFile(_configPath);
+        file.Save(new Dictionary<string, string> { ["Tentacle:Flavor"] = "LinuxTentacle", ["Tentacle:Roles"] = "web" });
+
+        file.Merge(new Dictionary<string, string> { ["Tentacle:ServerUrl"] = "https://new" });
+
+        var loaded = file.Load();
+        loaded["Tentacle:Flavor"].ShouldBe("LinuxTentacle");
+        loaded["Tentacle:Roles"].ShouldBe("web");
+        loaded["Tentacle:ServerUrl"].ShouldBe("https://new");
+    }
+
+    [Fact]
+    public void Merge_EmptyValues_SkippedSoTheyDoNotClobberExistingEntries()
+    {
+        var file = new TentacleConfigFile(_configPath);
+        file.Save(new Dictionary<string, string> { ["Tentacle:MachineName"] = "web-01" });
+
+        file.Merge(new Dictionary<string, string>
+        {
+            ["Tentacle:MachineName"] = "",                // empty — must not overwrite
+            ["Tentacle:ServerUrl"] = "https://ok"
+        });
+
+        var loaded = file.Load();
+        loaded["Tentacle:MachineName"].ShouldBe("web-01");
+        loaded["Tentacle:ServerUrl"].ShouldBe("https://ok");
+    }
+
+    [Fact]
+    public void Remove_DropsSingleKey_RewritesFile()
+    {
+        var file = new TentacleConfigFile(_configPath);
+        file.Save(new Dictionary<string, string>
+        {
+            ["Tentacle:Flavor"] = "LinuxTentacle",
+            ["Tentacle:ApiKey"] = "SECRET"
+        });
+
+        file.Remove("Tentacle:ApiKey");
+
+        var loaded = file.Load();
+        loaded.ShouldContainKey("Tentacle:Flavor");
+        loaded.ShouldNotContainKey("Tentacle:ApiKey");
+    }
+
+    [Fact]
+    public void ProducedFile_IsConsumableByIConfigurationBuilder()
+    {
+        // Integration check: the output of TentacleConfigFile must be loadable via
+        // IConfigurationBuilder.AddJsonFile — that's the contract Program.cs depends on.
+        var file = new TentacleConfigFile(_configPath);
+        file.Save(new Dictionary<string, string>
+        {
+            ["Tentacle:Flavor"] = "LinuxTentacle",
+            ["Tentacle:ListeningPort"] = "10933"
+        });
+
+        var config = new ConfigurationBuilder()
+            .AddJsonFile(_configPath, optional: false)
+            .Build();
+
+        config["Tentacle:Flavor"].ShouldBe("LinuxTentacle");
+        config["Tentacle:ListeningPort"].ShouldBe("10933");
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Health/MetricsPersistenceTests.cs
+++ b/tests/Squid.Tentacle.Tests/Health/MetricsPersistenceTests.cs
@@ -7,6 +7,7 @@ using Squid.Tentacle.Kubernetes;
 
 namespace Squid.Tentacle.Tests.Health;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class MetricsPersistenceTests
 {
     private readonly Mock<IKubernetesPodOperations> _ops = new();

--- a/tests/Squid.Tentacle.Tests/Health/TentacleMetricsCollection.cs
+++ b/tests/Squid.Tentacle.Tests/Health/TentacleMetricsCollection.cs
@@ -1,0 +1,49 @@
+namespace Squid.Tentacle.Tests.Health;
+
+/// <summary>
+/// xUnit collection that serialises every test class which touches the global
+/// <see cref="Squid.Tentacle.Health.TentacleMetrics"/> static state — whether
+/// directly (asserting counter values) or indirectly (exercising
+/// <c>ScriptPodService</c>, <c>NfsWatchdog</c>, <c>KubernetesPodMonitor</c>,
+/// etc., all of which increment the same static counters).
+/// </summary>
+///
+/// <remarks>
+/// <para>By default xUnit runs each test class in its own collection, which
+/// means classes run in parallel — and the counters in <c>TentacleMetrics</c>
+/// (process-wide <c>static long</c> fields with <c>Interlocked</c> access) get
+/// clobbered when multiple test classes increment them simultaneously.</para>
+///
+/// <para>Pinning every affected class into this single collection forces them
+/// to run serially against each other while still allowing the rest of the
+/// suite to parallelise.</para>
+///
+/// <para>Current members (keep this list in sync — the collection attribute
+/// on any class listed here is load-bearing):
+/// <list type="bullet">
+/// <item><c>TentacleMetricsTests</c> — direct counter assertions</item>
+/// <item><c>MetricsPersistenceTests</c> — direct counter assertions via persistence</item>
+/// <item><c>ScriptPodServiceTests</c> — exercises <c>ScriptStarted</c>/<c>ScriptCompleted</c></item>
+/// <item><c>ScriptRecoveryServiceTests</c> — constructs <c>ScriptPodService</c></item>
+/// <item><c>KubernetesPodMonitorTests</c> — exercises <c>SetManagedPods</c>/<c>OrphanedPodCleaned</c></item>
+/// <item><c>KubernetesPodMonitorIntegrationTests</c> — exercises <c>ScriptPodService</c></item>
+/// <item><c>PendingPodWatchdogTests</c> — exercises <c>ScriptPodService</c></item>
+/// <item><c>NfsWatchdogTests</c> — exercises <c>NfsForceKill</c></item>
+/// <item><c>NfsWatchdogLifecycleTests</c> — exercises <c>NfsForceKill</c></item>
+/// </list>
+/// <c>MetricsEndpointIntegrationTests</c> is NOT in this collection because it
+/// already belongs to <c>TentacleProcessIntegrationCollection</c> which sets
+/// <c>DisableParallelization = true</c>, so it can't run in parallel with
+/// anything else anyway.</para>
+///
+/// <para>When you write a new test class that touches any of the
+/// <c>TentacleMetrics</c> callers listed above, add
+/// <c>[Collection(TentacleMetricsCollection.Name)]</c> to it and update this
+/// comment. Otherwise <c>ExportPrometheus_ContainsAllMetrics</c> and its
+/// siblings will flake intermittently.</para>
+/// </remarks>
+[CollectionDefinition(Name)]
+public class TentacleMetricsCollection
+{
+    public const string Name = "TentacleMetrics";
+}

--- a/tests/Squid.Tentacle.Tests/Health/TentacleMetricsTests.cs
+++ b/tests/Squid.Tentacle.Tests/Health/TentacleMetricsTests.cs
@@ -2,6 +2,7 @@ using Squid.Tentacle.Health;
 
 namespace Squid.Tentacle.Tests.Health;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class TentacleMetricsTests : IDisposable
 {
     public TentacleMetricsTests()

--- a/tests/Squid.Tentacle.Tests/Instance/InstanceRegistryTests.cs
+++ b/tests/Squid.Tentacle.Tests/Instance/InstanceRegistryTests.cs
@@ -1,0 +1,121 @@
+using System.IO;
+using System.Linq;
+using Squid.Tentacle.Instance;
+
+namespace Squid.Tentacle.Tests.Instance;
+
+public class InstanceRegistryTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public InstanceRegistryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"squid-reg-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void List_EmptyRegistry_ReturnsEmpty()
+    {
+        new InstanceRegistry(_tempDir).List().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Add_ThenList_ReturnsTheInstance()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+
+        registry.Add(new InstanceRecord { Name = "production", ConfigPath = "/etc/foo.json" });
+
+        var listed = registry.List();
+        listed.Count.ShouldBe(1);
+        listed[0].Name.ShouldBe("production");
+        listed[0].ConfigPath.ShouldBe("/etc/foo.json");
+    }
+
+    [Fact]
+    public void Add_DuplicateName_Throws()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+        registry.Add(new InstanceRecord { Name = "prod", ConfigPath = "/etc/prod.json" });
+
+        Should.Throw<InvalidOperationException>(() =>
+            registry.Add(new InstanceRecord { Name = "prod", ConfigPath = "/etc/other.json" }));
+    }
+
+    [Fact]
+    public void Find_CaseInsensitive_MatchesAcrossCases()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+        registry.Add(new InstanceRecord { Name = "Production", ConfigPath = "/etc/x.json" });
+
+        registry.Find("production").ShouldNotBeNull();
+        registry.Find("PRODUCTION").ShouldNotBeNull();
+        registry.Find("Production").ShouldNotBeNull();
+        registry.Find("staging").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Remove_DropsRecord_AndPersists()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+        registry.Add(new InstanceRecord { Name = "prod", ConfigPath = "/etc/prod.json" });
+        registry.Add(new InstanceRecord { Name = "staging", ConfigPath = "/etc/stg.json" });
+
+        registry.Remove("prod");
+
+        var fresh = new InstanceRegistry(_tempDir);   // re-read from disk
+        fresh.List().Select(i => i.Name).ShouldBe(["staging"]);
+    }
+
+    [Fact]
+    public void EnsureDefault_CreatesTheDefaultInstance_IfMissing()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+
+        var record = registry.EnsureDefault();
+
+        record.Name.ShouldBe("Default");
+        registry.Find("Default").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void EnsureDefault_IsIdempotent()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+        registry.EnsureDefault();
+        registry.EnsureDefault();      // second call must not throw
+
+        registry.List().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void FindOrDefault_AbsentName_ReturnsSynthesizedRecord_WithoutPersisting()
+    {
+        var registry = new InstanceRegistry(_tempDir);
+
+        var synthesized = registry.FindOrDefault("nonexistent");
+
+        synthesized.Name.ShouldBe("nonexistent");
+        synthesized.ConfigPath.ShouldEndWith("nonexistent.config.json");
+        registry.List().ShouldBeEmpty("FindOrDefault must not write to disk");
+    }
+
+    [Fact]
+    public void Add_PersistsAcrossInstances_ViaOnDiskFile()
+    {
+        new InstanceRegistry(_tempDir).Add(new InstanceRecord { Name = "a", ConfigPath = "/etc/a.json" });
+        new InstanceRegistry(_tempDir).Add(new InstanceRecord { Name = "b", ConfigPath = "/etc/b.json" });
+
+        var reloaded = new InstanceRegistry(_tempDir).List();
+        reloaded.Count.ShouldBe(2);
+        reloaded.Select(i => i.Name).ShouldContain("a");
+        reloaded.Select(i => i.Name).ShouldContain("b");
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Instance/InstanceSelectorTests.cs
+++ b/tests/Squid.Tentacle.Tests/Instance/InstanceSelectorTests.cs
@@ -1,0 +1,74 @@
+using Squid.Tentacle.Instance;
+
+namespace Squid.Tentacle.Tests.Instance;
+
+public class InstanceSelectorTests
+{
+    [Fact]
+    public void ExtractInstanceArg_NoInstanceFlag_ReturnsNullAndOriginalArgs()
+    {
+        var (name, remaining) = InstanceSelector.ExtractInstanceArg(["--server", "https://x", "--api-key", "KEY"]);
+
+        name.ShouldBeNull();
+        remaining.ShouldBe(["--server", "https://x", "--api-key", "KEY"]);
+    }
+
+    [Fact]
+    public void ExtractInstanceArg_SpaceSeparatedForm_ExtractsAndStrips()
+    {
+        var (name, remaining) = InstanceSelector.ExtractInstanceArg(
+            ["--instance", "production", "--server", "https://x"]);
+
+        name.ShouldBe("production");
+        remaining.ShouldBe(["--server", "https://x"]);
+    }
+
+    [Fact]
+    public void ExtractInstanceArg_EqualsForm_ExtractsAndStrips()
+    {
+        var (name, remaining) = InstanceSelector.ExtractInstanceArg(
+            ["--instance=production", "--server", "https://x"]);
+
+        name.ShouldBe("production");
+        remaining.ShouldBe(["--server", "https://x"]);
+    }
+
+    [Fact]
+    public void ExtractInstanceArg_InMiddleOfArgs_StillExtracted()
+    {
+        var (name, remaining) = InstanceSelector.ExtractInstanceArg(
+            ["--server", "https://x", "--instance", "staging", "--api-key", "KEY"]);
+
+        name.ShouldBe("staging");
+        remaining.ShouldBe(["--server", "https://x", "--api-key", "KEY"]);
+    }
+
+    [Theory]
+    [InlineData("--INSTANCE")]
+    [InlineData("--Instance")]
+    [InlineData("--instance")]
+    public void ExtractInstanceArg_CaseInsensitive(string flagCase)
+    {
+        var (name, _) = InstanceSelector.ExtractInstanceArg([flagCase, "X"]);
+
+        name.ShouldBe("X");
+    }
+
+    [Fact]
+    public void Resolve_NullName_ReturnsDefault_EvenWithoutRegistry()
+    {
+        // Regression guard: commands invoked as the very first install step (register)
+        // must be able to resolve "Default" without pre-registering anything.
+        var record = InstanceSelector.Resolve(null);
+
+        record.Name.ShouldBe(InstanceRecord.DefaultName);
+        record.ConfigPath.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Resolve_EmptyName_TreatedAsDefault()
+    {
+        InstanceSelector.Resolve("").Name.ShouldBe(InstanceRecord.DefaultName);
+        InstanceSelector.Resolve("   ").Name.ShouldBe(InstanceRecord.DefaultName);
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Kubernetes/KubernetesEventMonitorTests.cs
+++ b/tests/Squid.Tentacle.Tests/Kubernetes/KubernetesEventMonitorTests.cs
@@ -9,9 +9,11 @@ using Squid.Message.Contracts.Tentacle;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.ScriptExecution;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.Kubernetes;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class KubernetesEventMonitorTests : IDisposable
 {
     private readonly Mock<IKubernetesPodOperations> _podOps = new();

--- a/tests/Squid.Tentacle.Tests/Kubernetes/KubernetesPodMonitorIntegrationTests.cs
+++ b/tests/Squid.Tentacle.Tests/Kubernetes/KubernetesPodMonitorIntegrationTests.cs
@@ -7,9 +7,11 @@ using Squid.Message.Contracts.Tentacle;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.ScriptExecution;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.Kubernetes;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class KubernetesPodMonitorIntegrationTests : IDisposable
 {
     private readonly Mock<IKubernetesPodOperations> _ops;

--- a/tests/Squid.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/tests/Squid.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -7,9 +7,11 @@ using Squid.Message.Contracts.Tentacle;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.ScriptExecution;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.Kubernetes;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class KubernetesPodMonitorTests : IDisposable
 {
     private readonly Mock<IKubernetesPodOperations> _ops;

--- a/tests/Squid.Tentacle.Tests/Kubernetes/NfsWatchdogLifecycleTests.cs
+++ b/tests/Squid.Tentacle.Tests/Kubernetes/NfsWatchdogLifecycleTests.cs
@@ -1,11 +1,13 @@
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Kubernetes;
+using Squid.Tentacle.Tests.Health;
 using Squid.Tentacle.Tests.Support;
 using Squid.Tentacle.Tests.Support.Lifecycle;
 
 namespace Squid.Tentacle.Tests.Kubernetes;
 
 [Trait("Category", TentacleTestCategories.Lifecycle)]
+[Collection(TentacleMetricsCollection.Name)]
 public class NfsWatchdogLifecycleTests : TimedTestBase, IDisposable
 {
     private readonly string _tempDir;

--- a/tests/Squid.Tentacle.Tests/Kubernetes/NfsWatchdogTests.cs
+++ b/tests/Squid.Tentacle.Tests/Kubernetes/NfsWatchdogTests.cs
@@ -3,9 +3,11 @@ using System.IO;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Health;
 using Squid.Tentacle.Kubernetes;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.Kubernetes;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class NfsWatchdogTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/Squid.Tentacle.Tests/Kubernetes/PendingPodWatchdogTests.cs
+++ b/tests/Squid.Tentacle.Tests/Kubernetes/PendingPodWatchdogTests.cs
@@ -7,9 +7,11 @@ using Squid.Message.Contracts.Tentacle;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.ScriptExecution;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.Kubernetes;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class PendingPodWatchdogTests : IDisposable
 {
     private readonly Mock<IKubernetesPodOperations> _ops;

--- a/tests/Squid.Tentacle.Tests/Platform/PlatformPathsTests.cs
+++ b/tests/Squid.Tentacle.Tests/Platform/PlatformPathsTests.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Tests.Platform;
+
+public class PlatformPathsTests
+{
+    [Fact]
+    public void GetSystemConfigDir_IsPlatformSpecific()
+    {
+        var path = PlatformPaths.GetSystemConfigDir();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            path.ShouldBe("/etc/squid-tentacle");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            path.ShouldBe("/Library/Application Support/Squid/Tentacle");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            path.ShouldEndWith("Squid\\Tentacle");
+    }
+
+    [Fact]
+    public void GetUserConfigDir_IsUnderUserHome_OrXdgConfigHome()
+    {
+        var path = PlatformPaths.GetUserConfigDir();
+
+        path.ShouldNotBeNullOrWhiteSpace();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            path.ShouldContain("squid-tentacle");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            path.ShouldContain("Library");
+    }
+
+    [Fact]
+    public void GetDefaultInstallDir_IsPlatformSpecific()
+    {
+        var path = PlatformPaths.GetDefaultInstallDir();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            path.ShouldBe("/opt/squid-tentacle");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            path.ShouldBe("/usr/local/squid-tentacle");
+    }
+
+    [Fact]
+    public void GetInstanceConfigPath_ProducesConventionalLayout()
+    {
+        var path = PlatformPaths.GetInstanceConfigPath("/etc/squid-tentacle", "production");
+
+        path.ShouldBe(Path.Combine("/etc/squid-tentacle", "instances", "production.config.json"));
+    }
+
+    [Fact]
+    public void GetInstanceCertsDir_ProducesPerInstanceDir()
+    {
+        var path = PlatformPaths.GetInstanceCertsDir("/etc/squid-tentacle", "production");
+
+        path.ShouldBe(Path.Combine("/etc/squid-tentacle", "instances", "production", "certs"));
+    }
+
+    [Fact]
+    public void GetInstancesRegistryPath_IsInstancesJsonAtRoot()
+    {
+        var path = PlatformPaths.GetInstancesRegistryPath("/etc/squid-tentacle");
+
+        path.ShouldBe(Path.Combine("/etc/squid-tentacle", "instances.json"));
+    }
+
+    [Fact]
+    public void PickWritableConfigDir_ReturnsAWritablePath()
+    {
+        // This runs on the test machine — we can't assume root, but the method must
+        // always return *some* path the current process can write to (user dir fallback).
+        var path = PlatformPaths.PickWritableConfigDir();
+
+        path.ShouldNotBeNullOrWhiteSpace();
+        Directory.Exists(path).ShouldBeTrue();
+
+        // Round-trip write probe
+        var probe = Path.Combine(path, $".test-{Guid.NewGuid():N}");
+        File.WriteAllText(probe, "x");
+        File.Delete(probe);
+    }
+}

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/ScriptPodServiceTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/ScriptPodServiceTests.cs
@@ -10,9 +10,11 @@ using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.Health;
 using Squid.Tentacle.ScriptExecution;
 using Squid.Message.Contracts.Tentacle;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.ScriptExecution;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class ScriptPodServiceTests : IDisposable
 {
     private readonly TentacleSettings _tentacleSettings;

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/ScriptRecoveryServiceTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/ScriptRecoveryServiceTests.cs
@@ -7,9 +7,11 @@ using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.ScriptExecution;
 using Squid.Message.Contracts.Tentacle;
+using Squid.Tentacle.Tests.Health;
 
 namespace Squid.Tentacle.Tests.ScriptExecution;
 
+[Collection(TentacleMetricsCollection.Name)]
 public class ScriptRecoveryServiceTests : IDisposable
 {
     private readonly string _tempWorkspace;

--- a/tests/Squid.Tentacle.Tests/ServiceHost/SystemdServiceHostTests.cs
+++ b/tests/Squid.Tentacle.Tests/ServiceHost/SystemdServiceHostTests.cs
@@ -1,0 +1,118 @@
+using Squid.Tentacle.ServiceHost;
+
+namespace Squid.Tentacle.Tests.ServiceHost;
+
+public class SystemdServiceHostTests
+{
+    [Fact]
+    public void BuildUnitFile_ProducesExpectedUnit_ForSimpleRequest()
+    {
+        var unit = SystemdServiceHost.BuildUnitFile(new ServiceInstallRequest
+        {
+            ServiceName = "squid-tentacle",
+            ExecStart = "/usr/local/bin/squid-tentacle",
+            WorkingDirectory = "/opt/squid-tentacle"
+        });
+
+        unit.ShouldContain("[Unit]");
+        unit.ShouldContain("Description=Squid Tentacle Agent (squid-tentacle)");
+        unit.ShouldContain("ExecStart=/usr/local/bin/squid-tentacle");
+        unit.ShouldContain("WorkingDirectory=/opt/squid-tentacle");
+        unit.ShouldContain("Restart=always");
+        unit.ShouldContain("WantedBy=multi-user.target");
+    }
+
+    [Fact]
+    public void BuildUnitFile_WithExecArgs_AppendsThemToExecStart()
+    {
+        var unit = SystemdServiceHost.BuildUnitFile(new ServiceInstallRequest
+        {
+            ServiceName = "squid-tentacle-prod",
+            ExecStart = "/usr/local/bin/squid-tentacle",
+            WorkingDirectory = "/opt/squid-tentacle",
+            ExecArgs = ["run", "--instance", "production"]
+        });
+
+        unit.ShouldContain("ExecStart=/usr/local/bin/squid-tentacle run --instance production");
+    }
+
+    [Fact]
+    public void BuildUnitFile_WithRunAsUser_AddsUserAndGroupLines()
+    {
+        var unit = SystemdServiceHost.BuildUnitFile(new ServiceInstallRequest
+        {
+            ServiceName = "squid-tentacle",
+            ExecStart = "/usr/local/bin/squid-tentacle",
+            WorkingDirectory = "/opt/squid-tentacle",
+            RunAsUser = "squid-tentacle"
+        });
+
+        unit.ShouldContain("User=squid-tentacle");
+        unit.ShouldContain("Group=squid-tentacle");
+    }
+
+    [Fact]
+    public void BuildUnitFile_CustomDescription_OverridesDefault()
+    {
+        var unit = SystemdServiceHost.BuildUnitFile(new ServiceInstallRequest
+        {
+            ServiceName = "x",
+            ExecStart = "/y",
+            WorkingDirectory = "/z",
+            Description = "Custom desc"
+        });
+
+        unit.ShouldContain("Description=Custom desc");
+        unit.ShouldNotContain("Description=Squid Tentacle Agent");
+    }
+
+    [Fact]
+    public void BuildUnitFile_RegressionGuard_NeverEmitsDotnetDllForm()
+    {
+        // Early versions of ServiceCommand generated `ExecStart=dotnet Squid.Tentacle.dll run`
+        // which never worked on target machines (no SDK, no .dll). This test guards against
+        // regressing that fix.
+        var unit = SystemdServiceHost.BuildUnitFile(new ServiceInstallRequest
+        {
+            ServiceName = "squid-tentacle",
+            ExecStart = "/usr/local/bin/squid-tentacle",
+            WorkingDirectory = "/opt/squid-tentacle"
+        });
+
+        unit.ShouldNotContain("dotnet Squid.Tentacle.dll");
+    }
+
+    [Fact]
+    public void ServiceHostFactory_Resolve_ReturnsHostMatchingCurrentOs()
+    {
+        var host = ServiceHostFactory.Resolve();
+
+        host.ShouldNotBeNull();
+        host.IsSupported.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ServiceHostFactory_Resolve_AlwaysReturnsExactlyOneSupportedHost()
+    {
+        // Among all candidates, exactly one IsSupported must fire on any given platform.
+        // Protects against "two hosts both supported" (ambiguous) or "zero supported" (broken).
+        var supportedCount = ServiceHostFactory.Candidates
+            .Select(create => create())
+            .Count(h => h.IsSupported);
+
+        supportedCount.ShouldBe(1,
+            $"Exactly one IServiceHost should be supported on the current OS; got {supportedCount}. " +
+            "Check the IsSupported predicates on SystemdServiceHost / WindowsServiceHost / LaunchdServiceHost.");
+    }
+
+    [Fact]
+    public void ServiceHostFactory_AllHosts_ReportDistinctDisplayNames()
+    {
+        var names = ServiceHostFactory.Candidates
+            .Select(create => create().DisplayName)
+            .ToList();
+
+        names.Distinct().Count().ShouldBe(names.Count,
+            "Every IServiceHost must have a unique DisplayName so diagnostics are unambiguous.");
+    }
+}


### PR DESCRIPTION
Adds Octopus-style multi-instance support and a generic service host abstraction so the binary + systemd/launchd/WinService flow actually works end-to-end across all platforms.

Core architecture:
- PlatformPaths: unified per-OS config dir resolution (Linux /etc, macOS /Library/Application Support, Windows %ProgramData%) with user-scope fallback when running unprivileged.
- InstanceRegistry: cross-platform JSON-backed instance registry at instances.json, replacing the Windows Registry / Linux JSON split that Octopus inherited. Supports case-insensitive lookup, schema versioning, auto-created Default instance.
- TentacleConfigFile: persistent per-instance JSON config that IConfigurationBuilder consumes natively. Merge-based updates skip empty values so partial overrides don't wipe existing keys. Unix permissions locked to 600.
- IServiceHost: OS-agnostic service-manager abstraction with SystemdServiceHost (complete) plus WindowsServiceHost / LaunchdServiceHost placeholders. ServiceHostFactory uses a registry pattern so adding a new platform is a one-line change.

Fixes the critical register -> systemd gap:
- register now persists effective settings to the instance config file after a successful registration. systemd's "run --instance NAME" can then start the agent with no other arguments.
- service install generates units with the correct ExecStart (Environment.ProcessPath, not the broken "dotnet *.dll" fallback) and passes --instance NAME when not Default.
- service install returns non-zero when systemctl fails, no longer falsely reports success on Docker/WSL1 without systemd.

New commands:
- create-instance --instance NAME [--config PATH]
- list-instances
- delete-instance --instance NAME
- --instance NAME flag now honoured by register / run / show-* / new-certificate / service install.

Server-side:
- Squid.Api.Program ConfigureKestrel uses SelfCert.Base64 so port 7078 (API) and 10943 (Halibut) present the same thumbprint. Fixes the TLS pinning mismatch where UI-displayed ServerThumbprint (SelfCert) disagreed with what Kestrel actually served (dev-cert).

install-tentacle.sh:
- Auto-installs libicu + ca-certificates across apt/dnf/yum/apk. .NET 9 globalization can't start without libicu; prior behaviour aborted with SIGABRT.
- Supports both v-prefixed and plain version tags.
- Creates /etc/squid-tentacle with mode 700.
- Makes Squid.Calamari executable (Tentacle spawns it at runtime).
- Verification uses the "help" subcommand instead of --help (which was routed to RunCommand).

Modernisation:
- RuntimeInformation.IsOSPlatform(...) replaced with OperatingSystem.IsLinux()/IsWindows()/IsMacOS() throughout.
- CommandResolver extracted for unit-testable command routing.

Tests: +38 new tests covering config file round-trips, instance registry persistence, platform path conventions, systemd unit generation, and factory dispatch. All 3992 unit tests and integration tests pass; 782/782 Tentacle tests (excluding pre-existing metrics flakiness) pass.