### PR TITLE
feat(LinuxTentacleE2E): Phase 12.L.E.9 — Phase B healthz fail → .bak rollback (Linux)

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
@@ -679,6 +679,16 @@ echo "::error:: Upgrade failed: $SERVICE_NAME did not become healthy after resta
 # from chasing a phantom upgrade regression when the agent was actually
 # unhealthy beforehand.
 BASELINE_HEALTHZ_PRE="${SQUID_UPGRADE_BASELINE_HEALTHZ:-unknown}"
+# Phase A's BASELINE_VERSION (line ~349) is propagated through the scope
+# handoff via --setenv=SQUID_UPGRADE_BASELINE_VERSION=... — but the
+# scoped bash starts as a fresh process with `set -u` enabled, so a bare
+# `$BASELINE_VERSION` reference (used below in the rollback success
+# message + ROLLED_BACK status detail) is "unbound variable" → bash
+# exits 1, BEFORE write_status "ROLLED_BACK" runs, BEFORE `exit 4`.
+# Operator-visible failure mode: last-upgrade.json stays at
+# "ROLLING_BACK" forever even though the binary was actually restored.
+# Caught by J.L.E.9 (E1uRollback_PhaseBHealthcheckFails_RestoresV1FromBak).
+BASELINE_VERSION="${SQUID_UPGRADE_BASELINE_VERSION:-unknown}"
 if [ "$BASELINE_HEALTHZ_PRE" = "FAIL" ]; then
   emit_event B baseline-was-fail "Pre-upgrade healthz was already FAIL — failure may be environmental, not upgrade-caused"
 fi

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -185,9 +185,37 @@ public sealed class LinuxLifecycleContext : IDisposable
     ///         to prove the swap actually landed.</item>
     /// </list>
     /// </summary>
-    public byte[] BuildV2BundleTarGz(string targetVersion)
+    public byte[] BuildV2BundleTarGz(string targetVersion, bool failHealthz = false)
     {
         var serviceScriptBytes = File.ReadAllBytes(TestServiceScript);
+
+        // J.L.E.9: optional surgical mutation that flips the embedded
+        // python3 healthz responder's success code (200) to a 5xx (503),
+        // so .sh's Phase B `curl -fsS` against /healthz fails (-f rejects
+        // 5xx as exit 22). HEALTH_OK stays 0 → retry loop exhausts →
+        // rollback path fires. Same script binds the same port, returns
+        // a real HTTP response — just an unhealthy one.
+        //
+        // Why not a separate v2 script: the .sh's Phase B mv-swap would
+        // work either way, but a separate file means the test infra has
+        // to maintain two service scripts. A surgical 1-call swap on a
+        // SINGLE script keeps the contract clean: same script, optional
+        // failure mode toggled per build. Mirrors Windows' `crashOnStart`
+        // parameter on `BuildV2BundleZip`.
+        if (failHealthz)
+        {
+            var script = Encoding.UTF8.GetString(serviceScriptBytes);
+            const string healthyResponse = "self.send_response(200)";
+            const string unhealthyResponse = "self.send_response(503)";
+
+            if (!script.Contains(healthyResponse))
+                throw new InvalidOperationException(
+                    $"Cannot inject failHealthz mutation: test service script does not contain expected sentinel '{healthyResponse}'. " +
+                    "If the script's healthz responder was rewritten, update this mutation site to match the new sentinel.");
+
+            script = script.Replace(healthyResponse, unhealthyResponse, StringComparison.Ordinal);
+            serviceScriptBytes = Encoding.UTF8.GetBytes(script);
+        }
 
         // version.txt content is the FULL target version (NOT stripped)
         // because the .sh's Phase B post-restart sanity check compares

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -414,6 +414,123 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
         ctx.MarkClean();
     }
 
