### PR TITLE
feat(LinuxTentacleE2E): Phase 12.M.L.B.0 — LinuxTentacleBinaryFixture (real binary build)

### DIFF
--- a/.github/workflows/tentacle-linux-e2e.yml
+++ b/.github/workflows/tentacle-linux-e2e.yml
@@ -24,7 +24,7 @@ on:
       test_filter:
         description: "xUnit --filter for the Squid.LinuxTentacleE2ETests step"
         required: false
-        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleInstallScriptE2E"
+        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleInstallScriptE2E|Category=LinuxTentacleBinaryE2E"
 
 permissions:
   contents: read

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxTentacleBinaryFixture.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxTentacleBinaryFixture.cs
@@ -1,0 +1,235 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 12.M.L.B.0+ — fixture that builds the REAL <c>Squid.Tentacle</c>
+/// binary (self-contained linux-x64) once per test process and shares
+/// the path across all tests that need to drive its CLI surface.
+///
+/// <para>UNBLOCKS Section B (service-lifecycle CLI), Section C (register),
+/// and Section G (multi-instance) — none of these can be tested with
+/// the bash-script placeholder used for upgrade-flow E2E (the placeholder
+/// has no <c>register</c> / <c>service install</c> handlers).</para>
+///
+/// <para><b>Why a real binary, not a placeholder</b>: the production
+/// <c>squid-tentacle service install</c> command writes a systemd unit
+/// that references the binary's actual path; <c>register</c> performs
+/// real REST POST + cert validation; <c>create-instance</c> walks
+/// real config dir layouts. Mocking these would slip to medium-fidelity
+/// (Rule 12 tier 🟡) and miss the binding-layer regressions an E2E
+/// is supposed to catch.</para>
+///
+/// <para><b>Build strategy</b>: <c>dotnet publish</c> with the same flags
+/// production CI uses (<c>-r linux-x64 --self-contained true
+/// -p:PublishSingleFile=true</c>) into a stable cache path under
+/// <c>bin/</c>. First call to <see cref="EnsureBuilt"/> takes ~20-30s
+/// (cold .NET SDK build); subsequent calls return immediately from
+/// the cached binary path.</para>
+///
+/// <para><b>Process-wide singleton</b>: build under a <see cref="object"/>
+/// lock so concurrent test classes that share the binary don't race
+/// on the dotnet publish invocation. xUnit's
+/// <c>LinuxTentacleHostStateCollection</c> serializes the consumers,
+/// but the collection's first test is what triggers the build — if
+/// classes ever escape the collection, the lock prevents double-build.</para>
+///
+/// <para><b>Skip-on-non-Linux</b>: the binary is built for linux-x64
+/// self-contained → won't run on macOS / Windows. <see cref="IsAvailable"/>
+/// returns true only on Linux + when <c>dotnet</c> is on PATH.</para>
+/// </summary>
+public sealed class LinuxTentacleBinaryFixture
+{
+    private static readonly object _buildLock = new();
+    private static string _cachedBinaryPath;
+
+    /// <summary>
+    /// Pinned version stamp baked into the binary at publish time via
+    /// <c>-p:Version=...</c>. The <c>version</c> subcommand reads
+    /// <c>AssemblyVersion.Canonical</c> and emits this string verbatim
+    /// (modulo trailing <c>.0</c> revision which is stripped). Tests
+    /// can <c>ShouldBe(BuildVersion)</c> against the binary's stdout to
+    /// confirm the build pipeline is wired correctly.
+    /// </summary>
+    public const string BuildVersion = "1.0.0-binarytest";
+
+    public static bool IsAvailable => OperatingSystem.IsLinux() && IsDotnetOnPath();
+
+    /// <summary>
+    /// Builds the binary if not already cached. Returns the absolute path
+    /// to the executable. Idempotent + thread-safe.
+    /// </summary>
+    public string EnsureBuilt()
+    {
+        lock (_buildLock)
+        {
+            if (_cachedBinaryPath != null && File.Exists(_cachedBinaryPath))
+                return _cachedBinaryPath;
+
+            var binaryPath = Build();
+
+            if (!File.Exists(binaryPath))
+                throw new InvalidOperationException(
+                    $"dotnet publish completed but binary not found at expected path: {binaryPath}. " +
+                    "Likely cause: production csproj's OutputType / publish target changed (Squid.Tentacle no longer produces a single-file Exe). " +
+                    "Confirm via `dotnet publish ... -o <out>` and inspect the directory.");
+
+            _cachedBinaryPath = binaryPath;
+            return _cachedBinaryPath;
+        }
+    }
+
+    /// <summary>
+    /// Runs the binary with the given args + a clean environment.
+    /// Returns (exitCode, combined stdout+stderr). 60s wall-clock cap —
+    /// individual subcommands like <c>version</c> are sub-second; longer
+    /// timeouts indicate hangs that should fail-fast.
+    /// </summary>
+    public (int exitCode, string output) Run(params string[] args)
+    {
+        var binaryPath = EnsureBuilt();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to launch {binaryPath}");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        if (!proc.WaitForExit(60_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException($"{binaryPath} {string.Join(' ', args)} did not complete within 60s.");
+        }
+
+        return (proc.ExitCode, stdoutTask.Result + Environment.NewLine + stderrTask.Result);
+    }
+
+    private static string Build()
+    {
+        var repoRoot = LocateRepoRoot();
+        var csproj = Path.Combine(repoRoot, "src", "Squid.Tentacle", "Squid.Tentacle.csproj");
+
+        if (!File.Exists(csproj))
+            throw new FileNotFoundException(
+                $"Could not locate Squid.Tentacle.csproj at {csproj}. Repo root resolved to {repoRoot}.");
+
+        // Stable cache path under the test assembly's bin/. Survives between
+        // test runs but cleared by `dotnet clean` / `git clean -xdf bin/`.
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var outputDir = Path.Combine(thisAssemblyDir, "squid-tentacle-binary-fixture", "linux-x64");
+
+        Directory.CreateDirectory(outputDir);
+
+        // Mirror production CI's publish flags exactly (build-publish-linux-
+        // tentacle.yml line 229+) — single self-contained binary, stamped
+        // version. Differences from production:
+        //   - Version: pinned to BuildVersion so tests can assert on it
+        //   - Configuration: Release (production also uses Release)
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("publish");
+        psi.ArgumentList.Add(csproj);
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add("Release");
+        psi.ArgumentList.Add("-r");
+        psi.ArgumentList.Add("linux-x64");
+        psi.ArgumentList.Add("--self-contained");
+        psi.ArgumentList.Add("true");
+        psi.ArgumentList.Add("-p:PublishSingleFile=true");
+        psi.ArgumentList.Add($"-p:Version={BuildVersion}");
+        psi.ArgumentList.Add("-o");
+        psi.ArgumentList.Add(outputDir);
+        // Quiet verbosity — full build log isn't useful for test diagnosis;
+        // errors still surface on stderr.
+        psi.ArgumentList.Add("--verbosity");
+        psi.ArgumentList.Add("quiet");
+        psi.ArgumentList.Add("--nologo");
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start dotnet publish");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        // Cold .NET SDK + restore + publish + self-contained runtime
+        // bundle ≈ 30-60s; budget 5min for the worst case (CI cold cache,
+        // fresh NuGet downloads).
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException(
+                "dotnet publish did not complete within 5min. Cold cache + NuGet restore typically takes 1-2min; longer indicates a build hang OR a dependency network issue.");
+        }
+
+        if (proc.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet publish failed with exit {proc.ExitCode}.\n" +
+                $"stdout: {stdoutTask.Result}\n" +
+                $"stderr: {stderrTask.Result}");
+        }
+
+        return Path.Combine(outputDir, "Squid.Tentacle");
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            // Repo root marker: presence of .github/ + src/Squid.Tentacle/
+            var githubDir = Path.Combine(dir, ".github");
+            var tentacleDir = Path.Combine(dir, "src", "Squid.Tentacle");
+            if (Directory.Exists(githubDir) && Directory.Exists(tentacleDir))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (no .github/ + src/Squid.Tentacle/ ancestor of {thisAssemblyDir}).");
+    }
+
+    private static bool IsDotnetOnPath()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("--version");
+
+            using var proc = Process.Start(psi);
+            if (proc == null) return false;
+            proc.WaitForExit(5_000);
+            return proc.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxTentacleBinaryFixture.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxTentacleBinaryFixture.cs
@@ -47,12 +47,31 @@ public sealed class LinuxTentacleBinaryFixture
     /// <summary>
     /// Pinned version stamp baked into the binary at publish time via
     /// <c>-p:Version=...</c>. The <c>version</c> subcommand reads
