### PR TITLE
Phase 12.J.E.6 — auto-rollback on Phase B failure (E7.u1)

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -58,6 +58,7 @@
 #   3   — missing binary in extracted archive
 #   5   — insufficient disk space
 #   7   — SHA256 mismatch (only when EXPECTED_SHA256 is non-empty)
+#   8   — Start-Service post-swap failed → rollback fired (J.E.6)
 #   12  — Windows version too old (PowerShell 5.0+ required, Server 2016+)
 #   13  — failed to acquire upgrade lock (concurrent upgrade in progress)
 #   14  — no install method succeeded (zip + future chocolatey/MSI all skipped or failed)
@@ -155,6 +156,106 @@ function Append-UpgradeLog {
     $stamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
     Add-Content -Path $LOG_FILE -Value "[$stamp] $Line"
     Write-Host $Line
+}
+
+# ── Rollback helper (J.E.6) ──────────────────────────────────────────────────
+# Restores the previous binary from .bak when Phase B can't bring the new
+# binary up. Three failure modes drive this:
+#   1. Start-Service throws (new binary's OnStart raised → SCM 1067 / "the
+#      service did not start in a timely fashion"). E.g., new binary has a
+#      broken DI graph that throws at construction time.
+#   2. Service start succeeded but new binary's healthcheck never returned
+#      200 within $HEALTHCHECK_RETRIES * 2 seconds — currently a warning
+#      (matches Octopus Tentacle's behaviour: capabilities probe will detect
+#      a missing version on the next health probe). A future env-var-gated
+#      "fatal" mode will make this a rollback trigger.
+#   3. Move-Item swap failed (rare: file in use, permission). Phase A
+#      already validated $extractDir exists; the only Move-Item failure
+#      mode here is filesystem-level. Best-effort: try restore.
+#
+# Rollback assumes: $bakDir, $INSTALL_DIR, $SERVICE_NAME, $INSTALL_METHOD,
+# $TARGET_VERSION are in scope (defined earlier in Phase A / Phase B).
+#
+# Status writes:
+#   - ROLLED_BACK              — clean restoration: old service is RUNNING again
+#   - ROLLBACK_NEEDED          — no .bak available (somehow), can't auto-restore
+#   - ROLLBACK_CRITICAL_FAILED — restored .bak but old service won't start either
+function Invoke-Rollback {
+    param(
+        [Parameter(Mandatory)] [string] $Reason,
+        [Parameter(Mandatory)] [int]    $ExitCode
+    )
+
+    Append-UpgradeLog "::warning:: [rollback] Initiating rollback: $Reason"
+
+    # Stop new service first if it managed to come up (degraded but running).
+    # Best-effort — SCM may already have force-killed it.
+    try {
+        $svc = Get-Service -Name $SERVICE_NAME -ErrorAction SilentlyContinue
+        if ($null -ne $svc -and $svc.Status -ne 'Stopped') {
+            Append-UpgradeLog "[rollback] Stopping new service (current state: $($svc.Status))"
+            Stop-Service -Name $SERVICE_NAME -Force -ErrorAction SilentlyContinue
+            $svc.WaitForStatus('Stopped', '00:00:30')
+        }
+    } catch {
+        Append-UpgradeLog "[rollback] Couldn't cleanly stop new service: $($_.Exception.Message). Proceeding with restore — Move-Item might still succeed if SCM has released the binary."
+    }
+
+    # Resolve the .bak path the same way Phase B's backup step did.
+    $installParent = Split-Path -Parent $INSTALL_DIR
+    $installLeaf = Split-Path -Leaf $INSTALL_DIR
+    $bakDir = Join-Path $installParent "$installLeaf.bak"
+
+    if (-not (Test-Path $bakDir)) {
+        Append-UpgradeLog "::error:: [rollback] No .bak directory at $bakDir — cannot auto-restore. Operator must manually reinstall."
+        Write-UpgradeStatus -Status 'ROLLBACK_NEEDED' -InstallMethod $INSTALL_METHOD -Detail "Failure: $Reason. No .bak available — manual reinstall required." -ExitCode $ExitCode
+        exit $ExitCode
+    }
+
+    # Move new (broken) binary aside so the restore Move-Item has a clean
+    # destination. Use a `.failed` suffix so the operator can inspect the
+    # broken binary post-mortem if they want.
+    $failedDir = Join-Path $installParent "$installLeaf.failed"
+    try {
+        if (Test-Path $failedDir) {
+            Remove-Item -Path $failedDir -Recurse -Force
+        }
+        if (Test-Path $INSTALL_DIR) {
+            Append-UpgradeLog "[rollback] Moving broken $INSTALL_DIR → $failedDir for post-mortem"
+            Move-Item -Path $INSTALL_DIR -Destination $failedDir -Force
+        }
+    } catch {
+        Append-UpgradeLog "::error:: [rollback] Couldn't archive broken binary: $($_.Exception.Message). Restore may fail next step."
+    }
+
+    # Restore .bak → INSTALL_DIR.
+    try {
+        Append-UpgradeLog "[rollback] Restoring $bakDir → $INSTALL_DIR"
+        Move-Item -Path $bakDir -Destination $INSTALL_DIR -Force
+    } catch {
+        Append-UpgradeLog "::error:: [rollback] Restore Move-Item failed: $($_.Exception.Message)"
+        Write-UpgradeStatus -Status 'ROLLBACK_CRITICAL_FAILED' -InstallMethod $INSTALL_METHOD -Detail "Restore failed: $($_.Exception.Message). Failure: $Reason. Broken binary at $failedDir." -ExitCode $ExitCode
+        exit $ExitCode
+    }
+
+    # Restart old service.
+    try {
+        Append-UpgradeLog "[rollback] Starting service (old binary)"
+        Start-Service -Name $SERVICE_NAME
+
+        # Wait for SCM to confirm RUNNING — synchronous proof that the old
+        # service is genuinely back up before we report ROLLED_BACK.
+        $svc = Get-Service -Name $SERVICE_NAME
+        $svc.WaitForStatus('Running', '00:00:30')
+
+        Append-UpgradeLog "[rollback] Service running (old binary)"
+        Write-UpgradeStatus -Status 'ROLLED_BACK' -InstallMethod $INSTALL_METHOD -Detail "Rolled back from failed upgrade. Reason: $Reason. Broken binary preserved at $failedDir for inspection." -ExitCode $ExitCode
+    } catch {
+        Append-UpgradeLog "::error:: [rollback] Old service won't start after restore: $($_.Exception.Message)"
+        Write-UpgradeStatus -Status 'ROLLBACK_CRITICAL_FAILED' -InstallMethod $INSTALL_METHOD -Detail "Restored .bak but old service won't start: $($_.Exception.Message). Original failure: $Reason." -ExitCode $ExitCode
+    }
+
+    exit $ExitCode
 }
 
 # ── Idempotency: lock file ───────────────────────────────────────────────────
