### PR TITLE
Phase 12.J.E.7 — stale-lock recovery + healthcheck-fatal opt-in

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -59,6 +59,7 @@
 #   5   — insufficient disk space
 #   7   — SHA256 mismatch (only when EXPECTED_SHA256 is non-empty)
 #   8   — Start-Service post-swap failed → rollback fired (J.E.6)
+#   9   — Healthcheck timeout in FATAL mode → rollback fired (J.E.7)
 #   12  — Windows version too old (PowerShell 5.0+ required, Server 2016+)
 #   13  — failed to acquire upgrade lock (concurrent upgrade in progress)
 #   14  — no install method succeeded (zip + future chocolatey/MSI all skipped or failed)
@@ -111,6 +112,12 @@ $HEALTHCHECK_URL  = '{{HEALTHCHECK_URL}}'
 # would fail on a quoted-and-cast empty string if the placeholder ever
 # defaults to empty.
 $HEALTHCHECK_RETRIES = {{HEALTHCHECK_RETRIES}}
+# Healthcheck failure mode. Substituted by the strategy as `$true` /
+# `$false` (PowerShell boolean literals — no quotes) so this assignment
+# is type-safe regardless of operator's env var format. Default `$false`
+# = warning + proceed (matches Octopus Tentacle); `$true` = strict =
+# rollback on timeout. See WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar.
+$HEALTHCHECK_FATAL = {{HEALTHCHECK_FATAL}}
 
 #  contract: %ProgramData%\Squid\Tentacle\upgrade\
 $STATUS_DIR  = Join-Path $env:ProgramData 'Squid\Tentacle\upgrade'
