### PR TITLE
feat(LinuxTentacleE2E): Phase 12.M.L.C.1 — first register E2E (Listening flavor) + slim StubSquidServer

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxStubSquidServer.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxStubSquidServer.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 12.M.L.C.1+ — slim in-process HTTP REST stub of the Squid
+/// server's <c>register</c> endpoint, used by Linux register E2E tests.
+///
+/// <para><b>Why a slim Linux-specific stub vs sharing Windows project's
+/// StubSquidServer</b>: the Windows project's full StubSquidServer
+/// includes Halibut polling listener + cert generation (~600 lines)
+/// — needed for the Windows upgrade-flow / dispatch tests but
+/// overkill for register E2E. This slim version is ~120 lines and
+/// only handles the register REST surface, keeping the Linux project
+/// self-contained without cross-project coupling.</para>
+///
+/// <para><b>What it provides:</b>
+/// <list type="bullet">
+///   <item>HTTP listener on a random loopback port (no admin / TLS setup).</item>
+///   <item>Routes <c>POST /api/machines/register/tentacle-listening</c> +
+///         <c>POST /api/machines/register/tentacle-polling</c> to a
+///         canned response with the configured <see cref="ServerThumbprint"/>.</item>
+///   <item><see cref="ReceivedRegistrations"/> records every register
+///         request body so tests can assert on payload shape (machineName,
+///         roles, thumbprint, etc.).</item>
+///   <item><see cref="ConfigureRegisterStatusCode"/> +
+///         <see cref="ConfigureRegisterBody"/> let failure-path tests
+///         inject 401 / 500 / malformed responses.</item>
+/// </list></para>
+///
+/// <para><b>HTTP not HTTPS</b>: non-root binding + no cert ACL = simpler.
+/// The production binary's <c>EnsureSchemeSafeForSecret</c> warns on
+/// <c>http://</c> but proceeds (Rule 11 enforcement Warn mode by default),
+/// so the stub works without SSL.</para>
+/// </summary>
+public sealed class LinuxStubSquidServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly Task _acceptLoop;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly ConcurrentBag<RegisterRequestRecord> _received = new();
+    private int _registerStatusCode = 200;
+    private string _registerBodyOverride;
+
+    /// <summary>Stub server thumbprint returned in register responses.</summary>
+    public string ServerThumbprint { get; } = "STUB1234567890ABCDEF1234567890ABCDEF1234";
+
+    /// <summary>Base URL operators pass via <c>--server</c>. Includes scheme + port + trailing slash.</summary>
+    public Uri BaseUrl { get; }
+
+    public IReadOnlyList<RegisterRequestRecord> ReceivedRegistrations => _received.ToArray();
+
+    private LinuxStubSquidServer(HttpListener listener, Uri baseUrl)
+    {
+        _listener = listener;
+        BaseUrl = baseUrl;
+        _acceptLoop = Task.Run(AcceptLoopAsync);
+    }
+
+    public static LinuxStubSquidServer Start()
+    {
+        // Allocate a random loopback port via TcpListener(0), then close
+        // before binding HttpListener (small race window acceptable for tests).
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        var baseUrl = new Uri($"http://127.0.0.1:{port}/");
+        var listener = new HttpListener();
+        listener.Prefixes.Add(baseUrl.ToString());
+        listener.Start();
+
+        return new LinuxStubSquidServer(listener, baseUrl);
+    }
+
+    /// <summary>Override the register status code (default: 200). Tests injecting 401 / 500 use this.</summary>
+    public void ConfigureRegisterStatusCode(int statusCode) => _registerStatusCode = statusCode;
+
+    /// <summary>Override the register response body (default: canonical success). Tests injecting malformed JSON / missing fields use this.</summary>
+    public void ConfigureRegisterBody(string body) => _registerBodyOverride = body;
+
+    private async Task AcceptLoopAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            HttpListenerContext ctx;
+            try
+            {
+                ctx = await _listener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Listener disposed mid-await — exit loop cleanly.
+                return;
+            }
+
+            try { HandleRequest(ctx); }
+            catch
+            {
+                // Don't let a per-request exception kill the loop;
+                // best-effort response close.
+                try { ctx.Response.StatusCode = 500; ctx.Response.OutputStream.Close(); } catch { }
+            }
+        }
+    }
+
+    private void HandleRequest(HttpListenerContext ctx)
+    {
+        var path = ctx.Request.Url?.AbsolutePath ?? string.Empty;
+
+        // Both flavors hit /api/machines/register/<flavor> with the same
+        // shape envelope. Record + respond to either.
+        if (path.StartsWith("/api/machines/register/", StringComparison.OrdinalIgnoreCase)
+            && ctx.Request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase))
+        {
+            HandleRegister(ctx, path);
+            return;
+        }
+
+        // Anything else: 404. Tests that rely on a specific endpoint
+        // surface this immediately rather than hanging.
+        ctx.Response.StatusCode = 404;
+        ctx.Response.OutputStream.Close();
+    }
+
+    private void HandleRegister(HttpListenerContext ctx, string path)
+    {
+        // Read the request body (UTF-8 JSON).
+        string body;
+        using (var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8))
+            body = reader.ReadToEnd();
+
+        // Capture headers operators may want to assert on (X-API-KEY etc.).
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in ctx.Request.Headers.AllKeys)
+            if (name != null) headers[name] = ctx.Request.Headers[name] ?? string.Empty;
+
+        _received.Add(new RegisterRequestRecord(path, body, headers));
+
+        // Build response (or use override).
+        var responseBody = _registerBodyOverride ?? BuildSuccessResponseBody();
+        var responseBytes = Encoding.UTF8.GetBytes(responseBody);
+
+        ctx.Response.StatusCode = _registerStatusCode;
+        ctx.Response.ContentType = "application/json";
+        ctx.Response.ContentLength64 = responseBytes.Length;
+        ctx.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+        ctx.Response.OutputStream.Close();
+    }
+
+    private string BuildSuccessResponseBody()
+    {
+        // Schema must match TentacleRegistrationClient.RegistrationResponse
+        // (camelCase via JsonNamingPolicy.CamelCase): { data: { machineId,
+        // serverThumbprint, subscriptionUri } }. MachineId must be > 0
+        // for EnsureRegistrationPayloadComplete to accept.
+        var payload = new
+        {
+            data = new
+            {
+                machineId = 12345,
+                serverThumbprint = ServerThumbprint,
+                subscriptionUri = $"poll://stub-{Guid.NewGuid():N}/"
+            }
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    public void Dispose()
+    {
+        try { _cts.Cancel(); } catch { /* best-effort */ }
+        try { _listener.Stop(); } catch { /* best-effort */ }
+        try { _acceptLoop.Wait(2_000); } catch { /* best-effort */ }
+        try { _listener.Close(); } catch { /* best-effort */ }
+        try { _cts.Dispose(); } catch { /* best-effort */ }
+    }
+}
+
+/// <summary>
+/// One captured register call. Used by tests to assert on the payload
+/// the production binary actually sent.
+/// </summary>
+public sealed record RegisterRequestRecord(string Path, string Body, Dictionary<string, string> Headers);

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxRegisterE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxRegisterE2ETests.cs
@@ -1,0 +1,244 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.M.L.C.1+ — E2E coverage for <c>squid-tentacle register</c>
+/// against a slim in-process REST stub
+/// (<see cref="LinuxStubSquidServer"/>). Drives the REAL production
+/// binary built by <see cref="LinuxTentacleBinaryFixture"/> through
+/// the full register handshake:
+///
+///   1. Binary loads/creates instance cert (TentacleCertificateManager)
+///   2. Binary POSTs JSON payload to stub's
+///      <c>/api/machines/register/tentacle-listening</c> endpoint
+///   3. Stub returns canned response with serverThumbprint + machineId
+///   4. Binary persists config to /etc/squid-tentacle/instances/.config.json
+///   5. Binary prints the registration result to stdout
+///
+/// <para><b>Tier 🟢 H</b> (Rule 12.4): real production binary + real
+/// HTTP request + real config persistence. The only stub is the server
+/// REST endpoint — same fidelity-tier as the upgrade flow's
+/// LocalReleaseMirror (real HTTP, canned response).</para>
+///
+/// <para>UNBLOCKS the agent-identity coverage gap. Without register E2E,
+/// regressions in any of the following ship silently:
+/// <list type="bullet">
+///   <item>Register payload shape (machineName / thumbprint / roles)</item>
+///   <item>X-API-KEY header propagation</item>
+///   <item>Config persistence path (/etc/squid-tentacle/instances/&lt;name&gt;.config.json)</item>
+///   <item>Serialization format of the persisted config (server thumbprint
+///         + subscription URI must round-trip readable for `run`)</item>
+/// </list></para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.TentacleBinary)]
+[Collection(LinuxTentacleHostStateCollection.Name)]
+public sealed class TentacleLinuxRegisterE2ETests
+{
+    // ========================================================================
+    // C1.h-Linux — Listening Tentacle register: persists config + calls server
+    //
+    // Documented operator workflow:
+    //
+    //   sudo squid-tentacle register \
+    //     --server https://squid.acme.internal:7078 \
+    //     --api-key API-XXXXXXXX \
+    //     --role web-server \
+    //     --environment Production \
+    //     --flavor LinuxTentacle
+    //
+    // The binary's RegisterCommand:
+    //   1. Reads --server / --api-key / --role / --environment from args
+    //   2. Loads or generates the instance's certificate
+    //   3. Resolves communication mode (no --comms-url → Listening)
+    //   4. Selects flavor → TentacleListeningRegistrar
+    //   5. POSTs to /api/machines/register/tentacle-listening with payload
+    //   6. Reads serverThumbprint + machineId from response
+    //   7. Writes config.json with all the persisted-settings fields
+    //
+    // Without this E2E pin, regressions in the chain ship silently —
+    // operator's first register fails with cryptic errors after deploy.
+    //
+    // Test mechanism:
+    //   - Slim LinuxStubSquidServer on random localhost port
+    //   - Binary registers against stub URL
+    //   - Assert exit 0 + stub received the call + payload shape correct
+    //     + config file persisted at expected path with stub's thumbprint
+    //
+    // Why HTTP not HTTPS: production EnsureSchemeSafeForSecret enforcement
+    // is Warn-by-default (Rule 11), so http:// emits a warning but proceeds.
+    // No TLS setup needed in test fixture.
+    //
+    // Tier: 🟢 H (Rule 12.4) — real binary + real HTTP + real config
+    // persistence. Only the REST endpoint is stubbed (canned response),
+    // same shape as upgrade-flow's LocalReleaseMirror.
+    //
+    // Expected runtime: ~1-2s.
+    // ========================================================================
+
+    [Fact]
+    public void C1h_RegisterListening_PersistsConfigAndCallsServer()
+    {
+        if (!LinuxTentacleBinaryFixture.IsAvailable) return;
+        if (!LinuxServiceFixture.IsAvailable) return;
+
+        using var ctx = new RegisterTestContext();
+
+        var (exitCode, output) = ctx.Binary.SudoRun(
+            "register",
+            "--instance", ctx.InstanceName,
+            "--server", ctx.Stub.BaseUrl.ToString().TrimEnd('/'),
+            "--api-key", "API-STUB-1234567890",
+            "--role", "web-server",
+            "--environment", "Production",
+            "--flavor", "LinuxTentacle");
+
+        exitCode.ShouldBe(0,
+            customMessage: $"register MUST exit 0 against the stub server. Got exit {exitCode}. " +
+                          $"If 1: registrar threw (likely server URL unreachable, payload validation failed, " +
+                          $"or response schema mismatch). " +
+                          $"output:\n{output}");
+
+        // ── Server-side assertions ──────────────────────────────────────────
+        // Stub recorded exactly one register call.
+        ctx.Stub.ReceivedRegistrations.Count.ShouldBe(1,
+            customMessage: $"stub MUST have received exactly 1 register call. Got {ctx.Stub.ReceivedRegistrations.Count}. " +
+                          $"If 0: binary couldn't reach the stub (port mismatch, firewall, DNS). " +
+                          $"If >1: registrar retried unexpectedly (request body might have a transient-error response interpretation regression).");
+
+        var register = ctx.Stub.ReceivedRegistrations[0];
+
+        // Path correctness — Listening flavor must hit the listening endpoint.
+        register.Path.ShouldBe("/api/machines/register/tentacle-listening",
+            customMessage: $"register endpoint path MUST be /api/machines/register/tentacle-listening for the Listening flavor. " +
+                          $"Got '{register.Path}'. If different: flavor → endpoint mapping regressed (TentacleListeningRegistrar's hardcoded path drift).");
+
+        // X-API-KEY header propagation — production registrars use this header
+        // for auth (TentacleListeningRegistrar line 167-168).
+        register.Headers.ShouldContainKey("X-API-KEY",
+            customMessage: $"register request MUST include X-API-KEY header for auth. Headers: {string.Join(", ", register.Headers.Keys)}. " +
+                          $"If absent: auth header propagation regressed; production server would reject with 401.");
+
+        register.Headers["X-API-KEY"].ShouldBe("API-STUB-1234567890",
+            customMessage: $"X-API-KEY header value MUST equal the --api-key arg. Got '{register.Headers["X-API-KEY"]}'.");
+
+        // ── Payload shape (per TentacleListeningRegistrar.SendRegistrationAsync) ──
+        // Parse JSON body and assert key fields. CamelCase per JsonNamingPolicy.
+        using var bodyDoc = JsonDocument.Parse(register.Body);
+        var body = bodyDoc.RootElement;
+
+        body.TryGetProperty("machineName", out var machineName).ShouldBeTrue(
+            customMessage: $"register body MUST contain machineName. Body: {register.Body}");
+        machineName.GetString().ShouldNotBeNullOrEmpty(
+            customMessage: "machineName MUST be non-empty (defaults to tentacle-{hostname} if --name not provided).");
+
+        body.TryGetProperty("thumbprint", out var thumbprint).ShouldBeTrue(
+            customMessage: $"register body MUST contain thumbprint (the agent's certificate thumbprint). Body: {register.Body}");
+        thumbprint.GetString().ShouldNotBeNullOrEmpty(
+            customMessage: "thumbprint MUST be non-empty — TentacleCertificateManager generated/loaded the cert.");
+
+        body.TryGetProperty("roles", out var roles).ShouldBeTrue("body MUST contain roles");
+        roles.GetString().ShouldBe("web-server",
+            customMessage: $"roles MUST equal --role arg. Got '{roles.GetString()}'.");
+
+        body.TryGetProperty("environments", out var environments).ShouldBeTrue("body MUST contain environments");
+        environments.GetString().ShouldBe("Production",
+            customMessage: $"environments MUST equal --environment arg. Got '{environments.GetString()}'.");
+
+        // ── Config persistence ──────────────────────────────────────────────
+        // RegisterCommand calls PersistInstanceConfig which writes to
+        // /etc/squid-tentacle/instances/<instance>.config.json.
+        var configPath = $"/etc/squid-tentacle/instances/{ctx.InstanceName}.config.json";
+        LinuxInstallScriptContext.SudoFileExists(configPath).ShouldBeTrue(
+            customMessage: $"instance config MUST be persisted at {configPath}. " +
+                          "If absent: PersistInstanceConfig regressed OR InstanceSelector resolved to a different path. " +
+                          "Production impact: agent's `run` command can't load identity → registration appeared to succeed but agent can't poll.");
+
+        // Config content includes the server URL (so `run` knows where to dial)
+        // and the server thumbprint (so TLS pinning works).
+        var configContent = LinuxInstallScriptContext.SudoReadAllText(configPath);
+        configContent.ShouldContain(ctx.Stub.BaseUrl.ToString().TrimEnd('/'),
+            customMessage: $"config MUST contain the registered ServerUrl '{ctx.Stub.BaseUrl}'. " +
+                          $"Without it, `run` falls back to default config and dials the wrong server. " +
+                          $"Config content:\n{configContent}");
+
+        configContent.ShouldContain(ctx.Stub.ServerThumbprint,
+            customMessage: $"config MUST contain the stub's ServerThumbprint '{ctx.Stub.ServerThumbprint}' (returned by stub in register response). " +
+                          $"Without it, TLS pinning would fail OR fall back to insecure mode. " +
+                          $"Config content:\n{configContent}");
+
+        // ── Operator-visible stdout pins ──────────────────────────────────
+        // RegisterCommand prints the registration result for operator
+        // confirmation (line 141-147 of RegisterCommand.cs).
+        output.ShouldContain("Registration complete",
+            customMessage: $"stdout MUST contain 'Registration complete' (operator's success signal). output:\n{output}");
+
+        output.ShouldContain($"ServerThumbprint: {ctx.Stub.ServerThumbprint}",
+            customMessage: $"stdout MUST echo the server thumbprint received from the response. " +
+                          "Operators read this to confirm pinning. If absent: print line dropped; cosmetic but operator-visible regression.");
+
+        ctx.MarkClean();
+    }
+
+    /// <summary>
+    /// Per-test context: owns the stub server + binary fixture + cleanup.
+    /// </summary>
+    private sealed class RegisterTestContext : IDisposable
+    {
+        private bool _clean;
+
+        public LinuxTentacleBinaryFixture Binary { get; } = new();
+        public LinuxStubSquidServer Stub { get; } = LinuxStubSquidServer.Start();
+        public string InstanceName { get; } = $"register-test-{Guid.NewGuid():N}";
+
+        public void MarkClean() => _clean = true;
+
+        public void Dispose()
+        {
+            if (!_clean)
+                Console.WriteLine($"[RegisterTestContext] Dispose called without MarkClean — register test for instance '{InstanceName}' failed before its happy-path conclusion.");
+
+            // Cleanup: rm the per-instance config + certs dir created by
+            // RegisterCommand. Both live under /etc/squid-tentacle/.
+            // Best-effort sudo rm — missing paths are no-ops.
+            TrySudoRm($"/etc/squid-tentacle/instances/{InstanceName}.config.json");
+            TrySudoRm($"/etc/squid-tentacle/instances/{InstanceName}");
+
+            // The instance also gets registered in
+            // /etc/squid-tentacle/instances.json. Leaving it stale would
+            // pollute `list-instances` for later tests. Easiest cleanup:
+            // wipe the parent /etc/squid-tentacle/instances/ + instances.json
+            // entirely — rebuilt on next test's register. NOT removing
+            // /etc/squid-tentacle/ itself in case other tests depend on its
+            // existence.
+            TrySudoRm("/etc/squid-tentacle/instances.json");
+
+            try { Stub.Dispose(); } catch { /* best-effort */ }
+        }
+
+        private static void TrySudoRm(string path)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "sudo",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+                psi.ArgumentList.Add("-n");
+                psi.ArgumentList.Add("rm");
+                psi.ArgumentList.Add("-rf");
+                psi.ArgumentList.Add(path);
+
+                using var proc = Process.Start(psi);
+                proc?.WaitForExit(5_000);
+            }
+            catch { /* best-effort */ }
+        }
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxRegisterE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxRegisterE2ETests.cs
@@ -200,6 +200,25 @@ public sealed class TentacleLinuxRegisterE2ETests
         public LinuxTentacleBinaryFixture Binary { get; } = new();
         public LinuxStubSquidServer Stub { get; } = LinuxStubSquidServer.Start();
 
+        public RegisterTestContext()
+        {
+            // Pre-create /etc/squid-tentacle/ to mimic post-install state.
+            // Production operators run `sudo install-tentacle.sh` (which
+            // creates this dir) BEFORE `sudo register`. Without this dir,
+            // PlatformPaths.ResolveActiveConfigDir falls back to the user
+            // config dir ($HOME/.config/squid-tentacle/) — when register
+            // runs via sudo, $HOME=/root so config lands at
+            // /root/.config/squid-tentacle/instances/Default.config.json,
+            // not the operator-expected /etc/squid-tentacle/ location.
+            //
+            // J.M.L.C.1.2: caught by first-runner of the Default-instance
+            // fix — register exit 0 + stub call recorded, but config went
+            // to user dir because the Install test's cleanup matrix
+            // removes /etc/squid-tentacle/ before this Register test runs
+            // (alphabetical class order: Install < Register).
+            TrySudoMkdirP("/etc/squid-tentacle/instances");
+        }
+
         public void MarkClean() => _clean = true;
 
         public void Dispose()
@@ -234,6 +253,29 @@ public sealed class TentacleLinuxRegisterE2ETests
                 psi.ArgumentList.Add("-n");
                 psi.ArgumentList.Add("rm");
                 psi.ArgumentList.Add("-rf");
+                psi.ArgumentList.Add(path);
+
+                using var proc = Process.Start(psi);
+                proc?.WaitForExit(5_000);
+            }
+            catch { /* best-effort */ }
+        }
+
+        private static void TrySudoMkdirP(string path)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "sudo",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+                psi.ArgumentList.Add("-n");
+                psi.ArgumentList.Add("mkdir");
+                psi.ArgumentList.Add("-p");
                 psi.ArgumentList.Add(path);
 
                 using var proc = Process.Start(psi);

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxRegisterE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxRegisterE2ETests.cs
@@ -86,9 +86,16 @@ public sealed class TentacleLinuxRegisterE2ETests
 
         using var ctx = new RegisterTestContext();
 