@@ -412,10 +513,29 @@ try {
         Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Binary swapped — restarting service"
     }
 
-    # Start the service (may already be running for first-install path)
+    # Start the service (may already be running for first-install path).
+    # Wrap in try/catch — if the new binary's OnStart throws (e.g. SCM 1067
+    # "service did not start in a timely fashion"), call Invoke-Rollback so
+    # the agent recovers to the old binary instead of being left in a half-
+    # swapped Stopped state. Wait for RUNNING state too — Start-Service
+    # returns when SCM accepts the start command, but the actual process
+    # OnStart may still throw a few seconds later. WaitForStatus surfaces
+    # that synchronously so the catch is reachable.
     if ($null -ne (Get-Service -Name $SERVICE_NAME -ErrorAction SilentlyContinue)) {
         Append-UpgradeLog "[upgrade] Starting service $SERVICE_NAME"
-        Start-Service -Name $SERVICE_NAME
+        try {
+            Start-Service -Name $SERVICE_NAME
+
+            $svcVerify = Get-Service -Name $SERVICE_NAME
+            $svcVerify.WaitForStatus('Running', '00:00:30')
+
+            Append-UpgradeLog "[upgrade] Service $SERVICE_NAME reached RUNNING state"
+        } catch {
+            # Auto-rollback to old binary. Reason is captured for operator
+            # diagnostics in last-upgrade.json + upgrade.log. Exit 8 is the
+            # documented "Start-Service post-swap failed" code.
+            Invoke-Rollback -Reason "Start-Service post-swap failed: $($_.Exception.Message)" -ExitCode 8
+        }
     }
 
     # ── Health check ────────────────────────────────────────────────────────

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -428,6 +428,75 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
     // no test actually ran the rendered .ps1 through to the verify step.
     // ========================================================================
 