@@ -262,10 +269,53 @@ function Invoke-Rollback {
 # Single per-host lock (NOT per-target-version) so two concurrent operator
 # clicks targeting different versions can't race the SCM Stop-Service +
 # Move-Item swap + Start-Service sequence. Mirrors the Linux flock layout.
+#
+# J.E.7 stale-lock detection: a crashed dispatch (host reboot mid-upgrade,
+# OOM kill, etc.) leaves the lock file with a dead PID. Pre-J.E.7 every
+# subsequent upgrade dispatch on that host failed with exit 13 forever
+# until manual lock-file deletion. Now: if the recorded PID isn't a live
+# process, log + break the stale lock + proceed. A live PID still wins
+# (real concurrent dispatch is correctly rejected). Pinned by
+# `WindowsTentacleUpgradeStrategyTests.RenderInnerScript_StaleLockBreak_PinnedStructurally`
+# + `TentacleUpgradeLifecycleE2ETests.E11u2_StaleLockWithDeadPid_BrokenAndDispatchProceeds`.
 if (Test-Path $LOCK_FILE) {
-    $existing = Get-Content $LOCK_FILE -ErrorAction SilentlyContinue
-    Append-UpgradeLog "::error:: Upgrade lock $LOCK_FILE already held (held by PID $existing) — refusing concurrent upgrade dispatch"
-    exit 13
+    $existing = (Get-Content $LOCK_FILE -ErrorAction SilentlyContinue | Out-String).Trim()
+
+    # Regex-parse PID. Avoids `[int]::TryParse([ref])` which has fragile
+    # PowerShell binding behaviour. Empty / non-numeric / negative content
+    # leaves $existingPid at 0 → falls through the > 0 guard → treated
+    # as stale (correct: a non-numeric lock file is corrupt and should
+    # be broken).
+    $existingPid = 0
+    if ($existing -match '^\d+$') {
+        $existingPid = [int]$existing
+    }
+
+    $holderAlive = $false
+    if ($existingPid -gt 0) {
+        # Get-Process throws if PID is not a live process. -ErrorAction
+        # SilentlyContinue + null check lets us distinguish "alive" (returns
+        # process) from "dead" (returns $null) cleanly.
+        $proc = Get-Process -Id $existingPid -ErrorAction SilentlyContinue
+        if ($null -ne $proc) {
+            $holderAlive = $true
+        }
+    }
+
+    if ($holderAlive) {
+        Append-UpgradeLog "::error:: Upgrade lock $LOCK_FILE held by LIVE PID $existingPid — refusing concurrent upgrade dispatch"
+        exit 13
+    }
+
+    # Stale lock — log + break + proceed. Operator-visible recovery from
+    # a previously-crashed dispatch that left the lock orphaned.
+    Append-UpgradeLog "::warning:: Upgrade lock $LOCK_FILE held by stale PID '$existing' (no live process) — breaking lock to recover from a previously-crashed dispatch"
+    try { Remove-Item -Path $LOCK_FILE -Force -ErrorAction Stop } catch {
+        # Couldn't break the lock (permissions / IO error). Operator must
+        # intervene; surface the failure clearly.
+        Append-UpgradeLog "::error:: Couldn't break stale lock at $LOCK_FILE`: $($_.Exception.Message). Operator must manually delete the lock file to recover."
+        exit 13
+    }
 }
 
 Set-Content -Path $LOCK_FILE -Value "$PID" -Force
@@ -570,7 +620,19 @@ try {
     }
 
     if (-not $healthOk) {
-        Append-UpgradeLog "::warning:: Healthcheck didn't respond within ${totalWaitSeconds}s — proceeding anyway, server will retry on next health probe"
+        if ($HEALTHCHECK_FATAL) {
+            # Strict mode (J.E.7): operator opted in to treat healthcheck
+            # timeout as a deal-breaker. Roll back to the previous binary
+            # rather than leave the operator with a Stopped+swapped service
+            # that the next capabilities probe will report as broken anyway.
+            # Exit 9 is the documented "healthcheck timeout (FATAL mode)
+            # → rollback fired" code.
+            Invoke-Rollback -Reason "Healthcheck didn't respond within ${totalWaitSeconds}s and SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true (strict mode)" -ExitCode 9
+        }
+
+        # Default mode (matches Octopus Tentacle): warning + proceed.
+        # Capabilities probe will detect a dead agent on the next probe.
+        Append-UpgradeLog "::warning:: Healthcheck didn't respond within ${totalWaitSeconds}s — proceeding anyway, server will retry on next health probe (set SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true to roll back instead)"
     }
 
     Write-UpgradeStatus -Status 'SUCCESS' -InstallMethod $INSTALL_METHOD -Detail "Upgrade to $TARGET_VERSION complete"

--- a/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
@@ -129,6 +129,32 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
     internal const int DefaultHealthcheckRetries = 30;
 
     /// <summary>
+    /// Operator override for the post-restart healthcheck failure mode.
+    /// Default behaviour (`false`) is "warning + proceed" — matching
+    /// Octopus Tentacle's permissive policy where the capabilities probe
+    /// detects a non-responsive new binary on the next health probe and
+    /// reports it server-side. Setting this env var to `true` enables
+    /// strict mode: a healthcheck timeout triggers <c>Invoke-Rollback</c>
+    /// + restores the previous binary.
+    ///
+    /// <para><b>When to enable</b>: production fleets where the agent's
+    /// <c>/healthz</c> endpoint is the canonical liveness contract — if
+    /// it doesn't respond, the agent is functionally dead and rolling
+    /// back to the previous-known-working version is preferred over
+    /// leaving the operator with a Stopped service. Air-gap fleets where
+    /// the upgrade is the only restart-eligible window.</para>
+    ///
+    /// <para><b>When to leave default</b>: deployments where new agents
+    /// take a variable time to come up healthy (heavy plugin enumeration,
+    /// startup migrations) and a temporary timeout shouldn't trigger a
+    /// rollback that disrupts a successful upgrade.</para>
+    ///
+    /// <para>Pinned per Rule 8 by
+    /// <c>WindowsTentacleUpgradeStrategyTests.HealthcheckFatalEnvVar_ConstantNamePinned</c>.</para>
+    /// </summary>
+    public const string HealthcheckFatalEnvVar = "SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL";
+
+    /// <summary>
     /// Wall-clock cap for a single upgrade dispatch. Mirrors Linux's
     /// 5-minute cap — must stay strictly less than
     /// <c>MachineUpgradeService.LockExpiry</c> (7 min) so an abandoned
@@ -381,6 +407,7 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
             .Replace("{{SERVICE_NAME}}", DefaultServiceName, StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_URL}}", ResolveHealthcheckUrl(), StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_RETRIES}}", ResolveHealthcheckRetries().ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
