### PR TITLE
Phase 12.L.E.1 — Linux E2E foundation + bash parse pin

### DIFF
--- a/.github/workflows/tentacle-linux-e2e.yml
+++ b/.github/workflows/tentacle-linux-e2e.yml
@@ -1,0 +1,66 @@
+name: Tentacle Linux E2E
+
+# Linux runners are 1x billing on GHA (vs Windows 2x), so we can afford to
+# run on every PR touching Linux-relevant paths. But the tentacle Linux E2E
+# is operationally heavier (apt/dnf interactions, systemd, sudo) and most
+# PRs don't touch the Linux upgrade flow. Match the Windows workflow's
+# cadence: nightly schedule + on-merge-to-main + workflow_dispatch for
+# on-demand runs.
+#
+# Future expansion (12.L.E.2+): when full systemd-driven E2E lands, this
+# workflow will drive `dotnet test` against ubuntu-latest (sudo + systemd
+# + apt available) and the test fixture will install/start a transient
+# systemd service for the upgrade-flow swap mechanics. Today the workflow
+# only runs the placeholder-drift + bash-parse tests which need no system
+# infrastructure.
+
+on:
+  schedule:
+    - cron: "0 9 * * *"    # 09:00 UTC daily — same window as Windows workflow
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test_filter:
+        description: "xUnit --filter for the Squid.LinuxTentacleE2ETests step"
+        required: false
+        default: "Category=LinuxTentacleUpgradeScriptE2E"
+
+permissions:
+  contents: read
+
+jobs:
+  linux-tentacle-e2e:
+    name: Linux Tentacle End-to-End
+    runs-on: ubuntu-latest
+    env:
+      NUGET_CONFIG: ${{ github.workspace }}/NuGet.Config
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Disable unreachable NuGet source
+        run: dotnet nuget disable source SJ.Nuget --configfile "$NUGET_CONFIG"
+
+      - name: Confirm bash + systemd available
+        run: |
+          bash --version | head -1
+          systemctl --version | head -1 || echo "systemd not on PATH (acceptable for L.E.1 — no systemd-driven tests yet)"
+
+      - name: Restore Squid.LinuxTentacleE2ETests
+        run: dotnet restore tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj --configfile "$NUGET_CONFIG"
+
+      - name: Run Squid.LinuxTentacleE2ETests
+        run: |
+          FILTER="${{ github.event.inputs.test_filter }}"
+          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E"; fi
+          dotnet test tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj \
+            --configuration Release --no-restore \
+            --filter "$FILTER" \
+            --logger "console;verbosity=normal"

--- a/Squid.sln
+++ b/Squid.sln
@@ -35,6 +35,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Squid.WindowsUpgradeE2E.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Squid.WindowsUpgradeE2E.VersionStampedShim", "tests\Squid.WindowsUpgradeE2E.VersionStampedShim\Squid.WindowsUpgradeE2E.VersionStampedShim.csproj", "{70B61BAD-F3FC-4A47-9201-3ECB4936B091}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Squid.LinuxTentacleE2ETests", "tests\Squid.LinuxTentacleE2ETests\Squid.LinuxTentacleE2ETests.csproj", "{4764B60D-869D-483B-B8F8-9985727AEE41}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,18 @@ Global
 		{70B61BAD-F3FC-4A47-9201-3ECB4936B091}.Release|x64.Build.0 = Release|Any CPU
 		{70B61BAD-F3FC-4A47-9201-3ECB4936B091}.Release|x86.ActiveCfg = Release|Any CPU
 		{70B61BAD-F3FC-4A47-9201-3ECB4936B091}.Release|x86.Build.0 = Release|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Debug|x64.Build.0 = Debug|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Debug|x86.Build.0 = Debug|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Release|x64.ActiveCfg = Release|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Release|x64.Build.0 = Release|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Release|x86.ActiveCfg = Release|Any CPU
+		{4764B60D-869D-483B-B8F8-9985727AEE41}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,6 +244,7 @@ Global
 		{60B2E9F3-4C01-4C34-AB04-C33B980D0306} = {39D26C72-1BD3-4793-A455-F651830208E7}
 		{C73A5594-231B-42E2-A42C-2D1EB786D82E} = {39D26C72-1BD3-4793-A455-F651830208E7}
 		{70B61BAD-F3FC-4A47-9201-3ECB4936B091} = {39D26C72-1BD3-4793-A455-F651830208E7}
