### PR TITLE
Phase 12.J.E.5 — healthcheck retries env-var override (Rule 8)

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -106,6 +106,10 @@ $EXPECTED_SHA256  = '{{EXPECTED_SHA256}}'
 $INSTALL_DIR      = '{{INSTALL_DIR}}'
 $SERVICE_NAME     = '{{SERVICE_NAME}}'
 $HEALTHCHECK_URL  = '{{HEALTHCHECK_URL}}'
+# Retry count substituted as a numeric literal (no quotes) — `[int]` cast
+# would fail on a quoted-and-cast empty string if the placeholder ever
+# defaults to empty.
+$HEALTHCHECK_RETRIES = {{HEALTHCHECK_RETRIES}}
 
 #  contract: %ProgramData%\Squid\Tentacle\upgrade\
 $STATUS_DIR  = Join-Path $env:ProgramData 'Squid\Tentacle\upgrade'
@@ -415,11 +419,21 @@ try {
     }
 
     # ── Health check ────────────────────────────────────────────────────────
-    Append-UpgradeLog "[upgrade] Waiting for healthcheck $HEALTHCHECK_URL"
+    # Retry count is server-substituted per dispatch (default 30 attempts ×
+    # 2s sleep = 60s wait window, see WindowsTentacleUpgradeStrategy.DefaultHealthcheckRetries).
+    # Operator override via SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_RETRIES
+    # env var on the SERVER side: deployments with slow-starting agents
+    # (heavy plugin enumeration, >60s) set this to 90 (3 min) so the wait
+    # is realistic for their environment without changing default behaviour.
+    # Tests set retries=1 to bypass the wait entirely (the test service
+    # doesn't expose HTTP, so every poll attempt 404s and the wait is pure
+    # cost). Pinned by `WindowsTentacleUpgradeStrategyTests.HealthcheckRetriesEnvVar_*`.
+    $totalWaitSeconds = $HEALTHCHECK_RETRIES * 2
+    Append-UpgradeLog "[upgrade] Waiting for healthcheck $HEALTHCHECK_URL (max $HEALTHCHECK_RETRIES attempts × 2s = ${totalWaitSeconds}s)"
 
     $healthOk = $false
 
