### PR TITLE
Phase 12.L.E.2 — Linux state-dir env-var override (foundation for full E2E)

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
@@ -66,7 +66,13 @@ SERVICE_NAME="{{SERVICE_NAME}}"
 SERVICE_USER="{{SERVICE_USER}}"
 HEALTHCHECK_URL="{{HEALTHCHECK_URL}}"
 
-STATUS_DIR="/var/lib/squid-tentacle"
+# State directory — server-substituted from LinuxTentacleUpgradeStrategy.
+# Default `/var/lib/squid-tentacle` matches what install-tentacle.sh
+# creates + chowns. Operator override via SQUID_TARGET_LINUX_TENTACLE_STATE_DIR
+# for FHS-strict deployments / container volume mounts / E2E test isolation.
+# Pinned by `LinuxTentacleUpgradeStrategyTests.StateDirEnvVar_*` + the .sh
+# placeholder drift detector in Squid.LinuxTentacleE2ETests.
+STATUS_DIR="{{STATE_DIR}}"
 STATUS_FILE="$STATUS_DIR/last-upgrade.json"
 # Lock file lives in the service-user-owned state dir (NOT /tmp) so a stale
 # root-owned lock left by a previous debug session / failed scope run can't

--- a/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
@@ -63,8 +63,41 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
     /// </summary>
     public const string HealthcheckUrlEnvVar = "SQUID_TARGET_LINUX_TENTACLE_HEALTHCHECK_URL";
 
+    /// <summary>
+    /// Operator override for the agent state directory — where the .sh
+    /// writes <c>last-upgrade.json</c>, <c>upgrade.lock</c>, and
+    /// <c>upgrade-events.jsonl</c>. Default
+    /// <c>/var/lib/squid-tentacle</c> matches what
+    /// <c>install-tentacle.sh</c> creates and chowns to the
+    /// <c>squid-tentacle</c> user. Operators with non-standard layouts
+    /// (FHS-3.0 strict deployments using <c>/srv/squid-tentacle</c>,
+    /// container deployments wanting state under a mounted volume,
+    /// E2E test harnesses needing per-test isolation) override here.
+    ///
+    /// <para><b>Why a state-dir env var (J.L.E.2)</b>: Linux .sh has no
+    /// equivalent of Windows .ps1's <c>$env:ProgramData</c> redirect (a
+    /// universal Windows env var that points at the analogous state
+    /// dir). Without an explicit override, the .sh's <c>STATUS_DIR</c>
+    /// is hardcoded to <c>/var/lib/squid-tentacle</c> — making test
+    /// isolation impossible without either running tests as root +
+    /// writing to a real <c>/var/lib</c> path, or running tests inside
+    /// containers. This env var is the test seam (and a real operator
+    /// option for non-standard layouts).</para>
+    ///
+    /// <para>Pinned per Rule 8 by
+    /// <c>LinuxTentacleUpgradeStrategyTests.StateDirEnvVar_ConstantNamePinned</c>.</para>
+    /// </summary>
+    public const string StateDirEnvVar = "SQUID_TARGET_LINUX_TENTACLE_STATE_DIR";
+
     private const string DefaultDownloadBaseUrl = "https://github.com/SolarifyDev/Squid/releases/download";
     private const string DefaultHealthcheckUrl = "http://127.0.0.1:8080/healthz";
+
+    /// <summary>
+    /// Default agent state directory. Matches what
+    /// <c>install-tentacle.sh</c> creates + chowns. Operators override via
+    /// <see cref="StateDirEnvVar"/>.
+    /// </summary>
+    internal const string DefaultStateDir = "/var/lib/squid-tentacle";
 
     /// <summary>
     /// Wall-clock cap for a single upgrade script dispatch. Must stay
@@ -347,6 +380,7 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
             .Replace("{{SERVICE_NAME}}", DefaultServiceName, StringComparison.Ordinal)
             .Replace("{{SERVICE_USER}}", DefaultServiceUser, StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_URL}}", ResolveHealthcheckUrl(), StringComparison.Ordinal)
+            .Replace("{{STATE_DIR}}", ResolveStateDir(), StringComparison.Ordinal)
             .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
     }
 
@@ -361,6 +395,25 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
         var baseUrl = ResolveDownloadBaseUrl();
 
         return $"{baseUrl}/{version}/squid-tentacle-{version}-{rid}.tar.gz";
