### PR TITLE
Phase 12.L.E.3 — LinuxServiceFixture + smoke tests (foundation for full lifecycle)

### DIFF
--- a/.github/workflows/tentacle-linux-e2e.yml
+++ b/.github/workflows/tentacle-linux-e2e.yml
@@ -24,7 +24,7 @@ on:
       test_filter:
         description: "xUnit --filter for the Squid.LinuxTentacleE2ETests step"
         required: false
-        default: "Category=LinuxTentacleUpgradeScriptE2E"
+        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E"
 
 permissions:
   contents: read
@@ -59,7 +59,7 @@ jobs:
       - name: Run Squid.LinuxTentacleE2ETests
         run: |
           FILTER="${{ github.event.inputs.test_filter }}"
-          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E"; fi
+          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E"; fi
           dotnet test tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj \
             --configuration Release --no-restore \
             --filter "$FILTER" \

--- a/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
+++ b/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Phase 12.L.E.3 — minimal systemd-compatible test service.
+#
+# Counterpart to Squid.WindowsUpgradeE2E.TestService for Linux. Used by:
+#   - LinuxServiceFixture: install + start + stop + uninstall against
+#     a real systemd unit, no sudo-fail / SCM-timeout edge cases
+#   - LinuxLifecycleContext (12.L.E.4): the upgrade .sh's Phase B targets
+#     this service for `systemctl restart` swap mechanics
+#
+# Behaviour:
+#   - On start: read $INSTALL_DIR/version.txt, write that version into
+#     a marker file at $INSTALL_DIR/service-running.marker, then sleep
+#     forever (until SIGTERM)
+#   - On stop (SIGTERM): delete the marker, exit 0
+#
+# The marker file is the proxy for "service is running and has read its
+# version" — same pattern as Windows TestUpgradeService. Tests assert
+# marker presence + content as proof of a successful start cycle.
+#
+# Why a script (not a compiled binary):
+#   - bash is universally available on every Linux distro the agent
+#     supports — no .NET runtime needed for the test service itself
+#   - Easier to reason about: one file, no cross-compile concerns
+#   - Same observable contract as Windows test service (marker file)
+#
+# INSTALL_DIR is passed via env var by systemd's Environment= directive in
+# the unit file the fixture writes. The script defaults to its own
+# directory if INSTALL_DIR is unset (defensive — caller should set it).
+# ==============================================================================
+
+set -uo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-$(dirname "$(readlink -f "$0")")}"
+VERSION_FILE="$INSTALL_DIR/version.txt"
+MARKER_FILE="$INSTALL_DIR/service-running.marker"
+
+read_version() {
+    if [ -f "$VERSION_FILE" ]; then
+        cat "$VERSION_FILE" | tr -d '[:space:]'
+    else
+        echo "unknown"
+    fi
+}
+
+cleanup() {
+    rm -f "$MARKER_FILE" 2>/dev/null || true
+    exit 0
+}
+
+trap cleanup TERM INT
+
+# Write marker on start.
+mkdir -p "$INSTALL_DIR" 2>/dev/null || true
+read_version > "$MARKER_FILE"
+
+# Sleep forever — systemd's main process. The trap above deletes the
+# marker on stop, so absence of the marker is the proof of "service
+# stopped cleanly" the fixture polls for.
+while true; do
+    sleep 60 &
+    wait $!
+done

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
@@ -1,0 +1,302 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 12.L.E.3 — Linux systemd analog of <c>WindowsServiceFixture</c>.
+/// Wraps <c>systemctl</c> + <c>sudo</c> for install + start + stop +
+/// uninstall of a transient systemd service, used by lifecycle E2E tests
+/// that need a real running service to drive the upgrade .sh's Phase B
+/// (Stop → swap → Start) against.
+///
+/// <para><b>Why an explicit fixture (vs systemd-run --scope ad-hoc)</b>:
+/// upgrade-linux-tentacle.sh's Phase B does <c>systemctl restart $SERVICE_NAME</c>,
+/// which only works against a properly-installed unit (not an
+/// ad-hoc transient run). Tests need to install a real .service file +
+/// daemon-reload + start, which is what this fixture does.</para>
+///
+/// <para><b>Sudo handling</b>: GHA <c>ubuntu-latest</c> runners have
+/// passwordless sudo. The fixture invokes <c>sudo systemctl ...</c> +
+/// <c>sudo cp ...</c> directly. Local Linux dev hosts that don't have
+/// passwordless sudo configured will see <see cref="IsAvailable"/>
+/// return false (probed via a no-op sudo call at fixture-construction
+/// time).</para>
+///
+/// <para><b>Cleanup discipline (Rule 12.3)</b>: <see cref="Dispose"/>
+/// is best-effort and idempotent — <c>systemctl stop</c> + <c>disable</c>
+/// + <c>rm</c> all swallow errors so a partial install or a Stop on a
+/// not-running service doesn't throw. Even on test-failure paths every
+/// staged artefact is reaped: unit file deleted, install dir removed,
+/// systemd reloaded.</para>
+///
+/// <para><b>Skip-on-non-Linux</b>: <see cref="IsAvailable"/> returns false
+/// on macOS/Windows dev hosts (no systemd). Tests using this fixture
+/// skip-guard via the existing <c>OperatingSystem.IsLinux()</c> pattern.</para>
+/// </summary>
+public sealed class LinuxServiceFixture : IDisposable
+{
+    /// <summary>
+    /// True only on Linux WITH systemd reachable via systemctl AND
+    /// passwordless sudo configured. Probed once at fixture
+    /// construction (not at static initialisation — env can change).
+    /// Tests guard with this; non-Linux dev hosts no-op-skip.
+    /// </summary>
+    public static bool IsAvailable
+    {
+        get
+        {
+            if (!OperatingSystem.IsLinux()) return false;
+
+            // Probe via `sudo -n true` — `-n` makes sudo fail immediately
+            // if a password would be required (vs hanging on the prompt).
+            // GHA runners + properly-configured CI hosts return 0; local
+            // dev hosts without passwordless sudo return non-zero.
+            try
+            {
+                var psi = new ProcessStartInfo("sudo", "-n true")
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                using var p = Process.Start(psi);
+                if (p == null) return false;
+                p.WaitForExit(2_000);
+                return p.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    private readonly string _serviceName;
+    private readonly string _installDir;
+    private bool _installed;
+
+    /// <summary>The service name registered with systemd (`systemctl status <name>`).</summary>
+    public string ServiceName => _serviceName;
+
+    /// <summary>The directory containing the test service script + version.txt + marker.</summary>
+    public string InstallDir => _installDir;
+
+    /// <summary>The full path to the test service script inside <see cref="InstallDir"/>.</summary>
+    public string ServiceScriptPath => Path.Combine(_installDir, "squid-linux-test-service.sh");
+
+    /// <summary>The path to the version.txt file the service reads on Start.</summary>
+    public string VersionFilePath => Path.Combine(_installDir, "version.txt");
+
+    /// <summary>The path to the marker file the service writes on Start (containing the version it read).</summary>
+    public string MarkerFilePath => Path.Combine(_installDir, "service-running.marker");
+
+    /// <summary>Path to the systemd unit file under <c>/etc/systemd/system/</c>.</summary>
+    public string UnitFilePath => $"/etc/systemd/system/{_serviceName}.service";
+
+    /// <summary>
+    /// Construct against a UNIQUE service name + UNIQUE install dir.
+    /// Caller responsible for uniqueness (recommended: GUID-suffix).
+    /// </summary>
+    public LinuxServiceFixture(string serviceName, string installDir)
+    {
+        if (string.IsNullOrWhiteSpace(serviceName))
+            throw new ArgumentException("serviceName is required", nameof(serviceName));
+        if (string.IsNullOrWhiteSpace(installDir))
+            throw new ArgumentException("installDir is required", nameof(installDir));
+
+        _serviceName = serviceName;
+        _installDir = installDir;
+    }
+
+    /// <summary>
+    /// Stage the test service script at <see cref="InstallDir"/> with the
+    /// supplied initial version, write a systemd unit file referencing
+    /// it, daemon-reload + start, polling until the service reaches
+    /// active(running) state OR the timeout expires.
+    /// </summary>
+    public void InstallAndStart(string testServiceScriptSourcePath, string initialVersion, TimeSpan startTimeout)
+    {
+        if (!IsAvailable) throw new PlatformNotSupportedException("LinuxServiceFixture only runs on Linux with passwordless sudo");
+
+        if (!File.Exists(testServiceScriptSourcePath))
+            throw new FileNotFoundException($"test service script not found at: {testServiceScriptSourcePath}");
+
+        // Idempotent cleanup of any stale prior install of the same name.
+        TryUninstall();
+
+        // Stage install dir + script + initial version.txt.
+        Directory.CreateDirectory(_installDir);
+        File.Copy(testServiceScriptSourcePath, ServiceScriptPath, overwrite: true);
+        File.WriteAllText(VersionFilePath, initialVersion);
+        RunSudo("chmod +x " + Quote(ServiceScriptPath));
+
+        // Write systemd unit file. Type=simple = main process is the
+        // ExecStart command (the bash script itself, which sleeps forever).
+        // KillMode=mixed sends SIGTERM to main process + SIGKILL to children
+        // so our trap-handler runs cleanly on stop.
+        var unitContent = new StringBuilder()
+            .AppendLine("[Unit]")
+            .AppendLine($"Description=Squid Linux Tentacle E2E Test Service — {_serviceName}")
+            .AppendLine()
+            .AppendLine("[Service]")
+            .AppendLine("Type=simple")
+            .AppendLine($"Environment=INSTALL_DIR={_installDir}")
+            .AppendLine($"ExecStart=/usr/bin/env bash {ServiceScriptPath}")
+            .AppendLine("KillMode=mixed")
+            .AppendLine("Restart=no")
+            .AppendLine()
+            .AppendLine("[Install]")
+            .AppendLine("WantedBy=multi-user.target")
+            .ToString();
+
+        var tempUnit = Path.Combine(Path.GetTempPath(), $"{_serviceName}.unit-staging");
+        File.WriteAllText(tempUnit, unitContent);
+        try
+        {
+            RunSudo($"cp {Quote(tempUnit)} {Quote(UnitFilePath)}");
+            RunSudo($"chmod 644 {Quote(UnitFilePath)}");
+        }
+        finally
+        {
+            try { File.Delete(tempUnit); } catch { /* best-effort */ }
+        }
+
+        RunSudo("systemctl daemon-reload");
+        RunSudo($"systemctl start {Quote(_serviceName)}");
+
+        _installed = true;
+
+        // Poll for active(running) state.
+        var deadline = DateTime.UtcNow + startTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (IsActive()) return;
+            Thread.Sleep(200);
+        }
+
+        // Capture diagnostic state for the test failure message.
+        var status = RunSudoCapture($"systemctl status {Quote(_serviceName)} --no-pager") ?? "(systemctl status unavailable)";
+        throw new TimeoutException(
+            $"systemd service '{_serviceName}' did not reach active(running) within {startTimeout}. " +
+            $"systemctl status:\n{status}");
+    }
+
+    /// <summary>
+    /// Stop the service (waits up to <paramref name="timeout"/> for it to
+    /// reach inactive). Best-effort — silently swallows errors if the
+    /// service is already stopped.
+    /// </summary>
+    public void Stop(TimeSpan timeout)
+    {
+        if (!_installed) return;
+
+        RunSudo($"systemctl stop {Quote(_serviceName)}");
+
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!IsActive()) return;
+            Thread.Sleep(200);
+        }
+    }
+
+    /// <summary>
+    /// True if `systemctl is-active <name>` returns "active". Consults
+    /// systemd directly (vs reading the marker file) so the fixture can
+    /// answer "running" even when the marker isn't present yet (start
+    /// race window).
+    /// </summary>
+    public bool IsActive()
+    {
+        var output = RunSudoCapture($"systemctl is-active {Quote(_serviceName)}");
+        return output?.Trim() == "active";
+    }
+
+    public void Dispose()
+    {
+        TryUninstall();
+    }
+
+    /// <summary>
+    /// Best-effort cleanup. Stops + disables + removes the unit file
+    /// + reloads daemon + removes the install dir. Each step swallows
+    /// errors — a partial install (e.g. unit file written but daemon-
+    /// reload failed) still reaps cleanly.
+    /// </summary>
+    private void TryUninstall()
+    {
+        // Order: stop → disable → rm unit → daemon-reload → rm install dir.
+        // disable is best-effort even if not enabled; rm unit + reload
+        // are idempotent.
+        try { RunSudo($"systemctl stop {Quote(_serviceName)}"); } catch { /* not running, fine */ }
+        try { RunSudo($"systemctl disable {Quote(_serviceName)}"); } catch { /* not enabled, fine */ }
+        try { RunSudo($"rm -f {Quote(UnitFilePath)}"); } catch { /* best-effort */ }
+        try { RunSudo("systemctl daemon-reload"); } catch { /* best-effort */ }
+        try { RunSudo($"rm -rf {Quote(_installDir)}"); } catch { /* best-effort */ }
+    }
+
+    /// <summary>
+    /// Runs <c>sudo &lt;command&gt;</c> via a shell, throws on non-zero
+    /// exit code with stderr captured. Uses bash -c so the command can
+    /// be a multi-token expression (e.g. systemctl args).
+    /// </summary>
+    private static void RunSudo(string command)
+    {
+        var psi = new ProcessStartInfo("sudo", "-n bash -c " + Quote(command))
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"failed to launch sudo for: {command}");
+
+        proc.WaitForExit(30_000);
+        if (proc.ExitCode != 0)
+        {
+            var stderr = proc.StandardError.ReadToEnd();
+            throw new InvalidOperationException($"sudo command failed (exit {proc.ExitCode}): {command}\nstderr:\n{stderr}");
+        }
+    }
+
+    /// <summary>
+    /// Variant of <see cref="RunSudo"/> that captures stdout and returns
+    /// it (or null on failure). Used for status probes that should NOT
+    /// throw on non-zero exit (e.g. `systemctl is-active` returns 3 if
+    /// inactive — that's expected, not an error).
+    /// </summary>
+    private static string RunSudoCapture(string command)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("sudo", "-n bash -c " + Quote(command))
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using var proc = Process.Start(psi);
+            if (proc == null) return null;
+
+            var stdout = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit(10_000);
+            return stdout;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Single-quote a string for safe inclusion in a bash -c command line.
+    /// Escapes embedded single quotes via the standard <c>'\''</c> idiom.
+    /// </summary>
+    private static string Quote(string value)
+        => "'" + value.Replace("'", "'\\''") + "'";
+}

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxServiceFixtureSmokeE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxServiceFixtureSmokeE2ETests.cs
@@ -1,0 +1,149 @@
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.L.E.3 — smoke tests for <see cref="LinuxServiceFixture"/>
+/// itself. Tier 🔵 Fixture-only (Rule 12) — proves the test harness
+/// works against real systemd before later phases consume it for
+/// production-flow E2E.
+///
+/// <para>Mirrors <c>WindowsServiceFixtureSmokeE2ETests</c> in the sibling
+/// project: install / start / verify marker / stop / verify marker gone /
+/// uninstall, plus an idempotent re-install test.</para>
+///
+/// <para><b>Skip-on-non-Linux + skip-on-no-sudo</b>: the fixture's
+/// <see cref="LinuxServiceFixture.IsAvailable"/> probe handles both
+/// dimensions (OS check + passwordless sudo check). macOS/Windows dev
+/// hosts return false; Linux hosts without sudo configured also return
+/// false. CI runs on <c>ubuntu-latest</c> which has both.</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.ServiceFixture)]
+public sealed class LinuxServiceFixtureSmokeE2ETests
+{
+    [Fact]
+    public void Fixture_FullLifecycle_InstallStartMarkerStopUninstall()
+    {
+        if (!LinuxServiceFixture.IsAvailable) return;
+
+        var serviceName = $"squid-linux-fixture-smoke-{Guid.NewGuid():N}";
+        var installDir = Path.Combine(Path.GetTempPath(), $"squid-linux-fixture-smoke-{Guid.NewGuid():N}");
+        var testServiceScript = LocateTestServiceScript();
+
+        using var fixture = new LinuxServiceFixture(serviceName, installDir);
+
+        // 1. Install + start at v1. Marker should appear with v1 within
+        //    the timeout window.
+        fixture.InstallAndStart(testServiceScript, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(15));
+
+        // 2. Service is active per systemctl.
+        fixture.IsActive().ShouldBeTrue(
+            customMessage: $"systemctl is-active should return 'active' after InstallAndStart. Service: {serviceName}");
+
+        // 3. Marker file exists with version content. Allow up to 5s for
+        //    the bash script's `read_version > $MARKER_FILE` to flush —
+        //    systemd's "active" state can fire slightly before the script
+        //    has written the marker, even with Type=simple.
+        WaitForFileContent(fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(5)).ShouldBeTrue(
+            customMessage: $"marker at {fixture.MarkerFilePath} MUST contain '1.0.0' after start — proves the script started, read version.txt, AND wrote the marker. " +
+                          "If marker absent: bash script crashed at start. If marker has wrong content: version.txt wasn't read correctly.");
+
+        // 4. Stop the service. KillMode=mixed in the unit file means
+        //    SIGTERM goes to the bash main → the trap-handler deletes
+        //    the marker → service exits.
+        fixture.Stop(TimeSpan.FromSeconds(10));
+
+        fixture.IsActive().ShouldBeFalse(
+            customMessage: $"systemctl is-active should NOT return 'active' after Stop. Service: {serviceName}");
+
+        // 5. Marker absent — proves the trap-handler ran (graceful stop).
+        WaitForFileAbsent(fixture.MarkerFilePath, TimeSpan.FromSeconds(5)).ShouldBeTrue(
+            customMessage: $"marker at {fixture.MarkerFilePath} MUST be absent after stop. " +
+                          "If present: bash trap-handler didn't run → service was killed before cleanup → potential file-in-use issues for upgrade tests' Move-Item swap.");
+
+        // 6. Uninstall (via Dispose) is idempotent + reaps unit file.
+        // Dispose is called at the using's end; unit file should be gone
+        // and systemctl no longer knows about the service.
+    }
+
+    [Fact]
+    public void Fixture_RepeatedInstall_DoesNotFailDueToStaleService()
+    {
+        if (!LinuxServiceFixture.IsAvailable) return;
+
+        var serviceName = $"squid-linux-fixture-repeat-{Guid.NewGuid():N}";
+        var installDir = Path.Combine(Path.GetTempPath(), $"squid-linux-fixture-repeat-{Guid.NewGuid():N}");
+        var testServiceScript = LocateTestServiceScript();
+
+        // Round 1: install fresh.
+        using (var fixture1 = new LinuxServiceFixture(serviceName, installDir))
+        {
+            fixture1.InstallAndStart(testServiceScript, "v1", TimeSpan.FromSeconds(15));
+            fixture1.IsActive().ShouldBeTrue();
+            // Dispose runs at end of using → uninstalls.
+        }
+
+        // Round 2: install AGAIN with the same service name, NEW fixture
+        // instance. The previous Dispose should have cleaned up enough
+        // that this works without "service exists" errors.
+        using (var fixture2 = new LinuxServiceFixture(serviceName, installDir))
+        {
+            fixture2.InstallAndStart(testServiceScript, "v2", TimeSpan.FromSeconds(15));
+            fixture2.IsActive().ShouldBeTrue();
+            WaitForFileContent(fixture2.MarkerFilePath, "v2", TimeSpan.FromSeconds(5)).ShouldBeTrue(
+                customMessage: "round-2 marker MUST reflect v2 content — proves the second install used its own version.txt, not stale v1");
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Locates the test-service bash script at the canonical sibling
+    /// project path. Mirrors the Windows project's
+    /// <c>LocateTestServiceExe</c> walk-up pattern.
+    /// </summary>
+    private static string LocateTestServiceScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "tests", "Squid.LinuxTentacleE2E.TestService", "squid-linux-test-service.sh");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException(
+            "Could not locate squid-linux-test-service.sh. Expected at tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh; " +
+            "if running from an unusual CI layout, the walk-up depth may need to increase.");
+    }
+
+    private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    var actual = File.ReadAllText(path).Trim();
+                    if (actual == expectedContent) return true;
+                }
+            }
+            catch { /* mid-write, retry */ }
+            Thread.Sleep(200);
+        }
+        return false;
+    }
+
+    private static bool WaitForFileAbsent(string path, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!File.Exists(path)) return true;
+            Thread.Sleep(200);
+        }
+        return false;
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
@@ -21,4 +21,17 @@ public static class LinuxTentacleE2ECategories
     /// systemd-run / systemctl restart / apt / dnf / curl flows.</para>
     /// </summary>
     public const string UpgradeScript = "LinuxTentacleUpgradeScriptE2E";
