### PR TITLE
Phase 12.L.E.7.2 — fix: bump healthz retries=10 for python3 spawn timing

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -118,7 +118,13 @@ public sealed class LinuxLifecycleContext : IDisposable
             // wanting a different port set HEALTHCHECK_URL env first.
             .Replace("{{HEALTHCHECK_URL}}", "http://127.0.0.1:8080/healthz", StringComparison.Ordinal)
             .Replace("{{STATE_DIR}}", StateDirOverride, StringComparison.Ordinal)
-            .Replace("{{HEALTHCHECK_RETRIES}}", "1", StringComparison.Ordinal)
+            // HEALTHCHECK_RETRIES=10: ~10-15s window. python3 healthz
+            // responder takes ~500ms-2s to spawn after systemd starts the
+            // service; retries=1 gives <1s and fails. retries=10 is the
+            // safe-margin balance: well under production's 90s default,
+            // generous enough for any reasonable python3 startup variance.
+            // J.L.E.7 first Linux runner pass with retries=1 timed out.
+            .Replace("{{HEALTHCHECK_RETRIES}}", "10", StringComparison.Ordinal)
             .Replace("{{INSTALL_METHODS}}", installMethodsBlock, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary

Second-iteration fix for J.L.E.7 Linux runner. Previous fix (J.L.E.7.1) resolved systemctl-restart-wrong-unit. New failure: healthz check fails because python3 responder needs ~500ms-2s to bind a port, but `retries=1` gives <1s.

## Fix

Bump `HEALTHCHECK_RETRIES` from 1 to 10. ~10-15s window — well under production's 90s default but generous enough for python3 startup variance.

## Why this is fine

Test-only timing tweak. Production .sh runs with 90 retries (default). The test seam just balances fast-enough vs reliable-enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)