### PR TITLE
Phase 12.J.E.8 — WaitForStatus timeout env var (audit Risk A) + _clean field cleanup

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -118,6 +118,15 @@ $HEALTHCHECK_RETRIES = {{HEALTHCHECK_RETRIES}}
 # = warning + proceed (matches Octopus Tentacle); `$true` = strict =
 # rollback on timeout. See WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar.
 $HEALTHCHECK_FATAL = {{HEALTHCHECK_FATAL}}
+# Per-WaitForStatus wall-clock cap (seconds). Default 30. Operators with
+# heavyweight agents (heavy plugin enumeration, slow .NET tiered JIT cold
+# start, AV scanning a 50MB binary before first run) override via
+# SQUID_TARGET_WINDOWS_TENTACLE_SERVICE_TIMEOUT_SECONDS to avoid false
+# rollbacks from a slow-but-eventually-successful Start. Used for both
+# Stop-Service and Start-Service WaitForStatus calls + Invoke-Rollback's
+# old-service-restart wait.
+$SERVICE_TIMEOUT_SECONDS = {{SERVICE_TIMEOUT_SECONDS}}
+$SERVICE_TIMEOUT_SPAN = [TimeSpan]::FromSeconds($SERVICE_TIMEOUT_SECONDS)
 
 #  contract: %ProgramData%\Squid\Tentacle\upgrade\
 $STATUS_DIR  = Join-Path $env:ProgramData 'Squid\Tentacle\upgrade'
