### PR TITLE
feat(LinuxTentacleE2E): Phase 12.L.E.10 — E11.u1-Linux flock contention (concurrent dispatch no-op)

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -369,6 +369,78 @@ public sealed class LinuxLifecycleContext : IDisposable
     }
 
     /// <summary>
+    /// Spawns a background process that holds an EXCLUSIVE kernel flock
+    /// on <see cref="LockFilePath"/> for <paramref name="holdSeconds"/>
+    /// seconds (default: 30). Used by E11.u1-Linux to simulate a
+    /// concurrent in-flight upgrade — the next .sh dispatch must hit the
+    /// `flock -n` failure branch and exit 0 as a no-op.
+    ///
+    /// <para>The Linux .sh uses kernel flock (BSD-style), NOT file-content
+    /// detection. Pre-staging a "stale" lockfile alone does NOT block a
+    /// second dispatch — the kernel auto-releases flocks when the holding
+    /// process exits, so an unattended file is just data. This helper
+    /// genuinely holds the lock at the kernel level for the test window.</para>
+    ///
+    /// <para>Returns a disposable wrapper. Caller MUST `using` it (or
+    /// Dispose explicitly) to release the lock + reap the child process
+    /// even if the test asserts mid-flight. The kernel ALSO auto-releases
+    /// the flock on process death, so even Process.Kill() during a panic
+    /// is safe.</para>
+    ///
+    /// <para>Implementation detail: invokes the <c>flock</c> CLI from
+    /// util-linux (universally available on every modern Linux distro
+    /// + GHA ubuntu-latest). Skipped on macOS via the test's
+    /// <see cref="IsAvailable"/> guard.</para>
+    /// </summary>
+    public FlockHolder StartFlockHolder(int holdSeconds = 30)
+    {
+        // Pre-create the lockfile so flock has something to grab. The .sh
+        // also auto-creates it via touch (line 285) but creating it here
+        // gives us deterministic existence timing.
+        Directory.CreateDirectory(StateDirOverride);
+        if (!File.Exists(LockFilePath))
+            File.WriteAllText(LockFilePath, string.Empty);
+
+        // `flock -n -x <file> sleep N` — acquires an exclusive lock,
+        // runs `sleep N` while holding it, releases on sleep exit.
+        // `-n` makes the acquire non-blocking (fail-fast if already held,
+        // which we don't expect since this IS the holder).
+        var psi = new ProcessStartInfo
+        {
+            FileName = "flock",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("-n");
+        psi.ArgumentList.Add("-x");
+        psi.ArgumentList.Add(LockFilePath);
+        psi.ArgumentList.Add("sleep");
+        psi.ArgumentList.Add(holdSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to spawn flock holder — `flock` CLI missing? util-linux must be installed.");
+
+        // Brief race window: flock acquires + sleeps, but our caller's
+        // upgrade .sh must run AFTER the lock is held. flock acquires the
+        // lock before exec'ing sleep, so a 100ms wait is conservative —
+        // gives the kernel time to register the lock without making tests
+        // sluggish. If flock dies before sleep starts, the lock is gone
+        // and Process.HasExited surfaces it on the next assertion.
+        Thread.Sleep(100);
+
+        if (proc.HasExited)
+            throw new InvalidOperationException(
+                $"flock holder exited prematurely with code {proc.ExitCode}. " +
+                $"Stderr: {proc.StandardError.ReadToEnd()}. " +
+                "The kernel flock acquire failed — likely another holder already exists, " +
+                "or sudo permissions on the lockfile path are wrong.");
+
+        return new FlockHolder(proc);
+    }
+
+    /// <summary>
     /// SHA256 over the file's bytes, lowercase hex. Stable across runs
     /// (same content → same digest). Used by E15.h-Linux to pin
     /// byte-for-byte preservation of pre-staged instance state across
@@ -515,3 +587,46 @@ public sealed class LinuxLifecycleContext : IDisposable
 /// E15.h-Linux can pin byte-for-byte preservation across an upgrade.
 /// </summary>
 public sealed record InstanceConfigPaths(string Registry, string Config, string Cert);
+
+/// <summary>
+/// Disposable wrapper around the background <c>flock</c> child process
+/// that holds an exclusive kernel flock on the upgrade lockfile during
+/// E11.u1-Linux. Disposing kills + reaps the child; the kernel
+/// auto-releases the flock on process death.
+/// </summary>
+public sealed class FlockHolder : IDisposable
+{
+    private readonly Process _proc;
+    private bool _disposed;
+
+    internal FlockHolder(Process proc)
+    {
+        _proc = proc;
+    }
+
+    /// <summary>True if the kernel flock holder is still alive.</summary>
+    public bool IsAlive => !_disposed && !_proc.HasExited;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        try
+        {
+            if (!_proc.HasExited)
+            {
+                _proc.Kill(entireProcessTree: true);
+                _proc.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // Best-effort. Even on panic the kernel auto-releases the
+            // flock on process death — leaking a Process handle is the
+            // worst-case impact.
+        }
+
+        try { _proc.Dispose(); } catch { /* best-effort */ }
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -531,6 +531,117 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
         ctx.MarkClean();
     }
 
+    // ========================================================================
+    // E11.u1-Linux — Concurrent dispatch: pre-existing kernel flock makes
+    //                second .sh dispatch a no-op (exit 0, no Phase A/B)
+    //
+    // Production stability target: an operator manually triggering an
+    // upgrade while a scheduled upgrade is mid-flight (or two operators
+    // racing) MUST NOT cause two parallel Phase A's competing on the
+    // same INSTALL_DIR + STATE_DIR. The .sh's `flock -n` guard at line
+    // 288 is the only thing preventing this; without it, two simultaneous
+    // mv-swaps would corrupt the install tree → unrecoverable agent.
+    //
+    // Linux-vs-Windows mechanism difference:
+    //   - Windows: file-content-based detection (.ps1 reads $LOCK_FILE,
+    //     checks if PID alive, exits 13 if held). Pre-staging the
+    //     lockfile content is sufficient.
+    //   - Linux: kernel BSD flock primitive. Lock state is held by an
+    //     ACTIVE process owning the file descriptor; lock file content
+    //     is informational only. Pre-staging an unattended file does
+    //     NOTHING — the kernel auto-releases flocks on process death.
+    //
+    // This test genuinely holds a kernel flock via a backgrounded
+    // `flock -n -x $LOCK_FILE sleep 30` child process for the duration
+    // of the upgrade .sh invocation. Disposing the FlockHolder kills the
+    // child + the kernel releases the lock.
+    //
+    // Expected behaviour (.sh line 288–295):
+    //   if ! flock -n "$LOCK_FD"; then
+    //     echo "An upgrade is already in progress on this host..."
+    //     exit 0
+    //   fi
+    //
+    // i.e. exit 0 as a NO-OP — the second dispatch is silently skipped,
+    // which is intentional: server-side dispatch is at-least-once, so a
+    // duplicate is expected behaviour and shouldn't surface as an error.
+    //
+    // Mirrors Windows E11.u1 with adjusted exit-code expectation
+    // (Linux: 0 no-op vs Windows: 13 fail) reflecting the different
+    // semantic per-platform.
+    //
+    // High-fidelity. Real prod .sh + real systemd + real bash + real
+    // kernel flock + real sleep-holder process.
+    // ========================================================================
+
+    [Fact]
+    public void E11u1_PreExistingFlock_LockHeldExitsZeroAsNoOp_Linux()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        // Stage v1 service so destructive Phase B WOULD have an effect if
+        // the lock check were broken. Reverse-asserting the marker stays
+        // at v1 proves Phase B never ran.
+        ctx.Fixture.InstallAndStart(ctx.TestServiceScript, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(15));
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running with v1 marker before E11.u1-Linux can validate Phase B was actually skipped (not run-and-rolled-back)");
+
+        // Hold an EXCLUSIVE kernel flock on the upgrade lockfile for the
+        // duration of the test. The .sh's `flock -n` against the same
+        // file MUST fail immediately → script falls into the no-op branch.
+        using var flockHolder = ctx.StartFlockHolder(holdSeconds: 30);
+
+        var v2Tarball = ctx.BuildV2BundleTarGz(targetVersion: "2.0.0-test");
+        ctx.Mirror.StagePreBuiltArchive(v2Tarball);
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, output) = ctx.RunUpgradeScript(script);
+
+        // Exit 0 (NO-OP) is the documented behaviour when flock is held —
+        // server-side dispatch is at-least-once, so duplicates are normal,
+        // not errors. Distinct from .sh's other exit codes (2/6/7/13/14)
+        // which are all fail-codes.
+        exitCode.ShouldBe(0,
+            customMessage: $"flock-held second dispatch MUST exit 0 as a no-op (per .sh line 294). Got exit {exitCode}. " +
+                          $"If 13: .sh's flock check broke and Phase B started — concurrent-dispatch protection failed. " +
+                          $"If 1: bash hit set-u or set-e on the no-op exit — guard logic itself errored. " +
+                          $"output tail (last 1k chars):\n{(output.Length > 1000 ? "..." + output.Substring(output.Length - 1000) : output)}");
+
+        // Operator-visible log MUST surface WHY the dispatch was a no-op
+        // — without this, a stuck-forever in-flight upgrade looks like
+        // total silence on every subsequent dispatch.
+        output.ShouldContain("upgrade is already in progress on this host",
+            customMessage: $"stdout MUST contain 'upgrade is already in progress on this host' so operators tailing the log see the no-op happened (vs total silence). " +
+                          $"output tail:\n{(output.Length > 1000 ? "..." + output.Substring(output.Length - 1000) : output)}");
+
+        // Reverse-assert: Phase A never spawned the scope. Without this,
+        // a flock-broken .sh might exit 0 falsely BUT have already
+        // downloaded + extracted to a staging area. So we need to verify
+        // none of Phase A's side effects happened.
+        output.ShouldNotContain("Detaching to systemd scope",
+            customMessage: "Phase A's 'Detaching to systemd scope' message MUST NOT appear — its presence proves the .sh got past the flock guard despite the lock being held.");
+
+        // Reverse-assert: Phase B never ran. Service still on v1 marker.
+        File.ReadAllText(ctx.Fixture.MarkerFilePath).Trim().ShouldBe("1.0.0",
+            customMessage: $"marker MUST stay at '1.0.0' — if it changed, Phase B's mv swap ran despite the flock-held no-op (concurrent-dispatch protection broken). Got: '{File.ReadAllText(ctx.Fixture.MarkerFilePath).Trim()}'");
+
+        // Reverse-assert: no .bak directory. Phase B's mv-swap creates
+        // INSTALL_DIR.bak; absence proves Phase B's mv never executed.
+        var noOpBakDir = ctx.Fixture.InstallDir + ".bak";
+        Directory.Exists(noOpBakDir).ShouldBeFalse(
+            customMessage: $".bak dir at {noOpBakDir} MUST NOT exist after a flock-rejected dispatch — Phase B's mv-swap never ran.");
+
+        // Sanity: holder is still alive when the upgrade .sh exited. If
+        // the holder died first, the lock was released and the .sh's
+        // flock acquire would have succeeded, invalidating the test.
+        flockHolder.IsAlive.ShouldBeTrue(
+            "flock holder process must still be alive at end of test — if it died, the kernel released the lock mid-test and the .sh actually proceeded through Phase A/B (and the assertions above passed coincidentally).");
+
+        ctx.MarkClean();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)


### PR DESCRIPTION
## Summary

Linux mirror of Windows E11.u1 with the platform-correct lock mechanism: kernel BSD flock (not file-content detection).

## Why ship-blocking

An operator manually triggering an upgrade while a scheduled upgrade is mid-flight (or two operators racing) MUST NOT cause two parallel Phase A's competing on the same INSTALL_DIR + STATE_DIR. The `.sh`'s `flock -n` guard at line 288 is the only thing preventing this; without it, two simultaneous `mv` swaps would corrupt the install tree → unrecoverable agent.

## Linux vs Windows mechanism

| Platform | Lock primitive | Lockfile content | Pre-stage sufficient? |
|---|---|---|---|
| Windows | File-existence + PID liveness check | Holds the lock state | ✅ |
| **Linux** | Kernel BSD flock (held by an active process owning the FD) | Informational only | ❌ **needs an active holder** |

So the Linux test must spawn a process that genuinely holds the kernel lock during the test window. Pre-staging an unattended file does nothing — the kernel auto-releases flocks on process death.

## Test mechanism

```csharp
using var flockHolder = ctx.StartFlockHolder(holdSeconds: 30);
```

Spawns a backgrounded `flock -n -x $LOCK_FILE sleep 30` child process. Disposing the holder kills the child; kernel auto-releases the flock.

## Expected behaviour (`.sh` line 288–295)

```bash
if ! flock -n "$LOCK_FD"; then
  echo "An upgrade is already in progress on this host..."
  exit 0
fi
```

Exit 0 as a NO-OP. Intentional: server-side dispatch is at-least-once, so duplicates are normal, not errors. **Distinct from .sh's other exit codes (2/6/7/13/14)** which are all fail-codes.

## Assertions

- `exitCode == 0`
- stdout contains `"upgrade is already in progress on this host"` (operator visibility)
- stdout does **NOT** contain `"Detaching to systemd scope"` (Phase A never spawned)
- Marker stays at `"1.0.0"` (Phase B never ran)
- `.bak` directory does **NOT** exist (mv-swap never executed)
- flock holder still alive at end (sanity: lock genuinely held throughout)

## Infrastructure additions

`LinuxLifecycleContext`:
- `StartFlockHolder(int holdSeconds)` → spawns backgrounded `flock` child holding kernel lock
- `FlockHolder` class wraps `Process`; Dispose kills + reaps; kernel auto-releases flock on process death even on test panic

## Fidelity tier

🟢 **High** (Rule 12.4): real prod `.sh` + real systemd + real bash + real util-linux flock + real backgrounded `sleep` holder. Skipped on macOS via `LinuxLifecycleContext.IsAvailable` (no flock CLI on darwin).

## Test plan

- [ ] Linux E2E workflow runs `Squid.LinuxTentacleE2ETests` to completion (manual `workflow_dispatch` after merge)
- [ ] `E11u1_PreExistingFlock_LockHeldExitsZeroAsNoOp_Linux` passes within ~5s
- [ ] No regression on existing 11 Linux E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)