+        // Use Default instance (no --instance flag): InstanceSelector.Resolve
+        // auto-creates the Default record without requiring `create-instance`
+        // pre-step, so first-run tests can register directly. Named instances
+        // throw "does not exist" unless pre-created — use Default for now;
+        // future tests that need multiple instances per run will prepend
+        // `create-instance --instance <name>` calls.
+        // J.M.L.C.1.1: caught by first runner — `--instance <guid>` threw
+        // "does not exist" because Resolve only auto-creates Default.
         var (exitCode, output) = ctx.Binary.SudoRun(
             "register",
-            "--instance", ctx.InstanceName,
             "--server", ctx.Stub.BaseUrl.ToString().TrimEnd('/'),
             "--api-key", "API-STUB-1234567890",
             "--role", "web-server",
@@ -149,8 +156,9 @@ public sealed class TentacleLinuxRegisterE2ETests
 
         // ── Config persistence ──────────────────────────────────────────────
         // RegisterCommand calls PersistInstanceConfig which writes to
-        // /etc/squid-tentacle/instances/<instance>.config.json.
-        var configPath = $"/etc/squid-tentacle/instances/{ctx.InstanceName}.config.json";
+        // /etc/squid-tentacle/instances/<instance>.config.json. Using
+        // Default instance, so config lands at Default.config.json.
+        var configPath = "/etc/squid-tentacle/instances/Default.config.json";
         LinuxInstallScriptContext.SudoFileExists(configPath).ShouldBeTrue(
             customMessage: $"instance config MUST be persisted at {configPath}. " +
                           "If absent: PersistInstanceConfig regressed OR InstanceSelector resolved to a different path. " +
@@ -191,28 +199,21 @@ public sealed class TentacleLinuxRegisterE2ETests
 
         public LinuxTentacleBinaryFixture Binary { get; } = new();
         public LinuxStubSquidServer Stub { get; } = LinuxStubSquidServer.Start();
-        public string InstanceName { get; } = $"register-test-{Guid.NewGuid():N}";
 
         public void MarkClean() => _clean = true;
 
         public void Dispose()
         {
             if (!_clean)
-                Console.WriteLine($"[RegisterTestContext] Dispose called without MarkClean — register test for instance '{InstanceName}' failed before its happy-path conclusion.");
+                Console.WriteLine($"[RegisterTestContext] Dispose called without MarkClean — register test failed before its happy-path conclusion.");
 
-            // Cleanup: rm the per-instance config + certs dir created by
-            // RegisterCommand. Both live under /etc/squid-tentacle/.
-            // Best-effort sudo rm — missing paths are no-ops.
-            TrySudoRm($"/etc/squid-tentacle/instances/{InstanceName}.config.json");
-            TrySudoRm($"/etc/squid-tentacle/instances/{InstanceName}");
-
-            // The instance also gets registered in
-            // /etc/squid-tentacle/instances.json. Leaving it stale would
-            // pollute `list-instances` for later tests. Easiest cleanup:
-            // wipe the parent /etc/squid-tentacle/instances/ + instances.json
-            // entirely — rebuilt on next test's register. NOT removing
-            // /etc/squid-tentacle/ itself in case other tests depend on its
-            // existence.
+            // Cleanup: rm Default instance state. Best-effort sudo rm —
+            // missing paths are no-ops. Wipe the whole /etc/squid-tentacle/
+            // instances/ subtree + instances.json so subsequent tests start
+            // with a clean state. /etc/squid-tentacle/ itself stays in case
+            // other tests depend on its existence.
+            TrySudoRm("/etc/squid-tentacle/instances/Default.config.json");
+            TrySudoRm("/etc/squid-tentacle/instances/Default");
             TrySudoRm("/etc/squid-tentacle/instances.json");
 
             try { Stub.Dispose(); } catch { /* best-effort */ }


### PR DESCRIPTION
## Summary

**Section C bootstrap.** UNBLOCKS agent-identity coverage. Drives the real production binary's `register` command end-to-end through the full handshake:

1. Binary loads/creates instance cert (`TentacleCertificateManager`)
2. Binary POSTs JSON payload to stub's `/api/machines/register/tentacle-listening`
3. Stub returns canned response with `serverThumbprint` + `machineId`
4. Binary persists config to `/etc/squid-tentacle/instances/<name>.config.json`
5. Binary prints registration result to stdout

## Why ship-blocking

Without this E2E pin, regressions in any of the following ship silently and only surface when an operator's first register fails:

- Register payload shape (`machineName` / `thumbprint` / `roles` / `environments`)
- `X-API-KEY` header propagation
- Config persistence path
- `ServerUrl` + `ServerThumbprint` round-trip into persisted config (without these, `run` can't dial the registered server)

## Architectural decision: slim Linux-specific stub

| Option | Choice | Rationale |
|---|---|---|
| Reference Windows project's `StubSquidServer` | ❌ | ~600 lines (Halibut polling + cert generation + comms-test) — overkill for register-only; cross-OS project coupling smells bad |
| **Slim Linux-specific `LinuxStubSquidServer`** | ✅ | ~150 lines, register-only HTTP listener; keeps Linux project self-contained |
| Refactor to shared project | Deferred | Right long-term; defer until register failure-path / polling tests need it |

## Test mechanism

- `LinuxStubSquidServer.Start()` → random loopback port via `TcpListener(0)`
- HTTP listener responds to `POST /api/machines/register/*` with canned 200 + JSON body matching `TentacleRegistrationClient.RegistrationResponse` schema
- `ConfigureRegisterStatusCode` / `ConfigureRegisterBody` for future failure-path tests
- Records every received request's path + body + headers for assertion

## Assertions

| Layer | Assertion |
|---|---|
| Exit | `exitCode == 0` |
| Stub server | Recorded exactly 1 register call |
| Path | `/api/machines/register/tentacle-listening` (Listening flavor) |
| Auth | `X-API-KEY` header present + matches `--api-key` arg |
| Payload | `machineName` + `thumbprint` (cert) + `roles` + `environments` |
| Persistence | Config file exists at `/etc/squid-tentacle/instances/<name>.config.json` |
| Round-trip | Config contains `ServerUrl` + `ServerThumbprint` (so `run` can dial) |
| stdout | `"Registration complete"` + `"ServerThumbprint: <stub>"` |

## Why HTTP (not HTTPS)

Production `EnsureSchemeSafeForSecret` enforcement is **Warn-by-default** (Rule 11), so `http://` emits a warning but proceeds. No TLS cert / ACL setup needed in test fixture — operator-friendly behavior matches air-gap deployments using internal HTTP mirrors.

## Fidelity tier

🟢 **High** (Rule 12.4): real production binary + real HTTP request + real config persistence. Only the REST endpoint is stubbed (canned response), same shape as upgrade-flow's `LocalReleaseMirror`.

Test class is in `LinuxTentacleHostStateCollection` (serializes against upgrade + install + service-fixture + binary-smoke + service-command tests — register writes `/etc/squid-tentacle/`).

Expected runtime: ~1-2s.

## Test plan

- [ ] Linux E2E workflow runs (manual `workflow_dispatch` after merge)
- [ ] `C1h_RegisterListening_PersistsConfigAndCallsServer` passes within ~5s
- [ ] No regression on existing 32 Linux E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)