### PR TITLE
Phase 12.L.E.7 — first Linux full lifecycle (E1.h-Linux happy path)

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -74,13 +74,18 @@ public sealed class LinuxLifecycleContext : IDisposable
     /// </summary>
     public string RenderProductionScriptForVersion(string targetVersion)
     {
-        // Set env vars for resolver-driven placeholders. Strategy reads
-        // SQUID_TARGET_LINUX_TENTACLE_DOWNLOAD_BASE_URL + the new
-        // SQUID_TARGET_LINUX_TENTACLE_STATE_DIR (12.L.E.2). HEALTHCHECK_URL
-        // also resolver-driven; default is fine because the test service
-        // doesn't expose HTTP and we want the "warning + proceed" path.
+        // Set env vars for resolver-driven placeholders. Strategy reads:
+        //   - DownloadBaseUrl → mirror's HTTP listener
+        //   - StateDir       → test-isolated per-test dir (12.L.E.2)
+        //   - HealthcheckRetries → 1 attempt for fast tests (12.L.E.6)
         Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, Mirror.BaseUri.ToString().TrimEnd('/'));
         Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, StateDirOverride);
+
+        // retries=1 cuts the .sh's 90s healthz wait down to 1s. With the
+        // test service's python3 healthz responder (SQUID_TEST_SERVICE_HEALTHZ=1
+        // set in systemd unit Environment), the responder is up by the
+        // time .sh's curl probe runs → HEALTH_OK=1 → success path.
+        Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, "1");
 
         // Tarball-only method order. Skips apt+yum probes which would
         // otherwise slow tests + introduce host-config sensitivity (apt's
@@ -89,6 +94,134 @@ public sealed class LinuxLifecycleContext : IDisposable
         var tarballOnly = new ILinuxUpgradeMethod[] { new TarballUpgradeMethod() };
 
         return LinuxTentacleUpgradeStrategy.BuildScript(targetVersion, tarballOnly);
