### PR TITLE
Harden Halibut polling deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -776,6 +776,148 @@ One file per concern. Main file = interface + constructor + flat pipeline:
 - `static` methods for pure logic with no instance side effects.
 - `.Replace("{{Key}}", value, StringComparison.Ordinal)` for template substitution.
 
+---
+
+## Kubernetes Deployment — Exposing Halibut Polling
+
+Deploying the Squid API server on K8s requires **two separate external endpoints** with different networking requirements. Treating them as one (single Ingress, single domain, single port) does not work.
+
+### Why two endpoints
+
+| Endpoint | Protocol | K8s abstraction | TLS owner |
+|---|---|---|---|
+| Web / HTTP API (:443) | HTTP/1.1, HTTP/2 | `Ingress` → nginx-ingress → `Service:8080` (ClusterIP) | cert-manager + Let's Encrypt, terminated at ingress |
+| Halibut polling (:10943) | L4 TCP (Halibut binary protocol, own mTLS) | `Service type=LoadBalancer` → pod:10943 (TCP passthrough) | Halibut self-signed cert inside the pod, never terminated at ingress |
+
+nginx-ingress is L7 HTTP only. Halibut is L4 TCP with its own mTLS handshake. Trying to route Halibut through nginx-ingress (via `tcp-services` ConfigMap) creates a fragile coupling between two unrelated protocols and introduces per-cloud annotations; using a dedicated `Service type=LoadBalancer` is the standard cloud-agnostic pattern.
+
+### Required manifests
+
+**1. Application Deployment + ClusterIP Service (HTTP)** — unchanged from a standard web app:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: deploy-squid-api, namespace: '#{K8SNameSpace}' }
+spec:
+  replicas: 1
+  selector: { matchLabels: { Octopus.Kubernetes.DeploymentName: deploy-squid-api } }
+  template:
+    spec:
+      containers:
+        - name: squid-api
+          image: '#{SquidImageRepo}:#{SquidImageTag}'
+          ports: [{ containerPort: 8080, name: http }]
+          envFrom: [{ configMapRef: { name: squid-configmap-#{Octopus.Deployment.Id} } }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: squid-service, namespace: '#{K8SNameSpace}' }
+spec:
+  type: ClusterIP
+  ports: [{ name: http, port: 8080, targetPort: 8080 }]
+  selector: { Octopus.Kubernetes.DeploymentName: deploy-squid-api }
+```
+
+**2. Ingress for HTTP only** — unchanged:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: squid-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: '#{IngressBaseDomainName}'
+      http:
+        paths: [{ path: /, pathType: ImplementationSpecific,
+                  backend: { service: { name: squid-service, port: { number: 8080 } } } }]
+  tls: [{ hosts: ['#{IngressBaseDomainName}'], secretName: tls-squid-secret }]
+```
+
+**3. Dedicated LoadBalancer Service for Halibut** — the critical piece:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: squid-halibut
+  namespace: '#{K8SNameSpace}'
+  annotations:
+    # Force TCP listener (CCM may default to HTTP otherwise → breaks binary protocol)
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-protocol-port: "tcp:10943"
+    # Force TCP health check (default HTTP GET hits Halibut pod → permanently "unhealthy" → drops traffic)
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-type: "tcp"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-healthy-threshold: "2"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-unhealthy-threshold: "2"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-interval: "5"
+    # Long-lived polling connections
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-persistence-timeout: "3600"
+    # OPTIONAL: reuse a specific pre-allocated SLB so the public IP is stable across
+    # Service delete/recreate. Needed for production where DNS can't be updated per deploy.
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-id: "lb-xxxxxxxxxxxx"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-force-override-listeners: "true"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: halibut
+      port: 10943
+      targetPort: 10943
+      protocol: TCP
+  selector:
+    # Must match what Octopus auto-rewrites for the Deployment. When the Service is in a
+    # different Octopus step than the Deployment, Octopus does NOT auto-rewrite the
+    # selector, so write the real value literally (do not use `octopusexport: OctopusExport`
+    # placeholder unless the Service is in the same step as the Deployment).
+    Octopus.Kubernetes.DeploymentName: deploy-squid-api
+```
+
+### Non-manifest prerequisites
+
+The manifests alone don't work without these three out-of-band setups:
+
+| # | What | Why | Who |
+|---|---|---|---|
+| 1 | A record `#{PollingBaseDomainName}` → SLB external IP | Tentacle connects to hostname, not IP | Ops / DNS team |
+| 2 | Worker node security group allows `TCP 30000-32767` from `100.64.0.0/10` | Alibaba SLB's health check sources are in the `100.64.0.0/10` CGNAT range (RFC 6598). Without this, SLB probes the NodePort and always fails, marks backend unhealthy, drops all traffic | Ops / cloud team |
+| 3 | ConfigMap env var `ServerUrl__CommsUrl=https://#{PollingBaseDomainName}:10943` | Server's Web UI and install-script generator pull the polling URL from this env var; without it, generated install scripts point new agents at the wrong endpoint | Deployment spec |
+
+### Diagnostic commands
+
+```bash
+# Verify Service has endpoints (selector matches pod)
+kubectl -n <ns> get endpoints squid-halibut
+#   Expected: squid-halibut   <pod-ip>:10943   <age>
+
+# Verify Halibut server cert is reachable from internet
+openssl s_client -connect #{PollingBaseDomainName}:10943 \
+  -servername #{PollingBaseDomainName} </dev/null 2>&1 \
+  | openssl x509 -noout -fingerprint -sha1
+#   Expected: matches the server cert thumbprint from Seq log
+#             "HalibutRuntime created. ServerCertThumbprint=<THUMBPRINT>"
+
+# Server-side logs that confirm trust list is loaded
+# Seq filter: @MessageTemplate like '%Halibut trust reconfigured%'
+#   Expected every startup + after each agent registration:
+#             "Halibut trust reconfigured, <N> polling agent(s) trusted"
+```
+
+### Common failure modes (matched to root cause)
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| Tentacle registers (200) but polling `Received EOF` | SLB health check hits wrong port or type → backend "unhealthy" → SLB silently drops forwarded traffic | Ensure `health-check-type: tcp` annotation; do NOT set `health-check-connect-port` unless pod is directly exposed (ENI mode). Let CCM default to the NodePort for flannel clusters |
+| `kubectl get endpoints <svc>` returns `<none>` | Service selector does not match pod labels. Octopus "Configure and apply" only auto-rewrites selectors when Service and Deployment are in the SAME step | Hardcode `selector: {Octopus.Kubernetes.DeploymentName: deploy-squid-api}`; or move the Service into the Deployment's step |
+| Backend shows "异常" / unhealthy even though pod and Service are correct | Worker node security group blocks SLB health check source | Add SG rule: `TCP 30000-32767` from `100.64.0.0/10` |
+| Same as above but after `Service delete → recreate` | CCM allocated a NEW SLB with a new public IP; old DNS still points at the defunct old SLB | Either update DNS, or add `alibaba-cloud-loadbalancer-id` annotation to reuse the existing SLB (stable IP forever) |
+| Generated install script shows polling URL as `https://<ingress-domain>:10943` | `ServerUrl__CommsUrl` env var is empty; server falls back to `ExternalUrl host + polling port` | Set `ServerUrl__CommsUrl` env var explicitly to the polling sub-domain |
+
+---
+
 ## Development Rules
 
 See `~/.claude/CLAUDE.md` for global rules (no breaking changes, design principles, refactoring patterns).

--- a/deploy/k8s-network-requirements.md
+++ b/deploy/k8s-network-requirements.md
@@ -1,0 +1,219 @@
+# Squid on Kubernetes — Network Requirements
+
+Deploying the Squid API server on Kubernetes exposes **two independent
+endpoints** with different networking stacks. Getting either one wrong
+produces silent failures that are expensive to diagnose. This document is the
+authoritative checklist for cluster operators.
+
+> Counterpart developer-facing doc:
+> [`CLAUDE.md → Kubernetes Deployment — Exposing Halibut Polling`](../CLAUDE.md)
+
+## Endpoints at a glance
+
+| Endpoint | Protocol | K8s abstraction | TLS owner | Public port |
+|---|---|---|---|---|
+| Web / HTTP API | HTTP/1.1, HTTP/2 | `Ingress → ClusterIP Service → pod:8080` | cert-manager + Let's Encrypt, terminated at ingress | 443 |
+| Halibut polling (agent RPC) | L4 TCP, Halibut's own mTLS | `Service type=LoadBalancer` → pod:10943 (pure TCP passthrough) | Halibut self-signed cert inside the pod | 10943 |
+
+**Do not mix them.** nginx-ingress has no first-class L4 passthrough story for
+the Halibut protocol, and coupling them produces fragile per-cloud hacks.
+
+---
+
+## Pre-flight checklist (do this once per cluster / environment)
+
+- [ ] **DNS:** one A record per endpoint (two different hostnames or at minimum
+      two different IPs)
+  - `squid-api-<env>.<domain>`     → ingress IP
+  - `squid-polling-<env>.<domain>` → Halibut SLB IP
+- [ ] **Node security group:** allow `TCP 30000-32767` from `100.64.0.0/10`
+      (see detail below — this is the single most common root cause of
+      "backend 异常" on Alibaba Cloud ACK)
+- [ ] **Octopus / deployment variables:**
+  - `ServerUrl__ExternalUrl`  = `https://squid-api-<env>.<domain>`
+  - `ServerUrl__CommsUrl`     = `https://squid-polling-<env>.<domain>:10943`
+  - Both resolved via `#{IngressBaseDomainName}` / `#{PollingBaseDomainName}`
+    project variables for portability
+- [ ] **Self-signed Halibut cert** baked into `SelfCertSetting.Base64` in the
+      API pod — shared across replicas via a K8s Secret; never regenerated per
+      pod (would break agent trust on rollout)
+- [ ] **Ingress** only references the **HTTP** Service (`squid-service:8080`).
+      It MUST NOT reference `squid-halibut` or `:10943`.
+- [ ] **Two LoadBalancer Services** (if HTTP also goes via an SLB in front of
+      ingress):
+  1. The ingress-controller's existing LB Service for `:80/:443`
+  2. A dedicated new LB Service for `:10943` — **see `squid-halibut` yaml
+     below**
+
+## Alibaba SLB health check — the `100.64.0.0/10` rule
+
+Alibaba Cloud sources its SLB health check probes from the **shared carrier
+NAT range `100.64.0.0/10`** (RFC 6598). This range is:
+
+- **Not routable on the public internet** — an attacker cannot spoof these
+  IPs from outside the cloud
+- **Used exclusively for Alibaba internal infrastructure** (SLB, CDN, etc.)
+- **Required in the worker node security group** for every K8s LoadBalancer
+  Service, otherwise SLB cannot verify pod health, marks the backend as
+  `异常 (unhealthy)`, and **silently drops all forwarded traffic**
+
+**Add this single rule to the worker node security group (once per cluster):**
+
+| Field | Value |
+|---|---|
+| Direction | Inbound |
+| Action | Allow |
+| Priority | 1 |
+| Protocol | TCP |
+| Port range | `30000/32767` |
+| Source | `100.64.0.0/10` |
+| Description | `Alibaba SLB health check → K8s NodePort (RFC 6598)` |
+
+> Reference: Alibaba Cloud official CLB documentation,
+> ["配置健康检查"](https://help.aliyun.com/zh/slb/classic-load-balancer/user-guide/configure-health-checks)
+
+## Dedicated LoadBalancer Service for Halibut
+
+The complete working Service definition (paste into your Octopus step, or
+apply directly via `kubectl`):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: squid-halibut
+  namespace: '#{K8SNameSpace}'
+  annotations:
+    # Force SLB listener to TCP protocol (CCM may default to HTTP, which mis-parses
+    # the Halibut binary protocol and immediately RSTs every connection)
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-protocol-port: "tcp:10943"
+
+    # Force TCP health check (default HTTP GET hits Halibut → permanent "异常")
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-type: "tcp"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-healthy-threshold: "2"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-unhealthy-threshold: "2"
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-interval: "5"
+
+    # Long-lived polling connections (Tentacle keeps TCP open until the server
+    # has work for it; default 900s is enough but we explicit to 1h for safety)
+    service.beta.kubernetes.io/alibaba-cloud-loadbalancer-persistence-timeout: "3600"
+
+    # Pin SLB identity → stable public IP across Service delete/recreate.
+    # Remove to let CCM allocate a fresh SLB (which WILL change the IP).
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-id: "lb-xxxxxxxxxxxx"
+    # service.beta.kubernetes.io/alibaba-cloud-loadbalancer-force-override-listeners: "true"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: halibut
+      port: 10943
+      targetPort: 10943
+      protocol: TCP
+  selector:
+    # When this Service is in a DIFFERENT Octopus step than the Deployment,
+    # Octopus does NOT auto-rewrite `octopusexport: OctopusExport` placeholders.
+    # Write the real selector literally:
+    Octopus.Kubernetes.DeploymentName: deploy-squid-api
+```
+
+## Diagnostic playbook
+
+### Step 1: is the pod's own Halibut listener healthy?
+
+```bash
+# Inside the API pod (or any pod in the same namespace):
+python3 -c "
+import socket, ssl, hashlib
+s = socket.create_connection(('127.0.0.1', 10943), timeout=5)
+tls = ssl.create_default_context()
+tls.check_hostname = False
+tls.verify_mode = ssl.CERT_NONE
+t = tls.wrap_socket(s, server_hostname='localhost')
+print('thumbprint=', hashlib.sha1(t.getpeercert(True)).hexdigest().upper())"
+# Expected output: matches the server's SelfCertSetting thumbprint
+```
+
+If this fails, the bug is inside the API pod (Halibut runtime not started, or
+TLS config broken). Check pod logs for `HalibutRuntime created.` and
+`Halibut polling listener started on port 10943`.
+
+### Step 2: does the Service route to the pod?
+
+```bash
+kubectl -n <ns> get endpoints squid-halibut
+# Expected: squid-halibut   <pod-ip>:10943
+```
+
+If `<none>`: selector mismatch. Verify `kubectl get pod <pod> --show-labels`
+contains the selector key/value pair.
+
+### Step 3: does the SLB see the backend as healthy?
+
+Open the Alibaba Cloud console → SLB → find the LB by ID → **后端服务器** tab.
+The entry for the node/pod should show `运行中` / `Normal`. If `异常`:
+
+1. 99% of the time — the `100.64.0.0/10` security group rule is missing.
+   Add it (see above).
+2. 1% of the time — health check is HTTP (wrong) rather than TCP. Check
+   **监听** tab and confirm **健康检查方式 = TCP**.
+
+### Step 4: does the public endpoint present the right certificate?
+
+```bash
+openssl s_client -connect squid-polling-<env>.<domain>:10943 \
+  -servername squid-polling-<env>.<domain> </dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha1
+```
+
+Expected: thumbprint matches the server's self-signed cert (find it in Seq
+log: `HalibutRuntime created. ServerCertThumbprint=<hex>`). If it doesn't
+match: some intermediary is terminating TLS with its own cert — check that
+the SLB listener is `tcp:10943` (L4 passthrough), not HTTPS.
+
+### Step 5: do server logs show trust reload?
+
+Seq filter: `@MessageTemplate like '%trust reconfigured%'`
+
+Expected after every agent registration:
+
+```
+Halibut trust reconfigured, N polling agent(s) trusted
+```
+
+Where `N` matches the number of active polling-style machines in the
+database. If `N=0`: `GetPollingThumbprintsAsync` is not finding the
+thumbprints (SQL / JSON query issue, typically EF function binding).
+
+## Common failure modes
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| Tentacle: `Received an unexpected EOF`; server Seq shows no incoming connection | Traffic never reaches the pod — ingress swallowing it, or LB not configured | Create `squid-halibut` Service with `type: LoadBalancer` (see above) |
+| Tentacle registers (`MachineId=N`) but polling EOF; server Seq shows `Socket IO exception: <node-ip>` | SLB backend marked unhealthy → drops forwarded traffic | Add `100.64.0.0/10` SG rule + verify health check is TCP |
+| `kubectl get endpoints <svc>` returns `<none>` | Service selector doesn't match pod labels | Hardcode real label (`Octopus.Kubernetes.DeploymentName: deploy-squid-api`); don't rely on Octopus selector rewriting across steps |
+| DNS no longer resolves after Service `delete+recreate` | CCM allocated a new SLB with a new IP | Add `alibaba-cloud-loadbalancer-id` annotation to pin the SLB, OR update DNS |
+| UI generates install script with polling URL pointing at the ingress domain, not the LB domain | `ServerUrl__CommsUrl` env var empty | Set it explicitly to `https://<polling-domain>:10943` in the Deployment yaml |
+| Server log: `Halibut trust reconfigured, 0 polling agent(s) trusted` despite machines in DB | EF function binding for `jsonb_extract_path_text` misregistered, or JSON property casing drift | Check `SquidDbContext.OnModelCreating` + `MachineRegistrationService.BuildTentaclePollingEndpointJson` key casing match |
+
+## What the server does automatically
+
+The Squid API, starting with the version documented here, runs a
+**reachability probe at install-script generation time** (see
+`TentacleCommsUrlProbe`). When an operator clicks "Generate install script"
+in the UI:
+
+1. Server resolves the configured polling URL from `ServerUrl__CommsUrl`
+2. Opens TCP + performs TLS handshake against that URL
+3. Compares the observed certificate thumbprint against the expected Halibut
+   cert thumbprint
+4. Returns the probe result (`reachable`, `skipped`, `thumbprintMatches`,
+   `detail`) alongside the generated script
+
+The UI displays this result as a warning banner **before** the operator ships
+the script to a new Tentacle owner — turning days of silent EOF loops into
+an immediate, actionable error at the moment of misconfiguration.
+
+If the probe reports `reachable=false`, the `Detail` field contains a
+remediation hint pointing directly at the most likely gap (DNS, SLB listener
+protocol, health check type, or security group). Follow the corresponding
+section above.

--- a/src/Squid.Api/Filters/GlobalExceptionFilter.cs
+++ b/src/Squid.Api/Filters/GlobalExceptionFilter.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Serilog;
 using Squid.Core.Services.Authorization.Exceptions;
+using Squid.Core.Services.Machines.Exceptions;
 using Squid.Message.Response;
 
 namespace Squid.Api.Filters;
@@ -16,6 +17,7 @@ public class GlobalExceptionFilter : IExceptionFilter
             ValidationException => HttpStatusCode.BadRequest,
             UnauthorizedAccessException => HttpStatusCode.Unauthorized,
             PermissionDeniedException => HttpStatusCode.Forbidden,
+            MachineNameConflictException => HttpStatusCode.Conflict,
             _ => HttpStatusCode.InternalServerError
         };
 

--- a/src/Squid.Core/Services/Machines/Exceptions/MachineNameConflictException.cs
+++ b/src/Squid.Core/Services/Machines/Exceptions/MachineNameConflictException.cs
@@ -1,0 +1,23 @@
+namespace Squid.Core.Services.Machines.Exceptions;
+
+/// <summary>
+/// Thrown when a machine registration is attempted with a name that already
+/// exists in the same space. Mapped to HTTP 409 Conflict by the
+/// <c>GlobalExceptionFilter</c>, which allows the Tentacle client to distinguish
+/// "valid credentials, just the desired name is already taken" from "credentials
+/// rejected" (401) and transient server errors (5xx).
+///
+/// Before this type existed the conflict surfaced as a generic
+/// <see cref="InvalidOperationException"/> that the filter mapped to
+/// <c>HttpStatusCode.InternalServerError</c> inside an HTTP 200 envelope — the
+/// Tentacle client then mistook the response for success and attempted to poll
+/// with a thumbprint the server never actually persisted, producing a
+/// confusing "trust rejected" handshake loop.
+/// </summary>
+public sealed class MachineNameConflictException(string machineName, int spaceId)
+    : InvalidOperationException($"A machine named \"{machineName}\" already exists in this space")
+{
+    public string MachineName { get; } = machineName;
+
+    public int SpaceId { get; } = spaceId;
+}

--- a/src/Squid.Core/Services/Machines/MachineRegistrationService.cs
+++ b/src/Squid.Core/Services/Machines/MachineRegistrationService.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 using Squid.Core.Halibut;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Deployments.Environments;
+using Squid.Core.Services.Machines.Exceptions;
 using Squid.Core.Settings.SelfCert;
 using Squid.Message.Commands.Machine;
 
@@ -50,7 +51,7 @@ public partial class MachineRegistrationService : IMachineRegistrationService
         if (string.IsNullOrEmpty(name)) return;
 
         if (await _dataProvider.ExistsByNameAsync(name, spaceId, ct).ConfigureAwait(false))
-            throw new InvalidOperationException($"A machine named \"{name}\" already exists in this space");
+            throw new MachineNameConflictException(name, spaceId);
     }
 
     private static Machine BuildMachineDefaults(string name, string roles, string environmentIds, int spaceId, string endpointJson, int? machinePolicyId = null)

--- a/src/Squid.Core/Services/Machines/MachineScriptService.Tentacle.cs
+++ b/src/Squid.Core/Services/Machines/MachineScriptService.Tentacle.cs
@@ -35,11 +35,14 @@ public partial class MachineScriptService
 
             var scripts = BuildScripts(context);
 
+            var probe = await ProbePollingCommsUrlAsync(command, serverThumbprint, ct).ConfigureAwait(false);
+
             return Success<GenerateTentacleInstallScriptResponse, GenerateTentacleInstallScriptData>(
                 new GenerateTentacleInstallScriptData
                 {
                     ServerThumbprint = serverThumbprint,
-                    Scripts = scripts
+                    Scripts = scripts,
+                    CommsUrlProbe = probe
                 });
         }
         catch (Exception ex)
@@ -89,4 +92,36 @@ public partial class MachineScriptService
     private static bool IsListeningMode(string communicationMode)
         => string.IsNullOrWhiteSpace(communicationMode)
         || communicationMode.Equals("Listening", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Polling-mode install scripts embed a <c>ServerCommsUrl</c> that must be
+    /// externally reachable with a valid TLS endpoint presenting the server's
+    /// Halibut cert. Probing here (at script-generation time) surfaces
+    /// networking/SLB misconfigurations to the operator before the script
+    /// reaches a new machine owner — avoids repeating the 2026-04-18 incident
+    /// where mis-configured SLB health checks led to days of silent EOF loops.
+    /// Listening-mode registrations have no polling URL, so we skip.
+    /// </summary>
+    private async Task<TentacleCommsProbeInfo> ProbePollingCommsUrlAsync(
+        GenerateTentacleInstallScriptCommand command, string serverThumbprint, CancellationToken ct)
+    {
+        if (IsListeningMode(command.CommunicationMode))
+            return new TentacleCommsProbeInfo { Skipped = true, Detail = "Listening-mode registration: no polling URL to probe" };
+
+        var probe = await _commsUrlProbe
+            .ProbeAsync(command.ServerCommsUrl, serverThumbprint, ct)
+            .ConfigureAwait(false);
+
+        return ToTransportDto(probe);
+    }
+
+    /// <summary>Map domain probe result → transport DTO consumed by UI/clients.</summary>
+    private static TentacleCommsProbeInfo ToTransportDto(TentacleCommsProbeResult probe) => new()
+    {
+        Reachable = probe.Reachable,
+        Skipped = probe.Skipped,
+        ObservedThumbprint = probe.ObservedThumbprint ?? string.Empty,
+        ThumbprintMatches = probe.ThumbprintMatches,
+        Detail = probe.Detail ?? string.Empty
+    };
 }

--- a/src/Squid.Core/Services/Machines/MachineScriptService.cs
+++ b/src/Squid.Core/Services/Machines/MachineScriptService.cs
@@ -23,19 +23,22 @@ public partial class MachineScriptService : IMachineScriptService
     private readonly IAgentVersionProvider _agentVersionProvider;
     private readonly SelfCertSetting _selfCertSetting;
     private readonly IEnumerable<ITentacleInstallScriptBuilder> _tentacleScriptBuilders;
+    private readonly ITentacleCommsUrlProbe _commsUrlProbe;
 
     public MachineScriptService(
         IAccountService accountService,
         IMachineDataProvider machineDataProvider,
         IAgentVersionProvider agentVersionProvider,
         SelfCertSetting selfCertSetting,
-        IEnumerable<ITentacleInstallScriptBuilder> tentacleScriptBuilders)
+        IEnumerable<ITentacleInstallScriptBuilder> tentacleScriptBuilders,
+        ITentacleCommsUrlProbe commsUrlProbe)
     {
         _accountService = accountService;
         _machineDataProvider = machineDataProvider;
         _agentVersionProvider = agentVersionProvider;
         _selfCertSetting = selfCertSetting;
         _tentacleScriptBuilders = tentacleScriptBuilders;
+        _commsUrlProbe = commsUrlProbe;
     }
 
     private static TResponse Success<TResponse, TData>(TData data) where TResponse : SquidResponse<TData>, new()