+    }
+
+    /// <summary>
+    /// Resolves the agent state directory. Defaults to
+    /// <see cref="DefaultStateDir"/> (<c>/var/lib/squid-tentacle</c>).
+    /// Trims trailing slashes — the .sh joins paths via <c>"$STATE_DIR/foo"</c>
+    /// and a double slash works on Linux but reads ugly in logs.
+    ///
+    /// <para>Empty / whitespace-only env values fall back to default —
+    /// operator-friendly: an unset-but-defined env var doesn't break the
+    /// upgrade flow with `bad path` errors.</para>
+    /// </summary>
+    internal static string ResolveStateDir()
+    {
+        var raw = System.Environment.GetEnvironmentVariable(StateDirEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultStateDir;
+
+        return raw.Trim().TrimEnd('/');
     }
 
     internal static string ResolveDownloadBaseUrl()

--- a/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
@@ -67,6 +67,7 @@ public sealed class UpgradeLinuxScriptE2ETests
             "INSTALL_METHODS",
             "SERVICE_NAME",
             "SERVICE_USER",
+            "STATE_DIR",
             "TARGET_VERSION"
         };
 

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -39,20 +39,24 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
 {
     private readonly string _previousBaseUrlOverride;
     private readonly string _previousHealthcheckUrlOverride;
+    private readonly string _previousStateDirOverride;
 
     public LinuxTentacleUpgradeStrategyTests()
     {
         _previousBaseUrlOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar);
         _previousHealthcheckUrlOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckUrlEnvVar);
+        _previousStateDirOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar);
 
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckUrlEnvVar, null);
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, null);
     }
 
     public void Dispose()
     {
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, _previousBaseUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckUrlEnvVar, _previousHealthcheckUrlOverride);
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, _previousStateDirOverride);
     }
 
     [Fact]
@@ -61,6 +65,87 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         // Renaming this constant breaks every air-gapped operator who pinned
         // a private mirror via env. Hard-pin in test.
         LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar.ShouldBe("SQUID_TARGET_LINUX_TENTACLE_DOWNLOAD_BASE_URL");
