### PR TITLE
feat(LinuxTentacleE2E): Phase 12.M.L.A.1 — Section A bootstrap + bogus-version exit-1

### DIFF
--- a/.github/workflows/tentacle-linux-e2e.yml
+++ b/.github/workflows/tentacle-linux-e2e.yml
@@ -24,7 +24,7 @@ on:
       test_filter:
         description: "xUnit --filter for the Squid.LinuxTentacleE2ETests step"
         required: false
-        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E"
+        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleInstallScriptE2E"
 
 permissions:
   contents: read

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxInstallScriptContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxInstallScriptContext.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 12.M.L.A.1+ — fixture for the production
+/// <c>deploy/scripts/install-tentacle.sh</c> bootstrap installer. Drives
+/// the real script against a real <see cref="LocalReleaseMirror"/> and
+/// real bash + curl + (where applicable) sudo, with cleanup of every
+/// host artefact the script could stage.
+///
+/// <para>Pollution surface is minimised by the recommended overrides:
+/// <c>INSTALL_DIR</c>=test-private temp dir, <c>NO_PKG_INSTALL=1</c>
+/// (skips the "optimistic APT/RPM" probe-then-install path), and
+/// <c>CREATE_USER=no</c> (skips <c>useradd squid-tentacle</c>). Tests
+/// that DO need the full pollution matrix (happy-path with systemd
+/// unit + sudoers) inherit <see cref="Dispose"/>'s best-effort
+/// cleanup of every well-known production path the script writes to.</para>
+///
+/// <para><b>Skip-on-non-Linux</b>: composes
+/// <see cref="LinuxServiceFixture.IsAvailable"/> (Linux + passwordless
+/// sudo, since the .sh's runtime-deps install + write to /etc/* needs
+/// sudo even with INSTALL_DIR override). Tests using this context call
+/// <see cref="IsAvailable"/> first and no-op-skip on non-Linux dev hosts.</para>
+/// </summary>
+public sealed class LinuxInstallScriptContext : IDisposable
+{
+    private bool _clean;
+
+    public static bool IsAvailable => LinuxServiceFixture.IsAvailable;
+
+    public LocalReleaseMirror Mirror { get; }
+
+    /// <summary>Path to the production install-tentacle.sh under deploy/scripts.</summary>
+    public string InstallScriptPath { get; }
+
+    /// <summary>Per-test isolated install dir (under /tmp). The .sh's `mkdir -p` only fires after successful download, so failed runs leave this absent.</summary>
+    public string InstallDir { get; }
+
+    public LinuxInstallScriptContext()
+    {
+        var unique = Guid.NewGuid().ToString("N");
+
+        InstallDir = Path.Combine(Path.GetTempPath(), $"squid-install-test-{unique}");
+        Mirror = LocalReleaseMirror.Start();
+        InstallScriptPath = LocateInstallScript();
+    }
+
+    /// <summary>
+    /// Runs <c>install-tentacle.sh</c> via <c>sudo bash</c> with the
+    /// given version + the recommended-minimum-pollution env overrides.
+    /// Returns (exitCode, combined stdout+stderr).
+    ///
+    /// <para>Why <c>sudo bash</c>: the .sh's <c>install_runtime_deps</c>
+    /// invokes <c>apt-get install libicu</c> and the post-extract phase
+    /// writes to <c>/etc/squid-tentacle</c>, <c>/var/lib/squid-tentacle</c>,
+    /// <c>/usr/local/bin</c> — all of which require root. Even with a
+    /// per-test INSTALL_DIR override, root is still needed for those.
+    /// On the GHA ubuntu-latest runner sudo is passwordless; the
+    /// <see cref="IsAvailable"/> guard skips on hosts without it.</para>
+    ///
+    /// <para>Recommended overrides applied:
+    /// <list type="bullet">
+    ///   <item><c>INSTALL_DIR</c> → test-private <see cref="InstallDir"/></item>
+    ///   <item><c>DOWNLOAD_BASE</c> → <see cref="Mirror"/>'s base URL (so 404s + tarball serves are deterministic + offline)</item>
+    ///   <item><c>NO_PKG_INSTALL=1</c> (skip APT/RPM repo probe path; goes direct to tarball)</item>
+    ///   <item><c>CREATE_USER=no</c> (skip useradd)</item>
+    ///   <item><c>SQUID_BASE_URL=http://localhost:1</c> defensive: even if NO_PKG_INSTALL is forgotten, bind to a non-resolvable host so the probe fails fast instead of hitting prod squid.solarifyai.com)</item>
+    /// </list></para>
+    /// </summary>
+    public (int exitCode, string output) RunInstallScript(string version, Dictionary<string, string> extraEnv = null)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "sudo",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        psi.ArgumentList.Add("-n");
+        psi.ArgumentList.Add("--preserve-env=INSTALL_DIR,DOWNLOAD_BASE,NO_PKG_INSTALL,CREATE_USER,SQUID_BASE_URL,TENTACLE_VERSION");
+        psi.ArgumentList.Add("bash");
+        psi.ArgumentList.Add(InstallScriptPath);
+        psi.ArgumentList.Add("--version");
+        psi.ArgumentList.Add(version);
+        psi.ArgumentList.Add("--install-dir");
+        psi.ArgumentList.Add(InstallDir);
+
+        psi.Environment["INSTALL_DIR"] = InstallDir;
+        psi.Environment["DOWNLOAD_BASE"] = Mirror.BaseUri.ToString().TrimEnd('/');
+        psi.Environment["NO_PKG_INSTALL"] = "1";
+        psi.Environment["CREATE_USER"] = "no";
+        // Defensive: even if NO_PKG_INSTALL is dropped on a future polish,
+        // the APT probe must fail-fast against a non-resolvable host
+        // instead of hitting the real squid.solarifyai.com mirror.
+        psi.Environment["SQUID_BASE_URL"] = "http://localhost:1";
+
+        if (extraEnv != null)
+        {
+            foreach (var kvp in extraEnv)
+                psi.Environment[kvp.Key] = kvp.Value;
+        }
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch sudo bash for install-tentacle.sh execution");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        // Generous timeout. Real installer takes ~30s in production
+        // (apt-get update + tarball download + extract + service setup);
+        // failures should surface much faster.
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException(
+                "install-tentacle.sh did not complete within 3min. " +
+                $"Stuck — check apt-get / curl progress. Mirror base: {Mirror.BaseUri}");
+        }
+
+        return (proc.ExitCode, stdoutTask.Result + Environment.NewLine + stderrTask.Result);
+    }
+
+    public void MarkClean()
+    {
+        _clean = true;
+    }
+
+    public void Dispose()
+    {
+        // Diagnostic: surface non-clean exits in CI logs.
+        if (!_clean)
+            Console.WriteLine($"[LinuxInstallScriptContext] Dispose called without MarkClean — install test for {InstallDir} failed before its happy-path conclusion.");
+
+        // Best-effort cleanup of every well-known production path the
+        // .sh writes to. Each step is `|| true`-style — missing paths
+        // (typical for failed-install tests where most paths were never
+        // created) are a no-op. Order matters: stop+disable systemd unit
+        // BEFORE removing its file; otherwise systemctl reports the unit
+        // as still-loaded and a subsequent test's daemon-reload may not
+        // pick up the new unit cleanly.
+        TrySudoRm(InstallDir);
+
+        // System paths the .sh creates on happy-path. None are touched
+        // by failure-path tests, but the rm is idempotent so we always
+        // run it (defensive against partial-state on assertion-failure
+        // mid-test).
+        TrySudoRm("/etc/squid-tentacle");
+        TrySudoRm("/var/lib/squid-tentacle");
+        TrySudoRm("/usr/local/bin/squid-tentacle");
+        TrySudoRm("/etc/apt/sources.list.d/squid.list");
+        TrySudoRm("/etc/apt/keyrings/squid.gpg");
+        TrySudoRm("/etc/apt/apt.conf.d/99-squid-direct.conf");
+        TrySudoRm("/etc/sudoers.d/squid-tentacle-upgrade");
+        TrySudoRm("/etc/systemd/system/squid-tentacle.service");
+
+        try { Mirror.Dispose(); } catch { /* best-effort */ }
+    }
+
+    private static void TrySudoRm(string path)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "sudo",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("-n");
+            psi.ArgumentList.Add("rm");
+            psi.ArgumentList.Add("-rf");
+            psi.ArgumentList.Add(path);
+
+            using var proc = Process.Start(psi);
+            proc?.WaitForExit(5_000);
+        }
+        catch
+        {
+            // Best-effort. Cleanup leak on failure is preferable to
+            // failing the test in the dispose path.
+        }
+    }
+
+    private static string LocateInstallScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "deploy", "scripts", "install-tentacle.sh");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException(
+            "Could not locate deploy/scripts/install-tentacle.sh. Expected at the repo root's deploy/scripts/.");
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxLifecycleContext.cs
@@ -705,6 +705,34 @@ public sealed class LinuxLifecycleContext : IDisposable
 
         try { Mirror.Dispose(); } catch { /* best-effort */ }
 
