### PR TITLE
feat(LinuxTentacleE2E): Phase 12.L.E.16 — upgrade-events.jsonl format contract pin

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -47,6 +47,9 @@ public sealed class LinuxLifecycleContext : IDisposable
     /// <summary>The <c>upgrade.lock</c> path the .sh writes (under StateDirOverride).</summary>
     public string LockFilePath => Path.Combine(StateDirOverride, "upgrade.lock");
 
+    /// <summary>The <c>upgrade-events.jsonl</c> path the .sh writes — append-only structured event log read by the server's UI timeline.</summary>
+    public string EventsFilePath => Path.Combine(StateDirOverride, "upgrade-events.jsonl");
+
     /// <summary>
     /// Test-private mirror of production's per-OS config-dir (Linux:
     /// <c>/etc/squid-tentacle</c>). Used by E15.h-Linux to assert that
@@ -536,6 +539,55 @@ public sealed class LinuxLifecycleContext : IDisposable
     }
 
     /// <summary>
+    /// Reads + parses every line of the .sh-written <c>upgrade-events.jsonl</c>
+    /// into <see cref="UpgradeEvent"/> records. Each line is required to be
+    /// valid JSON with t/phase/kind/msg fields — any line that fails to
+    /// parse throws (the format contract MUST hold).
+    ///
+    /// <para>Used by E1.uEventsContract-Linux to pin the contract that
+    /// every event the .sh emits is parseable as JSON, has all required
+    /// fields, and uses the documented phase + kind tag set. The server's
+    /// UI timeline reads this file via Capabilities RPC and any format
+    /// regression silently breaks operator visibility into upgrade
+    /// progress.</para>
+    /// </summary>
+    public IReadOnlyList<UpgradeEvent> ReadUpgradeEvents()
+    {
+        if (!File.Exists(EventsFilePath))
+            return new List<UpgradeEvent>();
+
+        var lines = File.ReadAllLines(EventsFilePath);
+        var events = new List<UpgradeEvent>();
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            try
+            {
+                var parsed = System.Text.Json.JsonDocument.Parse(line);
+                var root = parsed.RootElement;
+
+                events.Add(new UpgradeEvent(
+                    T: root.GetProperty("t").GetString() ?? string.Empty,
+                    Phase: root.GetProperty("phase").GetString() ?? string.Empty,
+                    Kind: root.GetProperty("kind").GetString() ?? string.Empty,
+                    Msg: root.GetProperty("msg").GetString() ?? string.Empty
+                ));
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"Malformed event line in {EventsFilePath}: '{line}'. " +
+                    "Server-side timeline parser would silently drop or crash on this. " +
+                    $"Underlying error: {ex.Message}", ex);
+            }
+        }
+
+        return events;
+    }
+
+    /// <summary>
     /// Reads the .sh-written <c>last-upgrade.json</c>. Returns null if
     /// the file doesn't exist OR is unparseable.
     /// </summary>
@@ -682,6 +734,14 @@ public sealed class LinuxLifecycleContext : IDisposable
 /// E15.h-Linux can pin byte-for-byte preservation across an upgrade.
 /// </summary>
 public sealed record InstanceConfigPaths(string Registry, string Config, string Cert);
+
+/// <summary>
+/// One parsed line from the .sh's <c>upgrade-events.jsonl</c> append-only
+/// event log. Mirrors the wire format the server's UI timeline parser
+/// consumes:
+/// <code>{"t":"2026-04-22T02:57:04Z","phase":"A","kind":"start","msg":"..."}</code>
+/// </summary>
+public sealed record UpgradeEvent(string T, string Phase, string Kind, string Msg);
 
 /// <summary>
 /// Disposable wrapper around the background <c>flock</c> child process

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -1108,6 +1108,156 @@ public sealed class TentacleLinuxUpgradeLifecycleE2ETests
         ctx.MarkClean();
     }
 