+    }
+
+    /// <summary>
+    /// Builds a multi-entry tar.gz mirroring the production GitHub
+    /// release tarball's shape — what the .sh's Phase A extracts +
+    /// Phase B swaps into INSTALL_DIR. Used by full-lifecycle tests
+    /// (J.L.E.7+) where the .sh's existence check
+    /// (<c>NEW_BIN="$EXTRACT/Squid.Tentacle"</c>) + the symlink chain +
+    /// the post-restart healthz poll all need a properly-shaped
+    /// payload.
+    ///
+    /// <para>Contents:</para>
+    /// <list type="bullet">
+    ///   <item><c>Squid.Tentacle</c> — placeholder shim (a copy of the
+    ///         test service script, chmod +x'd by .ps1 line 591).
+    ///         The .sh creates symlinks <c>squid-tentacle</c> → this,
+    ///         and global <c>/usr/local/bin/squid-tentacle</c>. Real
+    ///         systemd unit's ExecStart points at the bash script
+    ///         below — Squid.Tentacle is just for the .sh's
+    ///         existence-check + symlink chain.</item>
+    ///   <item><c>squid-linux-test-service.sh</c> — the actual systemd
+    ///         ExecStart target. After swap, INSTALL_DIR has this file
+    ///         and the systemd unit's restart picks it up.</item>
+    ///   <item><c>version.txt</c> — the test service reads on Start;
+    ///         the marker file's content is what tests assert against
+    ///         to prove the swap actually landed.</item>
+    /// </list>
+    /// </summary>
+    public byte[] BuildV2BundleTarGz(string targetVersion)
+    {
+        var serviceScriptBytes = File.ReadAllBytes(TestServiceScript);
+
+        // version.txt content is what test service reads on Start →
+        // writes to the marker. Strip pre-release suffix so marker
+        // assertions compare cleanly (e.g. "2.0.0-test" → "2.0.0").
+        var serviceVersion = targetVersion.Split('-')[0];
+        var versionTxtBytes = Encoding.UTF8.GetBytes(serviceVersion);
+
+        // Squid.Tentacle placeholder: just a copy of the test service
+        // script (an executable bash file). chmod +x at .sh line 591
+        // works on any bash file. Symlink chain works. The systemd
+        // unit's ExecStart points elsewhere (the .sh script below) so
+        // this placeholder isn't actually invoked as a service.
+        var squidTentacleBytes = serviceScriptBytes;
+
+        var entries = new (string Name, byte[] Content)[]
+        {
+            ("Squid.Tentacle", squidTentacleBytes),
+            ("squid-linux-test-service.sh", serviceScriptBytes),
+            ("version.txt", versionTxtBytes)
+        };
+
+        return BuildTarGz(entries);
+    }
+
+    /// <summary>
+    /// Hand-rolled multi-entry POSIX tar + gzip. <see cref="LocalReleaseMirror"/>
+    /// has a single-file BuildTarGz; this helper handles multiple files
+    /// (the J.L.E.7+ full-bundle case).
+    /// </summary>
+    private static byte[] BuildTarGz((string Name, byte[] Content)[] entries)
+    {
+        // Build uncompressed tar first (each entry's 512-byte header +
+        // content padded to 512 + 1024-byte trailer).
+        using var tarMs = new MemoryStream();
+        foreach (var entry in entries)
+        {
+            var header = BuildTarHeader(entry.Name, entry.Content.Length);
+            tarMs.Write(header, 0, header.Length);
+            tarMs.Write(entry.Content, 0, entry.Content.Length);
+            // Pad to 512-byte block
+            var pad = (512 - (entry.Content.Length % 512)) % 512;
+            if (pad > 0) tarMs.Write(new byte[pad], 0, pad);
+        }
+        // 1024-byte zero terminator
+        tarMs.Write(new byte[1024], 0, 1024);
+
+        // gzip-wrap
+        using var gzMs = new MemoryStream();
+        using (var gz = new System.IO.Compression.GZipStream(gzMs, System.IO.Compression.CompressionLevel.Fastest, leaveOpen: true))
+        {
+            var tarBytes = tarMs.ToArray();
+            gz.Write(tarBytes, 0, tarBytes.Length);
+        }
+        return gzMs.ToArray();
+    }
+
+    private static byte[] BuildTarHeader(string fileName, long size)
+    {
+        var header = new byte[512];
+
+        // Name (100 bytes, NUL-terminated)
+        var nameBytes = Encoding.ASCII.GetBytes(fileName);
+        Array.Copy(nameBytes, header, Math.Min(nameBytes.Length, 100));
+
+        // Mode 0755 — chmod-x ready (for Squid.Tentacle + the script)
+        WriteOctal(header, offset: 100, length: 8, value: 0x1ED);
+        WriteOctal(header, 108, 8, 0);   // uid
+        WriteOctal(header, 116, 8, 0);   // gid
+        WriteOctal(header, 124, 12, size);
+        WriteOctal(header, 136, 12, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        // Checksum field initially space-filled (for the checksum sum
+        // calculation below); type flag '0' = regular file.
+        for (var i = 148; i < 156; i++) header[i] = (byte)' ';
+        header[156] = (byte)'0';
+
+        // Magic "ustar" + version "00"
+        var ustar = Encoding.ASCII.GetBytes("ustar");
+        Array.Copy(ustar, 0, header, 257, ustar.Length);
+        header[263] = (byte)'0';
+        header[264] = (byte)'0';
+
+        // Checksum
+        var checksum = 0;
+        foreach (var b in header) checksum += b;
+        WriteOctal(header, 148, 7, checksum);
+        header[155] = 0;
+
+        return header;
+    }
+
+    private static void WriteOctal(byte[] buffer, int offset, int length, long value)
+    {
+        var s = Convert.ToString(value, 8).PadLeft(length - 1, '0');
+        var bytes = Encoding.ASCII.GetBytes(s);
+        Array.Copy(bytes, 0, buffer, offset, Math.Min(bytes.Length, length - 1));
+        buffer[offset + length - 1] = 0;
     }
 
     /// <summary>
@@ -191,6 +324,7 @@ public sealed class LinuxLifecycleContext : IDisposable
         // strictly needed (test process exits) but clean.
         try { Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null); } catch { }
         try { Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.StateDirEnvVar, null); } catch { }
+        try { Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.HealthcheckRetriesEnvVar, null); } catch { }
     }
 
     private static string LocateTestServiceScript()

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
@@ -114,8 +114,14 @@ public sealed class LinuxServiceFixture : IDisposable
     /// supplied initial version, write a systemd unit file referencing
     /// it, daemon-reload + start, polling until the service reaches
     /// active(running) state OR the timeout expires.
+    ///
+    /// <para>Optional <paramref name="extraEnvironment"/> entries are
+    /// added as additional <c>Environment=KEY=VALUE</c> lines in the
+    /// systemd unit. Used by J.L.E.7+ full-lifecycle tests to set
+    /// <c>SQUID_TEST_SERVICE_HEALTHZ=1</c> so the test service spawns
+    /// its python3 healthz responder.</para>
     /// </summary>
