### PR TITLE
Linux deploy E2E PR-2: first dispatch round-trip test (L-D1h echo bash)

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/SquidHalibutStubAgent.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/SquidHalibutStubAgent.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Halibut;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Squid.Message.Contracts.Tentacle;
+using Squid.Tentacle.ScriptExecution;
+
+namespace Squid.LinuxTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// In-process stub of a Squid Tentacle agent's Halibut surface — used by
+/// Phase 12.J E2E tests that need the SERVER → AGENT script-dispatch
+/// round-trip with REAL script execution (PowerShell on Windows, bash on
+/// Linux / macOS) WITHOUT spawning the production <c>Squid.Tentacle.exe</c>
+/// binary as a child process.
+///
+/// <para><b>Coverage delta vs <c>Squid.E2ETests.Infrastructure.TentacleStub</c>:</b>
+/// The legacy TentacleStub uses a bash-only ScriptRunner so it can't drive
+/// PowerShell on Windows. <see cref="StubAgent"/> wires the production
+/// <see cref="LocalScriptService"/> directly — same script-execution path
+/// the production tentacle uses, dispatching to PowerShell on Windows and
+/// bash on Linux/macOS based on <see cref="StartScriptCommand.ScriptSyntax"/>.
+/// Result: cross-OS deploy E2E without per-OS forks.</para>
+///
+/// <para><b>What it provides</b>:</para>
+/// <list type="bullet">
+///   <item>Self-signed agent certificate + thumbprint exposed to tests.</item>
+///   <item>Listening mode: binds Halibut on a unique loopback port; server
+///         (StubSquidServer) dials in via
+///         <see cref="StubSquidServer.DispatchScriptToListeningAgentAsync"/>.</item>
+///   <item>Polling mode: dials out to a server URL + subscription ID;
+///         server queues commands via
+///         <see cref="StubSquidServer.DispatchScriptToPollingAgentAsync"/>.</item>
+///   <item>Trust helper so the agent accepts the server's cert during
+///         the TLS handshake.</item>
+/// </list>
+///
+/// <para><b>Tier</b>: Test infrastructure (🔵 fixture-only by Rule 12).
+/// Tests that USE this stub achieve 🟢 high-fidelity because the path
+/// from server-side dispatch through Halibut RPC to LocalScriptService
+/// to real shell execution is all production code.</para>
+///
+/// <para><b>Lifetime</b>: <see cref="IAsyncDisposable"/>. Each test creates
+/// its own instance; unique cert + port per stub means concurrent tests
+/// don't collide.</para>
+///
+/// <para><b>Cross-platform</b>: Halibut + LocalScriptService are both
+/// .NET-cross-platform. Tests using this stub run identically on Windows /
+/// macOS / Linux — the OS-specific concern is the script syntax (caller
+/// chooses PowerShell or Bash via the StartScriptCommand).</para>
+/// </summary>
+public sealed class SquidHalibutStubAgent : IAsyncDisposable
+{
+    private readonly X509Certificate2 _agentCert;
+    private readonly HalibutRuntime _runtime;
+    private readonly LocalScriptService _scriptService;
+    private readonly StubCapabilitiesService _capabilitiesService;
+    private bool _disposed;
+
+    /// <summary>SHA-1 thumbprint of the stub agent's self-signed cert.</summary>
+    public string Thumbprint { get; }
+
+    /// <summary>
+    /// Agent version reported via the capabilities probe. Default is
+    /// "1.6.0-stub". Tests that simulate post-upgrade state flip this to
+    /// the new version mid-test, then re-probe to assert the fresh value
+    /// reaches the server.
+    /// </summary>
+    public string AgentVersion
+    {
+        get => _capabilitiesService.AgentVersion;
+        set => _capabilitiesService.AgentVersion = value;
+    }
+
+    /// <summary>
+    /// Convenience setter for <see cref="AgentVersion"/>. Common pattern:
+    /// probe → assert v1 → SetAgentVersion(v2) → probe → assert v2.
+    /// </summary>
+    public void SetAgentVersion(string version)
+    {
+        _capabilitiesService.AgentVersion = version;
+    }
+
+    /// <summary>
+    /// The agent's Halibut listening URI (Listening mode only). Format:
+    /// <c>https://localhost:&lt;loopback-port&gt;/</c>. Server uses this as
+    /// the dial-out target.
+    /// </summary>
+    public Uri ListeningUri { get; }
+
+    /// <summary>The Halibut listener port (Listening mode).</summary>
+    public int ListeningPort { get; }
+
+    /// <summary>The polling subscription ID (Polling mode only — null in Listening mode).</summary>
+    public string SubscriptionId { get; }
+
+    private SquidHalibutStubAgent(X509Certificate2 cert, HalibutRuntime runtime, LocalScriptService scriptService, StubCapabilitiesService capabilitiesService, int listeningPort, string subscriptionId)
+    {
+        _agentCert = cert;
+        _runtime = runtime;
+        _scriptService = scriptService;
+        _capabilitiesService = capabilitiesService;
+
+        Thumbprint = cert.Thumbprint;
+        ListeningPort = listeningPort;
+        ListeningUri = listeningPort > 0 ? new Uri($"https://localhost:{listeningPort}/") : null;
+        SubscriptionId = subscriptionId;
+    }
+
+    /// <summary>
+    /// Starts a Listening-mode stub agent on a unique loopback port. The
+    /// server dials in to <see cref="ListeningUri"/> to dispatch scripts.
+    /// </summary>
+    /// <param name="serverThumbprint">The server's cert thumbprint to
+    /// trust. Without this, the TLS handshake from the server fails.</param>
+    public static Task<SquidHalibutStubAgent> StartListeningAsync(string serverThumbprint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serverThumbprint);
+
+        var cert = CreateSelfSignedCert();
+        var scriptService = new LocalScriptService();
+        var capsService = new StubCapabilitiesService();
+        var runtime = BuildRuntime(cert, scriptService, capsService);
+
+        runtime.Trust(serverThumbprint);
+
+        // Halibut.Listen returns the actually-bound port (caller suggestion
+        // is just a hint). Re-read for the canonical URI (Rule 12.8).
+        var assignedPort = runtime.Listen(GetEphemeralPort());
+
+        return Task.FromResult(new SquidHalibutStubAgent(cert, runtime, scriptService, capsService, assignedPort, subscriptionId: null));
+    }
+
+    /// <summary>
+    /// Starts a Polling-mode stub agent that dials out to the given server
+    /// polling URI. The agent connects with a unique subscription ID; the
+    /// server queues commands for that subscription. Caller MUST trust the
+    /// agent's <see cref="Thumbprint"/> on the server side BEFORE calling
+    /// this method (otherwise the TLS handshake server-side rejects the
+    /// agent's cert).
+    /// </summary>
+    /// <param name="serverPollingUri">e.g. <c>https://localhost:10943/</c>
+    /// — the server's Halibut polling listener URI.</param>
+    /// <param name="serverThumbprint">The server's cert thumbprint to trust.</param>
+    public static Task<SquidHalibutStubAgent> StartPollingAsync(Uri serverPollingUri, string serverThumbprint)
+    {
+        ArgumentNullException.ThrowIfNull(serverPollingUri);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serverThumbprint);
+
+        var subscriptionId = Guid.NewGuid().ToString("N");
+
+        var cert = CreateSelfSignedCert();
+        var scriptService = new LocalScriptService();
+        var capsService = new StubCapabilitiesService();
+        var runtime = BuildRuntime(cert, scriptService, capsService);
+
+        runtime.Trust(serverThumbprint);
+
+        runtime.Poll(
+            new Uri($"poll://{subscriptionId}/"),
+            new ServiceEndPoint(serverPollingUri, serverThumbprint, HalibutTimeoutsAndLimits.RecommendedValues()),
+            CancellationToken.None);
+
+        return Task.FromResult(new SquidHalibutStubAgent(cert, runtime, scriptService, capsService, listeningPort: 0, subscriptionId));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        try { await _runtime.DisposeAsync().ConfigureAwait(false); } catch { }
+        try { _agentCert.Dispose(); } catch { }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static HalibutRuntime BuildRuntime(X509Certificate2 cert, LocalScriptService scriptService, StubCapabilitiesService capsService)
+    {
+        var asyncScriptAdapter = new AsyncScriptServiceAdapter(scriptService);
+        var asyncCapsAdapter = new AsyncCapabilitiesServiceAdapter(capsService);
+
+        var serviceFactory = new DelegateServiceFactory();
+        serviceFactory.Register<IScriptService, IScriptServiceAsync>(() => asyncScriptAdapter);
+        serviceFactory.Register<ICapabilitiesService, ICapabilitiesServiceAsync>(() => asyncCapsAdapter);
+
+        return new HalibutRuntimeBuilder()
+            .WithServiceFactory(serviceFactory)
+            .WithServerCertificate(cert)
+            .WithHalibutTimeoutsAndLimits(HalibutTimeoutsAndLimits.RecommendedValues())
+            .Build();
+    }
+
+    private static X509Certificate2 CreateSelfSignedCert()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var request = new CertificateRequest($"CN=stub-tentacle-agent-{Guid.NewGuid():N}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        using var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1));
+
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx, string.Empty), string.Empty, X509KeyStorageFlags.Exportable);
+    }
+
+    private static int GetEphemeralPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>
+    /// Sync → async adapter for IScriptService → IScriptServiceAsync.
+    /// LocalScriptService implements the sync IScriptService; Halibut RPC
+    /// uses IScriptServiceAsync. The adapter just calls the sync method
+    /// inside Task.FromResult — no actual async work happens at this
+    /// layer (the script execution itself spawns a background process and
+    /// returns immediately, with subsequent GetStatus/CompleteScript polls
+    /// reading from the process's output streams).
+    /// </summary>
+    private sealed class AsyncScriptServiceAdapter : IScriptServiceAsync
+    {
+        private readonly IScriptService _inner;
+
+        public AsyncScriptServiceAdapter(IScriptService inner) => _inner = inner;
+
+        public Task<ScriptStatusResponse> StartScriptAsync(StartScriptCommand command, CancellationToken ct)
+            => Task.FromResult(_inner.StartScript(command));
+
+        public Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, CancellationToken ct)
+            => Task.FromResult(_inner.GetStatus(request));
+
+        public Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, CancellationToken ct)
+            => Task.FromResult(_inner.CompleteScript(command));
+
+        public Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, CancellationToken ct)
+            => Task.FromResult(_inner.CancelScript(command));
+    }
+
+    /// <summary>
+    /// Stub <see cref="ICapabilitiesService"/> that responds to server-side
+    /// capabilities probes. <see cref="AgentVersion"/> is settable so tests
+    /// can simulate a tentacle that has upgraded mid-test (probe before →
+    /// "1.6.0"; SetAgentVersion("1.7.0"); probe again → "1.7.0").
+    ///
+    /// <para>Note: <see cref="CapabilitiesRequest"/> implements
+    /// <c>IEnumerable&lt;string&gt;</c> per the P0 fix in commit 9ce39b9.
+    /// Without that fix, every probe through this stub would throw
+    /// <c>ArgumentOutOfRangeException</c> from Halibut's cache-key
+    /// generator BEFORE reaching this method. Tests in
+    /// <c>HalibutCacheKeyBugReproductionTests</c> pin that the fix
+    /// stays in place.</para>
+    /// </summary>
+    private sealed class StubCapabilitiesService : ICapabilitiesService
+    {
+        public string AgentVersion { get; set; } = "1.6.0-stub";
+
+        public CapabilitiesResponse GetCapabilities(CapabilitiesRequest request)
+            => new()
+            {
+                AgentVersion = AgentVersion,
+                SupportedServices = new List<string> { "IScriptService", "ICapabilitiesService" },
+                Metadata = new Dictionary<string, string>
+                {
+                    ["flavor"] = "stub-tentacle-agent",
+                    ["os"] = Environment.OSVersion.Platform.ToString()
+                }
+            };
+    }
+
+    /// <summary>Sync → async adapter for capabilities, mirroring the script-service adapter.</summary>
+    private sealed class AsyncCapabilitiesServiceAdapter : ICapabilitiesServiceAsync
+    {
+        private readonly ICapabilitiesService _inner;
+
+        public AsyncCapabilitiesServiceAdapter(ICapabilitiesService inner) => _inner = inner;
+
+        public Task<CapabilitiesResponse> GetCapabilitiesAsync(CapabilitiesRequest request, CancellationToken ct)
+            => Task.FromResult(_inner.GetCapabilities(request));
+    }
+}