-    /// <c>AssemblyVersion.Canonical</c> and emits this string verbatim
-    /// (modulo trailing <c>.0</c> revision which is stripped). Tests
-    /// can <c>ShouldBe(BuildVersion)</c> against the binary's stdout to
-    /// confirm the build pipeline is wired correctly.
+    /// <see cref="AssemblyVersion.Canonical"/> which is computed from
+    /// the binary's NUMERIC <c>AssemblyName.Version</c> (4-part
+    /// <c>Major.Minor.Build.Revision</c>), with trailing <c>.0</c>
+    /// stripped — pre-release suffixes from
+    /// <c>AssemblyInformationalVersion</c> are NOT included.
+    ///
+    /// <para>Therefore <see cref="BuildVersion"/> must be a 3-component
+    /// numeric version. <c>99.99.99</c> chosen so it's:
+    /// <list type="bullet">
+    ///   <item>Distinguishable from any real production version
+    ///         (currently 1.x — semver guard against accidental
+    ///         match if test fixture leaks into production paths).</item>
+    ///   <item>Survives <see cref="AssemblyVersion.Canonical"/>'s
+    ///         computation unchanged: published Version="99.99.99" →
+    ///         numeric "99.99.99.0" → strip ".0" → "99.99.99".</item>
+    /// </list></para>
+    ///
+    /// <para>J.M.L.B.0 first runner caught my wrong assumption that
+    /// <c>-p:Version=1.0.0-binarytest</c> would propagate the
+    /// pre-release suffix to <c>version</c>'s output. It doesn't:
+    /// AssemblyVersion is numeric only, the suffix lives in a
+    /// different attribute. Test pinned this with the corrected
+    /// 99.99.99 value.</para>
     /// </summary>