+            .Replace("{{HEALTHCHECK_FATAL}}", ResolveHealthcheckFatal() ? "$true" : "$false", StringComparison.Ordinal)
             .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
     }
 
@@ -570,6 +597,36 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
         var raw = System.Environment.GetEnvironmentVariable(HealthcheckUrlEnvVar);
 
         return string.IsNullOrWhiteSpace(raw) ? DefaultHealthcheckUrl : raw.Trim().TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Resolves the post-restart healthcheck failure mode. Default
+    /// (env unset / empty) is <c>false</c> — warning + proceed (matches
+    /// Octopus Tentacle). When the env var parses as a recognised
+    /// truthy value (case-insensitive: <c>true</c> / <c>1</c> /
+    /// <c>yes</c> / <c>on</c>), strict mode is enabled — healthcheck
+    /// timeout triggers Invoke-Rollback. Any other value falls back to
+    /// the default with a structured warning so operator typos surface
+    /// in logs.
+    /// </summary>
+    internal static bool ResolveHealthcheckFatal()
+    {
+        var raw = System.Environment.GetEnvironmentVariable(HealthcheckFatalEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+
+        var normalized = raw.Trim().ToLowerInvariant();
+
+        if (normalized is "true" or "1" or "yes" or "on") return true;
+        if (normalized is "false" or "0" or "no" or "off") return false;
+
+        Log.Warning(
+            "[Upgrade] {EnvVar} is set to an unrecognised value ('{Value}'). " +
+            "Recognised truthy: 'true' / '1' / 'yes' / 'on'. " +
+            "Recognised falsy:  'false' / '0' / 'no' / 'off'. " +
+            "Falling back to default (false — warning + proceed on healthcheck timeout).",
+            HealthcheckFatalEnvVar, raw);
+        return false;
     }
 
     /// <summary>

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -46,16 +46,19 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
     private readonly string _previousBaseUrlOverride;
     private readonly string _previousHealthcheckUrlOverride;
     private readonly string _previousHealthcheckRetriesOverride;
+    private readonly string _previousHealthcheckFatalOverride;
 
     public WindowsTentacleUpgradeStrategyTests()
     {
         _previousBaseUrlOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar);
         _previousHealthcheckUrlOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar);
         _previousHealthcheckRetriesOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar);
+        _previousHealthcheckFatalOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar);
 
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, null);
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, null);
     }
 
     public void Dispose()
@@ -63,6 +66,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, _previousBaseUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar, _previousHealthcheckUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, _previousHealthcheckRetriesOverride);
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, _previousHealthcheckFatalOverride);
     }
 
     // ========================================================================
@@ -174,6 +178,129 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         // back to the safe 30-attempt default with a Serilog warning so
         // operators see the typo on their next dispatch.
         WindowsTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(30);
