### PR TITLE
Phase 12.L.E.7.5 — fix: version subcommand fast-path stops marker deletion

### DIFF
--- a/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
+++ b/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
@@ -35,6 +35,24 @@ INSTALL_DIR="${INSTALL_DIR:-$(dirname "$(readlink -f "$0")")}"
 VERSION_FILE="$INSTALL_DIR/version.txt"
 MARKER_FILE="$INSTALL_DIR/service-running.marker"
 
+# `version` subcommand fast-path. The production upgrade-linux-tentacle.sh's
+# Phase B post-restart sanity check runs:
+#   timeout 5 "$INSTALL_DIR/squid-tentacle" version
+# which (via symlink chain) invokes THIS script with $1=version. Without
+# this fast-path, we'd fall into the sleep loop, hit the timeout at 5s,
+# receive SIGTERM, and our cleanup() trap would rm the marker file —
+# leaving the test asserting on an absent marker even though the service
+# itself wrote it correctly. Bug found by J.L.E.7.4 diagnostic dump
+# (Linux runner). Real Squid.Tentacle's CLI handles `version` similarly.
+if [ "${1:-}" = "version" ]; then
+    if [ -f "$VERSION_FILE" ]; then
+        cat "$VERSION_FILE" | tr -d '[:space:]'
+    else
+        echo "unknown"
+    fi
+    exit 0
+fi
+
 # Optional healthz endpoint for J.L.E.6+ full-lifecycle tests. The .sh's
 # Phase B healthcheck loop curls $HEALTHCHECK_URL (default
 # http://127.0.0.1:8080/healthz) — without an actual responder the


### PR DESCRIPTION
## Summary

**Root cause finally pinned via J.L.E.7.4 diagnostic dump.**

The .sh's Phase B post-restart sanity check runs:
```bash
timeout 5 "$INSTALL_DIR/squid-tentacle" version
```

`squid-tentacle` is a symlink → `Squid.Tentacle` (our placeholder bash). Without `version` argument handling, the script falls into the sleep loop. After 5s timeout, SIGTERM fires the cleanup() trap which **removes the marker file** — even though the systemd service itself wrote it correctly seconds earlier.

## Trace (from diagnostic dump)

| Step | State |
|---|---|
| Phase B mv swap | InstallDir has v2 contents (version.txt = 2.0.0 ✓) |
| systemctl restart starts v2 | v2 service writes marker = "2.0.0" |
| healthz curl passes | python3 responder works |
| version probe runs symlink chain | timeout 5 → SIGTERM → cleanup → **rm marker** ❌ |
| .sh writes SUCCESS, exits 0 | |
| Test reads marker | ABSENT |

## Fix

Handle `version` subcommand fast-path in the test service script. When `$1=version`, print version.txt content + exit 0 immediately. No sleep loop, no trap fire, no marker removal.

This mirrors what the real `Squid.Tentacle` CLI does (per the .sh's comment: "use the `version` subcommand (added in the same Phase 2 Part 2 follow-up commit that added VersionCommand.cs)").

## Lesson

**No mock or unit test would have surfaced this.** The bug is the interaction of:
- Production .sh's exact version-probe argv invocation
- Bash placeholder running as the "agent binary"
- Bash trap on SIGTERM cleanup
- Marker removal happening AFTER service-side write

Only real systemd + real chain + real `timeout 5` could expose it. J.E.3.1 pattern continues — high-fidelity E2E earns its keep one bug at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)