### PR TITLE
fix(LinuxTentacleE2E): J.L.E.7.6 — write FULL pre-release version to version.txt (no stripping)

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -171,11 +171,17 @@ public sealed class LinuxLifecycleContext : IDisposable
     {
         var serviceScriptBytes = File.ReadAllBytes(TestServiceScript);
 
-        // version.txt content is what test service reads on Start →
-        // writes to the marker. Strip pre-release suffix so marker
-        // assertions compare cleanly (e.g. "2.0.0-test" → "2.0.0").
-        var serviceVersion = targetVersion.Split('-')[0];
-        var versionTxtBytes = Encoding.UTF8.GetBytes(serviceVersion);
+        // version.txt content is the FULL target version (NOT stripped)
+        // because the .sh's Phase B post-restart sanity check compares
+        // EXACT match between the running binary's `version` subcommand
+        // output AND TARGET_VERSION:
+        //   if [ "$RUNNING_VERSION" != "$TARGET_VERSION" ]; then rollback; fi
+        // J.L.E.7.5 runner caught this — pre-release "2.0.0-test" in
+        // TARGET_VERSION mismatched stripped "2.0.0" in version.txt →
+        // Phase B treated mismatch as failure → rolled back. Real
+        // Squid.Tentacle's version output IS the full InformationalVersion
+        // (includes pre-release suffix); production parity needs same.
+        var versionTxtBytes = Encoding.UTF8.GetBytes(targetVersion);
 
         // Squid.Tentacle placeholder: just a copy of the test service
         // script (an executable bash file). chmod +x at .sh line 591

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -54,7 +54,8 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
     //   6. Assertions:
     //      - exit 0
     //      - last-upgrade.json reports SUCCESS, target version, tarball method
-    //      - service marker file content swapped from "1.0.0" to "2.0.0"
+    //      - service marker file content swapped from "1.0.0" to "2.0.0-test"
+    //        (FULL pre-release suffix, matching .sh's exact-match version probe)
     //      - service is still running on systemctl is-active
     //
     // High-fidelity. No mocks at any layer — production .sh + real
@@ -123,7 +124,13 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
         // 30s timeout is generous; .sh's healthz already passed (.sh exited
         // 0 and last-upgrade.json shows SUCCESS), so service IS running —
         // we just need its marker write to land.
-        if (!WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0", TimeSpan.FromSeconds(30)))
+        //
+        // J.L.E.7.6: assert FULL "2.0.0-test" (not stripped "2.0.0") because
+        // version.txt now writes the full target version verbatim, matching
+        // the .sh's exact-string version probe in Phase B. If we asserted
+        // stripped "2.0.0" here AND the .sh's probe rejected stripped output,
+        // we'd never see the upgrade succeed end-to-end.
+        if (!WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0-test", TimeSpan.FromSeconds(30)))
         {
             // Diagnostic dump: capture install dir state for debugging.
             var diag = new System.Text.StringBuilder();
@@ -145,8 +152,9 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
             catch (Exception ex) { diag.AppendLine($"  (diagnostic dump failed: {ex.Message})"); }
 
             throw new Shouldly.ShouldAssertException(
-                $"after Phase B mv swap + systemctl restart, marker at {ctx.Fixture.MarkerFilePath} MUST contain '2.0.0' within 30s. " +
+                $"after Phase B mv swap + systemctl restart, marker at {ctx.Fixture.MarkerFilePath} MUST contain '2.0.0-test' within 30s. " +
                 "If marker still '1.0.0': swap failed OR new service didn't start. " +
+                "If marker shows stripped '2.0.0' (no '-test'): version.txt was stripped — check BuildV2BundleTarGz did NOT split on '-'. " +
                 "If marker absent: trap-handler ran OR rollback fired OR service script crashed pre-marker-write.\n\n" +
                 $"Diagnostic state:\n{diag}\n\n" +
                 $"Marker exists: {File.Exists(ctx.Fixture.MarkerFilePath)}, " +


### PR DESCRIPTION
## Summary

Sixth iteration of the J.L.E.7 Linux full-lifecycle test debug loop. The first runner caught five bugs in series:

| Iteration | Bug | Fix |
|---|---|---|
| J.L.E.7.1 | `SERVICE_NAME` defaulted to `squid-tentacle` (not test name) | Load template + manual substitution |
| J.L.E.7.2 | `HEALTHCHECK_RETRIES=1` too tight for python3 spawn | Bump to 10 |
| J.L.E.7.3 | python3 couldn't re-bind port 8080 (TIME_WAIT) | `allow_reuse_address=True` on TCPServer |
| J.L.E.7.4 | Marker asserted absent — diagnostic blind | Add install-dir dump on assertion failure |
| J.L.E.7.5 | `.sh` version probe (`timeout 5`) → SIGTERM → trap-cleanup rm marker | Add `version` subcommand fast-path in test service |
| **J.L.E.7.6 (this PR)** | **Stripped `version.txt` `2.0.0` ≠ `TARGET_VERSION` `2.0.0-test` → rollback** | **Stop stripping pre-release suffix** |

## Root cause

`upgrade-linux-tentacle.sh`'s Phase B post-restart sanity check is exact-string match:

```bash
if [ "$RUNNING_VERSION" != "$TARGET_VERSION" ]; then
    rollback_to_v1
fi
```

The test was writing `2.0.0` (stripped) to `version.txt` while the upgrade strategy passed `2.0.0-test` (full) as `TARGET_VERSION`. Mismatch → rollback fired → marker still `1.0.0` → assertion failed.

Runner output that caught this:

```
::warning:: New binary reports 2.0.0 but target was 2.0.0-test.
::warning:: Service is healthy but binary reports version '2.0.0' (expected '2.0.0-test').
```

## Fix

- `LinuxLifecycleContext.BuildV2BundleTarGz` — write `targetVersion` verbatim (no `.Split('-')[0]`)
- `TentacleLinuxUpgradeLifecycleE2ETests.E1h_FullLifecycle` — assert marker contains `"2.0.0-test"` (failure message also distinguishes the stripped-version diagnostic case for future regressions)

## Production parity

Real `Squid.Tentacle.exe version` emits the **full** `InformationalVersion` (including `-test`, `-rc.1`, `-beta`, etc.). Stripping was a test-only convenience that diverged from the contract the `.sh` enforces.

## Test plan

- [ ] CI Linux runner: E1.h-Linux full lifecycle now passes end-to-end
- [ ] Marker file at end-of-run contains `2.0.0-test` (not `1.0.0`, not `2.0.0`)
- [ ] `last-upgrade.json.targetVersion == "2.0.0-test"` (already passing in J.L.E.7.5)
- [ ] No rollback warnings in `.sh` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)