+        // Production .sh's Phase B (line 600) creates a symlink at
+        // /usr/local/bin/squid-tentacle pointing to $INSTALL_DIR. After
+        // INSTALL_DIR is rm'd above, the symlink dangles. Subsequent
+        // upgrade tests overwrite it (different target), so upgrade-
+        // suite alone never trips on this. But it's a real leak that
+        // J.M.L.A.1 (install-script test) caught — its reverse-assert
+        // "no symlink after a failed install" found the leftover from
+        // parallel/prior upgrade runs. Cleaning here keeps host state
+        // consistent across test classes.
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "sudo",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("-n");
+            psi.ArgumentList.Add("rm");
+            psi.ArgumentList.Add("-f");
+            psi.ArgumentList.Add("/usr/local/bin/squid-tentacle");
+            using var proc = Process.Start(psi);
+            proc?.WaitForExit(5_000);
+        }
+        catch { /* best-effort */ }
+
         // Reset env vars set during RenderProductionScriptForVersion. NOT
         // strictly needed (test process exits) but clean.
         try { Environment.SetEnvironmentVariable(LinuxTentacleUpgradeStrategy.DownloadBaseUrlEnvVar, null); } catch { }

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxTentacleHostStateCollection.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxTentacleHostStateCollection.cs
@@ -1,0 +1,38 @@
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// xUnit collection definition that SERIALIZES test classes touching
+/// shared Linux host state — sudo invocations, /etc/squid-tentacle,
+/// /var/lib/squid-tentacle, /usr/local/bin/squid-tentacle, /etc/sudoers.d,
+/// /etc/systemd/system, system users, and apt sources.
+///
+/// <para>By default xUnit runs different test classes IN PARALLEL on
+/// separate threads. For tests that modify shared host state, parallel
+/// execution races: two upgrade tests both writing
+/// /usr/local/bin/squid-tentacle, two install tests competing on
+/// /etc/sudoers.d/squid-tentacle-upgrade, etc. Even when each test's
+/// fixture cleans up its own state, the assertion phase can observe
+/// leftover state from a CONCURRENTLY-RUNNING test.</para>
+///
+/// <para>Caught by J.M.L.A.1 first runner: install-script test's
+/// "no /usr/local/bin/squid-tentacle after failed install" reverse-
+/// assert tripped on a leftover symlink from a parallel upgrade test
+/// (whose Phase B creates the symlink and whose fixture's prior
+/// Dispose didn't rm it). Two complementary fixes:
+/// <list type="number">
+///   <item>This collection — guarantees only one of these classes
+///         runs at a time, so no concurrent host-state observation.</item>
+///   <item>LinuxLifecycleContext.Dispose now also rm's the symlink
+///         (cleanup completeness — even on assertion-failure paths).</item>
+/// </list></para>
+///
+/// <para>Test classes that don't touch shared host state (e.g.
+/// UpgradeLinuxScriptE2ETests which only does string parsing on the
+/// rendered .sh) do NOT need this collection — they remain free to
+/// parallelise.</para>
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class LinuxTentacleHostStateCollection
+{
+    public const string Name = "LinuxTentacleHostState";
+}

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxServiceFixtureSmokeE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxServiceFixtureSmokeE2ETests.cs
@@ -19,6 +19,7 @@ namespace Squid.LinuxTentacleE2ETests;
 /// false. CI runs on <c>ubuntu-latest</c> which has both.</para>
 /// </summary>
 [Trait("Category", LinuxTentacleE2ECategories.ServiceFixture)]
