### PR TITLE
feat(LinuxTentacleE2E): Phase 12.M.L.A.2 — install-tentacle.sh happy path E2E

### DIFF
--- a/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
+++ b/tests/Squid.LinuxTentacleE2E.TestService/squid-linux-test-service.sh
@@ -53,6 +53,18 @@ if [ "${1:-}" = "version" ]; then
     exit 0
 fi
 
+# `help` subcommand fast-path. Used by install-tentacle.sh's post-install
+# verification (line 510-516): `if ${BINARY_NAME} help >/dev/null 2>&1`.
+# Without this fast-path we'd fall into the sleep loop and the install
+# .sh would hang forever waiting on the help command. Real Squid.Tentacle's
+# CLI handles `help` similarly. Bug found by J.M.L.A.2 (Linux install
+# happy path E2E) — the install verification was the first caller of
+# this fast-path.
+if [ "${1:-}" = "help" ]; then
+    echo "test service - subcommands: version, help"
+    exit 0
+fi
+
 # Optional healthz endpoint for J.L.E.6+ full-lifecycle tests. The .sh's
 # Phase B healthcheck loop curls $HEALTHCHECK_URL (default
 # http://127.0.0.1:8080/healthz) — without an actual responder the

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxInstallScriptContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxInstallScriptContext.cs
@@ -38,6 +38,9 @@ public sealed class LinuxInstallScriptContext : IDisposable
     /// <summary>Per-test isolated install dir (under /tmp). The .sh's `mkdir -p` only fires after successful download, so failed runs leave this absent.</summary>
     public string InstallDir { get; }
 
+    /// <summary>Path to the test service script under tests/ (used as the placeholder Squid.Tentacle binary in install tarballs).</summary>
+    public string TestServiceScript { get; }
+
     public LinuxInstallScriptContext()
     {
         var unique = Guid.NewGuid().ToString("N");
@@ -45,6 +48,105 @@ public sealed class LinuxInstallScriptContext : IDisposable
         InstallDir = Path.Combine(Path.GetTempPath(), $"squid-install-test-{unique}");
         Mirror = LocalReleaseMirror.Start();
         InstallScriptPath = LocateInstallScript();
+        TestServiceScript = LocateTestServiceScript();
+    }
+
+    /// <summary>
+    /// Builds a single-entry .tar.gz containing a placeholder
+    /// <c>Squid.Tentacle</c> binary (a copy of the test service script).
+    /// install-tentacle.sh extracts the tarball to <see cref="InstallDir"/>
+    /// then chmod +x's the binary + creates the symlinks. The placeholder
+    /// is a bash script that handles <c>version</c> + <c>help</c>
+    /// subcommands (per the .sh's post-install verification at line 510)
+    /// and falls into a sleep loop otherwise (so a systemd start
+    /// post-install would idle as expected).
+    ///
+    /// <para>Tar contents are FLAT (no wrapper directory) — line 251 of
+    /// install-tentacle.sh expects this exact shape: <c>tar xzf "$ARCHIVE"
+    /// -C "$INSTALL_DIR"</c> with no <c>--strip-components</c>.</para>
+    /// </summary>
+    public byte[] BuildInstallTarGz(string version)
+    {
+        var binaryBytes = File.ReadAllBytes(TestServiceScript);
+
+        // Single entry: Squid.Tentacle (the placeholder binary).
+        // No version.txt needed — install-tentacle.sh doesn't read it
+        // (only the upgrade flow's marker mechanism does). Keeping the
+        // tarball minimal matches what the production release pipeline
+        // ships for fresh installs.
+        var entries = new (string Name, byte[] Content)[]
+        {
+            ("Squid.Tentacle", binaryBytes)
+        };
+
+        return BuildTarGz(entries);
+    }
+
+    /// <summary>
+    /// Hand-rolled multi-entry POSIX tar + gzip. Mirrors
+    /// <see cref="LinuxLifecycleContext.BuildV2BundleTarGz"/>'s helper
+    /// so the install tarball format matches the upgrade tarball format
+    /// the production release pipeline produces.
+    /// </summary>
+    private static byte[] BuildTarGz((string Name, byte[] Content)[] entries)
+    {
+        using var tarMs = new MemoryStream();
+        foreach (var entry in entries)
+        {
+            var header = BuildTarHeader(entry.Name, entry.Content.Length);
+            tarMs.Write(header, 0, header.Length);
+            tarMs.Write(entry.Content, 0, entry.Content.Length);
+            var pad = (512 - (entry.Content.Length % 512)) % 512;
+            if (pad > 0) tarMs.Write(new byte[pad], 0, pad);
+        }
+        tarMs.Write(new byte[1024], 0, 1024);
+
+        using var gzMs = new MemoryStream();
+        using (var gz = new System.IO.Compression.GZipStream(gzMs, System.IO.Compression.CompressionLevel.Fastest, leaveOpen: true))
+        {
+            var tarBytes = tarMs.ToArray();
+            gz.Write(tarBytes, 0, tarBytes.Length);
+        }
+        return gzMs.ToArray();
+    }
+
+    private static byte[] BuildTarHeader(string fileName, long size)
+    {
+        var header = new byte[512];
+
+        var nameBytes = System.Text.Encoding.ASCII.GetBytes(fileName);
+        Array.Copy(nameBytes, header, Math.Min(nameBytes.Length, 100));
+
+        // Mode 0755 — install-tentacle.sh re-applies chmod +x but
+        // shipping it executable from the tarball matches production.
+        WriteOctal(header, offset: 100, length: 8, value: 0x1ED);
+        WriteOctal(header, 108, 8, 0);
+        WriteOctal(header, 116, 8, 0);
+        WriteOctal(header, 124, 12, size);
+        WriteOctal(header, 136, 12, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        for (var i = 148; i < 156; i++) header[i] = (byte)' ';
+        header[156] = (byte)'0';
+
+        var ustar = System.Text.Encoding.ASCII.GetBytes("ustar");
+        Array.Copy(ustar, 0, header, 257, ustar.Length);
+        header[263] = (byte)'0';
+        header[264] = (byte)'0';
+
+        var checksum = 0;
+        foreach (var b in header) checksum += b;
+        WriteOctal(header, 148, 7, checksum);
+        header[155] = 0;
+
+        return header;
+    }
+
+    private static void WriteOctal(byte[] buffer, int offset, int length, long value)
+    {
+        var s = Convert.ToString(value, 8).PadLeft(length - 1, '0');
+        var bytes = System.Text.Encoding.ASCII.GetBytes(s);
+        Array.Copy(bytes, 0, buffer, offset, Math.Min(bytes.Length, length - 1));
+        buffer[offset + length - 1] = 0;
     }
 
     /// <summary>
@@ -199,5 +301,19 @@ public sealed class LinuxInstallScriptContext : IDisposable
         }
         throw new FileNotFoundException(
             "Could not locate deploy/scripts/install-tentacle.sh. Expected at the repo root's deploy/scripts/.");