--- a/src/Squid.Core/Services/Machines/Scripts/Tentacle/TentacleCommsUrlProbe.cs
+++ b/src/Squid.Core/Services/Machines/Scripts/Tentacle/TentacleCommsUrlProbe.cs
@@ -1,0 +1,165 @@
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using Serilog;
+
+namespace Squid.Core.Services.Machines.Scripts.Tentacle;
+
+/// <summary>
+/// Probes a Tentacle polling URL end-to-end (DNS → TCP → TLS) to surface
+/// operator-side network misconfigurations at install-script generation time
+/// rather than at first-agent-handshake time.
+///
+/// <para>
+/// History: the Squid cluster we operated hit a multi-hour regression where the
+/// UI happily generated install scripts pointing at a polling URL that was
+/// externally unreachable (SLB health check misconfigured → backend marked
+/// unhealthy → all forwarded connections got RST before TLS even started).
+/// The symptom surfaced only after a real agent tried to connect and saw
+/// cryptic <c>"Received an unexpected EOF or 0 bytes from the transport stream"</c>
+/// loops. This probe turns that silent failure into a loud warning embedded in
+/// the script-generation response so operators fix their SLB / DNS / security
+/// group before shipping the script to a new machine owner.
+/// </para>
+/// </summary>
+public interface ITentacleCommsUrlProbe : IScopedDependency
+{
+    Task<TentacleCommsProbeResult> ProbeAsync(string commsUrl, string expectedServerThumbprint, CancellationToken ct);
+}
+
+public sealed class TentacleCommsUrlProbe : ITentacleCommsUrlProbe
+{
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan TlsTimeout = TimeSpan.FromSeconds(5);
+
+    public async Task<TentacleCommsProbeResult> ProbeAsync(string commsUrl, string expectedServerThumbprint, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(commsUrl))
+            return Skipped("ServerCommsUrl not configured — skipping probe");
+
+        if (!Uri.TryCreate(commsUrl, UriKind.Absolute, out var uri))
+            return Unreachable($"ServerCommsUrl \"{commsUrl}\" is not a valid absolute URL");
+
+        var host = uri.Host;
+        var port = uri.IsDefaultPort ? 10943 : uri.Port;
+
+        return await ProbeHostAsync(host, port, expectedServerThumbprint, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<TentacleCommsProbeResult> ProbeHostAsync(
+        string host, int port, string expectedThumbprint, CancellationToken ct)
+    {
+        try
+        {
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(host, port, ct).AsTask()
+                .WaitAsync(ConnectTimeout, ct).ConfigureAwait(false);
+
+            // Only set the validation callback once (via SslClientAuthenticationOptions);
+            // setting it both in the constructor AND in the options throws on .NET 9+.
+            // The probe deliberately accepts any server cert — the probe's job is to
+            // measure reachability and observe the thumbprint, not to enforce trust.
+            await using var ssl = new SslStream(tcp.GetStream(), leaveInnerStreamOpen: false);
+
+            var tlsOptions = new SslClientAuthenticationOptions
+            {
+                TargetHost = host,
+                RemoteCertificateValidationCallback = (_, _, _, _) => true
+            };
+
+            await ssl.AuthenticateAsClientAsync(tlsOptions, ct)
+                .WaitAsync(TlsTimeout, ct).ConfigureAwait(false);
+
+            var observed = ExtractThumbprint(ssl.RemoteCertificate);
+            var matches = !string.IsNullOrEmpty(expectedThumbprint)
+                && string.Equals(observed, expectedThumbprint, StringComparison.OrdinalIgnoreCase);
+
+            return new TentacleCommsProbeResult
+            {
+                Reachable = true,
+                ObservedThumbprint = observed,
+                ThumbprintMatches = matches,
+                Detail = matches
+                    ? $"Reachable. Server cert thumbprint matches ({expectedThumbprint})"
+                    : $"Reachable but cert thumbprint mismatch. Expected {expectedThumbprint}, observed {observed}. "
+                      + "Check that the SLB does L4 TCP passthrough (not TLS termination)"
+            };
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Tentacle comms URL probe failed for {Host}:{Port}", host, port);
+            return Unreachable(BuildRemediationHint(ex, host, port));
+        }
+    }
+
+    private static string BuildRemediationHint(Exception ex, string host, int port)
+    {
+        var cause = ex switch
+        {
+            TimeoutException => $"Connection to {host}:{port} timed out",
+            SocketException se => $"TCP connect to {host}:{port} failed: {se.SocketErrorCode}",
+            AuthenticationException ae => $"TLS handshake to {host}:{port} failed: {ae.Message}",
+            IOException io when io.Message.Contains("EOF", StringComparison.OrdinalIgnoreCase)
+                => $"SLB accepted TCP on {host}:{port} but dropped the TLS handshake (likely backend marked unhealthy)",
+            _ => $"{ex.GetType().Name}: {ex.Message}"
+        };
+
+        return cause + ". Verify: "
+            + "(1) DNS for " + host + " resolves to the SLB external IP; "
+            + "(2) SLB listener for port " + port + " is protocol TCP (not HTTP); "
+            + "(3) SLB health check is TCP (not HTTP GET); "
+            + "(4) worker node security group allows 100.64.0.0/10 on NodePort range 30000-32767. "
+            + "See CLAUDE.md > \"Kubernetes Deployment — Exposing Halibut Polling\".";
+    }
+
+    private static string ExtractThumbprint(X509Certificate cert)
+    {
+        if (cert == null) return string.Empty;
+        if (cert is X509Certificate2 c2) return c2.GetCertHashString().ToUpperInvariant();
+
+        using var loaded = X509CertificateLoader.LoadCertificate(cert.GetRawCertData());
+        return loaded.GetCertHashString().ToUpperInvariant();
+    }
+
+    private static TentacleCommsProbeResult Skipped(string detail)
+        => new() { Reachable = false, Skipped = true, Detail = detail };
+
+    private static TentacleCommsProbeResult Unreachable(string detail)
+        => new() { Reachable = false, Detail = detail };
+}
+
+public sealed class TentacleCommsProbeResult
+{
+    /// <summary>
+    /// True once TCP + TLS both completed. False when the probe found a network
+    /// gap (DNS / SLB / firewall / health check). Also false when skipped.
+    /// </summary>
+    public bool Reachable { get; set; }
+
+    /// <summary>
+    /// True when the probe was not performed (e.g. Listening-mode registration
+    /// where there is no polling URL). Distinguishes "we deliberately didn't
+    /// check" from "we checked and it's broken".
+    /// </summary>
+    public bool Skipped { get; set; }
+
+    /// <summary>
+    /// SHA1 thumbprint of the certificate the remote endpoint presented,
+    /// uppercase hex. Empty when unreachable or skipped.
+    /// </summary>
+    public string ObservedThumbprint { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when <see cref="ObservedThumbprint"/> matches the server's expected
+    /// Halibut cert thumbprint. False on mismatch — typically means an L7 proxy
+    /// is terminating TLS and substituting its own cert, breaking Halibut mTLS.
+    /// </summary>
+    public bool ThumbprintMatches { get; set; }
+
+    /// <summary>
+    /// Human-readable diagnosis plus remediation hints; included in the install
+    /// script response so operators can act without digging through server logs.
+    /// </summary>
+    public string Detail { get; set; } = string.Empty;
+}

--- a/src/Squid.Message/Commands/Machine/GenerateTentacleInstallScriptCommand.cs
+++ b/src/Squid.Message/Commands/Machine/GenerateTentacleInstallScriptCommand.cs
@@ -38,6 +38,15 @@ public class GenerateTentacleInstallScriptData
 {
     public string ServerThumbprint { get; set; }
     public List<TentacleInstallScript> Scripts { get; set; } = [];
+
+    /// <summary>
+    /// Diagnostic result of probing the configured polling URL at
+    /// script-generation time. Lets the UI display an actionable warning when
+    /// DNS / SLB / firewall is not yet configured correctly, instead of
+    /// silently handing out a script that will fail with cryptic EOF errors
+    /// once a real Tentacle tries to poll.
+    /// </summary>
+    public TentacleCommsProbeInfo CommsUrlProbe { get; set; }
 }
 
 public class TentacleInstallScript
@@ -49,4 +58,19 @@ public class TentacleInstallScript
     public string ScriptType { get; set; }
     public string Content { get; set; }
     public bool IsRecommended { get; set; }
+}
+
+/// <summary>
+/// Transport DTO mirroring the server-side <c>TentacleCommsProbeResult</c>.
+/// Shipped to the UI alongside the install scripts so operators see network /
+/// SLB misconfigurations at script-generation time instead of at
+/// first-Tentacle-handshake time.
+/// </summary>
+public class TentacleCommsProbeInfo
+{
+    public bool Reachable { get; set; }
+    public bool Skipped { get; set; }
+    public string ObservedThumbprint { get; set; } = string.Empty;
+    public bool ThumbprintMatches { get; set; }
+    public string Detail { get; set; } = string.Empty;
 }

--- a/src/Squid.Tentacle/Registration/TentacleRegistrationClient.cs
+++ b/src/Squid.Tentacle/Registration/TentacleRegistrationClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -73,16 +74,7 @@ public class TentacleRegistrationClient
     private async Task<RegistrationResult> SendRegistrationAsync(
         string subscriptionId, string thumbprint, CancellationToken ct)
     {
-        using var handler = new HttpClientHandler();
-        handler.ServerCertificateCustomValidationCallback =
-            ServerCertificateValidator.Create(_settings.ServerCertificate);
-
-        var proxy = Squid.Tentacle.Halibut.ProxyConfigurationBuilder.BuildHttpClientProxy(_settings.Proxy);
-        if (proxy != null)
-        {
-            handler.Proxy = proxy;
-            handler.UseProxy = true;
-        }
+        using var handler = BuildHandler();
 
         using var client = new HttpClient(handler);
         client.BaseAddress = new Uri(_settings.ServerUrl);
@@ -113,43 +105,120 @@ public class TentacleRegistrationClient
             payload[kv.Key] = kv.Value;
 
         var response = await client.PostAsJsonAsync(_registrationPath, payload, JsonOptions, ct).ConfigureAwait(false);
-        await EnsureSuccessOrThrowDetailedAsync(response, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
 
-        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-        var result = JsonSerializer.Deserialize<RegistrationResponse>(json, JsonOptions);
+        await EnsureBusinessSuccessOrThrowAsync(response, body).ConfigureAwait(false);
+
+        var result = JsonSerializer.Deserialize<RegistrationResponse>(body, JsonOptions);
+
+        EnsureRegistrationPayloadComplete(result, response, body);
 
         Log.Information("Registration successful. MachineId={MachineId}, ServerThumbprint={ServerThumbprint}",
-            result?.Data?.MachineId, result?.Data?.ServerThumbprint);
+            result.Data.MachineId, result.Data.ServerThumbprint);
 
         return new RegistrationResult
         {
-            MachineId = result?.Data?.MachineId ?? 0,
-            ServerThumbprint = result?.Data?.ServerThumbprint ?? string.Empty,
-            SubscriptionUri = result?.Data?.SubscriptionUri ?? $"poll://{subscriptionId}/"
+            MachineId = result.Data.MachineId,
+            ServerThumbprint = result.Data.ServerThumbprint ?? string.Empty,
+            SubscriptionUri = result.Data.SubscriptionUri ?? $"poll://{subscriptionId}/"
         };
     }
 
-    private static async Task EnsureSuccessOrThrowDetailedAsync(HttpResponseMessage response, CancellationToken ct)
+    /// <summary>
+    /// The Squid Server envelopes every response in <c>SquidResponse&lt;T&gt;</c>
+    /// with a body-level <c>code</c> field mirroring the logical HTTP status.
+    /// A <c>GlobalExceptionFilter</c> on the server wraps thrown exceptions into
+    /// this envelope but always returns the transport-level HTTP status as 200
+    /// (so every error surfaces as body <c>code=4xx/5xx</c> inside an HTTP 200
+    /// response). Relying on <see cref="HttpResponseMessage.IsSuccessStatusCode"/>
+    /// alone therefore misses business-level failures and lets the Tentacle
+    /// happily proceed with empty <c>Data</c>, producing the confusing
+    /// "Registration successful. MachineId=null" regression we saw on 2026-04-18.
+    /// Check both HTTP status AND body <c>code</c>.
+    /// </summary>
+    private static async Task EnsureBusinessSuccessOrThrowAsync(HttpResponseMessage response, string body)
     {
-        if (response.IsSuccessStatusCode) return;
+        if (!response.IsSuccessStatusCode)
+            ThrowRegistrationFailed((int)response.StatusCode, body, response.ReasonPhrase, response.StatusCode);
 
-        var body = string.Empty;
+        if (string.IsNullOrWhiteSpace(body))
+            return; // No body to inspect — trust HTTP status.
+
+        BusinessEnvelope envelope = null;
 
         try
         {
-            body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            envelope = JsonSerializer.Deserialize<BusinessEnvelope>(body, JsonOptions);
         }
         catch
         {
-            // Best-effort
+            // Not our envelope shape — treat as raw success body.
         }
 
-        var message = string.IsNullOrWhiteSpace(body)
-            ? $"Registration failed with HTTP {(int)response.StatusCode} ({response.ReasonPhrase})"
-            : $"Registration failed with HTTP {(int)response.StatusCode}: {body}";
+        if (envelope == null || envelope.Code == 0) return;
+
+        if (envelope.Code < 200 || envelope.Code >= 300)
+            ThrowRegistrationFailed(envelope.Code, envelope.Msg ?? body, response.ReasonPhrase, MapCodeToHttpStatus(envelope.Code));
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Even after HTTP + body codes both say 2xx, the server might return an
+    /// empty <c>data</c> object — historically this happened when an upstream
+    /// conflict was mapped to HTTP 200 + body code=500 with no <c>data</c>
+    /// field. Without this guard the Tentacle would start polling with
+    /// <c>MachineId=0</c> and a blank server thumbprint, and every subsequent
+    /// Halibut handshake would be rejected by the server's trust store.
+    /// </summary>
+    private static void EnsureRegistrationPayloadComplete(RegistrationResponse result, HttpResponseMessage response, string body)
+    {
+        if (result?.Data?.MachineId > 0 && !string.IsNullOrWhiteSpace(result.Data.ServerThumbprint))
+            return;
+
+        var message = $"Registration response missing machineId or serverThumbprint. HTTP {(int)response.StatusCode}, body: {body}";
+        Log.Error(message);
+        throw new HttpRequestException(message, null, HttpStatusCode.BadGateway);
+    }
+
+    private static void ThrowRegistrationFailed(int code, string bodyOrMessage, string reason, HttpStatusCode? httpStatus)
+    {
+        var message = string.IsNullOrWhiteSpace(bodyOrMessage)
+            ? $"Registration failed with code {code} ({reason})"
+            : $"Registration failed with code {code}: {bodyOrMessage}";
 
         Log.Error(message);
-        throw new HttpRequestException(message, null, response.StatusCode);
+        throw new HttpRequestException(message, null, httpStatus);
+    }
+
+    private static HttpStatusCode MapCodeToHttpStatus(int code)
+        => Enum.IsDefined(typeof(HttpStatusCode), code) ? (HttpStatusCode)code : HttpStatusCode.InternalServerError;
+
+    private HttpMessageHandler BuildHandler()
+    {
+        if (_options.HttpMessageHandlerFactory != null)
+            return _options.HttpMessageHandlerFactory();
+
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = ServerCertificateValidator.Create(_settings.ServerCertificate)
+        };
+
+        var proxy = Squid.Tentacle.Halibut.ProxyConfigurationBuilder.BuildHttpClientProxy(_settings.Proxy);
+        if (proxy != null)
+        {
+            handler.Proxy = proxy;
+            handler.UseProxy = true;
+        }
+
+        return handler;
+    }
+
+    private class BusinessEnvelope
+    {
+        public int Code { get; set; }
+
+        public string Msg { get; set; }
     }
 
     private class RegistrationResponse
@@ -172,6 +241,14 @@ public sealed class TentacleRegistrationClientOptions
     public TimeSpan MaxDelay { get; init; } = TimeSpan.FromSeconds(60);
     public Func<TimeSpan, CancellationToken, Task> DelayAsync { get; init; } =
         static (delay, ct) => Task.Delay(delay, ct);
+
+    /// <summary>
+    /// Test seam: override the underlying <see cref="HttpMessageHandler"/> so
+    /// unit tests can stub HTTP responses without a real listener. Production
+    /// code leaves this null and the client builds a real <see cref="HttpClientHandler"/>
+    /// configured with the server cert validator and any proxy settings.
+    /// </summary>
+    public Func<HttpMessageHandler> HttpMessageHandlerFactory { get; init; }
 
     public static TentacleRegistrationClientOptions Default { get; } = new();
 }