+[Collection(LinuxTentacleHostStateCollection.Name)]
 public sealed class LinuxServiceFixtureSmokeE2ETests
 {
     [Fact]

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
@@ -44,4 +44,20 @@ public static class LinuxTentacleE2ECategories
     /// configured. GHA <c>ubuntu-latest</c> runner has both.</para>
     /// </summary>
     public const string ServiceFixture = "LinuxServiceFixtureE2E";
+
+    /// <summary>
+    /// Phase 12.M.L.A.1+ E2E coverage for the production
+    /// <c>deploy/scripts/install-tentacle.sh</c> bootstrap installer.
+    /// Tier 🟢 high-fidelity — drives the real <c>.sh</c> against a real
+    /// <see cref="Infrastructure.LocalReleaseMirror"/> + real bash + real
+    /// curl + real sudo. Linux-only; skip-guards on macOS/Windows.
+    ///
+    /// <para>Pollution surface managed via env-var overrides:
+    /// <c>INSTALL_DIR</c>=test-private temp dir, <c>NO_PKG_INSTALL=1</c>
+    /// (skips APT/RPM repo writes), <c>CREATE_USER=no</c> (skips useradd
+    /// for the system user). Tests that DO need the full pollution
+    /// matrix (happy-path install with systemd unit + sudoers) handle
+    /// cleanup via the fixture's IDisposable per Rule 12.3.</para>
+    /// </summary>
+    public const string InstallScript = "LinuxTentacleInstallScriptE2E";
 }

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
@@ -1,0 +1,120 @@
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.M.L.A.1 — first E2E coverage of the production
+/// <c>deploy/scripts/install-tentacle.sh</c> bootstrap installer.
+///
+/// <para>This is the smallest viable scope for Section A: <b>bogus
+/// version → exit 1</b>. No successful install means no symlinks, no
+/// service install, no sudoers — minimal pollution surface, minimal
+/// cleanup, but real coverage of the .sh's argument parsing + URL
+/// construction + curl error handling code paths.</para>
+///
+/// <para>Subsequent phases (12.M.L.A.2+) will exercise the full install
+/// happy path with comprehensive cleanup of <c>/etc/squid-tentacle</c>,
+/// <c>/var/lib/squid-tentacle</c>, <c>/usr/local/bin/squid-tentacle</c>,
+/// systemd unit, sudoers rule, etc. The fixture's <see cref="LinuxInstallScriptContext.Dispose"/>
+/// already cleans all of those paths defensively, so this test class's
+/// scope expansion is just additive.</para>
+///
+/// <para>Tier: 🟢 H (Rule 12.4) — drives the real production .sh against
+/// real bash + real curl + real <see cref="Infrastructure.LocalReleaseMirror"/>
+/// returning real HTTP 404. No mocks at OS-resource layer.</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.InstallScript)]
+public sealed class TentacleLinuxInstallScriptE2ETests
+{
+    // ========================================================================
+    // A2.u1-Linux — Bogus version → exit 1, clean error message, no partial install
+    //
+    // Production scenario this pins: operator typos `--version 1.0.0` as
+    // `--version 1.O.O` (letter O instead of zero) OR specifies a version
+    // that doesn't exist (typo'd commit-derived version). The .sh's
+    // tarball download fails for both URL forms (plain + v-prefixed) →
+    // exits 1 with operator-actionable error.
+    //
+    // Why this test catches a real regression class:
+    //   - .sh's --version arg parsing fails to set VERSION → falls back
+    //     to "latest" → APT install path attempts (different code path
+    //     entirely) → silent success on the wrong version
+    //   - .sh's URL construction loses --version value → downloads
+    //     "latest" tarball regardless of operator's intent
+    //   - .sh's curl error handling regression → swallows 404 + reports
+    //     success → operator believes wrong version installed
+    //   - .sh's exit-on-failure regression → continues past failed
+    //     download → tries `tar xzf` on empty file → cryptic error
+    //
+    // Test mechanism: configure the LocalReleaseMirror to 404 BOTH the
+    // plain-version AND the v-prefixed download URLs (.sh tries both per
+    // line 234-241). No tarball is staged → both URL forms 404. .sh's
+    // download_ok wrapper retries 3× per URL; both URLs fail → exit 1
+    // with "Could not download" error.
+    //
+    // Reverse-asserts: INSTALL_DIR was never created (.sh's mkdir -p
+    // happens AFTER successful curl download); /etc/* paths were never
+    // touched; no service installed.
+    // ========================================================================
+
+    [Fact]
+    public void A2u1_BogusVersion_ExitsOneWithCleanErrorAndNoPartialInstall()
+    {
+        if (!LinuxInstallScriptContext.IsAvailable) return;
+
+        using var ctx = new LinuxInstallScriptContext();
+
+        // Configure mirror to 404 every download URL for this version.
+        // The .sh tries plain + v-prefixed, so both must 404.
+        const string bogusVersion = "999.999.999-bogus-test";
+        ctx.Mirror.ConfigureNotFoundForVersion(bogusVersion);
+        ctx.Mirror.ConfigureNotFoundForVersion($"v{bogusVersion}");
+
+        var (exitCode, output) = ctx.RunInstallScript(bogusVersion);
+
+        // Exit 1 — install-tentacle.sh's documented "could not download"
+        // failure code (line 240).
+        exitCode.ShouldBe(1,
+            customMessage: $"bogus --version MUST cause install-tentacle.sh to exit 1 after both download attempts (plain + v-prefixed) 404. " +
+                          $"Got exit {exitCode}. " +
+                          $"If 0: download somehow succeeded — mirror staged a tarball it shouldn't have, OR .sh's exit-on-failure regressed. " +
+                          $"If non-1: a different .sh failure path fired BEFORE the curl loop (arch detect? root check?) — investigate. " +
+                          $"output tail (last 2k chars):\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Operator-actionable error MUST surface in stdout. Without this,
+        // exit 1 + no message = operator has no idea what to fix.
+        output.ShouldContain("Could not download",
+            customMessage: $"stdout MUST contain operator-actionable 'Could not download' diagnostic. " +
+                          $"output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // The error MUST echo BOTH attempted URLs (plain + v-prefixed).
+        // Operators see them in logs to verify the mirror config and DNS
+        // resolution (4xx vs DNS-fail are distinct fixes).
+        output.ShouldContain($"{bogusVersion}/squid-tentacle-{bogusVersion}-",
+            customMessage: $"stdout MUST echo the constructed download URL containing the version. Operators use this to verify their --version typo. " +
+                          $"output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Reverse-assert: INSTALL_DIR was never created. The .sh's
+        // `mkdir -p "$INSTALL_DIR"` (line 251) only runs AFTER successful
+        // curl download. If it exists, .sh's exit-on-failure regressed
+        // and post-download steps ran on an empty/missing tarball.
+        Directory.Exists(ctx.InstallDir).ShouldBeFalse(
+            customMessage: $"INSTALL_DIR at {ctx.InstallDir} MUST NOT exist after a failed-download install. " +
+                          $".sh's `mkdir -p` runs only after successful curl; if dir exists, the .sh proceeded past the download failure (regression).");
+
+        // Reverse-assert: no system-wide artefacts. Belt-and-braces: the
+        // .sh's post-extract block writes /etc/squid-tentacle/ etc. only
+        // after a successful tarball download. If any of these got
+        // written despite exit 1, the .sh's exit ordering regressed.
+        Directory.Exists("/etc/squid-tentacle").ShouldBeFalse(
+            customMessage: "/etc/squid-tentacle MUST NOT exist after a failed install. If present: .sh proceeded past the download failure into post-install steps (regression in exit ordering).");
+
+        Directory.Exists("/var/lib/squid-tentacle").ShouldBeFalse(
+            customMessage: "/var/lib/squid-tentacle MUST NOT exist after a failed install (created by the .sh's post-install block, which never ran).");
+
+        File.Exists("/usr/local/bin/squid-tentacle").ShouldBeFalse(
+            customMessage: "/usr/local/bin/squid-tentacle symlink MUST NOT exist after a failed install — symlink creation is post-extract.");
+
+        ctx.MarkClean();
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
@@ -24,6 +24,7 @@ namespace Squid.LinuxTentacleE2ETests;
 /// returning real HTTP 404. No mocks at OS-resource layer.</para>
 /// </summary>
 [Trait("Category", LinuxTentacleE2ECategories.InstallScript)]
+[Collection(LinuxTentacleHostStateCollection.Name)]
 public sealed class TentacleLinuxInstallScriptE2ETests
 {
     // ========================================================================

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxUpgradeLifecycleE2ETests.cs
@@ -33,6 +33,7 @@ namespace Squid.LinuxTentacleE2ETests;
 /// CI <c>ubuntu-latest</c> runner has both.</para>
 /// </summary>
 [Trait("Category", LinuxTentacleE2ECategories.UpgradeLifecycle)]
+[Collection(LinuxTentacleHostStateCollection.Name)]
 public sealed class TentacleLinuxUpgradeLifecycleE2ETests
 {
     // ========================================================================


### PR DESCRIPTION
## Summary

**PIVOT to Section A** install-tentacle.sh after the upgrade-flow phase closed (J.L.E.7–19, 13 PRs, 20 E2E tests, 1 production bug fixed). The user's original goal is *"from install to deploy to lifecycle to upgrade — all functions confident"* — install was the largest unfilled gap.

This is the **smallest viable Section A scope**: bogus version → exit 1. No successful install means no symlinks, no service install, no sudoers — minimal pollution surface, minimal cleanup, but real coverage of the `.sh`'s argument parsing + URL construction + curl error handling.

## Why bogus-version first (not happy path)

| Concern | Bogus version | Happy path |
|---|---|---|
| Pollution surface | `INSTALL_DIR` only (failed mkdir, no other side effects) | `/etc/squid-tentacle`, `/var/lib/squid-tentacle`, `/usr/local/bin`, sudoers, systemd unit, system user, apt sources |
| Cleanup complexity | Trivial | Significant matrix |
| Caught regression class | arg parsing, URL construction, curl errors, exit ordering | All of bogus-version + extract + chmod + symlink + service install + ownership + APT repo persistence |
| Risk on first PR | Low | Higher (each cleanup gap is a leak between tests) |

The fixture (`LinuxInstallScriptContext`) already implements **full** cleanup defensively (covering every production path the script writes to), so happy-path tests in J.M.L.A.2+ drop in additively without re-engineering.

## Test mechanism

Configure `LocalReleaseMirror` to 404 BOTH the plain-version AND the v-prefixed download URLs (`.sh` tries both per lines 234-241). No tarball staged → both URL forms 404. `.sh`'s `download_ok` wrapper retries 3× per URL; both URLs fail → exit 1 with `"Could not download"` error.

## Assertions

| Assertion | Catches |
|---|---|
| `exitCode == 1` | `.sh` exit-on-failure regression |
| stdout contains `"Could not download"` | Operator-actionable diagnostic regression |
| stdout echoes the constructed URL | Operator can verify `--version` typo by reading the log |
| `INSTALL_DIR` does **NOT** exist | `.sh`'s `mkdir -p` runs only after successful curl; presence = exit ordering regressed |
| `/etc/squid-tentacle` does **NOT** exist | Post-install block never ran |
| `/var/lib/squid-tentacle` does **NOT** exist | Same |
| `/usr/local/bin/squid-tentacle` symlink does **NOT** exist | Symlink creation is post-extract |

## Infrastructure additions

- `LinuxInstallScriptContext` fixture (sibling of `LinuxLifecycleContext`; structurally different env vars + cleanup matrix so kept separate per ISP / Rule 7)
- `LinuxTentacleE2ECategories.InstallScript` constant
- `tentacle-linux-e2e.yml` workflow filter updated to include the new category in default (per CLAUDE.md trait-filter convention)

## Cleanup matrix (forward-compatible with happy path)

`Dispose()` runs `sudo rm -rf` against:
- `INSTALL_DIR` (per-test temp dir)
- `/etc/squid-tentacle/`
- `/var/lib/squid-tentacle/`
- `/usr/local/bin/squid-tentacle`
- `/etc/apt/sources.list.d/squid.list`
- `/etc/apt/keyrings/squid.gpg`
- `/etc/apt/apt.conf.d/99-squid-direct.conf`
- `/etc/sudoers.d/squid-tentacle-upgrade`
- `/etc/systemd/system/squid-tentacle.service`

Each is best-effort; missing paths are no-ops.

## Fidelity tier

🟢 **High** (Rule 12.4): drives the real production `.sh` against real bash + real curl + real `LocalReleaseMirror` returning real HTTP 404. No mocks at OS-resource layer.

Expected runtime: ~10s (curl retries 3× per URL × 2 URLs ~6s + apt-get update on first run ~3s; libicu typically pre-installed on ubuntu-latest so `install_runtime_deps` short-circuits).

## Test plan

- [ ] Linux E2E workflow runs `Squid.LinuxTentacleE2ETests` (manual `workflow_dispatch` after merge)
- [ ] `A2u1_BogusVersion_ExitsOneWithCleanErrorAndNoPartialInstall` passes within ~15s
- [ ] No regression on existing 20 Linux E2E tests
- [ ] New trait `Category=LinuxTentacleInstallScriptE2E` in workflow filter picks up the new test class

🤖 Generated with [Claude Code](https://claude.com/claude-code)