### PR TITLE
Fix: redirect Serilog output to stderr (clean stdout for diagnostic commands)

### DIFF
--- a/src/Squid.Tentacle/Program.cs
+++ b/src/Squid.Tentacle/Program.cs
@@ -3,10 +3,36 @@ using Squid.Tentacle.Commands;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Instance;
 using Serilog;
+using Serilog.Events;
 
+// Direct ALL Serilog output to stderr (Unix convention: diagnostic
+// log lines on stderr, command output on stdout). This keeps stdout
+// clean for shell pipelines like:
+//
+//   THUMBPRINT=$(squid-tentacle show-thumbprint)
+//   squid-tentacle list-instances | grep MyInstance
+//   squid-tentacle show-config | awk '/Roles:/ {print $2}'
+//
+// Without this, Serilog's INF lines from TentacleCertificateManager.
+// LoadOrCreateCertificate (and other config-load paths) bleed into
+// stdout, polluting the captured value. Caught by Linux D1h E2E first
+// runner — the test had to defensively regex-extract a 40-char hex
+// from stdout to work around the leak. With this fix, stdout for
+// read-only diagnostic commands is exactly the value (clean for
+// `$()` capture); operators who want the diagnostic context can
+// still see it via `2>&1` redirect.
+//
+// Affects: every command. Stdout-only commands (`version`,
+// `show-thumbprint`, `show-config`, `list-instances`,
+// `new-certificate`) gain clean pipeline UX. State-mutating commands
+// (`register`, `service install`) still emit their summary output
+// (MachineId, etc.) to stdout via Console.WriteLine — log noise just
+// moves to stderr where it belongs.
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Information()
-    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+    .WriteTo.Console(
+        standardErrorFromLevel: LogEventLevel.Verbose,
+        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
     .CreateLogger();
 
 var commands = new ITentacleCommand[]


### PR DESCRIPTION
## Summary

- **Production fix**: Serilog log lines were leaking onto stdout for diagnostic commands (`show-thumbprint`, `show-config`, `list-instances`, `new-certificate`), polluting `$(...)` shell captures.
- **Fix**: redirect Serilog's Console sink to stderr (Unix convention: diagnostic on stderr, output on stdout).
- **One-line change**: `standardErrorFromLevel: LogEventLevel.Verbose` parameter added to `WriteTo.Console`.

## Why this matters

Caught by Linux D1h + Windows W-D1h E2E tests. Without this fix:
```bash
THUMBPRINT=$(squid-tentacle show-thumbprint)
# THUMBPRINT contains "[12:34:56 INF] Loading existing ...\n1A2B3C..." (broken)
```

Operators using shell pipelines for trust-list debugging, fleet automation, or scripting hit silent bugs.

## Test plan

- [x] `dotnet build` green
- [ ] CI: existing 172 E2E tests still pass (the defensive regex extraction in tests continues to work correctly)
- [ ] Future: tighten D1h + W-D1h tests to assert stdout (alone) is exactly the thumbprint (separate PR after this lands)

## Affected commands

| Command | Effect |
|---|---|
| `version`, `show-thumbprint`, `show-config`, `list-instances`, `new-certificate` | Stdout becomes clean (only the actual value/output) |
| `register`, `service install`, `service start/stop/uninstall` | Summary output (MachineId, etc.) still on stdout; log diagnostics moved to stderr |
| `run` (systemd ExecStart) | systemd's journald captures both — no behavior change for operators |

🤖 Generated with [Claude Code](https://claude.com/claude-code)