-    public void InstallAndStart(string testServiceScriptSourcePath, string initialVersion, TimeSpan startTimeout)
+    public void InstallAndStart(string testServiceScriptSourcePath, string initialVersion, TimeSpan startTimeout, IReadOnlyDictionary<string, string> extraEnvironment = null)
     {
         if (!IsAvailable) throw new PlatformNotSupportedException("LinuxServiceFixture only runs on Linux with passwordless sudo");
 
@@ -135,13 +141,21 @@ public sealed class LinuxServiceFixture : IDisposable
         // ExecStart command (the bash script itself, which sleeps forever).
         // KillMode=mixed sends SIGTERM to main process + SIGKILL to children
         // so our trap-handler runs cleanly on stop.
-        var unitContent = new StringBuilder()
+        var unitBuilder = new StringBuilder()
             .AppendLine("[Unit]")
             .AppendLine($"Description=Squid Linux Tentacle E2E Test Service — {_serviceName}")
             .AppendLine()
             .AppendLine("[Service]")
             .AppendLine("Type=simple")
-            .AppendLine($"Environment=INSTALL_DIR={_installDir}")
+            .AppendLine($"Environment=INSTALL_DIR={_installDir}");
+
+        if (extraEnvironment != null)
+        {
+            foreach (var kvp in extraEnvironment)
+                unitBuilder.AppendLine($"Environment={kvp.Key}={kvp.Value}");
+        }
+
+        var unitContent = unitBuilder
             .AppendLine($"ExecStart=/usr/bin/env bash {ServiceScriptPath}")
             .AppendLine("KillMode=mixed")
             .AppendLine("Restart=no")

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -36,6 +36,104 @@ namespace Squid.LinuxTentacleE2ETests;
 public sealed class TentacleLinuxUpgradeLifecycleE2ETests
 {
     // ========================================================================
+    // E1.h-Linux — Full lifecycle happy path (Phase A + Phase B)
+    //
+    // The most operationally critical Linux test: drive .sh end-to-end
+    // against a real systemd service + real LocalReleaseMirror tarball
+    // + real curl + real systemctl restart + real /healthz responder.
+    //
+    // Mirrors Windows E1.h structure exactly:
+    //   1. Stage v1 service via LinuxServiceFixture (with healthz enabled)
+    //   2. Build v2 tarball via LinuxLifecycleContext.BuildV2BundleTarGz
+    //   3. Stage tarball at mirror
+    //   4. Render .sh (HEALTHCHECK_RETRIES=1, tarball-only methods,
+    //      state-dir override)
+    //   5. Run via bash (Phase A: download/SHA-skip/extract; Phase B:
+    //      systemd-run --scope → systemctl restart → healthz curl →
+    //      version probe → SUCCESS)
+    //   6. Assertions:
+    //      - exit 0
+    //      - last-upgrade.json reports SUCCESS, target version, tarball method
+    //      - service marker file content swapped from "1.0.0" to "2.0.0"
+    //      - service is still running on systemctl is-active
+    //
+    // High-fidelity. No mocks at any layer — production .sh + real
+    // mirror + real systemd + real bash + real python3 healthz.
+    //
+    // Expected runtime: ~5-10s (Phase A download instant from local
+    // mirror; retries=1 cuts the previous 90s healthz wait to 1s).
+    // ========================================================================
+
+    [Fact]
+    public void E1h_FullLifecycle_HappyPath_WritesSuccessAndSwapsBinary()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        // Stage v1 service with healthz responder ENABLED. The .sh's Phase B
+        // healthz curl will hit our python3 listener → 200 OK → HEALTH_OK=1.
+        ctx.Fixture.InstallAndStart(
+            ctx.TestServiceScript,
+            initialVersion: "1.0.0",
+            startTimeout: TimeSpan.FromSeconds(15),
+            extraEnvironment: new Dictionary<string, string>
+            {
+                ["SQUID_TEST_SERVICE_HEALTHZ"] = "1"
+            });
+
+        // Sanity: marker file confirms v1 is running.
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running with v1 marker before E1.h-Linux can validate the swap");
+
+        // Build v2 tarball (tarball method, multi-entry: Squid.Tentacle
+        // placeholder + script + version.txt). Mirror serves it raw.
+        var v2Tarball = ctx.BuildV2BundleTarGz(targetVersion: "2.0.0-test");
+        ctx.Mirror.StagePreBuiltArchive(v2Tarball);
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, output) = ctx.RunUpgradeScript(script);
+
+        exitCode.ShouldBe(0,
+            customMessage: $"full lifecycle MUST exit 0 on happy path. Got exit {exitCode}. " +
+                          (exitCode == 6 ? "Got exit 6 (download not reachable) — mirror config issue. " : "") +
+                          (exitCode == 7 ? "Got exit 7 (SHA mismatch) — mirror staged with mismatched SHA companion. " : "") +
+                          (exitCode == 13 ? "Got exit 13 (systemd-run --scope failed) — sudo / systemd missing or scope creation race. " : "") +
+                          (exitCode == 14 ? "Got exit 14 (no install method succeeded) — apt/yum probes intervened. " : "") +
+                          $"\noutput tail (last 2k chars):\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // last-upgrade.json reports SUCCESS — operator-visible outcome.
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull(
+            customMessage: $"last-upgrade.json MUST be written by .sh after Phase B success. Path: {ctx.StatusFilePath}. " +
+                          "If null: status atomic-write failed OR Phase B exited before reaching write_status SUCCESS.");
+
+        statusPayload.Status.ShouldBe("SUCCESS",
+            customMessage: $"last-upgrade.json status MUST be 'SUCCESS' on happy path. Got: '{statusPayload.Status}'. " +
+                          $"Detail: {statusPayload.Detail}");
+
+        statusPayload.TargetVersion.ShouldBe("2.0.0-test",
+            customMessage: $"targetVersion MUST echo what strategy passed. Got: '{statusPayload.TargetVersion}'");
+
+        statusPayload.InstallMethod.ShouldBe("tarball",
+            customMessage: $"installMethod MUST be 'tarball' (we passed [TarballUpgradeMethod()] only). Got: '{statusPayload.InstallMethod}'");
+
+        // Reverse-assert: marker now reports v2 (proves Phase B's mv
+        // swap landed AND new service started AND it read new version.txt).
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            customMessage: $"after Phase B mv swap + systemctl restart, marker at {ctx.Fixture.MarkerFilePath} MUST contain '2.0.0' — " +
+                          "proves swap landed AND new service started AND read new version.txt. " +
+                          "If marker still '1.0.0': swap failed OR new service didn't start. " +
+                          "If marker absent: trap-handler ran (service stopped) OR rollback fired.");
+
+        // Service is still active per systemd.
+        ctx.Fixture.IsActive().ShouldBeTrue(
+            customMessage: "service MUST still be active after upgrade — proves systemctl restart picked up the new binary cleanly");
+
+        ctx.MarkClean();
+    }
+
+    // ========================================================================
     // E1.u1-Linux — Download URL 404 → exit 6 + FAILED status with download detail
     //
     // Linux analog of Windows E1u1. The .sh's tarball-download HEAD probe
