### PR TITLE
Phase 12.L.E.6 — Linux HealthcheckRetries env var (Windows J.E.5 parity) + healthz responder seam

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
@@ -65,6 +65,12 @@ INSTALL_DIR="{{INSTALL_DIR}}"
 SERVICE_NAME="{{SERVICE_NAME}}"
 SERVICE_USER="{{SERVICE_USER}}"
 HEALTHCHECK_URL="{{HEALTHCHECK_URL}}"
+# Post-restart healthcheck poll count — server-substituted from
+# LinuxTentacleUpgradeStrategy.ResolveHealthcheckRetries (default 90 ×
+# 1s = 90s window). Operator override via
+# SQUID_TARGET_LINUX_TENTACLE_HEALTHCHECK_RETRIES. J.L.E.6 parity with
+# Windows J.E.5 hardening.
+HEALTHCHECK_RETRIES={{HEALTHCHECK_RETRIES}}
 
 # State directory — server-substituted from LinuxTentacleUpgradeStrategy.
 # Default `/var/lib/squid-tentacle` matches what install-tentacle.sh
@@ -619,7 +625,7 @@ timeout 90 sudo systemctl restart "$SERVICE_NAME" || {
 
 # ── Health check loop ────────────────────────────────────────────────────────
 if [ "$START_OK" = "1" ]; then
-  for i in $(seq 1 90); do
+  for i in $(seq 1 "$HEALTHCHECK_RETRIES"); do
     if sudo systemctl is-active --quiet "$SERVICE_NAME"; then
       if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 5 "$HEALTHCHECK_URL" >/dev/null 2>&1; then
         HEALTH_OK=1
@@ -630,7 +636,7 @@ if [ "$START_OK" = "1" ]; then
     sleep 1
   done
   if [ "$HEALTH_OK" != "1" ]; then
-    emit_event B healthz-fail "Service did not become healthy within 90s"
+    emit_event B healthz-fail "Service did not become healthy within ${HEALTHCHECK_RETRIES}s"
   fi
 fi
 

--- a/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
@@ -89,6 +89,26 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
     /// </summary>
     public const string StateDirEnvVar = "SQUID_TARGET_LINUX_TENTACLE_STATE_DIR";
 
+    /// <summary>
+    /// Operator override for the post-restart healthcheck poll count.
+    /// Default <see cref="DefaultHealthcheckRetries"/> (90 × 1s sleep =
+    /// 90s wait window) — matches the existing pre-J.L.E.6 behaviour.
+    /// Tests override to 1 to bypass the wait when the test service
+    /// has its python3 healthz responder ready by the time .sh polls.
+    ///
+    /// <para><b>Operator value</b>: deployments with slow-starting
+    /// agents (heavy plugin enumeration, JIT cold start) get false
+    /// rollbacks on every upgrade today. Setting this to 180 (3 min)
+    /// gives those environments room without changing default behaviour.
+    /// Direct parity with Windows
+    /// <c>WindowsTentacleUpgradeStrategy.HealthcheckRetriesEnvVar</c>
+    /// (J.E.5).</para>
+    ///
+    /// <para>Pinned per Rule 8 by
+    /// <c>LinuxTentacleUpgradeStrategyTests.HealthcheckRetriesEnvVar_ConstantNamePinned</c>.</para>
+    /// </summary>
+    public const string HealthcheckRetriesEnvVar = "SQUID_TARGET_LINUX_TENTACLE_HEALTHCHECK_RETRIES";
+
     private const string DefaultDownloadBaseUrl = "https://github.com/SolarifyDev/Squid/releases/download";
     private const string DefaultHealthcheckUrl = "http://127.0.0.1:8080/healthz";
 
@@ -98,6 +118,14 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
     /// <see cref="StateDirEnvVar"/>.
     /// </summary>
     internal const string DefaultStateDir = "/var/lib/squid-tentacle";
+
+    /// <summary>
+    /// Default post-restart healthcheck poll count. 90 × 1s sleep = 90s
+    /// wait window. Matches the existing hardcoded value from before
+    /// J.L.E.6. Operators with heavyweight agents override via
+    /// <see cref="HealthcheckRetriesEnvVar"/>.
+    /// </summary>
+    internal const int DefaultHealthcheckRetries = 90;
 
     /// <summary>
     /// Wall-clock cap for a single upgrade script dispatch. Must stay
@@ -381,6 +409,7 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
             .Replace("{{SERVICE_USER}}", DefaultServiceUser, StringComparison.Ordinal)
             .Replace("{{HEALTHCHECK_URL}}", ResolveHealthcheckUrl(), StringComparison.Ordinal)
             .Replace("{{STATE_DIR}}", ResolveStateDir(), StringComparison.Ordinal)
+            .Replace("{{HEALTHCHECK_RETRIES}}", ResolveHealthcheckRetries().ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
             .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
     }
 
@@ -395,6 +424,32 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
         var baseUrl = ResolveDownloadBaseUrl();
 
         return $"{baseUrl}/{version}/squid-tentacle-{version}-{rid}.tar.gz";
+    }
+
+    /// <summary>
+    /// Resolves the post-restart healthcheck poll count. Defaults to
+    /// <see cref="DefaultHealthcheckRetries"/> (90 × 1s sleep = 90s window).
+    /// Invalid values fall back to default — operator-friendly: a typo'd
+    /// env var doesn't break upgrades, just uses the safe default.
+    /// </summary>
+    internal static int ResolveHealthcheckRetries()
+    {
+        var raw = System.Environment.GetEnvironmentVariable(HealthcheckRetriesEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultHealthcheckRetries;
+
+        if (!int.TryParse(raw.Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            || parsed < 1)
+        {
+            Log.Warning(
+                "[Upgrade] {EnvVar} is set to an invalid value ('{Value}'). " +
+                "Must be a positive integer (number of 1-second poll attempts). " +
+                "Falling back to default of {Default}.",
+                HealthcheckRetriesEnvVar, raw, DefaultHealthcheckRetries);
+            return DefaultHealthcheckRetries;
+        }
+
+        return parsed;
     }
 
     /// <summary>

--- a/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
+++ b/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
@@ -35,6 +35,34 @@ INSTALL_DIR="${INSTALL_DIR:-$(dirname "$(readlink -f "$0")")}"
 VERSION_FILE="$INSTALL_DIR/version.txt"
 MARKER_FILE="$INSTALL_DIR/service-running.marker"
 
+# Optional healthz endpoint for J.L.E.6+ full-lifecycle tests. The .sh's
+# Phase B healthcheck loop curls $HEALTHCHECK_URL (default
+# http://127.0.0.1:8080/healthz) — without an actual responder the
+# upgrade always rolls back. python3 ships on every modern Linux distro
+# (and on the GHA ubuntu-latest runner) — use it to spawn a tiny HTTP
+# server in the background that returns 200/OK.
+#
+# Opt-in via SQUID_TEST_SERVICE_HEALTHZ=1 — when unset (default),
+# the script behaves as before (no HTTP listener). The fixture sets the
+# env var via the systemd unit's Environment= directive when needed.
+HEALTHZ_PID=""
+if [ "${SQUID_TEST_SERVICE_HEALTHZ:-0}" = "1" ] && command -v python3 >/dev/null 2>&1; then
+    HEALTHZ_PORT="${SQUID_TEST_SERVICE_HEALTHZ_PORT:-8080}"
+    python3 -c "
+import http.server, socketserver, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'OK\n')
+    def log_message(self, *args, **kwargs): pass
+with socketserver.TCPServer(('127.0.0.1', $HEALTHZ_PORT), H) as httpd:
+    httpd.serve_forever()
+" &
+    HEALTHZ_PID=$!
+fi
+
 read_version() {
     if [ -f "$VERSION_FILE" ]; then
         cat "$VERSION_FILE" | tr -d '[:space:]'
@@ -45,6 +73,9 @@ read_version() {
 
 cleanup() {
     rm -f "$MARKER_FILE" 2>/dev/null || true
+    if [ -n "$HEALTHZ_PID" ] && kill -0 "$HEALTHZ_PID" 2>/dev/null; then
+        kill "$HEALTHZ_PID" 2>/dev/null || true
+    fi
     exit 0
 }
 

--- a/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
@@ -62,6 +62,7 @@ public sealed class UpgradeLinuxScriptE2ETests
         {
             "DOWNLOAD_URL",
             "EXPECTED_SHA256",
+            "HEALTHCHECK_RETRIES",
             "HEALTHCHECK_URL",
             "INSTALL_DIR",
             "INSTALL_METHODS",

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -40,16 +40,19 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
     private readonly string _previousBaseUrlOverride;
     private readonly string _previousHealthcheckUrlOverride;
     private readonly string _previousStateDirOverride;
+    private readonly string _previousHealthcheckRetriesOverride;
 
     public LinuxTentacleUpgradeStrategyTests()
     {
         _previousBaseUrlOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar);
         _previousHealthcheckUrlOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckUrlEnvVar);
         _previousStateDirOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar);
+        _previousHealthcheckRetriesOverride = SystemEnvironment.GetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar);
 
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckUrlEnvVar, null);
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, null);
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, null);
     }
 
     public void Dispose()
