### PR TITLE
feat(LinuxTentacleE2E): Phase 12.M.L.A.3 — install-tentacle.sh v-prefix fallback E2E

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
@@ -85,6 +85,17 @@ public sealed class LocalReleaseMirror : IDisposable
     private byte[] _preBuiltArchive;
     private readonly HashSet<string> _notFoundVersions = new(StringComparer.OrdinalIgnoreCase);
     /// <summary>
+    /// Path-substring-based 404 list. Same matching shape as
+    /// <see cref="_notFoundVersions"/> but allows the caller to pass a
+    /// path-segment-aware string (e.g. <c>"/download/1.6.0/"</c>) that
+    /// won't match the v-prefixed sibling (<c>"/download/v1.6.0/"</c>) —
+    /// the leading-slash boundary character disambiguates. Used by
+    /// J.M.L.A.3 (A2.u2 v-prefix fallback) where we want to 404 ONLY
+    /// the plain-version URL form so the .sh's retry hits the
+    /// v-prefixed URL and succeeds.
+    /// </summary>
+    private readonly HashSet<string> _notFoundPaths = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
     /// Per-archive byte cache. <see cref="ZipArchive"/> + GZipStream both
     /// embed timestamps in entry headers, so a fresh build for the
     /// <c>.zip</c> request and a separate fresh build for the <c>.sha256</c>
@@ -206,6 +217,26 @@ public sealed class LocalReleaseMirror : IDisposable
     }
 
     /// <summary>
+    /// Configures the mirror to return 404 for any URL whose AbsolutePath
+    /// contains the given substring. Lower-level than
+    /// <see cref="ConfigureNotFoundForVersion"/>: lets the caller embed
+    /// path-segment boundary characters (leading <c>/</c>, trailing <c>/</c>)
+    /// to surgically 404 a single URL form without affecting siblings.
+    ///
+    /// <para>Use case: install-tentacle.sh's v-prefix fallback retry. The
+    /// .sh tries <c>/download/${VERSION}/...</c> first, then
+    /// <c>/download/v${VERSION}/...</c> on 404. To exercise the fallback
+    /// path, the test 404s the plain URL ONLY (e.g.
+    /// <c>ConfigureNotFoundForPath("/download/1.6.0/")</c>) — the leading
+    /// slash makes <c>/download/v1.6.0/...</c> NOT match (it has
+    /// <c>/download/v1.6.0/</c>, not <c>/download/1.6.0/</c>).</para>
+    /// </summary>
+    public void ConfigureNotFoundForPath(string pathSubstring)
+    {
+        _notFoundPaths.Add(pathSubstring);
+    }
+
+    /// <summary>
     /// Overrides the <c>.sha256</c> companion body. The mirror normally
     /// computes the real SHA256 of the staged archive on each request; this
     /// override forces a fixed string instead so tests can inject a
@@ -275,8 +306,12 @@ public sealed class LocalReleaseMirror : IDisposable
             _receivedRequests.Add(path);
         }
 
-        // 404 if the path mentions any of the configured "not found" versions.
-        if (_notFoundVersions.Any(v => path.Contains(v, StringComparison.OrdinalIgnoreCase)))
+        // 404 if the path mentions any of the configured "not found" versions
+        // OR matches any of the path-substring "not found" entries. Versions
+        // are coarse (substring of any URL); paths are surgical (used to 404
+        // the plain-version URL while letting the v-prefix sibling serve).
+        if (_notFoundVersions.Any(v => path.Contains(v, StringComparison.OrdinalIgnoreCase))
+            || _notFoundPaths.Any(p => path.Contains(p, StringComparison.OrdinalIgnoreCase)))
         {
             ctx.Response.StatusCode = 404;
             ctx.Response.OutputStream.Close();

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
@@ -229,4 +229,106 @@ public sealed class TentacleLinuxInstallScriptE2ETests
 
         ctx.MarkClean();
     }