@@ -202,7 +211,7 @@ function Invoke-Rollback {
         if ($null -ne $svc -and $svc.Status -ne 'Stopped') {
             Append-UpgradeLog "[rollback] Stopping new service (current state: $($svc.Status))"
             Stop-Service -Name $SERVICE_NAME -Force -ErrorAction SilentlyContinue
-            $svc.WaitForStatus('Stopped', '00:00:30')
+            $svc.WaitForStatus('Stopped', $SERVICE_TIMEOUT_SPAN)
         }
     } catch {
         Append-UpgradeLog "[rollback] Couldn't cleanly stop new service: $($_.Exception.Message). Proceeding with restore — Move-Item might still succeed if SCM has released the binary."
@@ -253,7 +262,7 @@ function Invoke-Rollback {
         # Wait for SCM to confirm RUNNING — synchronous proof that the old
         # service is genuinely back up before we report ROLLED_BACK.
         $svc = Get-Service -Name $SERVICE_NAME
-        $svc.WaitForStatus('Running', '00:00:30')
+        $svc.WaitForStatus('Running', $SERVICE_TIMEOUT_SPAN)
 
         Append-UpgradeLog "[rollback] Service running (old binary)"
         Write-UpgradeStatus -Status 'ROLLED_BACK' -InstallMethod $INSTALL_METHOD -Detail "Rolled back from failed upgrade. Reason: $Reason. Broken binary preserved at $failedDir for inspection." -ExitCode $ExitCode
@@ -515,7 +524,7 @@ try {
             # Wait up to 30s for the service to actually stop (Stop-Service
             # returns when the SCM accepts the stop command; the service
             # process may take a moment longer to exit).
-            $svc.WaitForStatus('Stopped', '00:00:30')
+            $svc.WaitForStatus('Stopped', $SERVICE_TIMEOUT_SPAN)
         }
     }
     else {
@@ -577,7 +586,7 @@ try {
             Start-Service -Name $SERVICE_NAME
 
             $svcVerify = Get-Service -Name $SERVICE_NAME
-            $svcVerify.WaitForStatus('Running', '00:00:30')
+            $svcVerify.WaitForStatus('Running', $SERVICE_TIMEOUT_SPAN)
 
             Append-UpgradeLog "[upgrade] Service $SERVICE_NAME reached RUNNING state"
         } catch {

--- a/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
@@ -155,6 +155,38 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
     public const string HealthcheckFatalEnvVar = "SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL";
 
     /// <summary>
+    /// Operator override for the wall-clock timeout the .ps1 waits on
+    /// `$svc.WaitForStatus('Running', ...)` and `WaitForStatus('Stopped', ...)`
+    /// after Start-Service / Stop-Service. Default <see cref="DefaultServiceTimeoutSeconds"/>
+    /// (30s) covers stock-agent boot (~3-5s) plus runtime warmup (~10-30s).
+    ///
+    /// <para><b>Why this matters</b>: a heavyweight agent (heavy plugin
+    /// enumeration, .NET tiered JIT cold start, AV scanning a 50MB binary
+    /// before the first run) can take >30s to reach the SCM RUNNING state.
+    /// Without this override, the post-Start `WaitForStatus` times out →
+    /// Invoke-Rollback fires → operator sees ROLLED_BACK on what was
+    /// actually a successful (just-slow) upgrade.</para>
+    ///
+    /// <para><b>Single var for both Stop and Start</b>: Stop-Service's
+    /// 30s default is rarely the bottleneck (a service stuck Stopping is
+    /// usually a CanStop=false / OnStop deadlock bug, not slowness).
+    /// Operators tuning for slow-start environments rarely need different
+    /// numbers for Stop vs Start. Keep one knob; revisit if 5+ env vars
+    /// triggers refactor (Rule 7).</para>
+    ///
+    /// <para>Pinned per Rule 8 by
+    /// <c>WindowsTentacleUpgradeStrategyTests.ServiceTimeoutSecondsEnvVar_ConstantNamePinned</c>.</para>
+    /// </summary>
+    public const string ServiceTimeoutSecondsEnvVar = "SQUID_TARGET_WINDOWS_TENTACLE_SERVICE_TIMEOUT_SECONDS";
+
+    /// <summary>
+    /// Default wall-clock cap on each <c>WaitForStatus</c> call (Stop and
+    /// Start). 30s × ~5s typical RUNNING transition = 6x margin. Operators
+    /// with heavyweight agents override via <see cref="ServiceTimeoutSecondsEnvVar"/>.
+    /// </summary>
+    internal const int DefaultServiceTimeoutSeconds = 30;
+
+    /// <summary>
     /// Wall-clock cap for a single upgrade dispatch. Mirrors Linux's
     /// 5-minute cap — must stay strictly less than
     /// <c>MachineUpgradeService.LockExpiry</c> (7 min) so an abandoned
@@ -408,6 +440,7 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
             .Replace("{{HEALTHCHECK_URL}}", ResolveHealthcheckUrl(), StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_RETRIES}}", ResolveHealthcheckRetries().ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_FATAL}}", ResolveHealthcheckFatal() ? "$true" : "$false", StringComparison.Ordinal)
+            .Replace("{{SERVICE_TIMEOUT_SECONDS}}", ResolveServiceTimeoutSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
             .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
     }
 
@@ -627,6 +660,32 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
             "Falling back to default (false — warning + proceed on healthcheck timeout).",
             HealthcheckFatalEnvVar, raw);
         return false;
+    }
+
+    /// <summary>
+    /// Resolves the SCM <c>WaitForStatus</c> wall-clock cap. Defaults to
+    /// <see cref="DefaultServiceTimeoutSeconds"/> (30s). Invalid values
+    /// (negative, non-numeric) silently fall back to default — operator-
+    /// friendly: a typo'd env var doesn't break upgrades.
+    /// </summary>
+    internal static int ResolveServiceTimeoutSeconds()
+    {
+        var raw = System.Environment.GetEnvironmentVariable(ServiceTimeoutSecondsEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultServiceTimeoutSeconds;
+
+        if (!int.TryParse(raw.Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            || parsed < 1)
+        {
+            Log.Warning(
+                "[Upgrade] {EnvVar} is set to an invalid value ('{Value}'). " +
+                "Must be a positive integer (seconds). " +
+                "Falling back to default of {Default}.",
+                ServiceTimeoutSecondsEnvVar, raw, DefaultServiceTimeoutSeconds);
+            return DefaultServiceTimeoutSeconds;
+        }
+
+        return parsed;
     }
 
     /// <summary>

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -47,6 +47,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
     private readonly string _previousHealthcheckUrlOverride;
     private readonly string _previousHealthcheckRetriesOverride;
     private readonly string _previousHealthcheckFatalOverride;
+    private readonly string _previousServiceTimeoutOverride;
 
     public WindowsTentacleUpgradeStrategyTests()
     {
@@ -54,11 +55,13 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         _previousHealthcheckUrlOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar);
         _previousHealthcheckRetriesOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar);
         _previousHealthcheckFatalOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar);