+    }
+
+    // ── J.E.7: HealthcheckFatalEnvVar pins ──────────────────────────────────
+
+    [Fact]
+    public void HealthcheckFatalEnvVar_ConstantNamePinned()
+    {
+        // Renaming this constant breaks every operator who pinned strict-mode
+        // healthcheck behaviour via env. Hard-pin the literal.
+        WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar
+            .ShouldBe("SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL");
+    }
+
+    [Fact]
+    public void ResolveHealthcheckFatal_NoEnvVar_ReturnsFalse()
+    {
+        // Default (env unset) MUST be false — matches Octopus Tentacle's
+        // permissive default. A polish that flips the default to true would
+        // mean every existing deployment with a slow-starting agent suddenly
+        // starts auto-rolling-back after upgrade.
+        WindowsTentacleUpgradeStrategy.ResolveHealthcheckFatal().ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("True", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("1", true)]
+    [InlineData("yes", true)]
+    [InlineData("on", true)]
+    [InlineData("  yes  ", true)]   // whitespace tolerant
+    [InlineData("false", false)]
+    [InlineData("FALSE", false)]
+    [InlineData("0", false)]
+    [InlineData("no", false)]
+    [InlineData("off", false)]
+    public void ResolveHealthcheckFatal_RecognisedValue_ParsesCorrectly(string envValue, bool expected)
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, envValue);
+
+        WindowsTentacleUpgradeStrategy.ResolveHealthcheckFatal().ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("strict")]               // operator might think this is the strict-mode flag value
+    [InlineData("enabled")]              // operator-friendly synonym we don't recognise
+    [InlineData("YES_PLEASE")]           // typo with an obvious intent
+    [InlineData("fatal")]                // ironic — looks like the variable but isn't recognised
+    [InlineData("")]                     // empty-after-trim is treated as unset above
+    public void ResolveHealthcheckFatal_UnrecognisedValue_FallsBackToFalseWithWarning(string envValue)
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, envValue);
+
+        // Operator-friendly: a typo doesn't accidentally enable strict mode
+        // (which would surprise them with auto-rollbacks). Falls back to
+        // permissive default; warning surfaces the typo in logs.
+        WindowsTentacleUpgradeStrategy.ResolveHealthcheckFatal().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RenderInnerScript_HealthcheckFatalPlaceholder_SubstitutedAsPowerShellBoolean()
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, "true");
+
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        // Strategy substitutes `$true` / `$false` (PowerShell boolean
+        // literals — no quotes) so the .ps1's `$HEALTHCHECK_FATAL = ...`
+        // assignment is type-safe regardless of operator's env var format.
+        inner.ShouldContain("$HEALTHCHECK_FATAL = $true",
+            customMessage: "RenderInnerScript MUST substitute $true (PowerShell boolean literal) when env-resolved fatal mode is on. " +
+                          "Quoted form ($HEALTHCHECK_FATAL = 'true') would make the variable a non-empty string, which is truthy in `if ($HEALTHCHECK_FATAL)` checks " +
+                          "→ FATAL=false would BEHAVE like FATAL=true. Safety regression. Pin the literal substitution shape.");
+
+        // The healthcheck loop MUST consult the variable.
+        inner.ShouldContain("if ($HEALTHCHECK_FATAL)",
+            customMessage: "healthcheck-fatal branch REGRESSED — operator opt-in is no-op without the if-check.");
+    }
+
+    [Fact]
+    public void RenderInnerScript_HealthcheckFatal_DefaultsToFalseLiteralInRender()
+    {
+        // No env var set → default false → strategy substitutes $false literal.
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("$HEALTHCHECK_FATAL = $false",
+            customMessage: "default render MUST inject $false — operators not-using-strict-mode see no behaviour change");
+        inner.ShouldNotContain("$HEALTHCHECK_FATAL = $true",
+            customMessage: "default render leaked strict-mode literal — every dispatch would trigger rollback on healthcheck timeout");
+    }
+
+    // ── J.E.7: stale-lock structural pin ───────────────────────────────────
+
+    [Fact]
+    public void RenderInnerScript_StaleLockBreak_PinnedStructurally()
+    {
+        // Pre-J.E.7 a crashed dispatch (host reboot mid-upgrade, OOM kill,
+        // etc.) left the lock file with a dead PID. Every subsequent
+        // upgrade dispatch failed with exit 13 forever until manual lock-
+        // file deletion. Pin the recovery contract:
+        //   1. Read the existing PID from the lock
+        //   2. Probe via Get-Process to determine alive vs dead
+        //   3. Live PID → keep exit 13 (real concurrent dispatch rejected)
+        //   4. Dead PID → log warning + Remove-Item + fall through
+        var asm = typeof(WindowsTentacleUpgradeStrategy).Assembly;
+        using var stream = asm.GetManifestResourceStream("Squid.Core.Resources.Upgrade.upgrade-windows-tentacle.ps1")
+            ?? throw new System.IO.InvalidDataException("embedded template not found");
+        using var reader = new System.IO.StreamReader(stream);
+        var template = reader.ReadToEnd();
+
+        // The Get-Process probe is the heart of stale detection.
+        template.ShouldContain("Get-Process -Id $existingPid",
+            customMessage: "stale-lock detection REGRESSED — without Get-Process probe, every previously-crashed dispatch leaves the lock orphaned forever");
+
+        // Stale-detected branch: warning + Remove-Item.
+        template.ShouldContain("breaking lock to recover",
+            customMessage: "stale-lock recovery log message REGRESSED — operators looking for 'lock broken' in upgrade.log won't find it");
+        template.ShouldContain("Remove-Item -Path $LOCK_FILE",
+            customMessage: "stale-lock break REGRESSED — Get-Process detected dead PID but didn't actually delete the orphan file");
+
+        // Live-PID branch still exits 13 (concurrent-dispatch protection intact).
+        template.ShouldContain("held by LIVE PID",
+            customMessage: "live-PID detection REGRESSED — concurrent real dispatches no longer differentiated from stale ones in logs");
     }
 
     [Fact]