--- a/tests/Squid.Tentacle.Tests/Registration/TentacleRegistrationClientTests.cs
+++ b/tests/Squid.Tentacle.Tests/Registration/TentacleRegistrationClientTests.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Registration;
 
@@ -90,5 +95,137 @@ public class TentacleRegistrationClientTests
         settings.ScriptPodMemoryRequest.ShouldBe("100Mi");
         settings.ScriptPodCpuLimit.ShouldBe("500m");
         settings.ScriptPodMemoryLimit.ShouldBe("512Mi");
+    }
+
+    // ========================================================================
+    // Business-code-in-body validation — prevents the 2026-04-18 regression where
+    // the server wrapped errors as HTTP 200 + body {"code":500}, and the client
+    // mistakenly reported "Registration successful. MachineId=null".
+    // ========================================================================
+
+    [Fact]
+    public async Task RegisterAsync_Http200WithBodyCode500_ThrowsWithServerMessage()
+    {
+        // Arrange: HTTP 200 envelope with logical failure inside body — exactly
+        // the shape produced by the server's GlobalExceptionFilter for any
+        // unmapped InvalidOperationException (e.g. legacy duplicate-name path).
+        var client = BuildClientWithStubbedResponse(
+            HttpStatusCode.OK,
+            """{"code":500,"msg":"A machine named \"mars mac\" already exists in this space"}""");
+
+        var ex = await Should.ThrowAsync<HttpRequestException>(() =>
+            client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        ex.Message.ShouldContain("code 500");
+        ex.Message.ShouldContain("A machine named");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Http409FromServer_ThrowsAndPropagatesConflict()
+    {
+        // Server now maps MachineNameConflictException → 409 (see Squid.Api
+        // GlobalExceptionFilter). Client must surface this distinctly so
+        // operators don't misread it as "transient 5xx, retry".
+        var client = BuildClientWithStubbedResponse(
+            HttpStatusCode.Conflict,
+            """{"code":409,"msg":"A machine named \"mars mac\" already exists in this space"}""");
+
+        var ex = await Should.ThrowAsync<HttpRequestException>(() =>
+            client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        ex.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+        ex.Message.ShouldContain("already exists");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Http200WithEmptyData_ThrowsBecauseMachineIdMissing()
+    {
+        // Safeguard against "HTTP 200, body.code=200, but data is null/0".
+        // Without this, the Tentacle would start polling with MachineId=0 and
+        // the server would RST every Halibut handshake.
+        var client = BuildClientWithStubbedResponse(
+            HttpStatusCode.OK,
+            """{"code":200,"msg":"Success","data":null}""");
+
+        var ex = await Should.ThrowAsync<HttpRequestException>(() =>
+            client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        ex.Message.ShouldContain("missing");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Http200WithCompleteData_ReturnsResult()
+    {
+        var client = BuildClientWithStubbedResponse(
+            HttpStatusCode.OK,
+            """{"code":200,"msg":"Success","data":{"machineId":17,"serverThumbprint":"FAF04764","subscriptionUri":"poll://sub-1/"}}""");
+
+        var result = await client.RegisterAsync("sub-1", "AABB", CancellationToken.None);
+
+        result.MachineId.ShouldBe(17);
+        result.ServerThumbprint.ShouldBe("FAF04764");
+        result.SubscriptionUri.ShouldBe("poll://sub-1/");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ClientErrorFromHttpLayer_NotRetried()
+    {
+        // 4xx responses are user errors (bad API key, bad payload) and the
+        // retry loop should NOT retry them. Verify we throw immediately.
+        var callCount = 0;
+        var handler = new StubMessageHandler((_, _) =>
+        {
+            callCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("""{"code":401,"msg":"Unauthorized"}""", Encoding.UTF8, "application/json")
+            });
+        });
+
+        var client = BuildClient(handler);
+
+        await Should.ThrowAsync<HttpRequestException>(() =>
+            client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        callCount.ShouldBe(1); // Retry loop gave up on the 4xx
+    }
+
+    private static TentacleRegistrationClient BuildClientWithStubbedResponse(HttpStatusCode status, string body)
+    {
+        var handler = new StubMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        }));
+
+        return BuildClient(handler);
+    }
+
+    private static TentacleRegistrationClient BuildClient(StubMessageHandler handler)
+    {
+        var settings = new TentacleSettings
+        {
+            ServerUrl = "https://unit-test-host",
+            ApiKey = "test-key",
+            MachineName = "mars mac",
+            SpaceId = 1
+        };
+
+        // Fast retries so tests don't block the suite.
+        var options = new TentacleRegistrationClientOptions
+        {
+            MaxRetries = 1,
+            InitialDelay = TimeSpan.FromMilliseconds(1),
+            MaxDelay = TimeSpan.FromMilliseconds(1),
+            DelayAsync = (_, _) => Task.CompletedTask,
+            HttpMessageHandlerFactory = () => handler
+        };
+
+        return new TentacleRegistrationClient(settings, "/api/machines/register/tentacle-polling", extraProperties: null, options);
+    }
+
+    private sealed class StubMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => respond(request, cancellationToken);
     }
 }

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/LocalScriptServiceIdempotencyTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/LocalScriptServiceIdempotencyTests.cs
@@ -149,21 +149,26 @@ public sealed class LocalScriptServiceIdempotencyTests : IDisposable
 
         firstAgent.StartScript(command);
 
-        // Poll loop: Process.OutputDataReceived is async and CI runners can be slow
-        // to deliver the first batch. Wait up to 10s for at least one line to show up.
-        var firstPoll = WaitForLogs(() => firstAgent.GetStatus(new ScriptStatusRequest(ticket, 0)), TimeSpan.FromSeconds(10));
-        firstPoll.Logs.Count.ShouldBeGreaterThanOrEqualTo(1, "bash must have emitted at least one line within 10s of start");
+        // Poll loop: Process.OutputDataReceived is async and CI runners can be very
+        // slow to deliver the first batch (Process redirection plumbing through the
+        // .NET runtime). Wait up to 30s for at least one line to show up — the
+        // script's `sleep 60` keeps the process alive so timing out is the only risk.
+        var firstPoll = WaitForLogs(() => firstAgent.GetStatus(new ScriptStatusRequest(ticket, 0)), TimeSpan.FromSeconds(30));
+        firstPoll.Logs.Count.ShouldBeGreaterThanOrEqualTo(1, "bash must have emitted at least one line within 30s of start");
         var cursor = firstPoll.NextLogSequence;
 
         // Simulate agent restart — new LocalScriptService instance sees only the disk state.
         var restartedAgent = CreateService();
         _servicesToDispose.Add(restartedAgent);
 
-        // Give the original process another second to finish emitting all 10 lines.
+        // Up to 30s for all 10 echo lines to flow through the OS pipe, .NET's
+        // OutputDataReceived dispatcher, then SequencedLogWriter's per-line flush.
+        // CI runners (especially Linux containers in GHA) routinely take 5-15s to
+        // settle on this path; 10s was previously flaky on this exact assertion.
         var secondPoll = WaitForAllTenLines(
             firstPoll,
             () => restartedAgent.GetStatus(new ScriptStatusRequest(ticket, cursor)),
-            TimeSpan.FromSeconds(10));
+            TimeSpan.FromSeconds(30));
 
         // Combined output: first + second batch covers all 10 echo lines, no duplicates.
         var allLogText = string.Join(" ", firstPoll.Logs.Concat(secondPoll.Logs).Select(l => l.Text));