+    // ========================================================================
+    // E1.uEventsContract — upgrade-events.jsonl format pin (server UI timeline)
+    //
+    // Every E1.h-style success ALREADY emits the structured event log the
+    // server's UI timeline reads (Capabilities probe streams events to the
+    // operator's deployment task view). What's NEVER been pinned: the
+    // wire format. If the .sh's emit_event regresses (renames a field,
+    // drops escaping, changes phase tag), every operator sees a frozen
+    // timeline silently — the server-side parser drops malformed lines.
+    //
+    // This test runs E1.h end-to-end, then PARSES every line of the
+    // resulting upgrade-events.jsonl as JSON and asserts:
+    //
+    //   1. Every line is valid JSON (no malformed lines silently swallowed
+    //      by the server-side parser).
+    //   2. Every line has the required fields {t, phase, kind, msg}.
+    //   3. The expected happy-path kind sequence is present in order:
+    //        start → baseline → method-selected → scope-exec  (Phase A)
+    //        swapped → restart-start → healthz-pass → success (Phase B)
+    //   4. Phase values are exactly "A" or "B" (not "1", "a", "PhaseA").
+    //   5. Timestamps are ISO 8601 UTC (Z suffix).
+    //
+    // Catches:
+    //   - JSON malformation (unescaped quotes, missing commas, wrong shape)
+    //   - Field renames (msg → message, kind → type, etc.)
+    //   - Phase tag drift ("A" → "PhaseA")
+    //   - Missing terminal events (success absent → operator UI never sees
+    //     "completed" state, timeline appears to hang forever)
+    //   - Out-of-order events (success before scope-exec → impossible
+    //     causality, operator confused)
+    //
+    // Wire format (line 206 of .sh comment):
+    //   {"t":"2026-04-22T02:57:04Z","phase":"A","kind":"method-try","msg":"apt: update"}
+    //
+    // High-fidelity. Real .sh + real systemd + real bash + real .jsonl
+    // file. Reuses E1.h-Linux infrastructure entirely; only adds parse +
+    // sequence assertions on top.
+    //
+    // Tier: 🟢 H. Runtime: same as E1.h (~5s) + a few ms for parse.
+    // ========================================================================
+
+    [Fact]
+    public void E1uEventsContract_AfterSuccess_AllLinesValidJsonInExpectedOrder()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        ctx.Fixture.InstallAndStart(
+            ctx.TestServiceScript,
+            initialVersion: "1.0.0",
+            startTimeout: TimeSpan.FromSeconds(15),
+            extraEnvironment: new Dictionary<string, string>
+            {
+                ["SQUID_TEST_SERVICE_HEALTHZ"] = "1"
+            });
+
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 must be running before E1.uEventsContract can validate events emitted during a successful upgrade");
+
+        var v2Tarball = ctx.BuildV2BundleTarGz(targetVersion: "2.0.0-test");
+        ctx.Mirror.StagePreBuiltArchive(v2Tarball);
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, output) = ctx.RunUpgradeScript(script);
+
+        exitCode.ShouldBe(0,
+            customMessage: $"E1.h precondition for events test: upgrade must succeed before we parse the event log. Got exit {exitCode}.\noutput tail:\n{(output.Length > 1000 ? "..." + output.Substring(output.Length - 1000) : output)}");
+
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            "v2 marker required: confirms the success path actually ran end-to-end (otherwise we're parsing events from an aborted run)");
+
+        // Parse the events file. ReadUpgradeEvents throws on any malformed
+        // line — that throw IS one of the assertions (server-side parser
+        // would drop the same malformed line silently).
+        var events = ctx.ReadUpgradeEvents();
+
+        events.Count.ShouldBeGreaterThan(0,
+            customMessage: $"upgrade-events.jsonl at {ctx.EventsFilePath} MUST contain at least one event after a successful upgrade. " +
+                          "If empty: emit_event never wrote anything → timeline UI shows a blank task. " +
+                          $"File exists: {File.Exists(ctx.EventsFilePath)}");
+
+        // Every event MUST have all four required fields.
+        foreach (var ev in events)
+        {
+            ev.T.ShouldNotBeNullOrWhiteSpace(customMessage: $"event {ev.Kind} missing 't' (timestamp). Server-side parser ignores events without timestamps.");
+            ev.Phase.ShouldNotBeNullOrWhiteSpace(customMessage: $"event {ev.Kind} missing 'phase'.");
+            ev.Kind.ShouldNotBeNullOrWhiteSpace(customMessage: $"event missing 'kind'.");
+            // msg may be empty intentionally (some events don't have a payload), but must be present as a field.
+        }
+
+        // Phase MUST be exactly "A" or "B". If it's something else, server-
+        // side parser may still accept (untagged events) but UI grouping
+        // by phase breaks.
+        foreach (var ev in events)
+        {
+            (ev.Phase == "A" || ev.Phase == "B").ShouldBeTrue(
+                customMessage: $"event {ev.Kind}: phase MUST be 'A' or 'B'. Got '{ev.Phase}'. Server UI groups timeline by phase — drift here breaks the grouping.");
+        }
+
+        // Timestamps MUST be ISO 8601 UTC (Z suffix). The .sh emits them
+        // via `date -u +"%Y-%m-%dT%H:%M:%SZ"`. If a future polish drops the
+        // Z or switches to non-UTC, server-side timeline ordering breaks.
+        foreach (var ev in events)
+        {
+            ev.T.ShouldEndWith("Z",
+                customMessage: $"event {ev.Kind} timestamp '{ev.T}' MUST end with 'Z' (UTC marker). Server-side ordering relies on UTC timestamps; non-UTC events appear out-of-order in the UI.");
+            // Spot-check format: must parse as DateTimeOffset.
+            DateTimeOffset.TryParse(ev.T, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AssumeUniversal, out _).ShouldBeTrue(
+                customMessage: $"event {ev.Kind} timestamp '{ev.T}' MUST be parseable as DateTimeOffset. Server-side parser uses the same path.");
+        }
+
+        // Expected kind sequence (subset — these MUST appear in this order
+        // for any successful upgrade). Other events may interleave, but
+        // these terminals + transitions MUST be present + ordered.
+        var kindSequence = events.Select(e => e.Kind).ToList();
+        var expectedOrder = new[] { "start", "method-selected", "scope-exec", "swapped", "restart-start", "healthz-pass", "success" };
+
+        var lastFoundIndex = -1;
+        foreach (var expectedKind in expectedOrder)
+        {
+            var foundAt = -1;
+            for (var i = lastFoundIndex + 1; i < kindSequence.Count; i++)
+            {
+                if (kindSequence[i] == expectedKind)
+                {
+                    foundAt = i;
+                    break;
+                }
+            }
+            foundAt.ShouldBeGreaterThan(-1,
+                customMessage: $"expected event kind '{expectedKind}' MUST appear AFTER the previous expected event in the sequence. " +
+                              $"Got kind sequence: [{string.Join(", ", kindSequence)}]. " +
+                              $"If '{expectedKind}' is absent or out-of-order: emit_event call site for that kind was dropped or the .sh's flow regressed. " +
+                              $"Operator impact: UI timeline misses a critical state transition.");
+            lastFoundIndex = foundAt;
+        }
+
+        // Last event MUST be "success" — terminal state. The server's
+        // timeline UI uses this to flip the task from "in-progress" to
+        // "completed". If the sequence ends on a non-terminal event,
+        // the UI hangs in "in-progress" forever.
+        events[^1].Kind.ShouldBe("success",
+            customMessage: $"final event MUST be 'success' on the happy path (terminal-state semantics). Got '{events[^1].Kind}'. " +
+                          $"Full sequence: [{string.Join(", ", kindSequence)}]. " +
+                          "If non-success terminal: the UI timeline never flips to 'completed' — operator sees in-progress forever.");
+
+        ctx.MarkClean();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)