+    // ========================================================================
+    // J.E.6 — auto-rollback contract
+    //
+    // The .ps1 MUST roll back to the previous binary if Phase B's
+    // post-swap Start-Service throws (new binary's OnStart raised → SCM
+    // marks service as failed). Without rollback, a failed upgrade leaves
+    // the operator with INSTALL_DIR holding a broken binary + service in
+    // Stopped state. With rollback, the agent auto-recovers to the
+    // previous version and the operator sees ROLLED_BACK status in the UI.
+    //
+    // E2E coverage: TentacleUpgradeLifecycleE2ETests.E7u1_*.
+    // This unit test pins the structural shape of the rollback contract
+    // (function exists in template, key operations present, status enum
+    // used) so a future polish that drops the rollback path is caught at
+    // build time, not at the next operator-broken-upgrade incident.
+    // ========================================================================
+
+    [Fact]
+    public void RenderInnerScript_RollbackContract_PinnedStructurally()
+    {
+        var asm = typeof(WindowsTentacleUpgradeStrategy).Assembly;
+        using var stream = asm.GetManifestResourceStream("Squid.Core.Resources.Upgrade.upgrade-windows-tentacle.ps1")
+            ?? throw new System.IO.InvalidDataException("embedded template not found");
+        using var reader = new System.IO.StreamReader(stream);
+        var template = reader.ReadToEnd();
+
+        // 1. The Invoke-Rollback function MUST exist.
+        template.ShouldContain("function Invoke-Rollback",
+            customMessage: "Invoke-Rollback function REGRESSED. " +
+                          "Without this, a failed upgrade leaves the operator's INSTALL_DIR holding a broken binary + service Stopped → manual SSH-and-restore required across every machine. " +
+                          "Restore via the J.E.6 commit's pattern: function Invoke-Rollback { Stop-Service → archive broken to .failed → Move .bak → INSTALL_DIR → Start-Service old → write ROLLED_BACK }.");
+
+        // 2. Start-Service post-swap MUST be wrapped in try/catch calling Invoke-Rollback.
+        // String search for the exact pattern is brittle to whitespace; pin
+        // the key tokens that MUST coexist in the start-service block.
+        template.ShouldContain("Start-Service -Name $SERVICE_NAME",
+            customMessage: "Start-Service call REGRESSED — Phase B no longer attempts to start the new binary");
+        template.ShouldContain("Invoke-Rollback -Reason \"Start-Service post-swap failed",
+            customMessage: "Start-Service catch path MUST call Invoke-Rollback. " +
+                          "If absent: a Start-Service exception bubbles to the outer catch which writes 'Unexpected failure' status with exit 14 — broken binary stays in INSTALL_DIR.");
+
+        // 3. ROLLED_BACK status enum is the documented happy-path-of-rollback outcome.
+        template.ShouldContain("Write-UpgradeStatus -Status 'ROLLED_BACK'",
+            customMessage: "ROLLED_BACK status emit REGRESSED — operator UI would show generic FAILED instead of the actionable rollback marker");
+
+        // 4. ROLLBACK_CRITICAL_FAILED is the worst-case status (rollback restored .bak but old service won't start).
+        template.ShouldContain("'ROLLBACK_CRITICAL_FAILED'",
+            customMessage: "ROLLBACK_CRITICAL_FAILED status enum REGRESSED — without it, a fully-broken host (new AND old binary won't start) produces no actionable status");
+
+        // 5. Exit code 8 is the documented "Start-Service post-swap failed → rollback fired" code.
+        template.ShouldContain("-ExitCode 8",
+            customMessage: "exit code 8 REGRESSED — operator parsing the .ps1's exit doesn't see the rollback-fired signal");
+
+        // 6. The .failed archive path preserves the broken binary for post-mortem.
+        template.ShouldContain("\"$installLeaf.failed\"",
+            customMessage: ".failed archive path REGRESSED — operators need access to the broken binary to diagnose the OnStart failure. " +
+                          "If absent: rollback deletes the broken binary → operator must reproduce the failure to debug it.");
+
+        // 7. WaitForStatus('Running', ...) is what surfaces the OnStart exception synchronously.
+        // Start-Service returns when SCM accepts the start; the OnStart
+        // exception arrives asynchronously a few seconds later. Without
+        // WaitForStatus, the catch wouldn't fire — the .ps1 would proceed
+        // to the healthcheck loop with a service that's actually crashed.
+        template.ShouldContain("WaitForStatus('Running'",
+            customMessage: "WaitForStatus('Running', ...) REGRESSED. " +
+                          "Without this synchronous wait after Start-Service, an OnStart exception arrives asynchronously and the .ps1's catch can't see it. " +
+                          "Result: rollback never fires for the most common 'new binary is broken' failure mode.");
+    }
+
     [Fact]
     public void RenderInnerScript_ShaVerifyUsesDirectDotNetApi_NotGetFileHashCmdlet()
     {

--- a/tests/Squid.WindowsUpgradeE2E.TestService/Program.cs
+++ b/tests/Squid.WindowsUpgradeE2E.TestService/Program.cs
@@ -87,6 +87,26 @@ public sealed class TestUpgradeService : ServiceBase
     /// </summary>
     public const string MarkerFileName = "service-running.marker";
 
+    /// <summary>
+    /// Sentinel file that, if present in the exe directory at OnStart
+    /// time, makes the service deliberately fail to start. SCM observes
+    /// the OnStart exception → registers the service as failed-to-start
+    /// (event 7000 / 1067). Used by upgrade-rollback E2E tests
+    /// (J.E.6 / E7.u1): the v2 bundle includes this marker so the
+    /// post-swap Start-Service call throws → upgrade-windows-tentacle.ps1's
+    /// rollback path fires → restores .bak (v1, no marker) → service
+    /// recovers at v1.
+    ///
+    /// <para><b>Why a sentinel file (not a separate "crashing" exe binary)</b>:
+    /// keeping the same binary keeps the test surface lean. The CRASHING
+    /// behaviour is a configuration of the same binary, identical to how
+    /// production agents differ across deployments by config file alone —
+    /// not by binary identity. A separate crashing-binary project would
+    /// duplicate the OnStart / OnStop / version-read logic and force tests
+    /// to manage two artifact paths.</para>
+    /// </summary>
+    public const string CrashOnStartMarkerFileName = "crash-on-start.marker";
+
     public TestUpgradeService()
     {
         ServiceName = "SquidUpgradeE2ETestService";  // overridden by sc.exe at install time
@@ -96,9 +116,21 @@ public sealed class TestUpgradeService : ServiceBase
 
     protected override void OnStart(string[] args)
     {
+        // Rollback-test sentinel check FIRST. If the v2 bundle was staged
+        // with `crash-on-start.marker`, throw deliberately so SCM marks the
+        // start as failed → triggers .ps1's rollback → service comes back
+        // at v1 (which has no marker) → operator-visible recovery.
+        var exeDir = AppContext.BaseDirectory;
+        var crashMarker = Path.Combine(exeDir, CrashOnStartMarkerFileName);
+        if (File.Exists(crashMarker))
+            throw new InvalidOperationException(
+                $"OnStart aborted by test sentinel at {crashMarker}. " +
+                "This is intentional: rollback-on-failure E2E tests stage this marker " +
+                "into the v2 bundle so the post-swap Start-Service throws and the .ps1's " +
+                "rollback path fires.");
+
         try
         {
-            var exeDir = AppContext.BaseDirectory;
             var markerPath = Path.Combine(exeDir, MarkerFileName);
             File.WriteAllText(markerPath, Program.ReadCurrentVersion());
         }

--- a/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -662,6 +662,92 @@ public sealed class TentacleUpgradeLifecycleE2ETests
     }
 
     // ========================================================================
+    // E7.u1 — New binary's OnStart fails post-swap → auto-rollback restores v1
+    //
+    // The most operationally critical "failed upgrade" path: Phase B's
+    // Stop-Service + Move-Item swap succeeded, but the new binary throws
+    // from OnStart (DI graph crash, missing dependency, broken config
+    // schema, etc.). SCM observes the OnStart exception → registers
+    // service as failed-to-start (event 1067 / 7000). The .ps1's
+    // Invoke-Rollback fires → moves new (broken) binary aside →
+    // restores .bak → restarts old binary → reports ROLLED_BACK.
+    //
+    // SHIP-BLOCKING. Without rollback, a failed upgrade leaves the
+    // operator's agent in a Stopped state with the new (broken) binary
+    // → manual SSH-and-restore required across every machine. With
+    // rollback, the operator sees ROLLED_BACK in the UI and the agent
+    // is auto-recovered to its previous version.
+    //
+    // Test mechanism: stage v1 service (clean), build v2 bundle WITH the
+    // crash-on-start.marker sentinel → Phase B swaps in v2 → SCM
+    // Start-Service throws (OnStart raised) → rollback fires → marker
+    // file goes back to "1.0.0" (proves v1 is running again).
+    // ========================================================================
+
+    [Fact]
+    public void E7u1_NewBinaryOnStartCrashes_TriggersAutoRollbackToV1()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        // Stage v1 service (clean — no crash marker).
+        ctx.Fixture.InstallAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running before E7.u1 can validate rollback restores to v1");
+
+        // Build v2 bundle with the crash sentinel — OnStart will throw post-swap.
+        var v2Bundle = ctx.BuildV2BundleZip(targetVersion: "2.0.0-test", crashOnStart: true);
+        ctx.Mirror.StagePreBuiltArchive(v2Bundle);
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, stdout) = ctx.RunUpgradeScript(script);
+
+        // Exit 8 is the documented "Start-Service post-swap failed → rollback fired" code.
+        exitCode.ShouldBe(8,
+            customMessage: $"crashing OnStart MUST trigger Invoke-Rollback (exit 8 per .ps1 header documentation). " +
+                          $"Got exit {exitCode}. If 0: rollback didn't fire → broken binary still in INSTALL_DIR. " +
+                          $"If 14: outer catch handled the Start-Service throw before Invoke-Rollback could (ordering bug in the .ps1). " +
+                          $"stdout:\n{stdout}");
+
+        // last-upgrade.json reports ROLLED_BACK with the operator-facing detail.
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull(
+            customMessage: "last-upgrade.json MUST be written even on rollback path — operators need to see WHY the upgrade was rolled back via the UI");
+
+        statusPayload.Status.ShouldBe("ROLLED_BACK",
+            customMessage: $"status MUST be 'ROLLED_BACK' after a successful auto-rollback. Got: '{statusPayload.Status}'. " +
+                          $"If 'FAILED': rollback never fired (broken state). " +
+                          $"If 'ROLLBACK_CRITICAL_FAILED': old binary couldn't restart either (a separate failure mode — different test). " +
+                          $"Detail: {statusPayload.Detail}");
+
+        statusPayload.Detail.ShouldContain("Start-Service post-swap failed",
+            customMessage: $"detail MUST surface the original failure cause for operator diagnosis. Got: '{statusPayload.Detail}'");
+
+        // The CRITICAL post-rollback assertion: service MUST be running at v1 again.
+        // The test service's OnStart writes the marker with the version from
+        // version.txt — after rollback, .bak (v1, version.txt = "1.0.0") is at
+        // INSTALL_DIR, and Start-Service of v1 succeeds (no crash marker).
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage: $"after auto-rollback, marker at {ctx.Fixture.MarkerFilePath} MUST contain '1.0.0' — " +
+                          "proves rollback restored v1 AND v1 service started cleanly. " +
+                          "If marker absent: rollback restored .bak but Start-Service didn't run / didn't reach RUNNING. " +
+                          "If marker = '2.0.0-test': swap proceeded despite crash → rollback didn't fire (ship-blocking regression).");
+
+        // Defense-in-depth: the broken v2 binary should be archived as `.failed`
+        // for operator post-mortem, not silently deleted.
+        var failedDir = Path.Combine(Path.GetDirectoryName(ctx.Fixture.InstallDir)!, Path.GetFileName(ctx.Fixture.InstallDir) + ".failed");
+        Directory.Exists(failedDir).ShouldBeTrue(
+            customMessage: $".failed directory MUST exist post-rollback at {failedDir} — operators need access to the broken binary for post-mortem. " +
+                          "If absent: rollback deleted the evidence → operator can't diagnose what made OnStart fail.");
+
+        // Clean up the .failed directory (fixture only owns INSTALL_DIR).
+        try { Directory.Delete(failedDir, recursive: true); } catch { /* best-effort */ }
+
+        ctx.MarkClean();
+    }
+
+    // ========================================================================
     // Drift detector — Pins the placeholder set this test substitutes against
     // the production .ps1's expected substitutions. New placeholders the
     // strategy adds without test-side rendering would silently leave