+    }
+
+    // ── J.L.E.2: StateDirEnvVar pins ────────────────────────────────────────
+
+    [Fact]
+    public void StateDirEnvVar_ConstantNamePinned()
+    {
+        // Renaming this constant breaks operators with FHS-strict
+        // deployments / container volume mounts who tuned state path.
+        // Hard-pin in test.
+        LinuxTentacleUpgradeStrategy.StateDirEnvVar
+            .ShouldBe("SQUID_TARGET_LINUX_TENTACLE_STATE_DIR");
+    }
+
+    [Fact]
+    public void ResolveStateDir_NoEnvVar_ReturnsDefaultVarLibPath()
+    {
+        // Default `/var/lib/squid-tentacle` matches what install-tentacle.sh
+        // creates + chowns. Pin the default literally — a polish that
+        // changes this would mass-break every default-install deployment
+        // (last-upgrade.json wouldn't be findable by the existing agent
+        // CapabilitiesService that reads it).
+        LinuxTentacleUpgradeStrategy.ResolveStateDir().ShouldBe("/var/lib/squid-tentacle");
+    }
+
+    [Theory]
+    [InlineData("/srv/squid-tentacle", "/srv/squid-tentacle")]              // FHS-strict deployment
+    [InlineData("/data/squid-tentacle", "/data/squid-tentacle")]            // container volume mount
+    [InlineData("/tmp/test-isolated/squid-tentacle", "/tmp/test-isolated/squid-tentacle")]  // E2E test isolation
+    [InlineData("/var/lib/squid-tentacle/", "/var/lib/squid-tentacle")]     // trailing slash trimmed
+    [InlineData("  /custom/path  ", "/custom/path")]                        // whitespace trimmed
+    public void ResolveStateDir_OperatorOverride_NormalisesAndReturns(string envValue, string expected)
+    {
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, envValue);
+
+        LinuxTentacleUpgradeStrategy.ResolveStateDir().ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("")]                          // empty after trim
+    [InlineData("   ")]                       // whitespace-only
+    [InlineData("\t\n")]                      // other whitespace
+    public void ResolveStateDir_EmptyOrWhitespace_FallsBackToDefault(string envValue)
+    {
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, envValue);
+
+        // Empty/whitespace falls back to the safe default. Operator-friendly:
+        // an unset-but-defined env var (e.g. `export FOO=` in a parent shell)
+        // doesn't break the upgrade flow with bad-path errors.
+        LinuxTentacleUpgradeStrategy.ResolveStateDir().ShouldBe("/var/lib/squid-tentacle");
+    }
+
+    [Fact]
+    public void BuildScript_StateDirPlaceholder_SubstitutedFromEnv()
+    {
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, "/srv/test-isolated/state");
+
+        var rendered = LinuxTentacleUpgradeStrategy.BuildScript("1.6.0", LinuxTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        // Rendered .sh has the env-resolved path in STATUS_DIR assignment.
+        rendered.ShouldContain("STATUS_DIR=\"/srv/test-isolated/state\"",
+            customMessage: "BuildScript MUST substitute the env-resolved state dir into STATUS_DIR. " +
+                          "If this fails: the {{STATE_DIR}} placeholder wasn't wired through Replace, OR the .sh dropped the assignment line.");
+
+        // Hardcoded `/var/lib/squid-tentacle` literal MUST NOT remain in
+        // the assignment position. The string still appears in COMMENTS
+        // (which is fine — they're documentation of the default), but
+        // the actual STATUS_DIR=... assignment must use the substituted value.
+        rendered.ShouldNotContain("STATUS_DIR=\"/var/lib/squid-tentacle\"",
+            customMessage: "stale hardcoded STATUS_DIR literal in the rendered .sh — the env override is no-op if this is present");
+    }
+
+    [Fact]
+    public void BuildScript_StateDir_DefaultsToVarLibInRender()
+    {
+        // No env var set → render uses the literal default. Operators not
+        // overriding see no behaviour change.
+        var rendered = LinuxTentacleUpgradeStrategy.BuildScript("1.6.0", LinuxTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        rendered.ShouldContain("STATUS_DIR=\"/var/lib/squid-tentacle\"",
+            customMessage: "default render MUST inject /var/lib/squid-tentacle — operators not-overriding see pre-PR behaviour");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Enables the next phase of Linux E2E (12.L.E.3+ full lifecycle tests). Pre-this-PR `upgrade-linux-tentacle.sh` hardcoded `STATUS_DIR="/var/lib/squid-tentacle"` — **no test isolation possible** without running as root or in containers. Equivalent of pre-J.E.3 Windows lacking `$env:ProgramData` redirection.

This is the **last production-side blocker** before full Linux E2E coverage can land.

## Operator value

| Use case | Override |
|---|---|
| FHS-strict deployments | `SQUID_TARGET_LINUX_TENTACLE_STATE_DIR=/srv/squid-tentacle` |
| Container with mounted volume | `SQUID_TARGET_LINUX_TENTACLE_STATE_DIR=/data/squid-tentacle` |
| E2E test isolation | `SQUID_TARGET_LINUX_TENTACLE_STATE_DIR=/tmp/test-{guid}/squid-tentacle` |
| (default) | `/var/lib/squid-tentacle` — pre-PR behaviour exactly |

## Production changes

### `LinuxTentacleUpgradeStrategy`
- `public const StateDirEnvVar = "SQUID_TARGET_LINUX_TENTACLE_STATE_DIR"`
- `internal const DefaultStateDir = "/var/lib/squid-tentacle"`
- `ResolveStateDir()` — trims trailing slashes + whitespace, falls back to default on empty (operator-friendly)
- `{{STATE_DIR}}` placeholder wired into `BuildScript`

### `upgrade-linux-tentacle.sh`
- `STATUS_DIR="{{STATE_DIR}}"` replaces hardcoded `"/var/lib/squid-tentacle"`
- All downstream paths (`STATUS_FILE`, `LOCK_FILE`, `EVENTS_FILE`) already derive from `STATUS_DIR` — auto-pick up override

## Unit tests (6 new)

| Test | Pin |
|---|---|
| `StateDirEnvVar_ConstantNamePinned` | Rule 8 |
| `ResolveStateDir_NoEnvVar_ReturnsDefaultVarLibPath` | Default `/var/lib/squid-tentacle` |
| `ResolveStateDir_OperatorOverride_NormalisesAndReturns` (Theory) | 5 real operator scenarios |
| `ResolveStateDir_EmptyOrWhitespace_FallsBackToDefault` (Theory) | Operator-friendly fallback |
| `BuildScript_StateDirPlaceholder_SubstitutedFromEnv` | Positive + reverse-pin (no stale hardcoded path) |
| `BuildScript_StateDir_DefaultsToVarLibInRender` | Default render unchanged |

## Drift detector updated

- `Squid.LinuxTentacleE2ETests.UpgradeLinuxScriptE2ETests.LinuxScript_PlaceholderSet_*` now expects 9 placeholders (was 8 + `STATE_DIR`)

## Local verification

- 5068/5068 unit tests pass
- 3/3 Linux E2E pass (incl. `bash -n` parse check on new STATE_DIR-substituted .sh)

## Next phase (12.L.E.3)

With state-dir override in place, can build:
- `LinuxServiceFixture` (systemd analog of `WindowsServiceFixture`)
- First full lifecycle test (Linux E1.h analog)
- Linux-side production hardening parity with Windows J.E.5/6/7/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)