### PR DESCRIPTION
## Summary

Pins the wire format the server's UI timeline parser consumes from `upgrade-events.jsonl`. Every E1.h-style success ALREADY emits these events; **what's never been pinned is the format contract** — server-side parser drops malformed lines silently → operator sees frozen timeline.

## Why this matters

Without this test, regressions in any of the following ship invisibly:
- JSON malformation (unescaped quotes, missing commas, wrong shape)
- Field renames (`msg` → `message`, `kind` → `type`)
- Phase tag drift (`"A"` → `"PhaseA"`)
- **Missing terminal events** (`success` absent → UI hangs in "in-progress" forever)
- Out-of-order events (success before scope-exec → broken causality)
- Non-UTC timestamps (UI ordering by timestamp breaks)

## Wire format pinned

```json
{"t":"2026-04-22T02:57:04Z","phase":"A","kind":"method-try","msg":"apt: update"}
```

(`.sh` line 206 docstring + line 249 `printf`)

## Test approach

Run E1.h-Linux end-to-end, then PARSE every line of the resulting `upgrade-events.jsonl` as JSON (using `System.Text.Json` — the same parser the server uses).

### Assertions

1. Every line is valid JSON (parser throws → assertion fails)
2. Every event has the four required fields `{t, phase, kind, msg}`
3. Phase values are EXACTLY `"A"` or `"B"` (not `"1"`, `"a"`, `"PhaseA"`)
4. Timestamps end with `Z` (UTC) and parse as `DateTimeOffset`
5. Expected kind sequence appears in order:
   - `start` → `method-selected` → `scope-exec` (Phase A)
   - `swapped` → `restart-start` → `healthz-pass` → `success` (Phase B)
6. Last event is `success` (terminal-state contract — UI flips from in-progress → completed only on this kind)

## Infrastructure additions

`LinuxLifecycleContext`:
- `EventsFilePath` property — `{STATE_DIR}/upgrade-events.jsonl`
- `ReadUpgradeEvents()` → `IReadOnlyList<UpgradeEvent>` — parses every line; throws on malformed lines (the throw IS one of the assertions — server-side parser would silently drop that same line)
- `UpgradeEvent` record `(T, Phase, Kind, Msg)` — mirrors the `.sh`'s `emit_event` JSON shape verbatim

## Fidelity tier

🟢 **High** (Rule 12.4): real prod `.sh` + real systemd + real bash + real `.jsonl` file emitted by real `emit_event` call site. Composes with E1.h's fixture entirely; only adds parse + sequence assertions on top.

Expected runtime: ~5s (same as E1.h + a few ms for parse).

## Test plan

- [ ] Linux E2E workflow runs (manual `workflow_dispatch` after merge)
- [ ] `E1uEventsContract_AfterSuccess_AllLinesValidJsonInExpectedOrder` passes within ~5s
- [ ] No regression on existing 16 Linux E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)