+
+    /// <summary>
+    /// Phase 12.L.E.3 smoke coverage for <see cref="Infrastructure.LinuxServiceFixture"/>.
+    /// Tier 🔵 Fixture-only (Rule 12) — does NOT count toward production
+    /// E2E coverage. Subsequent phases (12.L.E.4+) consume the fixture
+    /// for real upgrade-lifecycle tests where the fixture's systemd
+    /// service is the target of <c>systemctl restart</c> swap mechanics.
+    ///
+    /// <para>Linux-only: requires systemd + passwordless sudo. Skip-
+    /// guards on macOS/Windows + on Linux dev hosts without sudo
+    /// configured. GHA <c>ubuntu-latest</c> runner has both.</para>
+    /// </summary>
+    public const string ServiceFixture = "LinuxServiceFixtureE2E";
 }


### PR DESCRIPTION
## Summary

Linux fixture foundation for the upcoming full-lifecycle tests (J.L.E.4+). Mirrors `WindowsServiceFixture`'s role on the Linux side — install + start + stop + uninstall a real systemd service so subsequent upgrade-flow tests can drive the `.sh`'s `systemctl restart` Phase B swap mechanics against an actual running unit.

**Tier 🔵 Fixture-only (Rule 12)** — these smoke tests prove the harness works against real systemd; they don't count toward production E2E coverage. Subsequent J.L.E.4 lifecycle tests consume this fixture and achieve 🟢 high-fidelity.

