### PR TITLE
Phase 12.L.E.7.3 — fix: allow_reuse_address for python3 healthz Phase B re-bind

### DIFF
--- a/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
+++ b/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
@@ -57,7 +57,14 @@ class H(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(b'OK\n')
     def log_message(self, *args, **kwargs): pass
-with socketserver.TCPServer(('127.0.0.1', $HEALTHZ_PORT), H) as httpd:
+# allow_reuse_address=True is essential for Phase B re-bind. Without it,
+# v1's python3 leaves port \$HEALTHZ_PORT in TIME_WAIT (60s on Linux),
+# and v2's bind fails with 'Address already in use' → silent crash
+# (background & swallows the exception) → healthz unresponsive →
+# .sh thinks upgrade failed → rollback fires.
+class ReusableServer(socketserver.TCPServer):
+    allow_reuse_address = True
+with ReusableServer(('127.0.0.1', $HEALTHZ_PORT), H) as httpd:
     httpd.serve_forever()
 " &
     HEALTHZ_PID=$!


### PR DESCRIPTION
## Summary

**Root cause finally pinned.** Previous J.L.E.7.1 / .7.2 fixes were correct in their own right but neither fixed the actual issue: TIME_WAIT port lingering blocks v2's python3 healthz from rebinding port 8080 after v1's systemctl stop.

## Trace

1. v1 service receives SIGTERM
2. v1's trap kills python3 → port 8080 → TIME_WAIT (~60s on Linux)
3. v2 service starts → spawns new python3 → tries to bind 8080
4. `TCPServer.__init__` raises "Address already in use" (`allow_reuse_address` defaults to **False** in stdlib)
5. python3 crashes silently (background `&` swallows the error)
6. healthz never responds → .sh's curl loop times out → rollback

## Fix

Subclass `TCPServer` with `allow_reuse_address = True`. Standard recipe for short-lived restart-friendly test servers.

## Lesson

This is the kind of bug **only real systemd + real port + real restart** can surface. No mock would have caught it. The J.E.3.1 Windows pattern continues — high-fidelity E2E earns its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)