@@ -156,5 +254,26 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
             customMessage: $"detail MUST name 'SHA256 mismatch' so operators distinguish integrity failure from generic 'unknown' (which would lead them to re-trigger the upgrade pointlessly). Got: '{statusPayload.Detail}'");
 
         ctx.MarkClean();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    var actual = File.ReadAllText(path).Trim();
+                    if (actual == expectedContent) return true;
+                }
+            }
+            catch { /* mid-write, retry */ }
+            Thread.Sleep(200);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

🎯 **The Linux milestone.** First high-fidelity end-to-end test driving the production `upgrade-linux-tentacle.sh` through Phase A + Phase B + healthz + swap + restart against **REAL** systemd + bash + python3 healthz responder + LocalReleaseMirror tar.gz.

Mirrors Windows J.E.3 E1.h structure exactly. **Expected to surface remaining production .sh bugs** (analogous to J.E.3.1's 3 Windows P0s — the ArgumentList bug from J.L.E.3 was the first one).

## New infrastructure

| Artifact | Role |
|---|---|
| `LinuxLifecycleContext.BuildV2BundleTarGz` | Hand-rolled multi-entry POSIX ustar + gzip. Bundle: Squid.Tentacle placeholder + script + version.txt |
| `LinuxLifecycleContext.RenderProductionScriptForVersion` | Sets HEALTHCHECK_RETRIES=1 (cuts 90s wait → 1s) |
| `LinuxServiceFixture.InstallAndStart` | New optional `extraEnvironment` dict — adds `Environment=KEY=VALUE` lines to systemd unit. Used to enable `SQUID_TEST_SERVICE_HEALTHZ=1` for full lifecycle |

## New E2E test

`E1h_FullLifecycle_HappyPath_WritesSuccessAndSwapsBinary`:

1. v1 service running with healthz responder
2. v2 tarball staged at mirror
3. Run .sh end-to-end
4. Phase A: download → extract → systemd-run --scope handoff
5. Phase B: mv swap → chmod/symlink → systemctl restart → healthz curl OK → SUCCESS

**Assertions** (with 4 reverse-asserts on different failure exit codes pointing at specific layers):
- exit 0
- `last-upgrade.json`: SUCCESS / target version / tarball method
- Marker swapped from "1.0.0" to "2.0.0"
- `systemctl is-active` returns true

## Local verification (macOS)

8/8 pass: 3 cross-platform run, 5 Linux-only skip-guard. Real Linux runner verification on this PR.

## Expected Linux runner outcomes

May surface bugs (J.E.3.1 found 3 Windows P0s; J.L.E.3 found 1 Linux ArgumentList bug). Detailed customMessages + reverse-asserts on multiple exit codes will point directly at the failing layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)