--- a/tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj
+++ b/tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj
@@ -46,6 +46,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Squid.Core\Squid.Core.csproj" />
+    <!--
+      Phase 12.M.L.D — Squid.Tentacle reference needed for the Halibut-based
+      stub agent (SquidHalibutStubAgent) which wraps the production
+      LocalScriptService. Mirrors Squid.WindowsUpgradeE2ETests' reference.
+      Used by deploy E2E tests (PR-2+); Section A/B/C/D/G tests don't depend
+      on it but the reference is harmless when unused.
+    -->
+    <ProjectReference Include="..\..\src\Squid.Tentacle\Squid.Tentacle.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDeployE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDeployE2ETests.cs
@@ -1,0 +1,128 @@
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+using Squid.Message.Contracts.Tentacle;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.M.L.D — first-cut Linux deploy E2E coverage. Closes part
+/// of the P0 5.1 gap from the global audit: previously the Linux
+/// project had ZERO Halibut deploy E2E tests despite Windows having
+/// 13. Operators on a mixed fleet running the same documented
+/// "register agent → server pushes script" workflow had no Linux
+/// regression protection.
+///
+/// <para><b>Tier 🟢 high-fidelity</b> (Rule 12.4): real Halibut RPC
+/// + real <c>LocalScriptService</c> (production agent-side script
+/// runner) + real bash execution + real network round-trip on
+/// loopback. Only mocked components are the upstream Squid server
+/// (replaced by <see cref="SquidHalibutStubServer"/>) and the
+/// agent's process (replaced by in-process
+/// <see cref="SquidHalibutStubAgent"/> wrapping
+/// <c>LocalScriptService</c>).</para>
+///
+/// <para><b>Coverage delta vs <see cref="TentacleLinuxUpgradeBinaryIntegrationE2ETests"/></b>:
+/// that test pins the upgrade path's binary-swap mechanics. THIS
+/// test pins the deploy path's server→agent script-dispatch round-
+/// trip — different operator workflow, different production layer.</para>
+///
+/// <para><b>Why first-cut single test</b>: Phase 12.M.L.D is split:
+/// PR-1 ported infrastructure + smoke (this PR is PR-2 with the
+/// first real test). Subsequent PRs add the remaining ~12 deploy
+/// scenarios (non-zero exit, multi-line output, stderr, long-running,
+/// concurrent, polling, etc.) — each follows the pattern this PR
+/// establishes.</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.TentacleBinary)]
+public sealed class TentacleLinuxDeployE2ETests
+{
+    // ========================================================================
+    // L-D1.h-Linux — Listening: bash echo script dispatched + output captured
+    //
+    // Operator scenario: server has registered the Linux tentacle and
+    // dispatches a deployment step (a script). Production path:
+    //
+    //   Server → Halibut RPC → Agent → bash → captured output → Halibut RPC → Server
+    //
+    // This test exercises the full round-trip in-process:
+    //   1. Stub server starts (Halibut listener + cert)
+    //   2. Stub agent starts as listening (registers itself)
+    //   3. Server trusts agent's thumbprint
+    //   4. Server dispatches `echo 'hello-from-linux-deploy-e2e'`
+    //   5. Agent runs the bash script via LocalScriptService
+    //   6. Output round-trips back via Halibut
+    //   7. Test asserts exit 0 + output captured
+    //
+    // What this catches that script-tier tests don't:
+    //   - Halibut serialization regressions (e.g. ProcessOutput line
+    //     truncation)
+    //   - LocalScriptService bash-spawn regression on Linux
+    //     (PATH / shell-resolution issues)
+    //   - Halibut listener/poller TLS handshake regression
+    //   - Production observe-loop polling timing
+    //
+    // Tier: 🟢 H. Mirror of Windows
+    // <c>TentacleDeployE2ETests.Listening_EchoScript_OutputCapturedAndExitZero</c>;
+    // pins the same contract on Linux.
+    // ========================================================================
+
+    [Fact]
+    public async Task LD1h_Listening_EchoBashScript_OutputCapturedAndExitZero()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        await using var server = await SquidHalibutStubServer.StartAsync();
+        await using var agent = await SquidHalibutStubAgent.StartListeningAsync(server.ServerThumbprint);
+        server.TrustAgent(agent.Thumbprint);
+
+        // Bash echo — Linux path (no Windows branch needed; this test is
+        // skip-on-non-Linux above).
+        const string scriptBody = "echo 'hello-from-linux-deploy-e2e'";
+        const ScriptType scriptType = ScriptType.Bash;
+
+        var result = await DispatchAndObserveListeningAsync(server, agent.ListeningUri, agent.Thumbprint, scriptBody, scriptType);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"echo bash script MUST exit 0 on Linux. Got exit {result.ExitCode}.\nLogs:\n{result.AllText}");
+
+        result.AllText.ShouldContain("hello-from-linux-deploy-e2e",
+            customMessage: $"echo output MUST be captured in the Halibut RPC round-trip logs. " +
+                          "If absent: LocalScriptService didn't spawn bash correctly OR Halibut serialization dropped " +
+                          $"the ProcessOutput stream. " +
+                          $"\nGot logs:\n{result.AllText}");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a <see cref="StartScriptCommand"/> with a unique ticket and
+    /// dispatches it to the listening agent via the stub server's
+    /// <see cref="SquidHalibutStubServer.DispatchAndObserveListeningAsync"/>.
+    /// Local helper instead of a private nested class on the test (keeps
+    /// the file flat; can be promoted to shared infra in a follow-up PR).
+    /// </summary>
+    private static async Task<ObservedScriptResult> DispatchAndObserveListeningAsync(
+        SquidHalibutStubServer server,
+        Uri agentUri,
+        string agentThumbprint,
+        string scriptBody,
+        ScriptType scriptType,
+        TimeSpan? observeTimeout = null)
+    {
+        var ticket = new ScriptTicket($"e2e-linux-{Guid.NewGuid():N}");
+        var command = new StartScriptCommand(
+            ticket,
+            scriptBody,
+            ScriptIsolationLevel.NoIsolation,
+            TimeSpan.FromMinutes(1),
+            null,
+            Array.Empty<string>(),
+            ticket.TaskId,
+            TimeSpan.Zero)
+        {
+            ScriptSyntax = scriptType
+        };
+
+        var timeout = observeTimeout ?? TimeSpan.FromSeconds(30);
+        return await server.DispatchAndObserveListeningAsync(agentUri, agentThumbprint, command, timeout, CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary

- **PR-2 of P0 5.1** Linux deploy E2E rollout. PR-1 (#257) ported `StubSquidServer` + smoke. This PR adds the first **real deploy test**: server dispatches an echo script via Halibut RPC, listening agent runs bash, output round-trips back.
- New: `SquidHalibutStubAgent` (port of Windows `StubAgent`, ~290 lines) + `TentacleLinuxDeployE2ETests.cs` with `L-D1h_Listening_EchoBashScript_OutputCapturedAndExitZero`.
- Linux csproj now references `Squid.Tentacle` (mirroring Windows project) — needed because production `LocalScriptService` lives there.

## Why this matters

What this catches that the script-tier tests don't:
- Halibut serialization regressions on Linux (ProcessOutput truncation)
- LocalScriptService bash-spawn regression (PATH / shell resolution)
- Halibut listener/poller TLS handshake regression on Linux
- Production observe-loop polling timing

Mirror of Windows `TentacleDeployE2ETests.Listening_EchoScript` — closes the cross-OS coverage gap operators on mixed fleets relied on.

## Follow-up PRs (P0 5.1 PR-3+)

Will add: non-zero exit propagation, multi-line output preservation, stderr capture, long-running scripts, concurrent dispatches, polling-mode round-trip, output-variable round-trip, file transfer. ~12 more tests mirroring Windows deploy suite — each follows the pattern this PR establishes.

## Test plan

- [x] `dotnet build` green
- [ ] Linux CI passes `LD1h_Listening_EchoBashScript_OutputCapturedAndExitZero`
- [ ] Existing 51 Linux E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)