+		{4764B60D-869D-483B-B8F8-9985727AEE41} = {39D26C72-1BD3-4793-A455-F651830208E7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {60CBA761-5D3C-4D33-B808-977512C7E6ED}

--- a/src/Squid.Core/Squid.Core.csproj
+++ b/src/Squid.Core/Squid.Core.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Squid.UnitTests" />
     <InternalsVisibleTo Include="Squid.WindowsUpgradeE2ETests" />
+    <InternalsVisibleTo Include="Squid.LinuxTentacleE2ETests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Squid.LinuxTentacleE2ETests/GlobalUsings.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/GlobalUsings.cs
@@ -1,0 +1,10 @@
+global using System;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Reflection;
+global using System.Text.RegularExpressions;
+global using System.Threading;
+global using System.Threading.Tasks;
+global using Shouldly;
+global using Xunit;

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
@@ -1,0 +1,24 @@
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// xUnit Trait categories for the Linux upgrade E2E suite. Mirrors
+/// <c>WindowsUpgradeE2ECategories</c> for the Windows project.
+///
+/// <para>The CI workflow filters by these categories. A developer running
+/// the suite locally on macOS/Windows gets a clean "0 ran, 0 passed"
+/// rather than spurious failures from
+/// <c>if (!OperatingSystem.IsLinux()) return</c> short-circuits.</para>
+/// </summary>
+public static class LinuxTentacleE2ECategories
+{
+    /// <summary>
+    /// Phase 12.L.E.1 baseline E2E coverage for the production
+    /// <c>upgrade-linux-tentacle.sh</c> placeholder substitution + bash
+    /// parse-cleanliness contract. Cross-platform safe (uses bash -n
+    /// available on Linux + macOS); doesn't actually run an upgrade.
+    ///
+    /// <para>Subsequent phases (12.L.E.2+) extend this with real
+    /// systemd-run / systemctl restart / apt / dnf / curl flows.</para>
+    /// </summary>
+    public const string UpgradeScript = "LinuxTentacleUpgradeScriptE2E";
+}

--- a/tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj
+++ b/tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Phase 12.L (Linux E2E) — counterpart to Squid.WindowsUpgradeE2ETests.
+    Drives the production `upgrade-linux-tentacle.sh` + `install-tentacle.sh`
+    scripts end-to-end against real systemd / apt / dnf / curl / tar tooling
+    on the GHA `ubuntu-latest` runner.
+
+    Cross-platform build (compiles on Win/macOS/Linux); tests skip-guard
+    on `OperatingSystem.IsLinux()` so dev-host `dotnet test` runs cleanly.
+    The CI workflow that ACTUALLY exercises the tests is `.github/workflows/
+    tentacle-linux-e2e.yml` running on `ubuntu-latest`.
+
+    Why a separate project (vs adding to Squid.WindowsUpgradeE2ETests):
+      - Different fixture surface (systemd vs sc.exe; apt/dnf vs MSI/zip;
+        curl vs Invoke-WebRequest; tar.gz vs zip).
+      - Different runner image (`ubuntu-latest` vs `windows-latest`)
+        means separate workflow files; keeping projects 1:1 with workflows
+        simplifies the GHA filter mapping.
+      - Project-level `[Trait("Category", "Linux*E2E")]` partition lets
+        tests.yml + tentacle-linux-e2e.yml cleanly target only the Linux
+        side without filter cross-talk.
+
+    Convention parity with Windows project:
+      - Same csproj structure (no MSTest, xUnit + Shouldly + custom fixtures)
+      - Same skip-guard pattern (`if (!OperatingSystem.IsLinux()) return;`)
+      - Same naming (categories suffixed `*E2E`, classes suffixed `*E2ETests`)
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Squid.LinuxTentacleE2ETests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Squid.Core\Squid.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
@@ -1,0 +1,218 @@
+using System.Diagnostics;
+using System.Text;
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.L.E.1 — baseline E2E coverage for
+/// <c>upgrade-linux-tentacle.sh</c>'s placeholder substitution + bash
+/// parse-cleanliness contract.
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. The production .sh template is
+/// loaded from disk verbatim (the same bytes the strategy embeds); the
+/// strategy's <c>RenderInnerScript</c> is invoked to produce the rendered
+/// .sh; the rendered output is parsed by REAL bash via <c>bash -n</c>
+/// (parse-only mode — no execution). Catches placeholder-substitution
+/// regressions that would only surface at agent-side runtime.</para>
+///
+/// <para><b>Why this matters</b>: J.E.3 first-attempt on Windows caught a
+/// production P0 where `{{INSTALL_METHODS}}` in a comment got rewritten
+/// by `String.Replace`, splicing multi-line PowerShell into a #-prefixed
+/// line and producing parse errors invisible to ALL prior tests (no
+/// suite ran the rendered .ps1 through a real parser). The Linux .sh
+/// has a similar substitution shape; this test pins the parse contract
+/// so the same bug class can't slip through silently on the Linux side.
+/// Pairs with <see cref="LinuxScriptParsesAsBash"/>.</para>
+///
+/// <para><b>Cross-platform</b>: bash + grep are universally available on
+/// Linux + macOS. Tests skip-guard <c>OperatingSystem.IsLinux()</c> on
+/// macOS dev hosts (matches the convention for Windows-only tests in
+/// the sibling project).</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.UpgradeScript)]
+public sealed class UpgradeLinuxScriptE2ETests
+{
+    // ========================================================================
+    // Drift detector — placeholder set
+    //
+    // Pins which `{{TOKEN}}` placeholders the production .sh expects. The
+    // strategy MUST substitute exactly this set; a future polish that
+    // renames or adds a placeholder without updating the strategy would
+    // ship an unsubstituted `{{NEW_PLACEHOLDER}}` literal — bash treats
+    // that as a parameter expansion at parse time and may fail / silently
+    // expand to empty.
+    //
+    // Cross-platform — runs on every dev host without a Linux guard.
+    // ========================================================================
+
+    [Fact]
+    public void LinuxScript_PlaceholderSet_PinnedToProductionContract()
+    {
+        var template = File.ReadAllText(LocateLinuxTemplate());
+
+        // Same regex shape as the Windows pin. Includes digits because a
+        // future placeholder might have numeric suffix (e.g. SHA256).
+        var matches = Regex.Matches(template, @"\{\{([A-Z0-9_]+)\}\}");
+        var foundPlaceholders = matches.Select(m => m.Groups[1].Value).Distinct().OrderBy(s => s).ToArray();
+
+        // Linux-specific shape. Note SERVICE_USER (Linux runs services
+        // under a dedicated user, Windows uses SYSTEM identity).
+        var expected = new[]
+        {
+            "DOWNLOAD_URL",
+            "EXPECTED_SHA256",
+            "HEALTHCHECK_URL",
+            "INSTALL_DIR",
+            "INSTALL_METHODS",
+            "SERVICE_NAME",
+            "SERVICE_USER",
+            "TARGET_VERSION"
+        };
+
+        foundPlaceholders.ShouldBe(expected, ignoreOrder: false,
+            customMessage: $"production upgrade-linux-tentacle.sh placeholder set drifted from strategy substitution map. " +
+                          $"Expected: [{string.Join(", ", expected)}]. " +
+                          $"Found: [{string.Join(", ", foundPlaceholders)}]. " +
+                          $"FIX: extend LinuxTentacleUpgradeStrategy.RenderInnerScript to substitute the new placeholder " +
+                          $"(or remove it from the .sh if production removed it). Without this fix, the rendered .sh will " +
+                          $"contain a literal `{{{{NEW_PLACEHOLDER}}}}` token that bash treats as parameter expansion — " +
+                          $"either failing parse (`bad substitution`) or silently expanding to empty (worse: hides the bug).");
+    }
+
+    // ========================================================================
+    // Drift detector #2 — placeholder uniqueness
+    //
+    // Same bug class as the J.E.3.1 Windows P0 fix: any `{{TOKEN}}`
+    // appearing more than once in the template gets rewritten everywhere
+    // by `String.Replace`. For multi-line substitutions (e.g.
+    // INSTALL_METHODS → if-block), this splices code into single-line
+    // contexts (comments / string interpolations) producing silent
+    // syntax errors at agent runtime.
+    //
+    // The Linux .sh CURRENTLY has every placeholder appearing exactly
+    // once. This test pins that — a future polish that mentions a
+    // placeholder name in a comment or doc-string accidentally gets
+    // caught here at build time, not at the next operator-broken-upgrade
+    // incident.
+    // ========================================================================
+
+    [Fact]
+    public void LinuxScript_PlaceholderTokens_AppearExactlyOnceInTemplate()
+    {
+        var template = File.ReadAllText(LocateLinuxTemplate());
+
+        var matches = Regex.Matches(template, @"\{\{([A-Z0-9_]+)\}\}");
+        var occurrences = matches
+            .Cast<Match>()
+            .GroupBy(m => m.Groups[1].Value)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        foreach (var (name, count) in occurrences)
+        {
+            count.ShouldBe(1,
+                customMessage: $"placeholder '{{{{{name}}}}}' appears {count} times in upgrade-linux-tentacle.sh — MUST be exactly once. " +
+                              $"String.Replace substitutes EVERY occurrence, so a comment-line mention of the placeholder name gets rewritten too. " +
+                              $"For multi-line substitutions (e.g. INSTALL_METHODS → multi-statement block), this splices bash code into a `#`-prefixed " +
+                              $"comment line — bash parses the FIRST line as comment but treats subsequent lines as orphan code, producing parse errors " +
+                              $"that ONLY surface at agent-side `systemd-run --scope` re-exec. The pre-scope phase exit code stays 0 (its work was done " +
+                              $"— the scope was registered), strategy maps to Initiated, but the agent's scope-phase parse-fails and last-upgrade.json " +
+                              $"is never written. Identical bug class as the J.E.3.1 Windows {{{{INSTALL_METHODS}}}} comment fix. " +
+                              $"FIX: edit upgrade-linux-tentacle.sh to remove the duplicate occurrence (typically a comment-line mention of the placeholder by name).");
+        }
+    }
+
+    // ========================================================================
+    // Drift detector #3 — bash parses the rendered .sh cleanly
+    //
+    // The strategy's full RenderInnerScript output MUST be parseable by
+    // bash. Catches the same bug class the Windows pin catches but at
+    // a different layer: substring-checks (placeholder-appears-once) +
+    // syntactic check (bash -n exits 0). Belt-and-braces — if a future
+    // polish slips a placeholder past the substring check (e.g. a new
+    // multi-line substitution that splices into a different odd context),
+    // bash parsing surfaces the actual error.
+    //
+    // Skip-on-non-bash — runs on Linux + macOS (both ship bash). Windows
+    // dev hosts skip cleanly via the operating-system guard.
+    // ========================================================================
+
+    [Fact]
+    public async Task LinuxScript_RenderedFromStrategy_ParsesCleanlyAsBash()
+    {
+        // bash -n is universally available on Linux + macOS. The Windows
+        // sibling project skips this test (no native bash on windows-latest
+        // runner image's PATH by default; WSL is opt-in).
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+
+        // Render via the production strategy (NOT a test re-implementation).
+        // If the strategy's substitution logic regresses, this test catches it.
+        // Note: Linux strategy exposes `BuildScript` (Windows uses
+        // `RenderInnerScript`); they're analogous APIs at different layers
+        // (Linux .sh self-contains the scope re-exec, so there's no separate
+        // outer wrapper like Windows's Task Scheduler dispatch wrapper).
+        var rendered = LinuxTentacleUpgradeStrategy.BuildScript("1.6.0", LinuxTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        // Sanity assertion before invoking bash — fail fast with a clear
+        // message if the strategy's substitution dropped a placeholder.
+        rendered.ShouldNotMatch(@"\{\{[A-Z0-9_]+\}\}",
+            customMessage: "rendered .sh STILL contains an unsubstituted placeholder. " +
+                          "RenderInnerScript missed a placeholder — bash will treat it as parameter expansion at runtime. " +
+                          "FIX: add the missing .Replace call.");
+
+        // Write rendered to a temp file + invoke `bash -n` (parse-only).
+        // Temp file path uses /tmp on Linux/macOS — universally writable.
+        var tempScript = Path.Combine(Path.GetTempPath(), $"squid-linux-script-parse-check-{Guid.NewGuid():N}.sh");
+        File.WriteAllText(tempScript, rendered);
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "bash",
+                Arguments = $"-n \"{tempScript}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to launch bash for parse check");
+
+            var stderr = await proc.StandardError.ReadToEndAsync();
+            var stdout = await proc.StandardOutput.ReadToEndAsync();
+
+            proc.WaitForExit(5_000).ShouldBeTrue("bash -n must complete within 5s for a script of this size");
+
+            proc.ExitCode.ShouldBe(0,
+                customMessage: $"bash -n rejected the rendered upgrade-linux-tentacle.sh — placeholder substitution produced syntactically-invalid bash. " +
+                              $"This is the same bug class as the J.E.3.1 Windows {{{{INSTALL_METHODS}}}} comment fix: a multi-line substitution spliced code into " +
+                              $"an unexpected context (comment / string / heredoc) and broke the parse. " +
+                              $"bash stderr:\n{stderr}\n" +
+                              $"bash stdout (usually empty for -n):\n{stdout}");
+        }
+        finally
+        {
+            try { File.Delete(tempScript); } catch { /* best-effort */ }
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string LocateLinuxTemplate()
+    {
+        // Walk up from the test assembly's bin directory to the repo root.
+        // Same shape as Windows project's LocateProductionTemplate but
+        // pointing at the .sh instead of .ps1.
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "src", "Squid.Core", "Resources", "Upgrade", "upgrade-linux-tentacle.sh");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException("Could not locate upgrade-linux-tentacle.sh from the test assembly's directory tree");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the **largest audit gap** from PR #201's deep review: pre-this-PR no test in the repo ran the rendered `upgrade-linux-tentacle.sh` through a real bash parser. The same bug class as the J.E.3.1 Windows `{{INSTALL_METHODS}}`-in-comment P0 could be sitting in the .sh today and nobody would know until the next operator-broken-upgrade incident.

This PR establishes the Linux E2E foundation. Subsequent phases (12.L.E.2+) will build full systemd-driven lifecycle tests on top.

## Deliberately narrow scope (Rule 12.3 split-PR discipline)

- Project structure + GHA workflow + 3 foundational tests
- **NO** production code changes — pure additive scaffolding
- **NO** systemd / fixture / full lifecycle yet — separate PRs

## Foundation pieces

| Artifact | Role |
|---|---|
| `Squid.LinuxTentacleE2ETests` project | Cross-platform compile, skip-on-non-Linux pattern, parity with Windows project |
| `tentacle-linux-e2e.yml` workflow | Nightly + push-to-main + workflow_dispatch on `ubuntu-latest` |
| `LinuxTentacleE2ECategories.UpgradeScript` | xUnit Trait pattern matching Windows |
| `Squid.LinuxTentacleE2ETests` added to `InternalsVisibleTo` | Allows direct strategy method calls (no reflection) |

## 3 foundational tests (Tier 🟢 high-fidelity)

1. **`LinuxScript_PlaceholderSet_PinnedToProductionContract`** — drift detector. 8 placeholders incl. Linux-specific `SERVICE_USER` (Windows uses SYSTEM)
2. **`LinuxScript_PlaceholderTokens_AppearExactlyOnceInTemplate`** — pins against the J.E.3.1 Windows P0 bug class on the Linux side
3. **`LinuxScript_RenderedFromStrategy_ParsesCleanlyAsBash`** — belt-and-braces. Renders via production `BuildScript`, runs `bash -n` (parse-only). Catches multi-line substitution splicing into heredoc / string / case branch contexts that substring pins might miss

## Local verification (macOS)

3/3 pass — including the bash parse check **actually running against macOS's `/bin/bash`**. The Linux .sh is currently parse-clean; this PR establishes the pin so it stays that way.

## Deferred to 12.L.E.2+

- `SQUID_TENTACLE_STATE_DIR` env-var override (Linux equivalent of Windows `$env:ProgramData` redirect). Required for full lifecycle tests.
- `LinuxServiceFixture` (systemd analog of `WindowsServiceFixture`)
- First full lifecycle test (Linux E1.h analog)
- Linux-side production hardening parity with Windows J.E.5/6/7/8 (`HEALTHCHECK_RETRIES`, auto-rollback, stale-lock recovery, `SERVICE_TIMEOUT_SECONDS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)