+        _previousServiceTimeoutOverride = SystemEnvironment.GetEnvironmentVariable(WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar);
 
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, null);
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar, null);
     }
 
     public void Dispose()
@@ -67,6 +70,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckUrlEnvVar, _previousHealthcheckUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, _previousHealthcheckRetriesOverride);
         SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar, _previousHealthcheckFatalOverride);
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar, _previousServiceTimeoutOverride);
     }
 
     // ========================================================================
@@ -178,6 +182,92 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         // back to the safe 30-attempt default with a Serilog warning so
         // operators see the typo on their next dispatch.
         WindowsTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(30);
+    }
+
+    // ── J.E.8: ServiceTimeoutSecondsEnvVar pins ────────────────────────────
+
+    [Fact]
+    public void ServiceTimeoutSecondsEnvVar_ConstantNamePinned()
+    {
+        // Renaming this constant breaks operators who tuned `WaitForStatus`
+        // upper bounds for slow-startup agents. Hard-pin the literal.
+        WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar
+            .ShouldBe("SQUID_TARGET_WINDOWS_TENTACLE_SERVICE_TIMEOUT_SECONDS");
+    }
+
+    [Fact]
+    public void ResolveServiceTimeoutSeconds_NoEnvVar_ReturnsDefault30()
+    {
+        // 30s default = stock-agent boot (3-5s) × 6 margin. Pin the
+        // default — a polish that "tightens" or "loosens" without operator
+        // notice would mass-break heavyweight-agent deployments.
+        WindowsTentacleUpgradeStrategy.ResolveServiceTimeoutSeconds().ShouldBe(30);
+    }
+
+    [Theory]
+    [InlineData("60", 60)]                // typical "moderate slow agent" (1 min)
+    [InlineData("180", 180)]              // very slow agent (3 min, plugin enumeration heavy)
+    [InlineData("3600", 3600)]            // 1h — extreme but allowed (e.g., AV scanning huge bundle)
+    [InlineData("  120  ", 120)]          // whitespace tolerant
+    public void ResolveServiceTimeoutSeconds_ValidValue_RoundTripsAsInteger(string envValue, int expected)
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar, envValue);
+
+        WindowsTentacleUpgradeStrategy.ResolveServiceTimeoutSeconds().ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0")]                     // 0 is invalid (would skip the wait → race conditions)
+    [InlineData("-30")]                   // negative is invalid
+    [InlineData("30s")]                   // operator wrote "30s" instead of "30" — surprisingly common
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    public void ResolveServiceTimeoutSeconds_InvalidValue_FallsBackToDefault30(string envValue)
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar, envValue);
+
+        // Operator-friendly: invalid values fall back to 30s + Serilog warning.
+        // A typo'd env var doesn't accidentally pass 0 to WaitForStatus
+        // (which would race mid-Stop and cause Phase B to crash mid-swap).
+        WindowsTentacleUpgradeStrategy.ResolveServiceTimeoutSeconds().ShouldBe(30);
+    }
+
+    [Fact]
+    public void RenderInnerScript_ServiceTimeoutSecondsPlaceholder_SubstitutedFromEnv()
+    {
+        SystemEnvironment.SetEnvironmentVariable(WindowsTentacleUpgradeStrategy.ServiceTimeoutSecondsEnvVar, "120");
+
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        // Direct substitution: the placeholder gets the resolved integer.
+        inner.ShouldContain("$SERVICE_TIMEOUT_SECONDS = 120",
+            customMessage: "RenderInnerScript MUST substitute the env-resolved timeout into the script. " +
+                          "If this fails: the placeholder wasn't wired through Replace, OR the .ps1 dropped the variable assignment line.");
+
+        // Hardcoded '00:00:30' literals MUST be gone from the rendered script
+        // — every WaitForStatus call now uses $SERVICE_TIMEOUT_SPAN.
+        inner.ShouldNotContain("'00:00:30'",
+            customMessage: "stale '00:00:30' literal in the rendered .ps1 — should reference $SERVICE_TIMEOUT_SPAN dynamically. " +
+                          "If present: a WaitForStatus call still uses the hardcoded 30s upper bound, ignoring the operator's env var. " +
+                          "Heavy-agent operators would see false-rollback timeouts despite setting the override.");
+    }
+
+    [Fact]
+    public void RenderInnerScript_ServiceTimeoutSpanIsTimeSpanInstance()
+    {
+        // Pin the .ps1's variable shape — `$SERVICE_TIMEOUT_SPAN =
+        // [TimeSpan]::FromSeconds($SERVICE_TIMEOUT_SECONDS)` — so a future
+        // polish that "simplifies" by passing the integer directly to
+        // WaitForStatus (which expects TimeSpan) doesn't break Stop/Start
+        // synchronisation across the .ps1.
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("[TimeSpan]::FromSeconds($SERVICE_TIMEOUT_SECONDS)",
+            customMessage: "TimeSpan construction REGRESSED — WaitForStatus expects TimeSpan, passing int causes runtime cast errors");
+        inner.ShouldContain("WaitForStatus('Running', $SERVICE_TIMEOUT_SPAN)",
+            customMessage: "Start-Service WaitForStatus REGRESSED — must use $SERVICE_TIMEOUT_SPAN");
+        inner.ShouldContain("WaitForStatus('Stopped', $SERVICE_TIMEOUT_SPAN)",
+            customMessage: "Stop-Service WaitForStatus REGRESSED — must use $SERVICE_TIMEOUT_SPAN");
     }
 
     // ── J.E.7: HealthcheckFatalEnvVar pins ──────────────────────────────────