-    public const string BuildVersion = "1.0.0-binarytest";
+    public const string BuildVersion = "99.99.99";
 
     public static bool IsAvailable => OperatingSystem.IsLinux() && IsDotnetOnPath();
 

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
@@ -46,6 +46,24 @@ public static class LinuxTentacleE2ECategories
     public const string ServiceFixture = "LinuxServiceFixtureE2E";
 
     /// <summary>
+    /// Phase 12.M.L.B.0+ E2E coverage for the real production
+    /// <c>Squid.Tentacle</c> binary's CLI surface (<c>version</c>,
+    /// <c>service install/start/stop/uninstall</c>, <c>register</c>,
+    /// <c>create-instance</c>, etc.).
+    ///
+    /// <para>Tier 🟢 high-fidelity — drives the actual published binary
+    /// (built via <c>dotnet publish -r linux-x64 --self-contained</c>
+    /// matching production CI) against real systemd / real REST stub.
+    /// UNBLOCKS Section B (service-lifecycle CLI), Section C (register),
+    /// and Section G (multi-instance) which can't be covered with the
+    /// bash-script placeholder used for upgrade-flow E2E.</para>
+    ///
+    /// <para>Linux-only; the fixture's binary is a self-contained
+    /// <c>linux-x64</c> bundle that won't run on macOS / Windows.</para>
+    /// </summary>
+    public const string TentacleBinary = "LinuxTentacleBinaryE2E";
+
+    /// <summary>
     /// Phase 12.M.L.A.1+ E2E coverage for the production
     /// <c>deploy/scripts/install-tentacle.sh</c> bootstrap installer.
     /// Tier 🟢 high-fidelity — drives the real <c>.sh</c> against a real

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxBinarySmokeE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxBinarySmokeE2ETests.cs
@@ -1,0 +1,113 @@
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.M.L.B.0 — smoke tests for <see cref="LinuxTentacleBinaryFixture"/>.
+/// Tier 🔵 Fixture-only (Rule 12) — proves the build pipeline works
+/// (fixture compiles + binary runs + reports the expected version)
+/// before downstream Section B/C/G tests consume it.
+///
+/// <para>Why a smoke layer matters: the binary is built via
+/// <c>dotnet publish</c> which has many failure modes (missing SDK,
+/// network restore failure, csproj target drift, RID mismatch). A
+/// dedicated smoke test surfaces these failures BEFORE the bigger
+/// downstream tests start using the binary — much easier to debug
+/// "build failed" at smoke vs "register test mysteriously failed".</para>
+///
+/// <para>Mirrors the <see cref="LinuxServiceFixtureSmokeE2ETests"/>
+/// pattern: the fixture is fixture-only-tier; downstream tests that
+/// USE the fixture for production-flow E2E are tier 🟢 H.</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.TentacleBinary)]
+[Collection(LinuxTentacleHostStateCollection.Name)]
+public sealed class TentacleLinuxBinarySmokeE2ETests
+{
+    // ========================================================================
+    // Binary_Version_PrintsExpectedString
+    //
+    // Smallest viable smoke: build the binary + run `version` + assert
+    // the canonical-version string the production CLI prints matches the
+    // fixture's published version stamp.
+    //
+    // Catches:
+    //   - dotnet publish fails entirely (build pipeline regression)
+    //   - PublishSingleFile target produces a different output path
+    //   - VersionCommand regression (CLI prints something other than
+    //     AssemblyVersion.Canonical)
+    //   - -p:Version flag doesn't propagate to AssemblyInformationalVersion
+    //
+    // Why this test FIRST (before service / register tests): the most
+    // likely failure mode for J.M.L.B.0 is the build itself; downstream
+    // tests would then fail with cascading errors. Smoke isolates the
+    // build success contract.
+    // ========================================================================
+
+    [Fact]
+    public void Binary_Version_PrintsBuildVersionStamp()
+    {
+        if (!LinuxTentacleBinaryFixture.IsAvailable) return;
+
+        var fixture = new LinuxTentacleBinaryFixture();
+
+        var (exitCode, output) = fixture.Run("version");
+
+        exitCode.ShouldBe(0,
+            customMessage: $"`squid-tentacle version` MUST exit 0. Got exit {exitCode}. " +
+                          $"If non-zero: VersionCommand has a bug OR the binary is broken (build pipeline regression). " +
+                          $"output:\n{output}");
+
+        // VersionCommand reads AssemblyVersion.Canonical which is derived
+        // from -p:Version=BuildVersion. Production strips trailing `.0`
+        // revision (e.g. "1.0.0.0" → "1.0.0"), but our BuildVersion is
+        // a pre-release form ("1.0.0-binarytest") which has no .0 to strip.
+        // The output should match BuildVersion exactly (modulo whitespace).
+        output.Trim().ShouldBe(LinuxTentacleBinaryFixture.BuildVersion,
+            customMessage: $"`squid-tentacle version` stdout MUST be exactly '{LinuxTentacleBinaryFixture.BuildVersion}' " +
+                          $"(the -p:Version stamp the fixture passes to dotnet publish). " +
+                          $"Got: '{output.Trim()}'. " +
+                          $"If different: AssemblyVersion.Canonical computation regressed, OR -p:Version flag is being overridden by the csproj's <Version> property, " +
+                          $"OR Console.WriteLine is emitting extra text. " +
+                          $"Full output:\n{output}");
+    }
+
+    // ========================================================================
+    // Binary_NoArgs_DoesNotCrash
+    //
+    // Sanity: invoking the binary with no args goes through CommandResolver's
+    // default-to-RunCommand path. RunCommand starts the agent; without a
+    // valid config it should fail-fast with a clear error, NOT segfault /
+    // hang. We invoke with a 5s window (binary should respond well within
+    // that with a config-missing error) then kill it.
+    //
+    // Why this matters: regressions in CommandResolver / Program.cs Main
+    // (e.g. unhandled exception path that bypasses the help prompt) would
+    // surface here as a hang or crash. Catches at smoke tier so downstream
+    // service tests don't have to deal with it.
+    // ========================================================================
+
+    [Fact]
+    public void Binary_NoArgs_FailsClearlyWithoutHanging()
+    {
+        if (!LinuxTentacleBinaryFixture.IsAvailable) return;
+
+        var fixture = new LinuxTentacleBinaryFixture();
+
+        // Run without args. Expected: RunCommand path tries to start the
+        // agent with default config → fails fast (config not found / no
+        // instance registered) within seconds. We don't assert on the
+        // exact exit code (different config-error code paths), just that
+        // SOMETHING happens within the timeout (the fixture's 60s budget
+        // is the worst-case ceiling).
+        var (exitCode, output) = fixture.Run(/* no args */);
+
+        // Either a clean non-zero (config error) or 0 (if it somehow
+        // started successfully — unlikely without setup). The point is:
+        // didn't hang past the fixture timeout, didn't crash without
+        // any output.
+        output.ShouldNotBeNullOrEmpty(
+            customMessage: $"binary with no args produced empty stdout+stderr. Either it hung past the timeout (already caught by Run's 60s cap) " +
+                          $"OR crashed silently (segfault). Exit code: {exitCode}. " +
+                          "Production binary's RunCommand path should always produce some log output before exiting.");
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxBinarySmokeE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxBinarySmokeE2ETests.cs
@@ -57,14 +57,16 @@ public sealed class TentacleLinuxBinarySmokeE2ETests
                           $"If non-zero: VersionCommand has a bug OR the binary is broken (build pipeline regression). " +
                           $"output:\n{output}");
 
-        // VersionCommand reads AssemblyVersion.Canonical which is derived
-        // from -p:Version=BuildVersion. Production strips trailing `.0`
-        // revision (e.g. "1.0.0.0" → "1.0.0"), but our BuildVersion is
-        // a pre-release form ("1.0.0-binarytest") which has no .0 to strip.
-        // The output should match BuildVersion exactly (modulo whitespace).
+        // VersionCommand reads AssemblyVersion.Canonical which is computed
+        // from the numeric AssemblyName.Version (Major.Minor.Build.Revision)
+        // with trailing `.0` Revision stripped. Pre-release suffixes from
+        // AssemblyInformationalVersion are NOT included — caught by the
+        // J.M.L.B.0 first runner where I'd assumed the suffix would
+        // propagate. BuildVersion is now a numeric 3-part value chosen to
+        // survive the Canonical computation unchanged.
         output.Trim().ShouldBe(LinuxTentacleBinaryFixture.BuildVersion,
             customMessage: $"`squid-tentacle version` stdout MUST be exactly '{LinuxTentacleBinaryFixture.BuildVersion}' " +
-                          $"(the -p:Version stamp the fixture passes to dotnet publish). " +
+                          $"(the -p:Version stamp the fixture passes to dotnet publish, after AssemblyVersion.Canonical strips the trailing .0 revision). " +
                           $"Got: '{output.Trim()}'. " +
                           $"If different: AssemblyVersion.Canonical computation regressed, OR -p:Version flag is being overridden by the csproj's <Version> property, " +
                           $"OR Console.WriteLine is emitting extra text. " +


### PR DESCRIPTION
## Summary

**Big-infrastructure PR.** UNBLOCKS Section B (service-lifecycle CLI), Section C (register), and Section G (multi-instance) — none of these can be tested with the bash-script placeholder used for upgrade-flow E2E.

User direction (option a3 of self-audit after 26-test stage close): build the real binary fixture as a one-time investment to unlock the most important remaining functionality (register + service-lifecycle).

## Strategy

| Aspect | Choice | Rationale |
|---|---|---|
| Build flags | Mirror production CI exactly | Same as `build-publish-linux-tentacle.yml`: `-c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -p:Version=<stamp>` |
| Cache location | `bin/squid-tentacle-binary-fixture/linux-x64/` | Stable path under bin/, survives between runs, cleared by `dotnet clean` |
| Concurrency | Process-wide singleton via static lock | First test triggers ~30-60s build, subsequent reuse instantly |
| Skip-on-non-Linux | `IsAvailable` checks Linux + dotnet on PATH | Self-contained linux-x64 binary won't run on macOS/Windows |

## Why a real binary, not a placeholder

| Without real binary | With real binary |
|---|---|
| `service install` writes systemd unit pointing at fake binary → unit fails to start | Real binary path → real systemd start works |
| `register` requires real REST POST + cert validation | Production binary handles it |
| `create-instance` walks real config dir layouts | Production binary's `InstanceRegistry` does it |
| Would need Tier 🟡 mocking | Stays at Tier 🟢 H per Rule 12.4 |

## Scope of THIS PR

**Smallest viable foundation** + 2 smoke tests:

- `LinuxTentacleBinaryFixture` infrastructure (build + cache + run helper)
- `LinuxTentacleE2ECategories.TentacleBinary` trait constant
- `tentacle-linux-e2e.yml` workflow filter updated
- Smoke test class:
  - `Binary_Version_PrintsBuildVersionStamp` — proves build pipeline + AssemblyVersion.Canonical regression check
  - `Binary_NoArgs_FailsClearlyWithoutHanging` — sanity for default RunCommand path

## What this PR does NOT include

Deferred to follow-up PRs to keep this reviewable:

- **J.M.L.C.1+** register E2E (needs StubSquidServer-equivalent for Linux project)
- **J.M.L.B.1+** service install/start/stop E2E (uses this fixture + `LinuxServiceFixture`, no server needed)
- **J.M.L.G.1+** multi-instance E2E

## Fidelity tier

🔵 **Fixture-only** (Rule 12) for the smoke tests. Downstream production-flow tests (J.M.L.B.1+ / J.M.L.C.1+) that USE this fixture will be tier 🟢 H.

## Expected runtime

- **Cold (first run)**: 30-60s for `dotnet publish`
- **Warm (subsequent)**: <100ms per test
- **CI ubuntu-latest with cold NuGet cache**: ~60-90s for first build

## Test plan

- [ ] Linux E2E workflow runs (manual `workflow_dispatch` after merge)
- [ ] `Binary_Version_PrintsBuildVersionStamp` passes within 90s (first runner; build + assert)
- [ ] `Binary_NoArgs_FailsClearlyWithoutHanging` passes within ~5s (uses cached binary)
- [ ] No regression on existing 26 Linux E2E tests
- [ ] Workflow filter picks up new `Category=LinuxTentacleBinaryE2E` traited tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)