+    // ========================================================================
+    // E1.u-rollback-Linux — Phase B healthcheck fails → .bak rollback → v1 restored
+    //
+    // Highest-severity unguarded path on Linux until this test landed.
+    // The .sh's rollback contract (lines ~620–720 of upgrade-linux-tentacle.sh):
+    //
+    //   1. systemctl restart $SERVICE  →  service goes active
+    //   2. for i in 1..HEALTHCHECK_RETRIES: curl -fsS $HEALTHCHECK_URL
+    //   3. if any curl returns 200: HEALTH_OK=1, exit 0 (SUCCESS)
+    //   4. else (this test):
+    //        - emit healthz-fail event
+    //        - systemctl stop $SERVICE
+    //        - rm -rf $INSTALL_DIR
+    //        - mv $BAK_DIR $INSTALL_DIR
+    //        - systemctl start $SERVICE  ← v1 service back up
+    //        - wait is-active up to 30s
+    //        - exit 4 + write_status ROLLED_BACK
+    //
+    // Without this test, a future polish that breaks rollback (e.g. typo
+    // in BAK_DIR path, missing sudo, wrong sequence) ships silently, and
+    // the next bad upgrade leaves the agent BINARYLESS (rm $INSTALL_DIR
+    // succeeded, mv .bak failed) → ROLLBACK_CRITICAL_FAILED → operator
+    // intervention required. Pin the rollback contract NOW.
+    //
+    // Test mechanism: BuildV2BundleTarGz(failHealthz: true) injects a
+    // surgical 200→503 swap in the embedded python3 healthz responder.
+    // Same script binds the same port, returns a real HTTP response,
+    // just an unhealthy one. .sh's `curl -fsS` rejects 5xx → HEALTH_OK
+    // stays 0 → retry loop exhausts → rollback path fires.
+    //
+    // Mirrors Windows E7.u1 (`E7u1_NewBinaryOnStartCrashes_TriggersAutoRollbackToV1`)
+    // but at the healthz-failure axis since Linux's systemctl-start
+    // behaviour differs from Windows' SCM Start-Service throw semantics.
+    //
+    // High-fidelity. Real prod .sh + real systemd + real bash + real
+    // mirror + real python3 returning 503 + real Phase B mv-rollback
+    // + real v1 systemctl start + real marker rewrite.
+    //
+    // Expected runtime: ~20-30s (Phase A ~2s + restart ~3s + 10s healthz
+    // retry exhaust + rollback ~3s + v1 start + marker write).
+    // ========================================================================
+
+    [Fact]
+    public void E1uRollback_PhaseBHealthcheckFails_RestoresV1FromBak()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        // Stage v1 with healthz responder ENABLED (so v1's healthz returns 200).
+        ctx.Fixture.InstallAndStart(
+            ctx.TestServiceScript,
+            initialVersion: "1.0.0",
+            startTimeout: TimeSpan.FromSeconds(15),
+            extraEnvironment: new Dictionary<string, string>
+            {
+                ["SQUID_TEST_SERVICE_HEALTHZ"] = "1"
+            });
+
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running with v1 marker before rollback test can validate v2's failed-healthz triggers .bak restoration");
+
+        // Build v2 with failHealthz=true → embedded healthz responder
+        // returns 503 instead of 200 post-mv-swap.
+        var v2Tarball = ctx.BuildV2BundleTarGz(targetVersion: "2.0.0-test", failHealthz: true);
+        ctx.Mirror.StagePreBuiltArchive(v2Tarball);
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, output) = ctx.RunUpgradeScript(script);
+
+        // Exit 4 is the documented "Phase B healthz failed AND tarball rollback succeeded" code.
+        exitCode.ShouldBe(4,
+            customMessage: $"Phase B healthz fail MUST trigger .bak rollback with exit 4 (per .sh header). " +
+                          $"Got exit {exitCode}. " +
+                          $"If 0: rollback didn't fire — broken v2 still in INSTALL_DIR (ship-blocking regression). " +
+                          $"If 9: rollback fired BUT failed (mv .bak → INSTALL_DIR errored OR v1 didn't restart) — agent in unknown state, separate failure mode. " +
+                          $"If 13: systemd-run --scope failed pre-Phase-B (sudo / systemd missing). " +
+                          $"output tail (last 2k chars):\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // last-upgrade.json: ROLLED_BACK with operator-facing detail.
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull(
+            customMessage: "last-upgrade.json MUST be written even on rollback path — operators need the UI to surface WHY the upgrade rolled back");
+
+        statusPayload.Status.ShouldBe("ROLLED_BACK",
+            customMessage: $"status MUST be 'ROLLED_BACK' after a successful auto-rollback. Got: '{statusPayload.Status}'. " +
+                          $"If 'FAILED': rollback never fired — broken state. " +
+                          $"If 'ROLLBACK_CRITICAL_FAILED': old binary couldn't restart either — separate failure. " +
+                          $"Detail: {statusPayload.Detail}");
+
+        statusPayload.Detail.ShouldContain("New binary failed health check",
+            customMessage: $"detail MUST surface why rollback fired so operators distinguish 'environmental healthz blip' from 'bad new binary'. Got: '{statusPayload.Detail}'");
+
+        // CRITICAL: marker MUST eventually report v1 again.
+        // After rollback:
+        //   1. v2 service is stopped → v2 trap rm's marker
+        //   2. mv .bak INSTALL_DIR → v1 files in place (version.txt = "1.0.0")
+        //   3. systemctl start v1 → v1 reads version.txt → writes marker = "1.0.0"
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage: $"after auto-rollback, marker at {ctx.Fixture.MarkerFilePath} MUST contain '1.0.0' — " +
+                          "proves rollback restored v1's INSTALL_DIR AND v1 systemctl-started cleanly. " +
+                          "If marker absent: rollback restored .bak but v1 didn't start (or trap fired pre-marker). " +
+                          "If marker = '2.0.0-test': swap proceeded, healthz check NEVER fired rollback (ship-blocking regression).");
+
+        // Reverse-assert: .bak directory MUST be consumed by the rollback
+        // mv. If it still exists post-rollback, the .sh either skipped the
+        // mv step (rollback didn't actually run) OR there's a sequencing
+        // bug where the rm/mv pair didn't atomically consume .bak.
+        var bakDir = ctx.Fixture.InstallDir + ".bak";
+        Directory.Exists(bakDir).ShouldBeFalse(
+            customMessage: $".bak directory at {bakDir} MUST NOT exist after successful rollback — rollback's `mv $BAK_DIR $INSTALL_DIR` consumes it. " +
+                          "If .bak still exists: rollback path executed `rm -rf $INSTALL_DIR` but then either skipped the mv OR the mv failed silently. " +
+                          "Either way, agent is in an inconsistent state (binaryless OR has both INSTALL_DIR + .bak with old binary).");
+
+        ctx.MarkClean();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)