@@ -384,7 +511,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         {
             "TARGET_VERSION", "DOWNLOAD_URL", "EXPECTED_SHA256",
             "INSTALL_DIR", "SERVICE_NAME", "HEALTHCHECK_URL", "HEALTHCHECK_RETRIES",
-            "INSTALL_METHODS"
+            "HEALTHCHECK_FATAL", "INSTALL_METHODS"
         };
 
         foreach (var name in strategySubstituted)

--- a/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -568,13 +568,16 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         var v2Bundle = ctx.BuildV2BundleZip(targetVersion: "2.0.0-test");
         ctx.Mirror.StagePreBuiltArchive(v2Bundle);
 
-        // Pre-stage the lock file with a fake "first dispatch" PID. The .ps1
-        // reads $LOCK_FILE BEFORE writing $STATUS_DIR (no, wait — STATUS_DIR
-        // is created first; the lock check happens AFTER). The .ps1 ensures
-        // STATUS_DIR exists at line 116-118 then immediately reads the lock.
+        // Pre-stage the lock file with a guaranteed-LIVE PID. Post-J.E.7
+        // the .ps1 distinguishes stale (dead PID, breaks + proceeds) vs
+        // live (real concurrent dispatch, exits 13). We need a live one
+        // here to exercise the concurrent-dispatch-rejection path. The
+        // current test process itself is guaranteed alive throughout the
+        // test → use its PID. Pre-J.E.7 this test used a magic 99999
+        // which (correctly) gets treated as stale by the new detection.
         Directory.CreateDirectory(ctx.StatusDir);
         var lockFilePath = Path.Combine(ctx.StatusDir, "upgrade.lock");
-        const string firstDispatchPid = "99999";   // fake PID for the "first" dispatch
+        var firstDispatchPid = Process.GetCurrentProcess().Id.ToString(System.Globalization.CultureInfo.InvariantCulture);
         File.WriteAllText(lockFilePath, firstDispatchPid);
 
         var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");

--- a/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -748,6 +748,159 @@ public sealed class TentacleUpgradeLifecycleE2ETests
     }
 
     // ========================================================================
