### PR TITLE
Phase 12.L.E.4 — first Linux lifecycle E2E (E1.u1 download 404)

### DIFF
--- a/.github/workflows/tentacle-linux-e2e.yml
+++ b/.github/workflows/tentacle-linux-e2e.yml
@@ -24,7 +24,7 @@ on:
       test_filter:
         description: "xUnit --filter for the Squid.LinuxTentacleE2ETests step"
         required: false
-        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E"
+        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E"
 
 permissions:
   contents: read
@@ -59,7 +59,7 @@ jobs:
       - name: Run Squid.LinuxTentacleE2ETests
         run: |
           FILTER="${{ github.event.inputs.test_filter }}"
-          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E"; fi
+          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E"; fi
           dotnet test tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj \
             --configuration Release --no-restore \
             --filter "$FILTER" \

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using System.Text;
+using Squid.Core.Services.Machines.Upgrade;
+using Squid.Core.Services.Machines.Upgrade.Methods;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 12.L.E.4 — Linux analog of the Windows project's
+/// <c>UpgradeLifecycleContext</c>. Wraps every OS resource an
+/// upgrade-flow E2E test stages so cleanup is best-effort + idempotent
+/// (Rule 12.3): systemd unit, install dir, isolated state dir, mirror,
+/// staging dir, .bak. Each test creates its own instance via <c>using</c>.
+///
+/// <para><b>Test isolation strategy</b>: every artefact is GUID-suffixed
+/// so concurrent tests don't collide on the global systemd / sudo /
+/// filesystem namespace. State dir is redirected via the
+/// <see cref="LinuxTentacleUpgradeStrategy.StateDirEnvVar"/> override
+/// (added in 12.L.E.2) so <c>last-upgrade.json</c> /
+/// <c>upgrade.lock</c> / <c>upgrade-events.jsonl</c> all land under
+/// <c>/tmp/test-isolated-{guid}/</c> instead of the production
+/// <c>/var/lib/squid-tentacle/</c>.</para>
+///
+/// <para><b>Skip-on-non-Linux</b>: composes <see cref="LinuxServiceFixture.IsAvailable"/>
+/// (Linux + passwordless sudo). Tests using this context call
+/// <see cref="IsAvailable"/> first and no-op-skip on non-Linux dev hosts
+/// + Linux-without-sudo.</para>
+/// </summary>
+public sealed class LinuxLifecycleContext : IDisposable
+{
+    private bool _clean;
+
+    public static bool IsAvailable => LinuxServiceFixture.IsAvailable;
+
+    public LinuxServiceFixture Fixture { get; }
+    public LocalReleaseMirror Mirror { get; }
+
+    /// <summary>Path to the test service script under the test source tree.</summary>
+    public string TestServiceScript { get; }
+
+    /// <summary>Test-isolated state-dir. The .ps1's STATUS_DIR / LOCK_FILE / etc. all derive from here via the env override.</summary>
+    public string StateDirOverride { get; }
+
+    /// <summary>The <c>last-upgrade.json</c> path the .sh writes (under StateDirOverride).</summary>
+    public string StatusFilePath => Path.Combine(StateDirOverride, "last-upgrade.json");
+
+    /// <summary>The <c>upgrade.lock</c> path the .sh writes (under StateDirOverride).</summary>
+    public string LockFilePath => Path.Combine(StateDirOverride, "upgrade.lock");
+
+    public LinuxLifecycleContext()
+    {
+        var unique = Guid.NewGuid().ToString("N");
+
+        var serviceName = $"squid-linux-lifecycle-{unique}";
+        var installDir = Path.Combine(Path.GetTempPath(), $"squid-linux-lifecycle-install-{unique}");
+
+        Fixture = new LinuxServiceFixture(serviceName, installDir);
+        Mirror = LocalReleaseMirror.Start();
+        TestServiceScript = LocateTestServiceScript();
+
+        StateDirOverride = Path.Combine(Path.GetTempPath(), $"squid-linux-lifecycle-state-{unique}");
+        // The .sh creates this on demand via `sudo mkdir -p`. We pre-create
+        // it here only so test code can write to it directly (e.g. pre-staging
+        // a stale lock file for E11.u2 tests later).
+        Directory.CreateDirectory(StateDirOverride);
+    }
+
+    /// <summary>
+    /// Renders the production .sh with placeholders pointed at our test
+    /// fixtures: DOWNLOAD_URL → mirror, INSTALL_DIR / SERVICE_NAME →
+    /// fixture, STATE_DIR → test-isolated dir, INSTALL_METHODS → tarball-
+    /// only (skips apt + yum probes which would slow tests + introduce
+    /// host-config sensitivity).
+    /// </summary>
+    public string RenderProductionScriptForVersion(string targetVersion)
+    {
+        // Set env vars for resolver-driven placeholders. Strategy reads
+        // SQUID_TARGET_LINUX_TENTACLE_DOWNLOAD_BASE_URL + the new
+        // SQUID_TARGET_LINUX_TENTACLE_STATE_DIR (12.L.E.2). HEALTHCHECK_URL
+        // also resolver-driven; default is fine because the test service
+        // doesn't expose HTTP and we want the "warning + proceed" path.
+        Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, Mirror.BaseUri.ToString().TrimEnd('/'));
+        Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, StateDirOverride);
+
+        // Tarball-only method order. Skips apt+yum probes which would
+        // otherwise slow tests + introduce host-config sensitivity (apt's
+        // dpkg-query / yum's rpm -q on systems where these tools may or
+        // may not have squid-tentacle installed).
+        var tarballOnly = new ILinuxUpgradeMethod[] { new TarballUpgradeMethod() };
+
+        return LinuxTentacleUpgradeStrategy.BuildScript(targetVersion, tarballOnly);
+    }
+
+    /// <summary>
+    /// Reads the .sh-written <c>last-upgrade.json</c>. Returns null if
+    /// the file doesn't exist OR is unparseable.
+    /// </summary>
+    public UpgradeStatusPayload ReadLastUpgradeStatus()
+    {
+        if (!File.Exists(StatusFilePath)) return null;
+        var raw = File.ReadAllText(StatusFilePath);
+        return UpgradeStatusPayload.TryParse(raw);
+    }
+
+    /// <summary>
+    /// Runs the rendered .sh via <c>bash</c>. Returns (exitCode, combined
+    /// stdout+stderr). Bash on Linux + macOS handles set -uo pipefail +
+    /// trap chains the same way; the .sh is Linux-only in production
+    /// (uses systemd-run / systemctl) but its Phase A pre-scope flow
+    /// (download, SHA verify, extract, ldd check) is bash-only and runs
+    /// fine on macOS too.
+    /// </summary>
+    public (int exitCode, string output) RunUpgradeScript(string script)
+    {
+        var tempScript = Path.Combine(Path.GetTempPath(), $"squid-linux-lifecycle-{Guid.NewGuid():N}.sh");
+        File.WriteAllText(tempScript, script);
+        try
+        {
+            // chmod +x + bash invocation. We use `bash $script` (not
+            // `./$script`) so the file's executable bit isn't load-
+            // bearing — defensive against macOS attribute oddities.
+            var psi = new ProcessStartInfo
+            {
+                FileName = "bash",
+                Arguments = tempScript,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to launch bash for .sh execution");
+
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            var stderrTask = proc.StandardError.ReadToEndAsync();
+
+            // Generous timeout. Phase A download + SHA verify + extract
+            // is typically <10s; the 5min wall-clock matches the
+            // production strategy's UpgradeScriptTimeout — same upper
+            // bound the agent enforces.
+            if (!proc.WaitForExit(300_000))
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                throw new TimeoutException(
+                    "upgrade-linux-tentacle.sh did not complete within 5min. " +
+                    $"Inspect /var/log/squid-tentacle-upgrade.log if it exists, or check the rendered .sh at {tempScript} (left behind for diagnosis).");
+            }
+
+            return (proc.ExitCode, stdoutTask.Result + Environment.NewLine + stderrTask.Result);
+        }
+        finally
+        {
+            try { File.Delete(tempScript); } catch { /* best-effort */ }
+        }
+    }
+
+    public void MarkClean()
+    {
+        _clean = true;
+    }
+
+    public void Dispose()
+    {
+        // Diagnostic: surface non-clean exits in CI logs.
+        if (!_clean)
+            Console.WriteLine($"[LinuxLifecycleContext] Dispose called without MarkClean — test for service '{Fixture.ServiceName}' failed before its happy-path conclusion.");
+
+        try { Fixture.Dispose(); } catch { /* best-effort */ }
+
+        // .bak directory created by Phase B's mv swap (when Phase B runs).
+        try
+        {
+            var bakDir = Fixture.InstallDir + ".bak";
+            if (Directory.Exists(bakDir))
+                Directory.Delete(bakDir, recursive: true);
+        }
+        catch { /* best-effort */ }
+
+        // Test-isolated state dir.
+        try
+        {
+            if (Directory.Exists(StateDirOverride))
+                Directory.Delete(StateDirOverride, recursive: true);
+        }
+        catch { /* best-effort */ }
+
+        try { Mirror.Dispose(); } catch { /* best-effort */ }
+
+        // Reset env vars set during RenderProductionScriptForVersion. NOT
+        // strictly needed (test process exits) but clean.
+        try { Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null); } catch { }
+        try { Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, null); } catch { }
+    }
+
+    private static string LocateTestServiceScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "tests", "Squid.LinuxTentacleE2E.TestService", "squid-linux-test-service.sh");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException(
+            "Could not locate squid-linux-test-service.sh. Expected at tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh.");
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
@@ -237,19 +237,36 @@ public sealed class LinuxServiceFixture : IDisposable
     }
 
     /// <summary>