@@ -57,6 +60,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, _previousBaseUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckUrlEnvVar, _previousHealthcheckUrlOverride);
         SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, _previousStateDirOverride);
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, _previousHealthcheckRetriesOverride);
     }
 
     [Fact]
@@ -146,6 +150,80 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
 
         rendered.ShouldContain("STATUS_DIR=\"/var/lib/squid-tentacle\"",
             customMessage: "default render MUST inject /var/lib/squid-tentacle — operators not-overriding see pre-PR behaviour");
+    }
+
+    // ── J.L.E.6: HealthcheckRetriesEnvVar pins ─────────────────────────────
+
+    [Fact]
+    public void HealthcheckRetriesEnvVar_ConstantNamePinned()
+    {
+        LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar
+            .ShouldBe("SQUID_TARGET_LINUX_TENTACLE_HEALTHCHECK_RETRIES");
+    }
+
+    [Fact]
+    public void ResolveHealthcheckRetries_NoEnvVar_ReturnsDefault90()
+    {
+        // 90 × 1s sleep = 90s wait window. Pre-J.L.E.6 was hardcoded 90;
+        // pin to preserve operator-observable behaviour after the env-var
+        // refactor.
+        LinuxTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(90);
+    }
+
+    [Theory]
+    [InlineData("1", 1)]                  // tests use this to bypass the wait
+    [InlineData("180", 180)]              // 3min for slow agents
+    [InlineData("3600", 3600)]
+    [InlineData("  60  ", 60)]
+    public void ResolveHealthcheckRetries_ValidValue_RoundTripsAsInteger(string envValue, int expected)
+    {
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, envValue);
+
+        LinuxTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("90s")]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    public void ResolveHealthcheckRetries_InvalidValue_FallsBackToDefault90(string envValue)
+    {
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, envValue);
+
+        // Operator-friendly: invalid values fall back with Serilog warning.
+        // 0 specifically — passing 0 to seq would loop 0 times → healthz
+        // never checked → silent SUCCESS even on dead agent. Default
+        // protects against this.
+        LinuxTentacleUpgradeStrategy.ResolveHealthcheckRetries().ShouldBe(90);
+    }
+
+    [Fact]
+    public void BuildScript_HealthcheckRetriesPlaceholder_SubstitutedFromEnv()
+    {
+        SystemEnvironment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, "5");
+
+        var rendered = LinuxTentacleUpgradeStrategy.BuildScript("1.6.0", LinuxTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        // Direct substitution: the placeholder gets the resolved value as
+        // a numeric literal.
+        rendered.ShouldContain("HEALTHCHECK_RETRIES=5",
+            customMessage: "BuildScript MUST substitute the env-resolved retry count. " +
+                          "If this fails: placeholder wasn't wired through Replace, OR .sh dropped the variable assignment.");
+
+        // Healthcheck loop MUST reference the variable, not a hardcoded value.
+        rendered.ShouldContain("seq 1 \"$HEALTHCHECK_RETRIES\"",
+            customMessage: "healthcheck loop MUST use \\$HEALTHCHECK_RETRIES — if it's a fixed integer, operator override is no-op");
+    }
+
+    [Fact]
+    public void BuildScript_HealthcheckRetries_DefaultsTo90InRender()
+    {
+        var rendered = LinuxTentacleUpgradeStrategy.BuildScript("1.6.0", LinuxTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        rendered.ShouldContain("HEALTHCHECK_RETRIES=90",
+            customMessage: "default render MUST inject 90 — operators not-overriding see pre-J.L.E.6 90s wait window");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Linux production-hardening parity with Windows J.E.5. Adds operator-tunable healthcheck poll count + a python3 healthz responder seam in the test service, paving the way for J.L.E.7's first Linux full lifecycle test.

## Why narrowed scope (not full lifecycle yet)

Linux full lifecycle requires:
- Working healthz endpoint (otherwise .sh always rolls back at 90s healthz timeout)
- Tarball with proper structure (`Squid.Tentacle` + `version.txt`)
- BuildV2BundleTarGz helper in LinuxLifecycleContext

Each piece is independently small but together = larger PR. This PR delivers the **production hardening + healthz seam**; J.L.E.7 layers on the lifecycle test.

## Production changes

| File | Change |
|---|---|
| `LinuxTentacleUpgradeStrategy.cs` | New `HealthcheckRetriesEnvVar` (Rule 8) + `DefaultHealthcheckRetries=90` + `ResolveHealthcheckRetries()` + `{{HEALTHCHECK_RETRIES}}` placeholder |
| `upgrade-linux-tentacle.sh` | `HEALTHCHECK_RETRIES={{HEALTHCHECK_RETRIES}}` + loop uses `seq 1 "$HEALTHCHECK_RETRIES"` |
| `squid-linux-test-service.sh` | Optional python3 healthz responder gated on `SQUID_TEST_SERVICE_HEALTHZ=1` env var |

## Unit tests (5 new + 1 drift updated)

- Rule 8 const pin
- Default returns 90 (preserves pre-PR behaviour)
- Theory valid: 1 / 180 / 3600 / whitespace
- Theory invalid: 0 / -1 / "90s" / non-numeric / empty → fallback
- Substitution + variable-reference reverse-pin
- Default render injects 90
- Drift detector updated (9 placeholders)

## Local verification

5068+ unit tests pass (85 Linux strategy tests now). 7/7 Linux E2E pass (3 cross-platform run, 4 Linux-only skip).

## Next (J.L.E.7)

First Linux full lifecycle test (E1.h-Linux). Consumes `retries=1` + `SQUID_TEST_SERVICE_HEALTHZ=1` to run REAL Phase A + Phase B + healthz against real systemd. Expected to surface remaining production .sh bugs (analogous to J.E.3.1's 3 Windows P0s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)