### PR TITLE
feat(LinuxTentacleE2E): Phase 12.M.L.B.2 — `service install` idempotent re-run E2E

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxServiceCommandE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxServiceCommandE2ETests.cs
@@ -141,6 +141,106 @@ public sealed class TentacleLinuxServiceCommandE2ETests
         ctx.MarkClean();
     }
 
+    // ========================================================================
+    // B2.h-Linux — `service install` is idempotent (re-run succeeds on
+    //               existing-service state)
+    //
+    // Production scenario this pins: operators re-run the documented
+    // post-install step:
+    //
+    //   sudo squid-tentacle service install   (first time)
+    //   sudo squid-tentacle service install   (refresh / repair / fleet
+    //                                          automation re-trigger)
+    //
+    // Real-world drivers:
+    //   - Fleet automation (Ansible / Salt) re-runs install playbooks on
+    //     every host on every reboot for self-healing
+    //   - Operator sees a stuck service, runs install again as part of
+    //     "have you tried turning it off and on again"
+    //   - Upgrade flow's prerequisite: install-tentacle.sh (J.M.L.A.4
+    //     covers its idempotency) is followed by `service install` —
+    //     any operator script that wraps both must work twice
+    //
+    // Without this pin, a regression that adds a "service already exists,
+    // refusing to install" check ships silently and breaks every fleet
+    // refresh AND every operator self-healing attempt.
+    //
+    // The .sh's design IS idempotent today (per code inspection of
+    // SystemdServiceHost.Install):
+    //   - File.WriteAllText (overwrites existing unit file)
+    //   - systemctl daemon-reload (idempotent)
+    //   - systemctl enable (idempotent — already-enabled is no-op)
+    //   - systemctl start (idempotent — already-running is no-op)
+    //
+    // Test mechanism: install once (J.M.L.B.1's path), then install AGAIN
+    // with the same --service-name. Both must exit 0 + final unit file
+    // content unchanged (re-install is non-destructive overwrite of the
+    // same content).
+    //
+    // Tier: 🟢 H (Rule 12.4) — real production binary + real systemd.
+    //
+    // Expected runtime: ~2× single install (~5-8s).
+    // ========================================================================
+
+    [Fact]
+    public void B2h_ServiceInstall_IdempotentReRunSucceeds()
+    {
+        if (!LinuxTentacleBinaryFixture.IsAvailable) return;
+        if (!LinuxServiceFixture.IsAvailable) return;
+
+        using var ctx = new ServiceCommandTestContext();
+
+        // ── Run 1: clean install ────────────────────────────────────────────
+        var (exit1, output1) = ctx.Binary.SudoRun("service", "install", "--service-name", ctx.ServiceName);
+
+        exit1.ShouldBe(0,
+            customMessage: $"first install MUST succeed before idempotency can be tested. Got exit {exit1}.\noutput:\n{output1}");
+
+        var unitPath = $"/etc/systemd/system/{ctx.ServiceName}.service";
+        LinuxInstallScriptContext.SudoFileExists(unitPath).ShouldBeTrue("first install must write the unit file");
+
+        // Capture unit content for comparison after re-install.
+        var contentAfterRun1 = LinuxInstallScriptContext.SudoReadAllText(unitPath);
+        contentAfterRun1.ShouldNotBeNullOrEmpty("first install must produce non-empty unit content");
+
+        // ── Run 2: re-run on existing state ────────────────────────────────
+        // No cleanup between runs — the binary's idempotency contract MUST
+        // handle: existing unit file, already-enabled service, already-
+        // running service.
+        var (exit2, output2) = ctx.Binary.SudoRun("service", "install", "--service-name", ctx.ServiceName);
+
+        exit2.ShouldBe(0,
+            customMessage: $"SECOND `service install --service-name {ctx.ServiceName}` MUST succeed (idempotent contract). Got exit {exit2}. " +
+                          $"If 1: regression in idempotency — likely added an 'already exists, refusing' check, OR daemon-reload/enable started rejecting already-active state, OR File.WriteAllText changed to fail-if-exists. " +
+                          $"output:\n{output2}");
+
+        // Unit file content unchanged. WriteAllText overwrites with the
+        // SAME content (the binary regenerates the same unit text from
+        // the same input). Pin this contract: re-install must not alter
+        // unit content (otherwise it's not really idempotent — stale
+        // ExecArgs / Description drift across re-runs).
+        var contentAfterRun2 = LinuxInstallScriptContext.SudoReadAllText(unitPath);
+        contentAfterRun2.ShouldBe(contentAfterRun1,
+            customMessage: $"unit file content MUST be byte-identical after re-install. " +
+                          "If different: the binary is regenerating different content for the same input — operators see drift between re-runs, undermining the idempotency contract operators depend on. " +
+                          $"\n\nRun 1 content:\n{contentAfterRun1}\n\nRun 2 content:\n{contentAfterRun2}");
+
+        // Reverse-assert: no spurious error log. The .sh's overwrite path
+        // shouldn't log anything that looks like an error or warning.
+        output2.ShouldNotContain("already exists",
+            customMessage: "second-run stdout MUST NOT contain 'already exists' — that signal indicates a regression where idempotency was broken by adding an error-on-existing-state check.");
+
+        output2.ShouldNotContain("Permission denied",
+            customMessage: "second-run stdout MUST NOT contain 'Permission denied' — would indicate a stale unit file ownership issue blocking the overwrite.");
+
+        // Cleanup via the production CLI.
+        var (uninstallExit, _) = ctx.Binary.SudoRun("service", "uninstall", "--service-name", ctx.ServiceName);
+        uninstallExit.ShouldBe(0, "uninstall must succeed to leave clean state for next test");
+
+        ctx.MarkUninstalled();
+        ctx.MarkClean();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /// <summary>


### PR DESCRIPTION
## Summary

Pins the contract that re-running `sudo squid-tentacle service install` on an existing-service host is a **non-destructive no-op**. Critical for fleet automation + operator self-healing.

## Real-world drivers

- Fleet automation (Ansible / Salt) re-runs install playbooks on every reboot for self-healing
- Operator's "have you tried install again" reflex
- Composes with J.M.L.A.4's `install-tentacle.sh` idempotency: any operator wrapper that runs both `.sh` + `service install` must work twice end-to-end

Without this pin, a regression that adds an *"already exists, refusing to install"* check ships silently and breaks every fleet refresh.

## The binary's design IS idempotent today

Per `SystemdServiceHost.Install` inspection:
- `File.WriteAllText` **overwrites** unit file
- `systemctl daemon-reload` idempotent
- `systemctl enable` on already-enabled = no-op
- `systemctl start` on already-running = no-op

This test PINS those properties so a future regression fires CI immediately.

## Test mechanism

Install twice in succession with **NO cleanup between runs**, assert both exit 0 + unit file content byte-identical (same inputs → same regenerated content).

## Assertions

| Assertion | Pins |
|---|---|
| Run 1 exit 0 | Sanity baseline |
| **Run 2 exit 0** | **Idempotency contract** |
| Run 2 unit content == Run 1 content | Catches drift in regeneration (Description / ExecArgs / RestartSec) |
| Run 2 stdout does NOT contain `"already exists"` | No regression to error-on-existing-state path |
| Run 2 stdout does NOT contain `"Permission denied"` | No stale-ownership issue blocking overwrite |

## Fidelity tier

🟢 **High** (Rule 12.4): real production binary + real systemd. Composes with J.M.L.B.1's fixture + cleanup pattern.

Expected runtime: ~5-8s.

## Test plan

- [ ] Linux E2E workflow runs (manual `workflow_dispatch` after merge)
- [ ] `B2h_ServiceInstall_IdempotentReRunSucceeds` passes within ~10s
- [ ] No regression on existing 29 Linux E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)