+
+    // ========================================================================
+    // A2.u2-Linux — Plain --version 1.6.0 URL 404s, .sh falls back to v1.6.0
+    //               and installs successfully
+    //
+    // Production scenario this pins: install-tentacle.sh tries TWO download
+    // URL forms in sequence (line 230-241):
+    //
+    //   URL_PLAIN     = ${DOWNLOAD_BASE}/download/${VERSION}/squid-tentacle-${VERSION}-${RID}.tar.gz
+    //   URL_V_PREFIXED = ${DOWNLOAD_BASE}/download/v${VERSION}/squid-tentacle-${VERSION}-${RID}.tar.gz
+    //
+    // Real-world driver: GitHub Releases tag conventions vary across
+    // projects. Squid's current pipeline publishes both `v1.6.0` and
+    // `1.6.0` tags, but operators on legacy / private mirrors might
+    // only have ONE form. The .sh's retry-with-v-prefix is the
+    // operator-friendly compatibility shim.
+    //
+    // Without this test, a regression in the retry logic ships silently:
+    //   - .sh stops retrying on 404 → operator on legacy mirror sees
+    //     install fail with "could not download 1.6.0" even though
+    //     v1.6.0 IS published
+    //   - .sh doesn't echo the retry attempt → operators have no log
+    //     signal that the fallback was tried (vs "single shot fail")
+    //   - .sh's exit-on-failure regression after retry → silently
+    //     swallows the v-prefix 404 and exits 0 with no install
+    //
+    // Test mechanism: configure mirror to 404 ONLY the plain-version
+    // URL path (via the new ConfigureNotFoundForPath surgical-404 API
+    // — substring match with leading slash boundary). Mirror serves the
+    // v-prefixed path normally via StagePreBuiltArchive. Run install,
+    // assert exit 0 + retry log message + binary installed.
+    //
+    // Why surgical-404: ConfigureNotFoundForVersion("1.6.0") would also
+    // 404 the v-prefixed URL (substring "1.6.0" appears in both paths).
+    // ConfigureNotFoundForPath("/download/1.6.0/") matches ONLY the plain
+    // form because the v-prefixed path contains "/download/v1.6.0/".
+    //
+    // Tier: 🟢 H. Reuses J.M.L.A.2's fixture + tarball builder; only
+    // adds the surgical mirror config + retry-message assertion.
+    //
+    // Expected runtime: ~3-5s (curl 404 fast on plain URL → retry attempt
+    // → tarball download succeeds via v-prefix path → standard install).
+    // ========================================================================
+
+    [Fact]
+    public void A2u2_PlainVersion404FallsBackToVPrefix_InstallSucceeds()
+    {
+        if (!LinuxInstallScriptContext.IsAvailable) return;
+
+        using var ctx = new LinuxInstallScriptContext();
+
+        const string version = "1.6.0-vfallback";
+
+        // Surgical 404: plain version URL only. v-prefixed URL still serves.
+        // The leading slash in "/download/<version>/" disambiguates from
+        // the v-prefixed sibling "/download/v<version>/" — ConfigureNotFoundForPath
+        // does substring match, and `/download/v1.6.0-vfallback/` does NOT
+        // contain `/download/1.6.0-vfallback/` (the leading char of the
+        // version segment differs).
+        ctx.Mirror.ConfigureNotFoundForPath($"/download/{version}/");
+
+        // Stage tarball. Served by mirror at any URL that doesn't match
+        // the surgical-404 path → v-prefixed URL serves successfully.
+        var tarball = ctx.BuildInstallTarGz(version);
+        ctx.Mirror.StagePreBuiltArchive(tarball);
+
+        var (exitCode, output) = ctx.RunInstallScript(version);
+
+        exitCode.ShouldBe(0,
+            customMessage: $"v-prefix fallback install MUST succeed (plain URL 404, v-prefix serves). Got exit {exitCode}. " +
+                          $"If 1: .sh's retry logic regressed — operator log should show 'retrying with v...' and install should still succeed. " +
+                          $"If 2: arg parsing rejected --version. " +
+                          $"output tail (last 2k chars):\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Operator-visible signal: the .sh MUST log the retry attempt.
+        // Without this, operators on legacy mirrors can't distinguish
+        // "first attempt succeeded" from "fallback succeeded" — important
+        // because if BOTH attempts failed they'd want to know which URL
+        // forms were tried.
+        output.ShouldContain($"retrying with 'v{version}'",
+            customMessage: $"stdout MUST contain 'retrying with v{version}' so operators see the .sh tried both URL forms. " +
+                          $"If absent: retry log line at .sh line 236 was dropped — operators tailing the log can't tell whether the fallback fired. " +
+                          $"output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
+
+        // Operator-visible: the v-prefixed URL appears in the second
+        // download-attempt log message. If absent: the .sh constructed
+        // the wrong URL form and the test would fail above with exit 1
+        // anyway — but echoing the URL gives diagnostic precision.
+        output.ShouldContain($"v{version}/squid-tentacle-{version}-",
+            customMessage: $"stdout MUST echo the v-prefixed download URL containing 'v{version}/squid-tentacle-{version}-'. " +
+                          "Operators verify which URL form succeeded by reading this log.");
+
+        // Sanity: the install actually completed end-to-end via the v-prefix path.
+        File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle")).ShouldBeTrue(
+            customMessage: $"Squid.Tentacle binary MUST exist at {ctx.InstallDir}/Squid.Tentacle after v-prefix fallback install. " +
+                          "If absent: .sh logged retry but never actually downloaded — retry construction may produce a malformed URL.");
+
+        File.Exists("/usr/local/bin/squid-tentacle").ShouldBeTrue(
+            customMessage: "/usr/local/bin/squid-tentacle symlink MUST exist after v-prefix fallback install — confirms post-extract steps ran the same way as the plain-URL happy path.");
+
+        ctx.MarkClean();
+    }
 }