--- a/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/UpgradeLinuxScriptE2ETests.cs
@@ -200,6 +200,64 @@ public sealed class UpgradeLinuxScriptE2ETests
         }
     }
 
+    // ========================================================================
+    // J.L.E.9 fix-pin — Phase B MUST restore BASELINE_VERSION from
+    //                    SQUID_UPGRADE_BASELINE_VERSION env var
+    //
+    // Phase A captures BASELINE_VERSION (current binary's `version` output)
+    // and propagates it to the scoped Phase B via:
+    //   --setenv=SQUID_UPGRADE_BASELINE_VERSION="$BASELINE_VERSION"
+    //
+    // Phase B's rollback success path references `$BASELINE_VERSION` directly
+    // (not `$SQUID_UPGRADE_BASELINE_VERSION`) in the rollback-ok event + the
+    // ROLLED_BACK status detail. Because the .sh runs `set -euo pipefail`,
+    // a bare unbound reference triggers bash exit 1 BEFORE write_status
+    // "ROLLED_BACK" runs, BEFORE `exit 4`.
+    //
+    // Operator-visible failure mode (without restoration):
+    //   - .bak rollback ACTUALLY succeeds (mv ran, v1 service active)
+    //   - But last-upgrade.json stays at "ROLLING_BACK" forever — the
+    //     ROLLED_BACK write_status never executes
+    //   - .sh exits 1 instead of documented 4
+    //   - Server's UI shows the upgrade hung mid-rollback even though
+    //     the agent is fine
+    //
+    // The fix (in upgrade-linux-tentacle.sh, next to BASELINE_HEALTHZ_PRE):
+    //   BASELINE_VERSION="${SQUID_UPGRADE_BASELINE_VERSION:-unknown}"
+    //
+    // Caught by the J.L.E.9 E2E test E1uRollback_PhaseBHealthcheckFails_*.
+    // This unit test pins the FIX so a future polish can't silently drop
+    // the restoration line — the regression would otherwise only surface
+    // on a healthz-failing upgrade in production.
+    // ========================================================================
+
+    [Fact]
+    public void LinuxScript_PhaseB_RestoresBaselineVersionFromEnv_OrSetUWillKillRollback()
+    {
+        var template = File.ReadAllText(LocateLinuxTemplate());
+
+        // The exact restoration line. Drop the trailing `unknown` if you have
+        // a real-environment reason — but you must use `:-something` (not bare
+        // expansion), because `set -u` enforces SOMETHING-must-be-set semantics.
+        const string requiredRestoration = "BASELINE_VERSION=\"${SQUID_UPGRADE_BASELINE_VERSION:-unknown}\"";
+
+        template.ShouldContain(requiredRestoration,
+            customMessage: $"upgrade-linux-tentacle.sh MUST contain '{requiredRestoration}' " +
+                          $"to restore Phase A's BASELINE_VERSION across the systemd-run scope re-exec. " +
+                          $"Without it, ANY rollback-success path triggers `set -u` exit 1 BEFORE write_status " +
+                          $"\"ROLLED_BACK\" runs — operator sees last-upgrade.json stuck at ROLLING_BACK forever " +
+                          $"despite the rollback actually succeeding. Caught by J.L.E.9 (PR #219).");
+
+        // Also pin: BASELINE_HEALTHZ_PRE has the same shape (precedent
+        // we mirrored). If it ever diverges from the BASELINE_VERSION
+        // restoration we just pinned, the inconsistency would suggest a
+        // refactor is in flight and someone should re-check whether both
+        // need the same treatment.
+        template.ShouldContain("BASELINE_HEALTHZ_PRE=\"${SQUID_UPGRADE_BASELINE_HEALTHZ:-unknown}\"",
+            customMessage: "BASELINE_HEALTHZ_PRE restoration must remain present (the precedent BASELINE_VERSION mirrors). " +
+                          "If you're refactoring baseline propagation, update BOTH restorations together.");
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static string LocateLinuxTemplate()


### PR DESCRIPTION
## Summary

Linux mirror of Windows E7.u1 (`E7u1_NewBinaryOnStartCrashes_TriggersAutoRollbackToV1`) but at the **healthz-failure axis** — Linux's systemctl-start succeeds even when the new binary's healthz responder is broken, so the failure surfaces in the .sh's `curl -fsS` retry loop, not at service-start.

This is the **highest-severity unguarded path on Linux** until this test landed. Without this pin, a future polish that breaks rollback ships silently → next bad upgrade leaves the agent BINARYLESS → operator intervention required.

## What the test pins

The .sh's rollback contract (lines ~620–720 of `upgrade-linux-tentacle.sh`):

```
1. systemctl restart $SERVICE         ← v2 active
2. for i in 1..HEALTHCHECK_RETRIES:
     curl -fsS $HEALTHCHECK_URL       ← v2 returns 503 (this test)
3. retries exhausted → HEALTH_OK=0
4. Rollback path:
     - systemctl stop $SERVICE
     - rm -rf $INSTALL_DIR
     - mv $BAK_DIR $INSTALL_DIR       ← v1 binary back
     - systemctl start $SERVICE        ← v1 active
     - wait is-active up to 30s
     - exit 4 + write_status ROLLED_BACK
```

## Test mechanism — surgical 1-line mutation

```csharp
ctx.BuildV2BundleTarGz(targetVersion: "2.0.0-test", failHealthz: true);
```

Injects a 200→503 swap in the embedded python3 healthz responder. Same script binds the same port, returns a real HTTP response, just an unhealthy one. `.sh`'s `curl -fsS` rejects 5xx as exit 22 → HEALTH_OK stays 0 → retry loop exhausts → rollback fires.

The mutation guards against silent script drift: throws `InvalidOperationException` if the sentinel `self.send_response(200)` is no longer present, forcing the test author to update both sides in lockstep.

## Assertions

- `exitCode == 4` (rollback succeeded)
- `last-upgrade.json.Status == "ROLLED_BACK"`
- `last-upgrade.json.Detail` contains `"New binary failed health check"` (operator-actionable)
- Marker eventually `= "1.0.0"` (proves v1 systemctl-started AND wrote its marker post-rollback)
- `.bak` directory **consumed** by rollback's `mv` (reverse-assert; if it still exists, mv silently failed)

## Why this isn't already covered

E1.h-Linux (J.L.E.7): healthz **passes** → SUCCESS path
E1.u1-Linux: download 404 → Phase A bails before any swap
E12.u1-Linux: SHA mismatch → Phase A bails before any swap
E15.h-Linux (J.L.E.8): preservation across SUCCESS upgrade

None of these exercise Phase B's failure-then-restore path. This PR is the first Linux test to actually run rollback end-to-end.

## Fidelity tier

🟢 **High** (Rule 12.4): real production `.sh` + real systemd-run + real `sudo` + real `bash` + real LocalReleaseMirror + real python3 returning 503 + real `mv` rollback + real v1 systemctl-start + real marker rewrite. No mocks at any layer.

## Test plan

- [ ] Linux E2E workflow runs `Squid.LinuxTentacleE2ETests` to completion (manual `workflow_dispatch` after merge)
- [ ] `E1uRollback_PhaseBHealthcheckFails_RestoresV1FromBak` passes within ~30s
- [ ] Pre-existing 9 Linux E2E tests stay green (no regression on shared infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)