-    for ($i = 0; $i -lt 30; $i++) {
+    for ($i = 0; $i -lt $HEALTHCHECK_RETRIES; $i++) {
         Start-Sleep -Seconds 2
 
         try {
@@ -436,7 +450,7 @@ try {
     }
 
     if (-not $healthOk) {
-        Append-UpgradeLog "::warning:: Healthcheck didn't respond within 60s — proceeding anyway, server will retry on next health probe"
+        Append-UpgradeLog "::warning:: Healthcheck didn't respond within ${totalWaitSeconds}s — proceeding anyway, server will retry on next health probe"
     }
 
     Write-UpgradeStatus -Status 'SUCCESS' -InstallMethod $INSTALL_METHOD -Detail "Upgrade to $TARGET_VERSION complete"

--- a/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
@@ -96,8 +96,37 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
     /// </summary>
     public const string HealthcheckUrlEnvVar = "SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_URL";
 
+    /// <summary>
+    /// Operator override for the post-restart healthcheck poll count.
+    /// Default <see cref="DefaultHealthcheckRetries"/> (30) × 2s sleep =
+    /// 60s wait window; tests override to 1 to bypass the death-wait
+    /// (<see cref="LocalReleaseMirror"/> healthcheck endpoint is intentionally
+    /// unreachable in the lifecycle E2E since the test service doesn't
+    /// expose HTTP — every Phase B run currently sits in the 60s loop
+    /// before the .ps1's "::warning::" + proceed path fires).
+    ///
+    /// <para><b>Air-gap operator value</b>: deployments with slow-starting
+    /// services (e.g. heavy plugin enumeration on first run, &gt;60s) get
+    /// false-warnings every upgrade today; setting this to 90 (3 min) makes
+    /// the post-restart wait realistic for those environments without
+    /// changing default behaviour.</para>
+    ///
+    /// <para>Pinned per Rule 8 by
+    /// <c>WindowsTentacleUpgradeStrategyTests.HealthcheckRetriesEnvVar_ConstantNamePinned</c>.</para>
+    /// </summary>
+    public const string HealthcheckRetriesEnvVar = "SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_RETRIES";
+
     private const string DefaultDownloadBaseUrl = "https://github.com/SolarifyDev/Squid/releases/download";
     private const string DefaultHealthcheckUrl = "http://127.0.0.1:8080/healthz";
+
+    /// <summary>
+    /// Default healthcheck poll count. 30 × 2s sleep per attempt = 60s
+    /// total wait window after Start-Service. Generous enough for stock
+    /// agent boot (~3-5s) plus runtime / plugin warmup (~10-30s) on
+    /// reasonable hardware. Operators with slower starts override via
+    /// <see cref="HealthcheckRetriesEnvVar"/>.
+    /// </summary>
+    internal const int DefaultHealthcheckRetries = 30;
 
     /// <summary>
     /// Wall-clock cap for a single upgrade dispatch. Mirrors Linux's
@@ -351,6 +380,7 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
             .Replace("{{INSTALL_DIR}}", DefaultInstallDir, StringComparison.Ordinal)
             .Replace("{{SERVICE_NAME}}", DefaultServiceName, StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_URL}}", ResolveHealthcheckUrl(), StringComparison.Ordinal)
+            .Replace("{{HEALTHCHECK_RETRIES}}", ResolveHealthcheckRetries().ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
             .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
     }
 
@@ -540,6 +570,33 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
         var raw = System.Environment.GetEnvironmentVariable(HealthcheckUrlEnvVar);
 
         return string.IsNullOrWhiteSpace(raw) ? DefaultHealthcheckUrl : raw.Trim().TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Resolves the post-restart healthcheck poll count. Defaults to
+    /// <see cref="DefaultHealthcheckRetries"/> (30 × 2s = 60s window).
+    /// Invalid values (negative, non-numeric) silently fall back to default
+    /// — operator-friendly: a typo'd env var doesn't break upgrades, just
+    /// uses the safe default.
+    /// </summary>
+    internal static int ResolveHealthcheckRetries()
+    {
+        var raw = System.Environment.GetEnvironmentVariable(HealthcheckRetriesEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultHealthcheckRetries;
+
+        if (!int.TryParse(raw.Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            || parsed < 1)
+        {
+            Log.Warning(
+                "[Upgrade] {EnvVar} is set to an invalid value ('{Value}'). " +
+                "Must be a positive integer (number of 2-second poll attempts). " +
+                "Falling back to default of {Default}.",
+                HealthcheckRetriesEnvVar, raw, DefaultHealthcheckRetries);
+            return DefaultHealthcheckRetries;
+        }
+
+        return parsed;
     }
 
     // ── Embedded script loading ──────────────────────────────────────────────

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -45,20 +45,24 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
 {
     private readonly string _previousBaseUrlOverride;
     private readonly string _previousHealthcheckUrlOverride;
+    private readonly string _previousHealthcheckRetriesOverride;
 
     public WindowsTentacleUpgradeStrategyTests()
     {
         _previousBaseUrlOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar);
         _previousHealthcheckUrlOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar);
+        _previousHealthcheckRetriesOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar);
 
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar, null);
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, null);
     }
 
     public void Dispose()
     {
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, _previousBaseUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar, _previousHealthcheckUrlOverride);
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, _previousHealthcheckRetriesOverride);
     }
 
     // ========================================================================