@@ -865,8 +951,15 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         /// Mirrors what the production tentacle release zip looks like:
         /// every framework-dependent .NET binary needs its sibling .dll /
         /// .runtimeconfig.json / .deps.json + runtimes\ subdir to start.
+        ///
+        /// <para><b>crashOnStart</b> (J.E.6): when true, includes the
+        /// `crash-on-start.marker` sentinel file in the bundle. The test
+        /// service's OnStart detects this and throws → SCM 1067 ("service
+        /// did not start in a timely fashion") → triggers .ps1's
+        /// rollback path. The OLD binary at .bak doesn't have the marker,
+        /// so post-rollback Start-Service succeeds at v1.</para>
         /// </summary>
-        public byte[] BuildV2BundleZip(string targetVersion)
+        public byte[] BuildV2BundleZip(string targetVersion, bool crashOnStart = false)
         {
             using var ms = new MemoryStream();
             using (var zip = new System.IO.Compression.ZipArchive(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
@@ -921,6 +1014,18 @@ public sealed class TentacleUpgradeLifecycleE2ETests
                 // never matches the targetVersion ⇒ the upgrade proceeds.
                 // (No-op — included as a comment to document why we don't
                 // need a separate "doesn't short-circuit" test.)
+
+                // J.E.6 rollback test seam: when crashOnStart=true, include
+                // the sentinel file the test service detects in OnStart →
+                // throws → SCM rejects start → triggers .ps1's rollback.
+                // Pinned by `TestUpgradeService.CrashOnStartMarkerFileName`.
+                if (crashOnStart)
+                {
+                    var crashMarkerEntry = zip.CreateEntry("crash-on-start.marker", System.IO.Compression.CompressionLevel.Fastest);
+                    using var crashStream = crashMarkerEntry.Open();
+                    using var writer = new StreamWriter(crashStream, new UTF8Encoding(false));
+                    writer.Write("# E2E rollback test sentinel — TestUpgradeService.OnStart throws when this file exists");
+                }
             }
 
             return ms.ToArray();


### PR DESCRIPTION
## Summary

🛡️ **Ship-blocking production gap closed.** Pre-this-PR, if a new tentacle binary's OnStart threw post-swap (DI graph crash, broken config, etc.), the operator's machine was left in a broken state with the bad binary in `INSTALL_DIR` + service Stopped + `last-upgrade.json` reporting generic 'FAILED'. **Manual SSH-and-restore was required across every machine.**

This PR adds an `Invoke-Rollback` path: detect Start-Service failure → archive broken binary at `.failed` → restore `.bak` → restart old binary → emit `ROLLED_BACK` status. The operator sees `ROLLED_BACK` in the UI and the agent auto-recovers to its previous version.

## Production changes (upgrade-windows-tentacle.ps1)

- **New `Invoke-Rollback` function (~50 lines)**: Stop new svc → archive broken to `.failed` → Move `.bak` → INSTALL_DIR → Start old → WaitForStatus(Running) → write status. Three status enum exits: `ROLLED_BACK` (clean), `ROLLBACK_NEEDED` (no .bak), `ROLLBACK_CRITICAL_FAILED` (old won't start either).
- **Start-Service wrapped in try/catch**: adds `WaitForStatus('Running', '00:00:30')` so OnStart exception arrives synchronously (without it, the catch can't see the asynchronous SCM failure). On exception → Invoke-Rollback with exit 8.
- **New documented exit code 8**: "Start-Service post-swap failed → rollback fired"

## Test infrastructure

- **`TestUpgradeService.CrashOnStartMarkerFileName` sentinel** (same binary, configuration via filesystem state): if `crash-on-start.marker` exists in exeDir, OnStart throws → SCM rejects start → rollback fires. Clean teardown via existing fixture — no separate crashing-binary project to maintain.
- **`UpgradeLifecycleContext.BuildV2BundleZip(crashOnStart=false)`**: opt-in parameter that includes the sentinel in the bundle.

## E2E test (1 new)

`E7u1_NewBinaryOnStartCrashes_TriggersAutoRollbackToV1`:
- Stage v1 service → build v2 bundle WITH crash sentinel → run upgrade
- Assertions:
  - Exit code 8
  - `last-upgrade.json` status = `ROLLED_BACK` with detail naming Start-Service failure
  - Marker file = `1.0.0` (proves v1 is running again — only way is v1 successfully started post-rollback)
  - `.failed` directory exists (broken v2 binary preserved for post-mortem)

## Unit test (1 new — 7 structural pins)

`RenderInnerScript_RollbackContract_PinnedStructurally`:
1. Invoke-Rollback function exists
2. Start-Service wrapped in try/catch calling Invoke-Rollback
3. ROLLED_BACK status emit
4. ROLLBACK_CRITICAL_FAILED enum
5. Exit code 8
6. `.failed` archive path for post-mortem
7. `WaitForStatus('Running')` for synchronous OnStart-exception capture

Each pin has an actionable `customMessage` explaining the regression scenario + fix pattern.

## Local verification

- 227/227 unit tests pass
- 85/85 cross-platform E2E tests pass

## Deferred to J.E.7+

- **E6.u1** (Phase B Move-Item failure) — requires reliable filesystem-level fault injection
- **Healthcheck-fatal env var** (currently warning + proceed; opt-in rollback on healthcheck timeout)
- **E4.h** (already-up-to-date) — requires version-stamped test binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)