--- a/tests/Squid.UnitTests/Services/Machines/MachineInstallScriptServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineInstallScriptServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Squid.Core.Services.Account;
 using Squid.Core.Services.Machines;
+using Squid.Core.Services.Machines.Scripts.Tentacle;
 using Squid.Message.Commands.Account;
 using Squid.Message.Commands.Machine;
 using Squid.Message.Constants;
@@ -12,6 +13,7 @@ public class MachineInstallScriptServiceTests
     private readonly Mock<IAccountService> _accountService = new();
     private readonly Mock<IMachineDataProvider> _machineDataProvider = new();
     private readonly Mock<IAgentVersionProvider> _agentVersionProvider = new();
+    private readonly Mock<ITentacleCommsUrlProbe> _commsUrlProbe = new();
     private readonly MachineScriptService _service;
 
     public MachineInstallScriptServiceTests()
@@ -20,12 +22,18 @@ public class MachineInstallScriptServiceTests
             .Setup(x => x.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CreateApiKeyResponseData { ApiKey = "test-api-key" });
 
+        // Default: probe skipped — individual tests that care can override.
+        _commsUrlProbe
+            .Setup(x => x.ProbeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TentacleCommsProbeResult { Skipped = true, Detail = "Stubbed for unit test" });
+
         _service = new MachineScriptService(
             _accountService.Object,
             _machineDataProvider.Object,
             _agentVersionProvider.Object,
             new Squid.Core.Settings.SelfCert.SelfCertSetting(),
-            []);
+            [],
+            _commsUrlProbe.Object);
     }
 
     private static GenerateKubernetesAgentInstallScriptCommand CreateCommand(
@@ -318,5 +326,97 @@ public class MachineInstallScriptServiceTests
         response.Code.ShouldBe(HttpStatusCode.InternalServerError);
         response.Msg.ShouldContain("Failed to create API key");
         response.Data.ShouldBeNull();
+    }
+
+    // ========================================================================
+    // Polling URL probe — attaches SLB/DNS diagnostic to Tentacle install scripts
+    // so operators catch misconfigurations before shipping scripts to users.
+    // ========================================================================
+
+    [Fact]
+    public async Task GenerateTentacleInstallScript_PollingMode_InvokesProbeAndSurfacesResult()
+    {
+        _commsUrlProbe
+            .Setup(x => x.ProbeAsync("https://polling.example.com:10943", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TentacleCommsProbeResult
+            {
+                Reachable = true,
+                ThumbprintMatches = true,
+                ObservedThumbprint = "FAF04764",
+                Detail = "Reachable. Server cert thumbprint matches (FAF04764)"
+            });
+
+        var response = await _service.GenerateTentacleInstallScriptAsync(new GenerateTentacleInstallScriptCommand
+        {
+            MachineName = "mars-mac",
+            ServerUrl = "https://squid-api.example.com",
+            ServerCommsUrl = "https://polling.example.com:10943",
+            CommunicationMode = "Polling",
+            SpaceId = 1
+        }, CancellationToken.None);
+
+        response.Code.ShouldBe(HttpStatusCode.OK);
+        response.Data.CommsUrlProbe.ShouldNotBeNull();
+        response.Data.CommsUrlProbe.Reachable.ShouldBeTrue();
+        response.Data.CommsUrlProbe.ThumbprintMatches.ShouldBeTrue();
+        response.Data.CommsUrlProbe.ObservedThumbprint.ShouldBe("FAF04764");
+
+        _commsUrlProbe.Verify(
+            x => x.ProbeAsync("https://polling.example.com:10943", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateTentacleInstallScript_ListeningMode_SkipsProbe()
+    {
+        // Listening tentacles have no polling URL — probing is meaningless.
+        var response = await _service.GenerateTentacleInstallScriptAsync(new GenerateTentacleInstallScriptCommand
+        {
+            MachineName = "listening-tentacle",
+            ServerUrl = "https://squid-api.example.com",
+            ServerCommsUrl = "",
+            CommunicationMode = "Listening",
+            ListeningHostName = "tentacle.example.com",
+            ListeningPort = 10933,
+            SpaceId = 1
+        }, CancellationToken.None);
+
+        response.Code.ShouldBe(HttpStatusCode.OK);
+        response.Data.CommsUrlProbe.ShouldNotBeNull();
+        response.Data.CommsUrlProbe.Skipped.ShouldBeTrue();
+        response.Data.CommsUrlProbe.Detail.ShouldContain("Listening");
+
+        _commsUrlProbe.Verify(
+            x => x.ProbeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateTentacleInstallScript_UnreachableComms_SurfacesDiagnosticInResponse()
+    {
+        // This is the failure mode we want to catch at script-generation time
+        // instead of at first-agent-handshake time.
+        _commsUrlProbe
+            .Setup(x => x.ProbeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TentacleCommsProbeResult
+            {
+                Reachable = false,
+                Detail = "SLB accepted TCP but dropped the TLS handshake. Verify: ... 100.64.0.0/10 ..."
+            });
+
+        var response = await _service.GenerateTentacleInstallScriptAsync(new GenerateTentacleInstallScriptCommand
+        {
+            MachineName = "mars-mac",
+            ServerUrl = "https://squid-api.example.com",
+            ServerCommsUrl = "https://polling.example.com:10943",
+            CommunicationMode = "Polling",
+            SpaceId = 1
+        }, CancellationToken.None);
+
+        // Script still generated — probe is advisory, not blocking — but the
+        // diagnostic flows through so the UI can render a warning banner.
+        response.Code.ShouldBe(HttpStatusCode.OK);
+        response.Data.CommsUrlProbe.Reachable.ShouldBeFalse();
+        response.Data.CommsUrlProbe.Detail.ShouldContain("100.64.0.0/10");
     }
 }

--- a/tests/Squid.UnitTests/Services/Machines/MachineRegistrationServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineRegistrationServiceTests.cs
@@ -6,6 +6,7 @@ using Squid.Core.Halibut;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Deployments.Environments;
 using Squid.Core.Services.Machines;
+using Squid.Core.Services.Machines.Exceptions;
 using Squid.Core.Settings.SelfCert;
 using Squid.Message.Commands.Machine;
 using Squid.Message.Models.Deployments.Machine;
@@ -628,13 +629,13 @@ public class MachineRegistrationServiceTests
     }
 
     [Fact]
-    public async Task RegisterSsh_DuplicateNameInSpace_ThrowsInvalidOperation()
+    public async Task RegisterSsh_DuplicateNameInSpace_ThrowsMachineNameConflict()
     {
         _machineDataProvider
             .Setup(x => x.ExistsByNameAsync("duplicate-ssh", 1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+        var ex = await Should.ThrowAsync<MachineNameConflictException>(() =>
             _service.RegisterSshAsync(new RegisterSshCommand
             {
                 MachineName = "duplicate-ssh",
@@ -642,10 +643,41 @@ public class MachineRegistrationServiceTests
                 Host = "host.example.com"
             }, CancellationToken.None));
 
+        ex.MachineName.ShouldBe("duplicate-ssh");
+        ex.SpaceId.ShouldBe(1);
         ex.Message.ShouldContain("duplicate-ssh");
+        // Must derive from InvalidOperationException so old `catch (InvalidOperationException)`
+        // sites in callers still work — verifies non-breaking refactor.
+        ex.ShouldBeAssignableTo<InvalidOperationException>();
         _machineDataProvider.Verify(
             x => x.AddMachineAsync(It.IsAny<Machine>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterTentaclePolling_DuplicateNameInSpace_ThrowsMachineNameConflict()
+    {
+        _machineDataProvider
+            .Setup(x => x.GetMachineBySubscriptionIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Machine)null);
+        _machineDataProvider
+            .Setup(x => x.ExistsByNameAsync("duplicate-tentacle", 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var ex = await Should.ThrowAsync<MachineNameConflictException>(() =>
+            _service.RegisterTentaclePollingAsync(new RegisterTentaclePollingCommand
+            {
+                MachineName = "duplicate-tentacle",
+                SpaceId = 1,
+                Thumbprint = "AABBCCDD",
+                SubscriptionId = "new-sub"
+            }, CancellationToken.None));
+
+        ex.MachineName.ShouldBe("duplicate-tentacle");
+        _machineDataProvider.Verify(
+            x => x.AddMachineAsync(It.IsAny<Machine>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _trustDistributor.Verify(x => x.Reconfigure(), Times.Never);
     }
 
     // ========================================================================

--- a/tests/Squid.UnitTests/Services/Machines/MachineUpgradeScriptServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineUpgradeScriptServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Account;
 using Squid.Core.Services.Machines;
+using Squid.Core.Services.Machines.Scripts.Tentacle;
 using Squid.Message.Commands.Machine;
 using Squid.Message.Models.Deployments.Machine;
 
@@ -13,6 +14,7 @@ public class MachineUpgradeScriptServiceTests
     private readonly Mock<IMachineDataProvider> _machineDataProvider = new();
     private readonly Mock<IAgentVersionProvider> _agentVersionProvider = new();
     private readonly Mock<IAccountService> _accountService = new();
+    private readonly Mock<ITentacleCommsUrlProbe> _commsUrlProbe = new();
     private readonly MachineScriptService _service;
 
     public MachineUpgradeScriptServiceTests()
@@ -22,7 +24,8 @@ public class MachineUpgradeScriptServiceTests
             _machineDataProvider.Object,
             _agentVersionProvider.Object,
             new Squid.Core.Settings.SelfCert.SelfCertSetting(),
-            []);
+            [],
+            _commsUrlProbe.Object);
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/GenerateTentacleInstallScriptServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/GenerateTentacleInstallScriptServiceTests.cs
@@ -14,12 +14,17 @@ public class GenerateTentacleInstallScriptServiceTests
     private readonly Mock<IAccountService> _accountService = new();
     private readonly Mock<IMachineDataProvider> _machineDataProvider = new();
     private readonly Mock<IAgentVersionProvider> _agentVersionProvider = new();
+    private readonly Mock<ITentacleCommsUrlProbe> _commsUrlProbe = new();
 
     public GenerateTentacleInstallScriptServiceTests()
     {
         _accountService
             .Setup(x => x.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CreateApiKeyResponseData { ApiKey = "API-TEST" });
+
+        _commsUrlProbe
+            .Setup(x => x.ProbeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TentacleCommsProbeResult { Skipped = true, Detail = "Stubbed for unit test" });
     }
 
     [Fact]
@@ -108,7 +113,8 @@ public class GenerateTentacleInstallScriptServiceTests
             _machineDataProvider.Object,
             _agentVersionProvider.Object,
             new Squid.Core.Settings.SelfCert.SelfCertSetting(),
-            builders);
+            builders,
+            _commsUrlProbe.Object);
     }
 
     private sealed class FakeBuilder : ITentacleInstallScriptBuilder

--- a/tests/Squid.UnitTests/Services/Machines/TentacleCommsUrlProbeTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/TentacleCommsUrlProbeTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Squid.Core.Services.Machines.Scripts.Tentacle;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// Behavioural coverage for <see cref="TentacleCommsUrlProbe"/>. The probe's job
+/// is to turn operator-side network misconfigurations into actionable errors at
+/// install-script-generation time rather than at first-Tentacle-handshake time.
+///
+/// <para>Listening-mode registration has no polling URL, so we only exercise
+/// the Polling path here. The probe must distinguish three outcomes:</para>
+/// <list type="bullet">
+/// <item>Skipped — operator didn't supply a comms URL yet (blank)</item>
+/// <item>Unreachable — DNS / TCP / TLS failed (each with its own remediation hint)</item>
+/// <item>Reachable — TLS handshake succeeded, thumbprint may or may not match expected</item>
+/// </list>
+/// </summary>
+public sealed class TentacleCommsUrlProbeTests : IDisposable
+{
+    private readonly TentacleCommsUrlProbe _probe = new();
+    private readonly List<IDisposable> _resources = new();
+
+    public void Dispose()
+    {
+        foreach (var d in _resources) d.Dispose();
+    }
+
+    [Fact]
+    public async Task Probe_EmptyUrl_ReturnsSkipped()
+    {
+        var result = await _probe.ProbeAsync(commsUrl: "", expectedServerThumbprint: "AABB", CancellationToken.None);
+
+        result.Skipped.ShouldBeTrue();
+        result.Reachable.ShouldBeFalse();
+        result.Detail.ShouldContain("not configured");
+    }
+
+    [Fact]
+    public async Task Probe_MalformedUrl_ReturnsUnreachableWithRemediation()
+    {
+        var result = await _probe.ProbeAsync(commsUrl: "not-a-url", expectedServerThumbprint: "AABB", CancellationToken.None);
+
+        result.Reachable.ShouldBeFalse();
+        result.Skipped.ShouldBeFalse();
+        result.Detail.ShouldContain("not a valid");
+    }
+
+    [Fact]
+    public async Task Probe_UnreachableHost_ReturnsRemediationHintWithChecklist()
+    {
+        // Port 1 is almost certainly closed; TCP connect will fail fast.
+        var result = await _probe.ProbeAsync(
+            commsUrl: "https://127.0.0.1:1/",
+            expectedServerThumbprint: "DEADBEEF",
+            CancellationToken.None);
+
+        result.Reachable.ShouldBeFalse();
+        result.ObservedThumbprint.ShouldBeEmpty();
+        // Hint must surface the most common root causes so operators know where to look
+        // without digging through Seq — same signals we'd share in CLAUDE.md.
+        result.Detail.ShouldContain("100.64.0.0/10");
+        result.Detail.ShouldContain("TCP");
+        result.Detail.ShouldContain("health check");
+    }
+
+    [Fact]
+    public async Task Probe_ReachableTlsEndpointWithMatchingThumbprint_ReportsMatch()
+    {
+        using var cert = BuildSelfSignedCert();
+        var expectedThumbprint = cert.Thumbprint; // uppercase hex by default in .NET
+        var port = StartTlsEchoServer(cert);
+        // Give the background accept loop a tick to be ready.
+        await Task.Delay(50);
+
+        var result = await _probe.ProbeAsync(
+            commsUrl: $"https://127.0.0.1:{port}/",
+            expectedServerThumbprint: expectedThumbprint,
+            CancellationToken.None);
+
+        result.Reachable.ShouldBeTrue(customMessage: $"Detail was: {result.Detail}");
+        result.ThumbprintMatches.ShouldBeTrue();
+        result.ObservedThumbprint.ShouldBe(expectedThumbprint, StringCompareShould.IgnoreCase);
+        result.Detail.ShouldContain("matches");
+    }
+
+    [Fact]
+    public async Task Probe_ReachableTlsEndpointWithWrongThumbprint_ReportsMismatch()
+    {
+        using var cert = BuildSelfSignedCert();
+        var port = StartTlsEchoServer(cert);
+
+        var result = await _probe.ProbeAsync(
+            commsUrl: $"https://127.0.0.1:{port}/",
+            expectedServerThumbprint: "BAADF00DBAADF00DBAADF00DBAADF00DBAADF00D",
+            CancellationToken.None);
+
+        result.Reachable.ShouldBeTrue();
+        result.ThumbprintMatches.ShouldBeFalse();
+        // Hint tells operator the typical cause: L7 proxy re-signing the cert
+        result.Detail.ShouldContain("passthrough");
+    }
+
+    // ============================================================================
+    // Test helpers
+    // ============================================================================
+
+    private static X509Certificate2 BuildSelfSignedCert()
+    {
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest("CN=comms-probe-test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(5));
+        // Round-trip through PFX so the private key is retained across usage sites.
+        var pfx = cert.Export(X509ContentType.Pfx);
+        return X509CertificateLoader.LoadPkcs12(pfx, password: null);
+    }
+
+    private int StartTlsEchoServer(X509Certificate2 cert)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, port: 0);
+        listener.Start();
+        _resources.Add(new ListenerHandle(listener));
+
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                while (true)
+                {
+                    var client = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
+                    _ = Task.Run(async () => await HandleClientAsync(client, cert).ConfigureAwait(false));
+                }
+            }
+            catch (ObjectDisposedException) { /* listener stopped */ }
+            catch (SocketException) { /* listener stopped */ }
+        });
+
+        return port;
+    }
+
+    // Handles one TCP connection: authenticates as TLS server, then keeps the
+    // socket open briefly so the client can read the presented certificate
+    // before we tear down (probe reads cert IMMEDIATELY after handshake, but a
+    // too-quick close can race on some kernels and surface as a handshake
+    // failure on the client side).
+    private static async Task HandleClientAsync(TcpClient client, X509Certificate2 cert)
+    {
+        try
+        {
+            await using var ssl = new SslStream(client.GetStream(), leaveInnerStreamOpen: false);
+            await ssl.AuthenticateAsServerAsync(
+                new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = cert,
+                    ClientCertificateRequired = false
+                }, CancellationToken.None).ConfigureAwait(false);
+
+            // Keep the connection alive long enough for the probe to finish
+            // reading RemoteCertificate on the client side.
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Expected: probe disconnects right after handshake.
+        }
+        finally
+        {
+            client.Dispose();
+        }
+    }
+
+    private sealed class ListenerHandle(TcpListener listener) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { listener.Stop(); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
409 on name conflict, body-code va…idation, install-script probe, K8s runbook

Closes the root causes and guardrails for the 2026-04-18 production incident where a Tentacle registered successfully (HTTP 200) but polling loop-failed with opaque EOF errors because:
  1. server returned HTTP 200 + body{code:500} on duplicate-machine-name, which the client mistook for success;
  2. the generated install script embedded a polling URL that was externally unreachable (SLB health check mis-configured + node security group missing 100.64.0.0/10 ingress rule);
  3. no documentation / runbook existed to tell operators which network preconditions Halibut polling actually requires.

Code changes (non-breaking — MachineNameConflictException derives from InvalidOperationException so existing catch sites keep working):

  • MachineNameConflictException with MachineName + SpaceId context
  • EnsureUniqueNameAsync throws the new exception instead of raw
    InvalidOperationException
  • GlobalExceptionFilter maps MachineNameConflictException → HTTP 409
  • TentacleRegistrationClient now validates body `code` (not only HTTP
    status), plus enforces MachineId > 0 && ServerThumbprint != empty
    before declaring "Registration successful"
  • Optional HttpMessageHandlerFactory test seam on
    TentacleRegistrationClientOptions
  • New ITentacleCommsUrlProbe + TentacleCommsUrlProbe: TCP+TLS probe with
    actionable remediation hints baked into Detail
  • MachineScriptService.GenerateTentacleInstallScriptAsync runs the probe
    and attaches result to response; UI can now render a warning banner
    instead of silently handing out a broken script
  • GenerateTentacleInstallScriptData carries new TentacleCommsProbeInfo

Docs:
  • CLAUDE.md adds "Kubernetes Deployment — Exposing Halibut Polling"
    section with full yaml, SG rule, diagnostic commands, failure matrix
  • deploy/k8s-network-requirements.md runbook for operators (independent
    of developer-facing CLAUDE.md), covering all 5 debugging steps used in
    the 2026-04-18 incident

Tests (all green: UnitTests 4052, Tentacle.Tests 1002, Calamari 115, Watchdog 17 = 5186 total):
  • RegisterSsh + RegisterTentaclePolling duplicate-name → 409 regression
    tests
  • TentacleRegistrationClient: Http200+bodyCode500, Http409, Http200+
    emptyData, Http200+goodData, 4xx-not-retried
  • TentacleCommsUrlProbe: empty URL, malformed URL, unreachable host
    (asserts remediation hint mentions 100.64.0.0/10), in-proc TLS server
    with matching + mismatching thumbprint
  • MachineInstallScriptService: polling-mode invokes probe, listening-
    mode skips, unreachable probe surfaces to response