@@ -124,6 +128,71 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
     {
         WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar
             .ShouldBe("SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_URL");
+    }
+
+    [Fact]
+    public void HealthcheckRetriesEnvVar_ConstantNamePinned()
+    {
+        // Renaming this constant breaks every air-gapped operator who pinned
+        // a slow-startup retry count via env. Hard-pin the literal.
+        WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar
+            .ShouldBe("SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_RETRIES");
+    }
+
+    [Fact]
+    public void ResolveHealthcheckRetries_NoEnvVar_ReturnsDefault30()
+    {
+        // Default 30 attempts × 2s = 60s wait window. Pin the default so a
+        // future polish that "tightens" or "loosens" the wait surfaces in
+        // review (operator-impacting change → must be intentional).
+        WindowsTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(30);
+    }
+
+    [Theory]
+    [InlineData("1", 1)]                 // tests use this to bypass the wait
+    [InlineData("90", 90)]               // air-gap operator with slow-starting plugin host
+    [InlineData("  45  ", 45)]           // whitespace tolerant
+    [InlineData("3600", 3600)]           // 2h wait — extreme but allowed
+    public void ResolveHealthcheckRetries_ValidValue_RoundTripsAsInteger(string envValue, int expected)
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, envValue);
+
+        WindowsTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0")]                    // 0 is invalid (would skip the wait entirely on a logical level — not what operators mean)
+    [InlineData("-1")]                   // negative is invalid
+    [InlineData("not-a-number")]         // typo
+    [InlineData("3.14")]                 // non-integer
+    [InlineData("inf")]                  // float-special
+    public void ResolveHealthcheckRetries_InvalidValue_FallsBackToDefault(string envValue)
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, envValue);
+
+        // Operator-friendly: a typo'd env var must NOT break upgrades; falls
+        // back to the safe 30-attempt default with a Serilog warning so
+        // operators see the typo on their next dispatch.
+        WindowsTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(30);
+    }
+
+    [Fact]
+    public void RenderInnerScript_HealthcheckRetriesPlaceholder_SubstitutedFromEnv()
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, "5");
+
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        // Direct substitution: the placeholder gets the resolved value as
+        // a numeric literal (no quotes / no [int] cast — see .ps1 comment).
+        inner.ShouldContain("$HEALTHCHECK_RETRIES = 5",
+            customMessage: "RenderInnerScript MUST substitute the env-resolved retry count into the script. " +
+                          "If this fails: the placeholder wasn't wired through Replace, OR the .ps1 dropped the variable assignment line.");
+
+        // The previously-hardcoded 60s wait message should NOT remain in
+        // the inner — the new dynamic wait message uses the variable.
+        inner.ShouldNotContain("within 60s",
+            customMessage: "stale '60s' literal in the .ps1 — should reference $HEALTHCHECK_RETRIES * 2 dynamically so air-gap operators with retries=90 see the correct wait window");
     }
 
     [Fact]
@@ -314,7 +383,8 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var strategySubstituted = new[]
         {
             "TARGET_VERSION", "DOWNLOAD_URL", "EXPECTED_SHA256",
-            "INSTALL_DIR", "SERVICE_NAME", "HEALTHCHECK_URL", "INSTALL_METHODS"
+            "INSTALL_DIR", "SERVICE_NAME", "HEALTHCHECK_URL", "HEALTHCHECK_RETRIES",
+            "INSTALL_METHODS"
         };
 
         foreach (var name in strategySubstituted)

--- a/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -689,6 +689,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         {
             "DOWNLOAD_URL",
             "EXPECTED_SHA256",
+            "HEALTHCHECK_RETRIES",
             "HEALTHCHECK_URL",
             "INSTALL_DIR",
             "INSTALL_METHODS",
@@ -836,6 +837,17 @@ public sealed class TentacleUpgradeLifecycleE2ETests
             // healthcheck never responds).
             var healthcheckUrl = "http://127.0.0.1:1/healthz";
 
+            // HEALTHCHECK_RETRIES: 1 attempt (= 2s wait) for tests. Default
+            // 30 attempts × 2s = 60s wait window in production; tests don't
+            // need to exercise the wait itself, just that the .ps1 proceeds
+            // past the warning. Cuts ~58s per test → CI runtime drops from
+            // 2m+ per lifecycle test to ~30s. Pinned by the
+            // `RenderInnerScript_HealthcheckRetriesPlaceholder_*` unit test.
+            // Substituted as a numeric literal (matches the .ps1's
+            // `$HEALTHCHECK_RETRIES = {{HEALTHCHECK_RETRIES}}` line — no
+            // quotes / no [int] cast).
+            const string healthcheckRetries = "1";
+
             return template
                 .Replace("{{TARGET_VERSION}}", targetVersion, StringComparison.Ordinal)
                 .Replace("{{DOWNLOAD_URL}}", downloadUrl, StringComparison.Ordinal)
@@ -843,6 +855,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
                 .Replace("{{INSTALL_DIR}}", Fixture.InstallDir, StringComparison.Ordinal)
                 .Replace("{{SERVICE_NAME}}", Fixture.ServiceName, StringComparison.Ordinal)
                 .Replace("{{HEALTHCHECK_URL}}", healthcheckUrl, StringComparison.Ordinal)
+                .Replace("{{HEALTHCHECK_RETRIES}}", healthcheckRetries, StringComparison.Ordinal)
                 .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
         }
 