## New artifacts

| Artifact | Purpose |
|---|---|
| `tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh` | Minimal systemd-compatible bash service. On start: read version.txt, write marker. On SIGTERM: trap deletes marker, exits 0 |
| `LinuxServiceFixture` | systemctl install/start/stop/uninstall via passwordless sudo. Type=simple unit, KillMode=mixed for clean SIGTERM trap firing |
| `LinuxServiceFixture.IsAvailable` | Dual probe: OS check + `sudo -n true` (passwordless sudo). Skip-guards for macOS/Windows + Linux-without-sudo dev hosts |
| `Fixture_FullLifecycle_InstallStartMarkerStopUninstall` | Install + start → verify active + marker → stop → verify marker absent (proves trap ran, not SIGKILL) → dispose |
| `Fixture_RepeatedInstall_DoesNotFailDueToStaleService` | Pins idempotent re-install: round-1 dispose reaps enough that round-2 install succeeds with new fixture instance |

## Why bash (not a binary)

- systemd-compatible by design
- Universal on every supported Linux distro (no .NET runtime needed for the test service itself)
- Easier to reason about: one file, no cross-compile concerns
- Same observable contract as Windows test service (marker file with version content)

## Local verification (macOS)

5/5 pass. The 3 cross-platform script tests run; the 2 fixture smoke tests skip-guard via `IsAvailable=false` on macOS (no systemd).

## Workflow update

`tentacle-linux-e2e.yml` default filter extended to include the new category.

## Next phase (J.L.E.4)

- `LinuxLifecycleContext` (IDisposable wrapper around fixture + LocalReleaseMirror + state-dir override + cleanup)
- First full Linux lifecycle test (E1.h-Linux analog): drive .sh end-to-end → SUCCESS in last-upgrade.json + service swapped to v2
- Surface any production .sh bugs that the J.L.E.1 placeholder + parse pin couldn't catch (systemd-run --scope re-exec, apt/yum/tarball method probing, sudo handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)