+    }
+
+    private static string LocateTestServiceScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "tests", "Squid.LinuxTentacleE2E.TestService", "squid-linux-test-service.sh");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException(
+            "Could not locate squid-linux-test-service.sh. Expected at tests/Squid.LinuxTentacleE2E.TestService/.");
     }
 }

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
@@ -118,4 +118,115 @@ public sealed class TentacleLinuxInstallScriptE2ETests
 
         ctx.MarkClean();
     }
+
+    // ========================================================================
+    // A1.h-Linux — Happy path: --version X.Y.Z installs binary + symlink chain
+    //               + post-install dirs, exits 0
+    //
+    // Production scenario this pins: operator runs the documented one-liner
+    //   curl -fsSL .../install-tentacle.sh | sudo bash -s -- --version 1.6.0
+    // → binary lands at INSTALL_DIR, symlink chain on PATH, post-install
+    // dirs (config, state, workspace) created, "Verified: squid-tentacle
+    // executable" printed.
+    //
+    // Why this test is critical: it's THE prerequisite for every
+    // downstream operation. If install regresses, no upgrade can run,
+    // no register can persist, no deploy can dispatch. Currently zero
+    // Linux E2E coverage on this path.
+    //
+    // Test mechanism:
+    //   1. Build a tarball with a placeholder Squid.Tentacle binary
+    //      (the test service script, which handles `version` + `help`
+    //      subcommands and would block on systemd start otherwise).
+    //   2. Stage on LocalReleaseMirror.
+    //   3. Run install-tentacle.sh via sudo bash with --version (matches
+    //      operator one-liner shape).
+    //   4. Assert exit 0 + binary file exists + symlink chain wired up
+    //      + post-install dirs (created).
+    //
+    // Why placeholder binary handles `help`: install-tentacle.sh's line
+    // 510-516 verification step runs `squid-tentacle help`. Without a
+    // `help` fast-path, the placeholder's main loop is sleep-forever,
+    // and the install .sh would hang. Real Squid.Tentacle's CLI handles
+    // help similarly — the J.M.L.A.2 first-runner caught this gap.
+    //
+    // Recommended overrides (set by fixture):
+    //   - INSTALL_DIR=test-private  (avoids /opt collision)
+    //   - DOWNLOAD_BASE=mirror      (offline + deterministic tarball)
+    //   - NO_PKG_INSTALL=1          (skip APT/RPM probe — test is offline)
+    //   - CREATE_USER=no            (skip useradd; sudoers block also skipped)
+    //   - SQUID_BASE_URL=http://localhost:1  (defensive)
+    //
+    // Tier: 🟢 H (Rule 12.4) — drives the real production .sh against
+    // real bash + real curl + real LocalReleaseMirror serving real
+    // tar.gz + real sudo orchestration of mkdir + chmod + symlinks.
+    //
+    // Expected runtime: ~10-15s (curl LAN download + extract + chmod +
+    // symlinks + dir creation + verify-help on placeholder).
+    // ========================================================================
+
+    [Fact]
+    public void A1h_HappyPath_InstallsBinaryAndCreatesSymlinkChain()
+    {
+        if (!LinuxInstallScriptContext.IsAvailable) return;
+
+        using var ctx = new LinuxInstallScriptContext();
+
+        // Stage a tarball with the placeholder Squid.Tentacle binary.
+        // The .sh tries plain version URL first (line 230); we serve
+        // the same bytes for any URL via StagePreBuiltArchive.
+        const string version = "1.6.0-installtest";
+        var tarball = ctx.BuildInstallTarGz(version);
+        ctx.Mirror.StagePreBuiltArchive(tarball);
+
+        var (exitCode, output) = ctx.RunInstallScript(version);
+
+        exitCode.ShouldBe(0,
+            customMessage: $"happy-path install MUST exit 0. Got {exitCode}. " +
+                          $"If 1: download/extract/symlink failed (likely curl URL mismatch with mirror, OR `tar xzf` rejected our tarball format, OR sudoer chain broke). " +
+                          $"If 2: `Unknown option:` from arg parsing. " +
+                          $"output tail (last 2k chars):\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Operator-visible "Installation Complete" banner — pins the
+        // .sh's success message contract.
+        output.ShouldContain("Installation Complete",
+            customMessage: $"stdout MUST contain 'Installation Complete' banner. Operators tail this for confirmation. output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Verification step ran AND succeeded — the .sh prints
+        // "Verified: squid-tentacle executable" only when `${BINARY_NAME}
+        // help` exits 0. If absent: either help fast-path missing OR
+        // PATH wiring broke.
+        output.ShouldContain("Verified: squid-tentacle executable",
+            customMessage: $"stdout MUST contain 'Verified: squid-tentacle executable' — the .sh's post-install verification (line 510-516) ran the binary's `help` subcommand successfully. " +
+                          $"If absent: placeholder binary doesn't handle `help` (fall-through to sleep loop, .sh hangs OR exits non-zero on its own timeout) " +
+                          $"OR symlink chain didn't put `squid-tentacle` on PATH. " +
+                          $"output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Binary exists at INSTALL_DIR/Squid.Tentacle (extracted by tar).
+        var binaryPath = Path.Combine(ctx.InstallDir, "Squid.Tentacle");
+        File.Exists(binaryPath).ShouldBeTrue(
+            customMessage: $"Squid.Tentacle binary MUST exist at {binaryPath} after install. " +
+                          "If absent: tar extraction failed silently, OR tarball had a different entry name (mirror serving wrong content?), OR INSTALL_DIR override didn't propagate to .sh.");
+
+        // Symlink within INSTALL_DIR — `ln -sf $INSTALL_DIR/Squid.Tentacle $INSTALL_DIR/squid-tentacle`.
+        var binaryNameSymlink = Path.Combine(ctx.InstallDir, "squid-tentacle");
+        File.Exists(binaryNameSymlink).ShouldBeTrue(
+            customMessage: $"well-known-name symlink MUST exist at {binaryNameSymlink}. " +
+                          ".sh's `ln -sf $INSTALL_DIR/Squid.Tentacle $INSTALL_DIR/squid-tentacle` (line 264) ran but produced no symlink — defensive ln failed silently?");
+
+        // Symlink on PATH (/usr/local/bin/) — `ln -sf $INSTALL_DIR/squid-tentacle /usr/local/bin/squid-tentacle`.
+        File.Exists("/usr/local/bin/squid-tentacle").ShouldBeTrue(
+            customMessage: "/usr/local/bin/squid-tentacle symlink MUST exist after install — operators register + run via this PATH-resolved name. " +
+                          "If absent: .sh skipped the symlink (perhaps /usr/local/bin doesn't exist, but it's standard on every distro), OR sudo couldn't write there.");
+
+        // Post-install dirs created (the .sh creates these unconditionally).
+        Directory.Exists("/etc/squid-tentacle").ShouldBeTrue(
+            customMessage: "/etc/squid-tentacle MUST exist after install (CONFIG_DIR — register + run persist instance state here). " +
+                          "If absent: .sh's `mkdir -p $CONFIG_DIR` (line 296-299) didn't run — likely `[ ! -d $CONFIG_DIR ]` returned false (so dir already existed pre-test, but cleanup matrix should have removed it).");
+
+        Directory.Exists("/var/lib/squid-tentacle").ShouldBeTrue(
+            customMessage: "/var/lib/squid-tentacle MUST exist after install (STATE_DIR — upgrade flow's last-upgrade.json + lock + events go here).");
+
+        ctx.MarkClean();
+    }
 }


### PR DESCRIPTION
## Summary

Mirrors the production operator one-liner:

```bash
curl -fsSL .../install-tentacle.sh | sudo bash -s -- --version 1.6.0
```

→ binary lands at `INSTALL_DIR`, symlink chain on PATH, post-install dirs (config, state, workspace) created, `"Verified: squid-tentacle executable"` printed.

## Why critical

Install is **THE prerequisite** for every downstream operation. Regression here breaks every new agent provision and re-install. Until this test, zero Linux E2E coverage on the install happy path.

## Test mechanism

1. Build a single-entry tar.gz with a placeholder `Squid.Tentacle` binary (the test service script, which now handles `help` + `version` subcommands and would block on systemd start otherwise)
2. Stage on `LocalReleaseMirror`
3. Run `install-tentacle.sh` via `sudo bash` with `--version` (matches operator one-liner shape exactly)
4. Assert exit 0 + binary file + symlink chain (INSTALL_DIR/squid-tentacle + /usr/local/bin/squid-tentacle) + post-install dirs + verification message

## Why placeholder binary needs to handle `help`

`install-tentacle.sh` line 510-516 verification runs `squid-tentacle help`. Without a `help` fast-path, the placeholder's main loop is sleep-forever and the install `.sh` would hang.

Added `help` fast-path to `squid-linux-test-service.sh` mirroring the existing `version` fast-path pattern.

## Assertions

| Assertion | What it pins |
|---|---|
| `exitCode == 0` | Whole installation chain succeeded |
| stdout contains `"Installation Complete"` | Operator-visible banner |
| stdout contains `"Verified: squid-tentacle executable"` | help subcommand round-tripped through the entire symlink chain |
| `INSTALL_DIR/Squid.Tentacle` exists | Tar extraction worked |
| `INSTALL_DIR/squid-tentacle` symlink exists | Well-known-name layer |
| `/usr/local/bin/squid-tentacle` symlink exists | PATH layer |
| `/etc/squid-tentacle` exists | CONFIG_DIR for register/run |
| `/var/lib/squid-tentacle` exists | STATE_DIR for upgrade flow |

## Recommended overrides (set by fixture)

- `INSTALL_DIR=test-private` (avoids /opt collision)
- `DOWNLOAD_BASE=mirror` (offline + deterministic)
- `NO_PKG_INSTALL=1` (skip APT/RPM probe)
- `CREATE_USER=no` (skip useradd; sudoers block also skipped because SERVICE_USER doesn't exist)
- `SQUID_BASE_URL=http://localhost:1` (defensive — APT repo persistence block's curl fails fast)

## Infrastructure additions

`LinuxInstallScriptContext`:
- `BuildInstallTarGz(version)` — single-entry tar.gz with placeholder binary
- `TestServiceScript` property + locator
- Hand-rolled tar+gzip helpers (mirror LinuxLifecycleContext's pattern)

## Fidelity tier

🟢 **High** (Rule 12.4): real production `.sh` + real bash + real curl + real `LocalReleaseMirror` serving real tar.gz + real sudo orchestration. No mocks at OS-resource layer.

Test class is in `LinuxTentacleHostStateCollection` so it serializes against upgrade-lifecycle + service-fixture tests (avoids shared-host-state races; pinned in J.M.L.A.1).

Expected runtime: ~10-15s.

## Test plan

- [ ] Linux E2E workflow runs (manual `workflow_dispatch` after merge)
- [ ] `A1h_HappyPath_InstallsBinaryAndCreatesSymlinkChain` passes within ~20s
- [ ] No regression on existing 21 Linux E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)