@@ -511,7 +601,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         {
             "TARGET_VERSION", "DOWNLOAD_URL", "EXPECTED_SHA256",
             "INSTALL_DIR", "SERVICE_NAME", "HEALTHCHECK_URL", "HEALTHCHECK_RETRIES",
-            "HEALTHCHECK_FATAL", "INSTALL_METHODS"
+            "HEALTHCHECK_FATAL", "SERVICE_TIMEOUT_SECONDS", "INSTALL_METHODS"
         };
 
         foreach (var name in strategySubstituted)

--- a/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsUpgradeE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -937,6 +937,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
             "INSTALL_DIR",
             "INSTALL_METHODS",
             "SERVICE_NAME",
+            "SERVICE_TIMEOUT_SECONDS",
             "TARGET_VERSION"
         };
 
@@ -1100,6 +1101,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
                 .Replace("{{HEALTHCHECK_URL}}", healthcheckUrl, StringComparison.Ordinal)
                 .Replace("{{HEALTHCHECK_RETRIES}}", healthcheckRetries, StringComparison.Ordinal)
                 .Replace("{{HEALTHCHECK_FATAL}}", healthcheckFatal ? "$true" : "$false", StringComparison.Ordinal)
+                .Replace("{{SERVICE_TIMEOUT_SECONDS}}", "30", StringComparison.Ordinal)
                 .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
         }
 
@@ -1269,6 +1271,15 @@ public sealed class TentacleUpgradeLifecycleE2ETests
             // Always-runs cleanup, even on test-failure paths (Rule 12.3).
             // Order: stop service → delete service → delete .bak → delete
             // installdir → delete program-data override → dispose mirror.
+
+            // Diagnostic breadcrumb: if Dispose runs without MarkClean
+            // having fired, the test exited via assertion / exception
+            // BEFORE its happy-path completion. Surfacing this in stdout
+            // helps disambiguate "test passed but cleanup failed" from
+            // "test failed → MarkClean never reached" when reading CI
+            // logs. No-op when _clean = true (happy path).
+            if (!_clean)
+                Console.WriteLine($"[UpgradeLifecycleContext] Dispose called without MarkClean — test for service '{Fixture.ServiceName}' failed before its happy-path conclusion. Cleanup will still attempt all artefacts best-effort.");
 
             try { Fixture.Dispose(); } catch { /* best-effort */ }
 


### PR DESCRIPTION
## Summary