-    /// Runs <c>sudo &lt;command&gt;</c> via a shell, throws on non-zero
-    /// exit code with stderr captured. Uses bash -c so the command can
-    /// be a multi-token expression (e.g. systemctl args).
+    /// Runs <c>sudo &lt;command&gt;</c> via bash -c, throws on non-zero exit
+    /// with stderr captured. Uses ArgumentList (NOT the Arguments string)
+    /// so each argv entry passes verbatim through .NET's Process.Start
+    /// without Linux argv quoting trouble.
+    ///
+    /// <para><b>Why ArgumentList not Arguments</b>: J.L.E.3's first Linux
+    /// runner attempt failed with `bash: line 1: unexpected EOF while
+    /// looking for matching '\''` because the previous implementation
+    /// bash-quoted the command string and passed it via Arguments —
+    /// but .NET's Linux argv parser doesn't understand bash-style
+    /// single quotes (it uses CommandLineToArgvW-style rules,
+    /// double-quotes only). ArgumentList passes each string as a
+    /// SEPARATE argv entry, no parsing → bash -c receives the command
+    /// verbatim. Same fix pattern catches similar bugs in any
+    /// cross-platform Process.Start scenario where shell metacharacters
+    /// matter.</para>
     /// </summary>
     private static void RunSudo(string command)
     {
-        var psi = new ProcessStartInfo("sudo", "-n bash -c " + Quote(command))
+        var psi = new ProcessStartInfo("sudo")
         {
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             CreateNoWindow = true
         };
+        psi.ArgumentList.Add("-n");
+        psi.ArgumentList.Add("bash");
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add(command);
 
         using var proc = Process.Start(psi)
             ?? throw new InvalidOperationException($"failed to launch sudo for: {command}");
@@ -272,13 +289,17 @@ public sealed class LinuxServiceFixture : IDisposable
     {
         try
         {
-            var psi = new ProcessStartInfo("sudo", "-n bash -c " + Quote(command))
+            var psi = new ProcessStartInfo("sudo")
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+            psi.ArgumentList.Add("-n");
+            psi.ArgumentList.Add("bash");
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add(command);
 
             using var proc = Process.Start(psi);
             if (proc == null) return null;
@@ -294,8 +315,13 @@ public sealed class LinuxServiceFixture : IDisposable
     }
 
     /// <summary>
-    /// Single-quote a string for safe inclusion in a bash -c command line.
-    /// Escapes embedded single quotes via the standard <c>'\''</c> idiom.
+    /// Bash single-quote a string for safe inclusion INSIDE a bash -c
+    /// command (where the quoting matters to bash, not to .NET's argv
+    /// parser). Used when constructing multi-token bash commands that
+    /// already contain spaces / special chars in arguments. Each
+    /// individual ArgumentList entry doesn't need quoting (verbatim
+    /// argv); but commands that bash itself parses (e.g.
+    /// "cp /a /b" inside bash -c) need bash-quoted args.
     /// </summary>
     private static string Quote(string value)
         => "'" + value.Replace("'", "'\\''") + "'";

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
@@ -1,0 +1,552 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+// J.L.E.4: copied from Squid.WindowsUpgradeE2ETests.Infrastructure (verbatim
+// — same wire shape: zip / tar.gz / .sha256 companion). The Linux upgrade
+// E2E uses tar.gz; install-tentacle.sh tests use the same surface.
+//
+// DUPLICATION NOTE: This is an intentional copy of the Windows project's
+// LocalReleaseMirror. The two will stay in sync because:
+//   1. Both serve the SAME wire shape (zip / tar.gz / .sha256 companion)
+//      — there's no Windows- or Linux-specific behaviour at the HTTP layer
+//   2. Each project's tests pin behaviour against its own copy, so drift
+//      between the two is automatically caught at test time
+//   3. A future refactor (Squid.E2E.Shared library) can deduplicate WITHOUT
+//      breaking either consumer because both consume the same surface
+// If the two copies start to diverge meaningfully, that's the signal to
+// extract the shared library — not before.
+
+/// <summary>
+/// In-process HTTP server stub that mimics the GitHub Releases / private-mirror
+/// download surface the production <c>install-tentacle.{sh,ps1}</c> scripts
+/// expect. Used by Phase 12.K E2E tests to drive the install scripts WITHOUT
+/// touching the real GitHub Releases CDN.
+///
+/// <para><b>Wire shapes mirrored from the production scripts</b>:</para>
+/// <list type="bullet">
+///   <item><c>GET /latest/download/squid-tentacle-{rid}.zip</c> → 200 + zip body
+///         (the <c>--version latest</c> path, used by both ps1 and sh)</item>
+///   <item><c>GET /download/{version}/squid-tentacle-{version}-{rid}.zip</c>
+///         → 200 + zip body (Windows pinned-version path)</item>
+///   <item><c>GET /download/v{version}/squid-tentacle-{version}-{rid}.zip</c>
+///         → fallback URL the scripts try if the un-prefixed tag 404s</item>
+///   <item><c>GET /download/{version}/squid-tentacle-{version}-{rid}.tar.gz</c>
+///         → Linux tarball variant</item>
+/// </list>
+///
+/// <para><b>Tier</b>: 🔵 Fixture-only (Rule 12) — test infrastructure for
+/// the install-script E2E suite. Tests using it achieve 🟢 high-fidelity
+/// because the install scripts themselves are production code; only the
+/// upstream release CDN is replaced.</para>
+///
+/// <para><b>Cross-platform</b>: <see cref="HttpListener"/> works identically
+/// on Windows / Linux / macOS for plain HTTP loopback bindings. Tests don't
+/// need OS-specific branches at the fixture level.</para>
+///
+/// <para><b>Configurable per-test</b>:</para>
+/// <list type="bullet">
+///   <item><see cref="StageBinary"/> — supplies the byte content packed into
+///         the served zip / tarball. Tests use a tiny fake binary content
+///         (e.g. an empty file or a dummy script) — install scripts only
+///         verify the binary EXISTS post-extract, not that it actually runs.</item>
+///   <item><see cref="ConfigureNotFoundForVersion"/> — makes the mirror
+///         return 404 for a specific version, exercising the script's
+///         fallback / error path.</item>
+/// </list>
+///
+/// <para><b>Lifetime</b>: <see cref="IDisposable"/>. Each test creates its
+/// own instance via <see cref="Start"/>; unique loopback port per fixture
+/// (Rule 12.8) means concurrent tests don't collide.</para>
+/// </summary>
+public sealed class LocalReleaseMirror : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly CancellationTokenSource _loopCts;
+    private readonly Task _loopTask;
+    private byte[] _stagedBinary;
+    private string _stagedBinaryFileName;
+    /// <summary>
+    /// Pre-built archive bytes staged directly. When set, the mirror serves
+    /// THESE bytes verbatim for every <c>.zip</c> / <c>.tar.gz</c> request
+    /// — bypasses the auto-wrap-single-binary path that <see cref="StageBinary"/>
+    /// follows. Used by full-bundle tests (e.g. J.E.3 upgrade lifecycle) that
+    /// need to supply a multi-entry archive (binary tree + version files +
+    /// `Squid.Tentacle.exe` placeholder) mirroring the production GitHub
+    /// release zip's shape. <see cref="StageBinary"/> would double-wrap such
+    /// content because it treats the supplied bytes as a single file inside
+    /// a fresh zip — this field is the explicit "no wrapping, this IS the
+    /// archive" seam.
+    /// </summary>
+    private byte[] _preBuiltArchive;
+    private readonly HashSet<string> _notFoundVersions = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// Per-archive byte cache. <see cref="ZipArchive"/> + GZipStream both
+    /// embed timestamps in entry headers, so a fresh build for the
+    /// <c>.zip</c> request and a separate fresh build for the <c>.sha256</c>
+    /// companion request would produce different bytes → SHA mismatch
+    /// false-positive in the production .ps1's verify step. Cache by URL
+    /// path so every consumer of the same archive sees identical bytes
+    /// (and the companion's hash matches).
+    /// </summary>
+    private readonly Dictionary<string, byte[]> _archiveBytesCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _archiveCacheLock = new();
+    /// <summary>
+    /// Override for the <c>.sha256</c> companion content. When set, the
+    /// mirror serves THIS string as the companion body instead of computing
+    /// the actual SHA256 of the served archive. Used by the SHA-mismatch
+    /// E2E test (J.E.3 / E12.u1) to inject a deliberately-wrong digest so
+    /// the .ps1's <c>Get-FileHash</c> compare path triggers an exit 7.
+    /// Null = serve the real computed SHA (happy-path coverage).
+    /// </summary>
+    private string _sha256Override;
+    /// <summary>
+    /// When true, the mirror returns 404 for every <c>.sha256</c> path even
+    /// if the underlying archive is staged. Tests the production .ps1's
+    /// "skip-with-warning" fallback for older releases / private mirrors that
+    /// haven't replicated companion files yet (J.E.3 / E12.u2 — not in this
+    /// PR but the toggle is here for future use).
+    /// </summary>
+    private bool _suppressSha256;
+    private bool _disposed;
+
+    /// <summary>The mirror's base URL. Pass this as <c>--DownloadBase</c>
+    /// (Windows) / <c>DOWNLOAD_BASE</c> env (Linux) to the install script.</summary>
+    public Uri BaseUri { get; }
+
+    /// <summary>The bound loopback port (Rule 12.8 — OS-allocated).</summary>
+    public int Port { get; }
+
+    /// <summary>
+    /// Snapshot of every download path requested. Tests assert on this to
+    /// prove the script actually hit the mirror (vs falling through to the
+    /// real GitHub URL).
+    /// </summary>
+    public IReadOnlyList<string> ReceivedRequests => _receivedRequests;
+
+    private readonly List<string> _receivedRequests = new();
+    private readonly object _requestsLock = new();
+
+    private LocalReleaseMirror(HttpListener listener, int port, CancellationTokenSource loopCts)
+    {
+        _listener = listener;
+        _loopCts = loopCts;
+
+        Port = port;
+        BaseUri = new Uri($"http://localhost:{port}/");
+
+        _loopTask = Task.Run(() => RunLoopAsync(loopCts.Token));
+    }
+
+    /// <summary>Starts the mirror on a unique loopback port.</summary>
+    public static LocalReleaseMirror Start()
+    {
+        var port = GetEphemeralPort();
+        var listener = new HttpListener();
+        listener.Prefixes.Add($"http://localhost:{port}/");
+        listener.Start();
+
+        var cts = new CancellationTokenSource();
+        return new LocalReleaseMirror(listener, port, cts);
+    }
+
+    /// <summary>
+    /// Stages the binary content that will be packed into every zip /
+    /// tarball the mirror serves. Default is a tiny shim file. Tests can
+    /// override with PowerShell scripts / shell scripts so the install
+    /// script's post-extract probes (e.g. <c>squid-tentacle help</c>)
+    /// produce expected output.
+    /// </summary>
+    public void StageBinary(string binaryFileName, byte[] content)
+    {
+        _stagedBinaryFileName = binaryFileName;
+        _stagedBinary = content;
+    }
+
+    /// <summary>
+    /// Stages a PRE-BUILT archive that the mirror serves verbatim — no
+    /// auto-wrapping. Use this when a test needs the served zip / tarball
+    /// to contain MULTIPLE entries (e.g. a full binary tree + version
+    /// files + canonical exe placeholder mirroring the production GitHub
+    /// release zip's shape).
+    ///
+    /// <para><b>Why a separate API from <see cref="StageBinary"/></b>: the
+    /// existing <see cref="StageBinary"/> API was designed for the install-
+    /// script E2E tests where a single binary file inside the archive
+    /// suffices. The upgrade-lifecycle E2E (12.J.E.3) requires a
+    /// realistic full bundle (recursive copy of a service exe's runtime
+    /// tree + a top-level <c>Squid.Tentacle.exe</c> the .ps1 existence-
+    /// check expects). Passing such a pre-built zip via <see cref="StageBinary"/>
+    /// would double-wrap it (the mirror would treat the bytes as a single
+    /// file content + auto-create a fresh zip wrapper). This API is the
+    /// explicit "no auto-wrap, these bytes ARE the archive" seam.</para>
+    ///
+    /// <para>SHA256 companion responses still work — they hash the pre-
+    /// built bytes (cached per URL path so the .zip and .sha256 stay in
+    /// sync byte-for-byte; same cache the auto-wrap path uses).</para>
+    /// </summary>
+    public void StagePreBuiltArchive(byte[] preBuiltArchiveBytes)
+    {
+        ArgumentNullException.ThrowIfNull(preBuiltArchiveBytes);
+        _preBuiltArchive = preBuiltArchiveBytes;
+    }
+
+    /// <summary>
+    /// Configures the mirror to return 404 for the given version (any
+    /// download URL containing the version). Used by tests that exercise
+    /// the script's bogus-version error path.
+    /// </summary>
+    public void ConfigureNotFoundForVersion(string version)
+    {
+        _notFoundVersions.Add(version);
+    }
+
+    /// <summary>
+    /// Overrides the <c>.sha256</c> companion body. The mirror normally
+    /// computes the real SHA256 of the staged archive on each request; this
+    /// override forces a fixed string instead so tests can inject a
+    /// deliberately-wrong hash to exercise the production .ps1's exit-7
+    /// (checksum failed) path.
+    ///
+    /// <para><b>Format mirrors <c>sha256sum</c></b>: <c>"&lt;64 hex&gt;  &lt;filename&gt;"</c>.
+    /// The .ps1's parser splits on whitespace and takes the first token, so
+    /// the suffix is cosmetic — but matching the canonical format keeps the
+    /// fixture realistic for any future test that asserts on the wire body
+    /// shape.</para>
+    /// </summary>
+    public void StageSha256Override(string sha256Body)
+    {
+        _sha256Override = sha256Body;
+    }
+
+    /// <summary>
+    /// When set, every <c>.sha256</c> URL returns 404 regardless of what's
+    /// staged for the underlying archive. Exercises the .ps1's
+    /// skip-with-warning fallback (release without companion file).
+    /// </summary>
+    public void SuppressSha256Companion()
+    {
+        _suppressSha256 = true;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        try { _loopCts.Cancel(); } catch { }
+        try { _listener.Stop(); _listener.Close(); } catch { }
+        try { _loopTask.Wait(2_000); } catch { }
+    }
+
+    // ── HTTP loop ───────────────────────────────────────────────────────────
+
+    private async Task RunLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            HttpListenerContext ctx;
+            try { ctx = await _listener.GetContextAsync().ConfigureAwait(false); }
+            catch { return; }
+
+            try { HandleRequest(ctx); }
+            catch
+            {
+                try
+                {
+                    ctx.Response.StatusCode = 500;
+                    ctx.Response.OutputStream.Close();
+                }
+                catch { }
+            }
+        }
+    }
+
+    private void HandleRequest(HttpListenerContext ctx)
+    {
+        var path = ctx.Request.Url?.AbsolutePath ?? string.Empty;
+
+        lock (_requestsLock)
+        {
+            _receivedRequests.Add(path);
+        }
+
+        // 404 if the path mentions any of the configured "not found" versions.
+        if (_notFoundVersions.Any(v => path.Contains(v, StringComparison.OrdinalIgnoreCase)))
+        {
+            ctx.Response.StatusCode = 404;
+            ctx.Response.OutputStream.Close();
+            return;
+        }
+
+        // Serve a zip / tarball depending on the URL extension. The
+        // install-tentacle.{sh,ps1} scripts hit different URLs for
+        // Windows (zip) and Linux (tar.gz). Companion `.sha256` files
+        // are served alongside (production upgrade-windows-tentacle.ps1's
+        // opportunistic verification path appends `.sha256` to DOWNLOAD_URL).
+        if (path.EndsWith(".sha256", StringComparison.OrdinalIgnoreCase))
+        {
+            ServeSha256(ctx, path);
+            return;
+        }
+
+        if (path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            ServeZip(ctx);
+            return;
+        }
+
+        if (path.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+        {
+            ServeTarGz(ctx);
+            return;
+        }
+
+        // Unknown path → 404.
+        ctx.Response.StatusCode = 404;
+        ctx.Response.OutputStream.Close();
+    }
+
+    /// <summary>
+    /// Serves the SHA256 companion for the underlying archive. Production
+    /// upgrade-windows-tentacle.ps1 fetches <c>$DOWNLOAD_URL.sha256</c>
+    /// after a successful zip download; the body must be in
+    /// <c>sha256sum</c> format (<c>"&lt;64-hex&gt;  &lt;filename&gt;"</c>).
+    /// </summary>
+    private void ServeSha256(HttpListenerContext ctx, string companionPath)
+    {
+        if (_suppressSha256)
+        {
+            ctx.Response.StatusCode = 404;
+            ctx.Response.OutputStream.Close();
+            return;
+        }
+
+        // The companion's SHA target is the path with `.sha256` stripped —
+        // mirror computes the SHA of whatever archive WOULD be served at
+        // that path. Routed through the same cache the zip/tar.gz handlers
+        // use so the digest matches byte-for-byte what the .ps1 just
+        // downloaded (timestamps in archive headers are non-deterministic
+        // across separate builds).
+        var archivePath = companionPath.Substring(0, companionPath.Length - ".sha256".Length);
+        var archiveFileName = Path.GetFileName(archivePath);
+
+        if (!archivePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) &&
+            !archivePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+        {
+            ctx.Response.StatusCode = 404;
+            ctx.Response.OutputStream.Close();
+            return;
+        }
+
+        string body;
+        if (_sha256Override != null)
+        {
+            // Override path — used by SHA-mismatch tests to inject a
+            // deliberately-wrong digest. Body still mimics sha256sum
+            // format so the .ps1's parser handles it identically.
+            body = _sha256Override;
+        }
+        else
+        {
+            var archiveBytes = GetOrBuildArchiveBytes(archivePath);
+            var hash = SHA256.HashData(archiveBytes);
+            var hex = Convert.ToHexString(hash).ToLowerInvariant();
+            body = $"{hex}  {archiveFileName}\n";
+        }
+
+        var bodyBytes = Encoding.ASCII.GetBytes(body);
+        ctx.Response.ContentType = "text/plain; charset=ascii";
+        ctx.Response.ContentLength64 = bodyBytes.Length;
+        ctx.Response.OutputStream.Write(bodyBytes, 0, bodyBytes.Length);
+        ctx.Response.OutputStream.Close();
+    }
+
+    private void ServeZip(HttpListenerContext ctx)
+    {
+        var path = ctx.Request.Url?.AbsolutePath ?? string.Empty;
+        var zipBytes = GetOrBuildArchiveBytes(path);
+
+        ctx.Response.ContentType = "application/zip";
+        ctx.Response.ContentLength64 = zipBytes.Length;
+        ctx.Response.OutputStream.Write(zipBytes, 0, zipBytes.Length);
+        ctx.Response.OutputStream.Close();
+    }
+
+    private void ServeTarGz(HttpListenerContext ctx)
+    {
+        var path = ctx.Request.Url?.AbsolutePath ?? string.Empty;
+        var tarGzBytes = GetOrBuildArchiveBytes(path);
+
+        ctx.Response.ContentType = "application/gzip";
+        ctx.Response.ContentLength64 = tarGzBytes.Length;
+        ctx.Response.OutputStream.Write(tarGzBytes, 0, tarGzBytes.Length);
+        ctx.Response.OutputStream.Close();
+    }
+
+    /// <summary>
+    /// Returns the cached bytes for a given archive URL path, building on
+    /// first request. Caching is required because ZipArchive + GZipStream
+    /// embed timestamps in entry headers — a separate build for the .zip
+    /// request and the .sha256 companion request would produce different
+    /// bytes and fail the production .ps1's hash verify.
+    /// </summary>
+    private byte[] GetOrBuildArchiveBytes(string archivePath)
+    {
+        lock (_archiveCacheLock)
+        {
+            if (_archiveBytesCache.TryGetValue(archivePath, out var cached))
+                return cached;
+
+            byte[] bytes;
+
+            // Pre-built archive takes precedence — caller supplied a fully-
+            // shaped multi-entry zip / tarball. Serve verbatim, no wrapping.
+            if (_preBuiltArchive != null)
+            {
+                bytes = _preBuiltArchive;
+            }
+            else
+            {
+                // Auto-wrap-single-binary path (StageBinary). The default
+                // when only a single file's content has been staged.
+                var binaryContent = _stagedBinary ?? DefaultBinaryShim();
+
+                if (archivePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    var binaryName = _stagedBinaryFileName ?? "Squid.Tentacle.exe";
+                    bytes = BuildZip(binaryName, binaryContent);
+                }
+                else if (archivePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+                {
+                    var binaryName = _stagedBinaryFileName ?? "squid-tentacle";
+                    bytes = BuildTarGz(binaryName, binaryContent);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unsupported archive path: {archivePath}");
+                }
+            }
+
+            _archiveBytesCache[archivePath] = bytes;
+            return bytes;
+        }
+    }
+
+    // ── Archive builders ────────────────────────────────────────────────────
+
+    private static byte[] BuildZip(string binaryName, byte[] binaryContent)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry(binaryName, CompressionLevel.Fastest);
+            using var entryStream = entry.Open();
+            entryStream.Write(binaryContent, 0, binaryContent.Length);
+        }
+
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Minimal POSIX-tar (ustar) builder + gzip wrapper. Real tar tooling is
+    /// not in System.IO.Compression, but a single-entry ustar archive is
+    /// straightforward to hand-write — 512-byte header + content blocks
+    /// padded to 512 bytes + 1024-byte zero terminator. The install-
+    /// tentacle.sh script only does <c>tar xzf</c> which accepts this format.
+    /// </summary>
+    private static byte[] BuildTarGz(string binaryName, byte[] binaryContent)
+    {
+        var tar = BuildTar(binaryName, binaryContent);
+
+        using var gzMs = new MemoryStream();
+        using (var gz = new System.IO.Compression.GZipStream(gzMs, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            gz.Write(tar, 0, tar.Length);
+        }
+
+        return gzMs.ToArray();
+    }
+
+    private static byte[] BuildTar(string fileName, byte[] content)
+    {
+        // ustar header: 512 bytes
+        var header = new byte[512];
+
+        // Name (100 bytes, NUL-terminated)
+        var nameBytes = Encoding.ASCII.GetBytes(fileName);
+        Array.Copy(nameBytes, header, Math.Min(nameBytes.Length, 100));
+
+        // Mode (8 bytes, octal "0000644")
+        WriteOctal(header, offset: 100, length: 8, value: 0x1ED);   // 0755
+
+        // Uid (8), Gid (8)
+        WriteOctal(header, 108, 8, 0);
+        WriteOctal(header, 116, 8, 0);
+
+        // Size (12 bytes, octal)
+        WriteOctal(header, 124, 12, content.Length);
+
+        // Mtime (12 bytes, octal — current time)
+        WriteOctal(header, 136, 12, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        // Checksum field initially space-filled, computed below.
+        for (var i = 148; i < 156; i++) header[i] = (byte)' ';
+
+        // Type flag: '0' = regular file
+        header[156] = (byte)'0';
+
+        // Magic "ustar" + version "00"
+        var ustar = Encoding.ASCII.GetBytes("ustar");
+        Array.Copy(ustar, 0, header, 257, ustar.Length);
+        header[263] = (byte)'0';
+        header[264] = (byte)'0';
+
+        // Checksum: sum of all header bytes (with checksum field as spaces)
+        var checksum = 0;
+        foreach (var b in header) checksum += b;
+        WriteOctal(header, 148, 7, checksum);
+        header[155] = 0;   // NUL terminator after checksum
+
+        // Pad content to 512-byte block.
+        var paddedSize = (content.Length + 511) / 512 * 512;
+        var content512 = new byte[paddedSize];
+        Array.Copy(content, content512, content.Length);
+
+        // 1024-byte zero terminator.
+        var terminator = new byte[1024];
+
+        var tar = new byte[header.Length + content512.Length + terminator.Length];
+        Array.Copy(header, 0, tar, 0, header.Length);
+        Array.Copy(content512, 0, tar, header.Length, content512.Length);
+        Array.Copy(terminator, 0, tar, header.Length + content512.Length, terminator.Length);
+
+        return tar;
+    }
+
+    private static void WriteOctal(byte[] buffer, int offset, int length, long value)
+    {
+        var s = Convert.ToString(value, 8).PadLeft(length - 1, '0');
+        var bytes = Encoding.ASCII.GetBytes(s);
+        Array.Copy(bytes, 0, buffer, offset, Math.Min(bytes.Length, length - 1));
+        buffer[offset + length - 1] = 0;   // NUL terminator
+    }
+
+    private static byte[] DefaultBinaryShim()
+        => Encoding.UTF8.GetBytes("# fake binary shim — install-script E2E test only\n");
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static int GetEphemeralPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
@@ -23,6 +23,16 @@ public static class LinuxTentacleE2ECategories
     public const string UpgradeScript = "LinuxTentacleUpgradeScriptE2E";
 
     /// <summary>
+    /// Phase 12.L.E.4+ E2E coverage for the production
+    /// <c>upgrade-linux-tentacle.sh</c> end-to-end against a real
+    /// <see cref="Infrastructure.LocalReleaseMirror"/> + (later)
+    /// <see cref="Infrastructure.LinuxServiceFixture"/>. Tier 🟢
+    /// high-fidelity. Linux-only — requires bash + sudo. CI runs on
+    /// <c>ubuntu-latest</c>.
+    /// </summary>
+    public const string UpgradeLifecycle = "LinuxTentacleUpgradeLifecycleE2E";
+
+    /// <summary>
     /// Phase 12.L.E.3 smoke coverage for <see cref="Infrastructure.LinuxServiceFixture"/>.
     /// Tier 🔵 Fixture-only (Rule 12) — does NOT count toward production
     /// E2E coverage. Subsequent phases (12.L.E.4+) consume the fixture

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -1,0 +1,99 @@
+using Squid.Core.Services.Machines.Upgrade;
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.L.E.4 — first real lifecycle E2E on the Linux side. Mirrors
+/// the J.E.3 Windows lifecycle suite scoping discipline: start with
+/// the SIMPLEST scenarios that don't need systemd / Phase B, surface
+/// any production .sh bugs, then layer on full lifecycle in subsequent
+/// phases.
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity (Rule 12). Production .sh loaded
+/// from disk verbatim via <c>LinuxTentacleUpgradeStrategy.BuildScript</c>;
+/// real <see cref="LocalReleaseMirror"/> serving real HTTP; real
+/// <c>curl</c> + <c>tar</c> on the agent side; only the upstream
+/// GitHub Releases CDN is replaced.</para>
+///
+/// <para><b>This phase covers Phase A only</b> — the .sh's pre-scope
+/// flow (download, SHA verify, extract, ldd check). Phase B
+/// (<c>systemd-run --scope</c> + <c>systemctl restart</c>) requires
+/// LinuxServiceFixture-installed unit + sudo and lands in J.L.E.5+.
+///
+/// Coverage map this phase:
+/// <list type="bullet">
+///   <item>E1.u1-Linux: download 404 → exit 6 + FAILED status with
+///         "Target tarball not reachable" detail</item>
+/// </list></para>
+///
+/// <para><b>Skip-on-non-Linux + skip-on-no-sudo</b>: composes
+/// <see cref="LinuxLifecycleContext.IsAvailable"/>. macOS / Windows
+/// dev hosts no-op-skip; Linux without passwordless sudo also skips.
+/// CI <c>ubuntu-latest</c> runner has both.</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.UpgradeLifecycle)]
+public sealed class TentacleLinuxUpgradeLifecycleE2ETests
+{
+    // ========================================================================
+    // E1.u1-Linux — Download URL 404 → exit 6 + FAILED status with download detail
+    //
+    // Linux analog of Windows E1u1. The .sh's tarball-download HEAD probe
+    // fires `exit 6` if `curl --fail` returns non-2xx (404 in our test).
+    // BEFORE the systemd-run --scope detach — proves Phase A's pre-scope
+    // error path writes status + exits cleanly.
+    //
+    // Why E1.u1 first (not E1.h): the happy-path full lifecycle requires
+    // Phase B's systemctl restart against a real running service, which
+    // needs LinuxServiceFixture wired up. E1.u1 only needs the mirror to
+    // be reachable AND configured to 404 — surfaces the Phase A error-
+    // handling code path that real operators hit when:
+    //   - Tarball isn't published yet (recent tag, build pipeline still running)
+    //   - Air-gap mirror missing the version
+    //   - Firewall blocks GitHub Releases for the agent host
+    //   - Operator typo'd a version number
+    // ========================================================================
+
+    [Fact]
+    public void E1u1_DownloadVersionNotFound_ExitsSixAndWritesFailedStatusWithDownloadDetail()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        // Mirror configured to 404 the target version.
+        ctx.Mirror.ConfigureNotFoundForVersion("9.99.99-not-released");
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "9.99.99-not-released");
+        var (exitCode, output) = ctx.RunUpgradeScript(script);
+
+        // .sh's tarball-method HEAD-probe-fail path emits exit 6.
+        // Documented in upgrade-linux-tentacle.sh header: "6 — target
+        // tarball URL not reachable (tarball method only)".
+        exitCode.ShouldBe(6,
+            customMessage: $"download 404 MUST produce exit 6 (documented in upgrade-linux-tentacle.sh header). " +
+                          $"Got exit {exitCode}. " +
+                          (exitCode == 2 ? "Got exit 2 (download failure during the actual download, not the HEAD probe) — different code path; the .sh fell THROUGH the HEAD probe. " : "") +
+                          (exitCode == 14 ? "Got exit 14 (no install method succeeded) — apt/yum probes ran instead of falling through to tarball-only render. " : "") +
+                          $"output:\n{output}");
+
+        // last-upgrade.json reports FAILED with the operator-actionable detail.
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull(
+            customMessage: $"last-upgrade.json MUST be written even on Phase A error path — operators must see WHY the upgrade failed via the UI, not just 'no status'. Path: {ctx.StatusFilePath}");
+
+        statusPayload.Status.ShouldBe("FAILED",
+            customMessage: $"download 404 status MUST be 'FAILED'. Got: '{statusPayload.Status}'");
+
+        statusPayload.Detail.ShouldContain("not reachable",
+            customMessage: $"detail MUST contain 'not reachable' so operators distinguish a download failure from generic 'unknown error'. Got: '{statusPayload.Detail}'");
+
+        // The mirror SHOULD have received the HEAD probe attempt (curl
+        // --fsSI is the .sh's probe — it counts as a request from the
+        // mirror's perspective). Mirror returned 404, .sh exited.
+        ctx.Mirror.ReceivedRequests.ShouldNotBeEmpty(
+            customMessage: "mirror MUST have received the HEAD probe — proves the .sh actually attempted the download (vs failing earlier in Phase A and never reaching the network)");
+
+        ctx.MarkClean();
+    }
+}


### PR DESCRIPTION
## Summary

**First production-flow E2E on the Linux side.** Mirrors the J.E.3 Windows scoping discipline: start with simplest Phase A error scenario, surface any production `.sh` bugs the J.L.E.1 placeholder + parse pin couldn't catch, layer on full lifecycle in J.L.E.5+.

**Tier 🟢 high-fidelity.** Production `.sh` loaded verbatim via `LinuxTentacleUpgradeStrategy.BuildScript`; real `LocalReleaseMirror` serving real HTTP; real `curl` + `tar` on agent side. Only upstream GitHub Releases CDN replaced. Phase A only — Phase B (systemd-run + systemctl restart) lands in J.L.E.5.

## New infrastructure

| Artifact | Role |
|---|---|
| `LocalReleaseMirror` (copied from Windows project verbatim) | Same wire shape (zip / tar.gz / .sha256). Intentional copy with explicit drift-acceptance note — refactor to shared library if meaningful divergence appears |
| `LinuxLifecycleContext` | IDisposable: fixture + mirror + state-dir override + cleanup. GUID-suffixed isolation. Tarball-only method render (skips apt/yum host-config sensitivity). 5min bash timeout matching production. |

## New test (1)

**`E1u1_DownloadVersionNotFound_ExitsSixAndWritesFailedStatusWithDownloadDetail`**

| Step | Assertion |
|---|---|
| Mirror returns 404 for target version | (setup) |
| `.sh` exits 6 | Documented per `.sh` header: "target tarball URL not reachable" |
| `last-upgrade.json` written with `Status=FAILED` | Operator UI visibility |
| Detail contains "not reachable" | Operator-actionable failure mode |
| Mirror got the HEAD probe | Proves `.sh` reached the network (vs failing earlier in Phase A) |

Each assertion has a `customMessage` explaining DIFFERENT possible exit codes (2 / 14) so a regression's error points at the right diagnosis.

## Workflow filter updated

Default now includes `Category=LinuxTentacleUpgradeLifecycleE2E`.

## Local verification (macOS)

6/6 tests pass: 3 cross-platform script tests run, 3 Linux-only tests skip-guard via `IsAvailable=false`. Linux runner verification on this PR's auto-trigger.

## Expected Linux runner outcomes

This is the first time a real `.sh` upgrade flow runs on a real Linux runner end-to-end. May surface bugs analogous to J.E.3.1's 3 Windows P0s (placeholder-in-comment, Get-FileHash auto-loader, etc.). The detailed customMessage diagnostics + audit trail will point directly at the failing layer.

## Next (J.L.E.5)

- SHA mismatch test (E12.u1-Linux analog)
- Linux full lifecycle (E1.h-Linux): needs LinuxServiceFixture-installed unit + Phase B handoff via systemd-run --scope. Larger work, own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)