### PR DESCRIPTION
## Summary

Pins the `.sh`'s two-URL retry contract: when `--version 1.6.0` returns 404 from the plain URL form, the `.sh` MUST retry with the v-prefixed form (`v1.6.0`).

## Real-world driver

GitHub Releases tag conventions vary: some operators publish only `v1.6.0`, some only `1.6.0`, some both. The `.sh`'s retry-with-v-prefix is the operator-friendly compatibility shim. Without coverage, regressions in this path break operators on legacy / private mirrors silently.

## Production failure modes regression-pinned

- `.sh` stops retrying on plain 404 → operator on legacy mirror sees install fail with `"could not download 1.6.0"` even though `v1.6.0` IS published
- `.sh` doesn't echo the retry attempt → operators have no log signal that the fallback was tried (vs "single shot fail")
- `.sh`'s exit-on-failure regression after retry → silently swallows the v-prefix 404 and exits 0 with no actual install

## Test mechanism — surgical 404

```csharp
ctx.Mirror.ConfigureNotFoundForPath($"/download/{version}/");
```

New `ConfigureNotFoundForPath` API does substring match on URL `AbsolutePath`. The **leading slash** in `"/download/<version>/"` makes it NOT match the v-prefixed sibling `"/download/v<version>/"` because the leading character of the version segment differs.

`ConfigureNotFoundForVersion("1.6.0-vfallback")` would have 404'd BOTH URLs (substring `"1.6.0-vfallback"` appears in both paths). The new API is the strict-substring escape hatch needed for path-disambiguating tests.

## Assertions

| Assertion | Pins |
|---|---|
| `exitCode == 0` | Fallback succeeded |
| stdout contains `"retrying with 'v<version>'"` | `.sh` line 236 retry log fires |
| stdout echoes the v-prefixed URL | Operators verify which form worked |
| `INSTALL_DIR/Squid.Tentacle` exists | Binary actually downloaded via v-prefix path |
| `/usr/local/bin/squid-tentacle` symlink exists | Post-extract steps ran the same way as plain-URL happy path |

## Infrastructure additions

`LocalReleaseMirror.ConfigureNotFoundForPath(string pathSubstring)` — surgical 404 sibling of `ConfigureNotFoundForVersion`. Composes with `StagePreBuiltArchive`: configure 404 for the plain path, archive serves at the v-prefixed path.

## Fidelity tier

🟢 **High** (Rule 12.4): real `.sh` + real bash + real curl + real `LocalReleaseMirror` responding 404 vs 200 per-URL. No mocks at OS-resource layer.

Test runs in `LinuxTentacleHostStateCollection` (serializes against upgrade + service-fixture tests on shared host state).

Expected runtime: ~5s.

## Test plan

- [ ] Linux E2E workflow runs (manual `workflow_dispatch` after merge)
- [ ] `A2u2_PlainVersion404FallsBackToVPrefix_InstallSucceeds` passes within ~10s
- [ ] No regression on existing 22 Linux E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)