Closes **audit Risk A** identified in PR #201's deep review: heavyweight agents (heavy plugin enumeration / .NET tiered JIT cold start / AV scanning a 50MB binary) can take >30s to reach SCM RUNNING state. The Phase B Start-Service `WaitForStatus` is **inside** J.E.6's try/catch that triggers Invoke-Rollback → false rollback on a slow-but-successful upgrade.

Fix: operator-tunable env var following the established Rule 8 pattern.

```bash
# heavyweight agent (3min plugin enumeration on first start)
export SQUID_TARGET_WINDOWS_TENTACLE_SERVICE_TIMEOUT_SECONDS=240
```

Single var covers all 4 `WaitForStatus` call sites; default 30s preserves pre-PR behaviour exactly.

## Production changes

### `WindowsTentacleUpgradeStrategy`
- New `public const ServiceTimeoutSecondsEnvVar`
- New `internal const DefaultServiceTimeoutSeconds = 30`
- `ResolveServiceTimeoutSeconds()` — matches sibling `Resolve*` shape (positive-integer parse + invalid-fallback-with-warning)
- `{{SERVICE_TIMEOUT_SECONDS}}` placeholder wired into `RenderInnerScript`

### `upgrade-windows-tentacle.ps1`
- `$SERVICE_TIMEOUT_SECONDS = {{SERVICE_TIMEOUT_SECONDS}}` numeric literal
- `$SERVICE_TIMEOUT_SPAN = [TimeSpan]::FromSeconds($SERVICE_TIMEOUT_SECONDS)` constructed once at top (avoids 4× construction per upgrade)
- All 4 hardcoded `'00:00:30'` replaced with `$SERVICE_TIMEOUT_SPAN`:
  1. Phase B Stop-Service
  2. Phase B Start-Service (the audit-Risk-A target)
  3. Invoke-Rollback Stop new
  4. Invoke-Rollback Restart old

## Unit tests (6 new)

| Test | What it pins |
|---|---|
| `ServiceTimeoutSecondsEnvVar_ConstantNamePinned` | Rule 8 — silent rename breaks operators |
| `ResolveServiceTimeoutSeconds_NoEnvVar_ReturnsDefault30` | Default preserves pre-PR behaviour |
| `ResolveServiceTimeoutSeconds_ValidValue_RoundTripsAsInteger` (Theory) | 60 / 180 / 3600 / whitespace-padded |
| `ResolveServiceTimeoutSeconds_InvalidValue_FallsBackToDefault30` (Theory) | 0 / -30 / "30s" / non-numeric / empty — including the common typo where operators write a unit suffix |
| `RenderInnerScript_ServiceTimeoutSecondsPlaceholder_SubstitutedFromEnv` | Substitution + reverse-pin ("'00:00:30'" stale literal must NOT remain) |
| `RenderInnerScript_ServiceTimeoutSpanIsTimeSpanInstance` | Pins the TimeSpan construction shape — a "simplification" that passes int to `WaitForStatus` (which expects `TimeSpan`) would crash at runtime |

## Drift detector updates

- Unit: `RenderInnerScript_PlaceholderTokens_AppearExactlyOnceInTemplate` extended
- E2E: `UpgradeScript_PlaceholderSet_PinnedToProductionContract` extended

## Bonus: `_clean` field finally has a purpose

Pre-this-PR `_clean` was assigned but never read (CS0414 warning since J.E.3). Now used in `Dispose()` to emit a diagnostic `Console.WriteLine` when cleanup runs without `MarkClean` having fired (= test failed before happy-path completion). Useful when reading CI logs to disambiguate "test passed but cleanup failed" from "test failed → MarkClean never reached".

## Local verification

- 262/262 unit tests pass
- 87/87 cross-platform E2E pass

## Deferred

The 5th env var triggers consideration of an `IUpgradeOverride[]` refactor (Rule 7). Currently:
1. `DownloadBaseUrlEnvVar`
2. `HealthcheckUrlEnvVar`
3. `HealthcheckRetriesEnvVar`
4. `HealthcheckFatalEnvVar`
5. `ServiceTimeoutSecondsEnvVar` ← THIS PR

Deferred until 6th — refactoring at exactly the threshold is over-eager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)