### PR TITLE
Fix LocalReleaseMirror cache invalidation on StageBinary (test-fixture bug)

### DIFF
--- a/tests/Squid.WindowsUpgradeE2ETests/Infrastructure/LocalReleaseMirror.cs
+++ b/tests/Squid.WindowsUpgradeE2ETests/Infrastructure/LocalReleaseMirror.cs
@@ -150,6 +150,22 @@ public sealed class LocalReleaseMirror : IDisposable
     {
         _stagedBinaryFileName = binaryFileName;
         _stagedBinary = content;
+
+        // Invalidate the per-archive byte cache so subsequent .zip / .tar.gz
+        // requests rebuild from the new staged content. Without this,
+        // tests that re-stage between two install invocations (e.g.
+        // InstallScript_ReRun_OverExistingInstall_Succeeds, which stages
+        // v1 → install → re-stages v2 → install) would see the SECOND
+        // install receive cached v1 bytes and produce v1 content on disk
+        // — the test would fail with "expected v2, got # v1" even
+        // though the production install script worked correctly.
+        // Caught by 4+ consecutive Windows CI failures of that test on
+        // main: the per-URL cache (added for SHA256 companion consistency)
+        // had no invalidation hook for re-staged content.
+        lock (_archiveCacheLock)
+        {
+            _archiveBytesCache.Clear();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

**Root cause was misdiagnosed**. The `InstallScript_ReRun_OverExistingInstall_Succeeds` test was failing because the **mirror fixture's per-URL cache** kept serving stale `v1` content for the second install — production `install-tentacle.ps1` was working correctly all along.

**Real fix**: invalidate `_archiveBytesCache` in `StageBinary` so re-staged content takes effect. The original `install-tentacle.ps1` `Expand-Archive -Force` is restored unchanged.

## Why this matters

The test was claiming a production regression (`Expand-Archive -Force isn't overwriting?`) but the bytes the script extracted on the second install were CORRECTLY v1's bytes — because that's what the cached zip was. The test's `StageBinary(v2, ...)` between calls didn't invalidate the cache, so the second install got the same v1 zip the first install had.

**Test-discipline value**: this is a great example of why deeper investigation matters — the surface symptom looked like a production bug, but careful tracing of the data flow revealed the test fixture as the actual culprit.

## Files changed

| File | Change |
|---|---|
| `tests/Squid.WindowsUpgradeE2ETests/Infrastructure/LocalReleaseMirror.cs` | `StageBinary` now clears `_archiveBytesCache` |
| `deploy/scripts/install-tentacle.ps1` | (No actual change — restored to original) |

## Test plan

- [x] `dotnet build` green
- [ ] Windows CI: `InstallScript_ReRun_OverExistingInstall_Succeeds` turns green
- [ ] Existing 4+ consecutive failures on main are caused by this same cache issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)