+    // E11.u2 — Stale lock file with dead PID is broken + dispatch proceeds
+    //
+    // Pre-J.E.7 a crashed dispatch (host reboot mid-upgrade, OOM kill)
+    // left the lock file with a dead PID. Every subsequent dispatch on
+    // that machine failed with exit 13 forever until manual intervention.
+    // Now: the .ps1 reads the recorded PID, probes via Get-Process, and
+    // breaks the lock if the holder isn't alive.
+    //
+    // Test mechanism: spawn-and-die pattern. Start cmd.exe, wait for it to
+    // exit, capture its PID. The OS will recycle that PID slot eventually,
+    // but during the test window it's guaranteed dead → .ps1 detects stale
+    // → breaks lock → upgrade proceeds.
+    //
+    // Reverse-assert: marker file goes from v1 to v2 (proves Phase B
+    // actually ran, not just the lock check).
+    // ========================================================================
+
+    [Fact]
+    public void E11u2_StaleLockWithDeadPid_BrokenAndDispatchProceeds()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue();
+
+        var v2Bundle = ctx.BuildV2BundleZip(targetVersion: "2.0.0-test");
+        ctx.Mirror.StagePreBuiltArchive(v2Bundle);
+
+        // Capture a guaranteed-dead PID via spawn-and-die. Spawn cmd.exe
+        // that immediately exits, wait for the process to terminate
+        // synchronously, then use the (now dead) PID as the stale lock
+        // value. More realistic than a fixed magic number — mirrors the
+        // crashed-dispatch scenario exactly (an upgrade .ps1 wrote its
+        // PID, then the process died for any reason).
+        int deadPid;
+        var psi = new ProcessStartInfo("cmd.exe", "/c exit 0")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            CreateNoWindow = true
+        };
+        using (var transient = Process.Start(psi))
+        {
+            transient.ShouldNotBeNull("cmd.exe must spawn for the spawn-and-die PID capture");
+            transient!.WaitForExit(5_000).ShouldBeTrue("cmd.exe /c exit 0 must terminate within 5s");
+            deadPid = transient.Id;
+        }
+
+        // Pre-stage the stale lock with the now-dead PID.
+        Directory.CreateDirectory(ctx.StatusDir);
+        var lockFilePath = Path.Combine(ctx.StatusDir, "upgrade.lock");
+        File.WriteAllText(lockFilePath, deadPid.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, stdout) = ctx.RunUpgradeScript(script);
+
+        exitCode.ShouldBe(0,
+            customMessage: $"stale lock with dead PID {deadPid} MUST be broken + upgrade proceeds (exit 0). " +
+                          $"Got exit {exitCode}. " +
+                          (exitCode == 13 ? "Stale-lock detection broken: .ps1 still treats dead-PID lock as live → operator must manually delete lock file forever after any crash." : "Other failure path; check stdout for diagnosis.") +
+                          $"\nstdout:\n{stdout}");
+
+        // The .ps1 logs a structured warning when breaking a stale lock.
+        stdout.ShouldContain("breaking lock to recover",
+            customMessage: "stale-lock recovery log message MUST appear so operators can audit when an automatic recovery happened (vs a manual intervention)");
+
+        // Reverse-assert: Phase B actually ran (marker now reads v2).
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage: "post-upgrade marker MUST reflect v2 — proves the .ps1 didn't just break-the-lock-and-exit, it actually ran Phase A+B successfully after recovery");
+
+        // last-upgrade.json reports SUCCESS — recovery is invisible to the operator UI's status.
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull();
+        statusPayload.Status.ShouldBe("SUCCESS",
+            customMessage: $"after stale-lock recovery + clean upgrade, last-upgrade.json MUST be SUCCESS. Got: '{statusPayload.Status}'. " +
+                          "If 'FAILED': the recovery log was written but the actual Phase B failed downstream — different bug.");
+
+        ctx.MarkClean();
+    }
+
+    // ========================================================================
+    // F.healthcheck-fatal — Healthcheck timeout in FATAL mode triggers rollback
+    //
+    // When SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true the .ps1
+    // treats a post-Start healthcheck timeout as a deal-breaker: roll
+    // back to the previous binary instead of proceeding with warning.
+    // For operators where the agent's /healthz endpoint IS the canonical
+    // liveness contract, this is preferable to leaving a Stopped+swapped
+    // service.
+    //
+    // Test mechanism: HEALTHCHECK_URL in test renders points at
+    // 127.0.0.1:1 (unreachable). With FATAL=true + retries=1, the post-
+    // Start polling exits the loop without success → healthcheck-fatal
+    // branch fires Invoke-Rollback → exit 9 + ROLLED_BACK status +
+    // marker back at v1.
+    //
+    // Reverse-assert: with FATAL=false (default), same setup must
+    // produce SUCCESS (covered by E1.h — proves the FATAL path is opt-in
+    // and doesn't accidentally trigger).
+    // ========================================================================
+
+    [Fact]
+    public void HealthcheckFatalMode_TimeoutTriggersAutoRollback()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue();
+
+        // Plain v2 bundle (no crash sentinel) — service WOULD start fine.
+        // The healthcheck timeout is the only failure mode.
+        var v2Bundle = ctx.BuildV2BundleZip(targetVersion: "2.0.0-test");
+        ctx.Mirror.StagePreBuiltArchive(v2Bundle);
+
+        // Render with HEALTHCHECK_FATAL=true. Same retries=1 + unreachable
+        // HEALTHCHECK_URL as default tests; only difference is the FATAL
+        // flag. With FATAL on, the .ps1 calls Invoke-Rollback after retries
+        // exhaust without 200.
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test", healthcheckFatal: true);
+        var (exitCode, stdout) = ctx.RunUpgradeScript(script);
+
+        exitCode.ShouldBe(9,
+            customMessage: $"FATAL=true + healthcheck timeout MUST produce exit 9 (documented per .ps1 header — 'Healthcheck timeout in FATAL mode → rollback fired'). " +
+                          $"Got exit {exitCode}. " +
+                          (exitCode == 0 ? "FATAL flag was ignored — strict mode opt-in is broken." : "Other failure path; check stdout.") +
+                          $"\nstdout:\n{stdout}");
+
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull();
+        statusPayload.Status.ShouldBe("ROLLED_BACK",
+            customMessage: $"FATAL=true healthcheck-timeout-rollback MUST emit ROLLED_BACK status (so operator UI shows 'rolled back' instead of generic FAILED). Got: '{statusPayload.Status}'");
+        statusPayload.Detail.ShouldContain("HEALTHCHECK_FATAL=true",
+            customMessage: $"detail MUST mention the HEALTHCHECK_FATAL flag so operators can disambiguate this rollback path from the Start-Service-failed one. Got: '{statusPayload.Detail}'");
+
+        // Reverse-assert: marker back at v1 (proves rollback restored).
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage: "post-rollback marker MUST be v1 — proves Invoke-Rollback restored .bak AND restarted v1 successfully");
+
+        // .failed dir holds the v2 binary.
+        var failedDir = Path.Combine(Path.GetDirectoryName(ctx.Fixture.InstallDir)!, Path.GetFileName(ctx.Fixture.InstallDir) + ".failed");
+        Directory.Exists(failedDir).ShouldBeTrue(
+            customMessage: ".failed dir MUST exist for operator post-mortem of the unhealthy v2 binary");
+
+        try { Directory.Delete(failedDir, recursive: true); } catch { /* best-effort */ }
+
+        ctx.MarkClean();
+    }
+
+    // ========================================================================
     // Drift detector — Pins the placeholder set this test substitutes against
     // the production .ps1's expected substitutions. New placeholders the
     // strategy adds without test-side rendering would silently leave