### PR DESCRIPTION
## Summary

Production hardening + CI speedup. Adds `SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_RETRIES` env-var override following the established Rule 8 pattern (e.g. `SQUID_TARGET_WINDOWS_TENTACLE_DOWNLOAD_BASE_URL`).

## Operator value

Deployments with slow-starting agents (heavy plugin enumeration, runtime warmup, >60s startup) get false `healthcheck didn't respond` warnings on every upgrade today. This PR lets such operators set a longer wait window without changing default behaviour for everyone else.

Example: `SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_RETRIES=90` → 90 attempts × 2s = 180s wait.

## CI value

J.E.3 + J.E.4 lifecycle E2E tests each spent ~60s in the hardcoded healthcheck wait loop (test service doesn't expose HTTP → every poll 404'd → all 30 retries × 2s elapsed before the `.ps1`'s `::warning::` + proceed path fired). Setting `retries=1` in the test render cuts this to ~2s per test.

**Expected E1.h drop from 2m2s to ~25s; multi-test suite drops by ~5 min.**

## Changes

| File | Change |
|---|---|
| `WindowsTentacleUpgradeStrategy.cs` | `public const HealthcheckRetriesEnvVar`, `internal const DefaultHealthcheckRetries = 30`, `ResolveHealthcheckRetries()` with positive-integer validation + fallback-with-warning, `{{HEALTHCHECK_RETRIES}}` substitution wired in `RenderInnerScript` |
| `upgrade-windows-tentacle.ps1` | `$HEALTHCHECK_RETRIES` variable replaces hardcoded `30`; warning message uses dynamic `$totalWaitSeconds` instead of stale `60s` literal |
| `WindowsTentacleUpgradeStrategyTests.cs` | 5 new unit tests + 2 drift detector updates |
| `TentacleUpgradeLifecycleE2ETests.cs` | E2E renders set `HEALTHCHECK_RETRIES=1` to bypass the wait |

## Unit tests (5 new)

1. `HealthcheckRetriesEnvVar_ConstantNamePinned` — Rule 8 pin against silent rename breaking pre-pinned operators
2. `ResolveHealthcheckRetries_NoEnvVar_ReturnsDefault30` — pin the default so a future "tighten / loosen" change surfaces in review
3. `ResolveHealthcheckRetries_ValidValue_RoundTripsAsInteger` (Theory) — 1 / 90 / whitespace-padded / 3600 all parse correctly
4. `ResolveHealthcheckRetries_InvalidValue_FallsBackToDefault` (Theory) — 0 / -1 / non-numeric / float → default-30 with warning (operator-friendly: typo'd env doesn't break upgrades)
5. `RenderInnerScript_HealthcheckRetriesPlaceholder_SubstitutedFromEnv` — end-to-end strategy injection AND asserts stale '60s' literal is gone

## Drift detectors updated

- `WindowsTentacleUpgradeStrategyTests.RenderInnerScript_PlaceholderTokens_AppearExactlyOnceInTemplate` now expects `HEALTHCHECK_RETRIES`
- `TentacleUpgradeLifecycleE2ETests.UpgradeScript_PlaceholderSet_PinnedToProductionContract` same — caught my own miss on first run

## Local verification

- 212/212 unit tests pass
- 84/84 cross-platform E2E tests pass
- Will verify on Windows runner that lifecycle suite drops from ~5 min to ~1 min

## Foundation for J.E.6

The next phase (rollback logic in `.ps1`) needs to distinguish "healthcheck slow" (retry warning, proceed) from "service genuinely dead" (rollback). The retries override is the test seam that makes this distinction testable without each E2E sitting 60s in a fixed wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)