@@ -775,6 +928,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         {
             "DOWNLOAD_URL",
             "EXPECTED_SHA256",
+            "HEALTHCHECK_FATAL",
             "HEALTHCHECK_RETRIES",
             "HEALTHCHECK_URL",
             "INSTALL_DIR",
@@ -898,7 +1052,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         /// <para>Drift detector at class level pins this substitution map
         /// against the .ps1's actual placeholder set.</para>
         /// </summary>
-        public string RenderProductionScriptForVersion(string targetVersion)
+        public string RenderProductionScriptForVersion(string targetVersion, bool healthcheckFatal = false)
         {
             var template = File.ReadAllText(LocateProductionTemplate());
 
@@ -942,6 +1096,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
                 .Replace("{{SERVICE_NAME}}", Fixture.ServiceName, StringComparison.Ordinal)
                 .Replace("{{HEALTHCHECK_URL}}", healthcheckUrl, StringComparison.Ordinal)
                 .Replace("{{HEALTHCHECK_RETRIES}}", healthcheckRetries, StringComparison.Ordinal)
+                .Replace("{{HEALTHCHECK_FATAL}}", healthcheckFatal ? "$true" : "$false", StringComparison.Ordinal)
                 .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
         }
 


### PR DESCRIPTION
## Summary

Two narrow production hardenings, both real-world recovery paths:

### 1. Stale-lock recovery (E11.u2)

Pre-this-PR: a crashed dispatch (host reboot mid-upgrade, OOM kill, any reason a `.ps1` died without removing its lock) left `upgrade.lock` with a dead PID. **Every subsequent upgrade dispatch on that machine failed with exit 13 forever** until manual intervention. For a fleet operator, a single mid-upgrade crash permanently blocked all future upgrades on that host.

Now: `.ps1` reads recorded PID, probes via `Get-Process`, takes one of three actions:
- **Live PID** → exit 13 (real concurrent dispatch correctly rejected)
- **Dead PID** → log warning + `Remove-Item` + proceed (auto-recovery)
- **Non-numeric content** → treated as stale (corrupt lock file is safe to break)

### 2. Healthcheck-fatal opt-in

Previously: post-Start healthcheck timeout = "warning + proceed". For operators where `/healthz` IS the canonical liveness contract, leaving a Stopped+swapped service is worse than rollback — but flipping the default would break every deployment with a slow-starting agent.

Now: opt-in via `SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true`. Strict mode → `Invoke-Rollback` (reuses J.E.6 infra). Default stays permissive.

## E2E tests (2 new)

| Test | Scenario | Mechanism |
|---|---|---|
| `E11u2_StaleLockWithDeadPid_BrokenAndDispatchProceeds` | Crashed-dispatch recovery | **Spawn-and-die**: `cmd.exe /c exit 0` → `WaitForExit` → use the now-dead PID as the stale lock content. Realistic crashed-process simulation, not a fixed magic number. |
| `HealthcheckFatalMode_TimeoutTriggersAutoRollback` | Strict mode timeout | Render with `healthcheckFatal=true` + unreachable healthz URL → expect exit 9 + ROLLED_BACK + marker back at v1 |

Both tests reverse-assert: stale-lock recovery is **invisible** to operator final status (they see `SUCCESS`), and FATAL mode is genuinely **opt-in** (default still produces SUCCESS — proven by E1.h continuing to pass).

## Unit tests (8 new)

- `HealthcheckFatalEnvVar_ConstantNamePinned` (Rule 8)
- `ResolveHealthcheckFatal_NoEnvVar_ReturnsFalse` (default permissive)
- `ResolveHealthcheckFatal_RecognisedValue_ParsesCorrectly` (Theory, 12 cases)
- `ResolveHealthcheckFatal_UnrecognisedValue_FallsBackToFalseWithWarning` (Theory, 5 cases — operator typos)
- `RenderInnerScript_HealthcheckFatalPlaceholder_SubstitutedAsPowerShellBoolean` (pins `$true` literal — NOT `'true'` string which would always be truthy)
- `RenderInnerScript_HealthcheckFatal_DefaultsToFalseLiteralInRender`
- `RenderInnerScript_StaleLockBreak_PinnedStructurally` (4 structural ops)

Plus drift detector updates (placeholder set extended to include `HEALTHCHECK_FATAL`).

## Local verification

- 249/249 unit tests pass (was 227 + 22 new)
- 87/87 cross-platform E2E pass (was 85 + 2 new)

## Deferred

- **E6.u1** (Phase B Move-Item failure) — fault injection unreliable; revisit if production hits this
- **E4.h** (already-up-to-date) — needs version-stamped binary; J.E.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)