### PR TITLE
Fix: add register --force flag to bypass already-registered skip

### DIFF
--- a/src/Squid.Tentacle/Abstractions/TentacleFlavorModels.cs
+++ b/src/Squid.Tentacle/Abstractions/TentacleFlavorModels.cs
@@ -30,6 +30,25 @@ public sealed class TentacleFlavorContext
     public required TentacleSettings TentacleSettings { get; init; }
 
     public required IConfiguration Configuration { get; init; }
+
+    /// <summary>
+    /// When true, the flavor's registrar resolution MUST bypass the
+    /// "already registered (Registered=true) → NoOpRegistrar" skip path
+    /// and run the actual register HTTP call.
+    ///
+    /// <para>Set by <c>RegisterCommand.ExecuteAsync</c> when the
+    /// operator passes <c>--force</c>. The skip path is right for the
+    /// <c>run</c> command (systemd restart shouldn't re-register on
+    /// every boot) but wrong for explicit operator-invoked
+    /// <c>register --force</c> after role/environment/api-key changes
+    /// — without this flag, those updates would silently never reach
+    /// the server.</para>
+    ///
+    /// <para>Defaults to <c>false</c> for backward compat: existing
+    /// callers (run command, in-UI upgrade flow) keep the same skip
+    /// behaviour.</para>
+    /// </summary>
+    public bool ForceRegistration { get; init; }
 }
 
 public enum TentacleCommunicationMode

--- a/src/Squid.Tentacle/Commands/RegisterCommand.cs
+++ b/src/Squid.Tentacle/Commands/RegisterCommand.cs
@@ -77,7 +77,17 @@ public sealed class RegisterCommand : ITentacleCommand
         var (instanceName, argsWithoutInstance) = InstanceSelector.ExtractInstanceArg(args);
         var instance = InstanceSelector.Resolve(instanceName);
 
-        var expandedArgs = ExpandShorthandArgs(argsWithoutInstance);
+        // --force bypasses the "already registered → NoOpRegistrar" skip
+        // path in flavor.ResolveRegistrar. Without --force, an operator
+        // re-running register to update roles / environment / api-key
+        // is silently no-op'd because Tentacle:Registered=true is
+        // persisted from the first register. With --force, the second
+        // register actually hits the server. Caught by Linux C3h E2E.
+        // Strip --force from args before AddCommandLine sees it (it's
+        // not a Tentacle:* config key).
+        var (forceRegistration, argsAfterForce) = ExtractForceFlag(argsWithoutInstance);
+
+        var expandedArgs = ExpandShorthandArgs(argsAfterForce);
 
         // Per-instance certs path takes priority over whatever's in config, so multi-instance
         // setups don't clobber each other's certificates.
@@ -116,7 +126,8 @@ public sealed class RegisterCommand : ITentacleCommand
         var runtime = flavor.CreateRuntime(new TentacleFlavorContext
         {
             TentacleSettings = settings,
-            Configuration = merged
+            Configuration = merged,
+            ForceRegistration = forceRegistration
         });
 
         Log.Information("Registering with {ServerUrl} as flavor {Flavor}...", settings.ServerUrl, flavor.Id);
@@ -200,6 +211,35 @@ public sealed class RegisterCommand : ITentacleCommand
         file.Merge(updates);
 
         Log.Information("Persisted settings to {Path}", instance.ConfigPath);
+    }
+
+    /// <summary>
+    /// Detects + strips the <c>--force</c> flag from the args. Returns
+    /// (<c>force</c>, <c>args without --force</c>). Stripped because
+    /// <c>--force</c> is not a Tentacle:* configuration key — passing
+    /// it through to <see cref="ConfigurationBuilder.AddCommandLine"/>
+    /// would land it as <c>Tentacle:force=true</c> in IConfiguration
+    /// and confuse settings binding.
+    /// </summary>
+    internal static (bool force, string[] remaining) ExtractForceFlag(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        var force = false;
+        var remaining = new List<string>();
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i].Equals("--force", StringComparison.OrdinalIgnoreCase))
+            {
+                force = true;
+                continue;
+            }
+
+            remaining.Add(args[i]);
+        }
+
+        return (force, remaining.ToArray());
     }
 
     internal static string[] ExpandShorthandArgs(string[] args)

--- a/src/Squid.Tentacle/Flavors/LinuxTentacle/LinuxTentacleFlavor.cs
+++ b/src/Squid.Tentacle/Flavors/LinuxTentacle/LinuxTentacleFlavor.cs
@@ -22,7 +22,7 @@ public sealed class LinuxTentacleFlavor : ITentacleFlavor
 
         Log.Information("LinuxTentacle starting in {Mode} mode", communicationMode);
 
-        var registrar = ResolveRegistrar(communicationMode, tentacleSettings);
+        var registrar = ResolveRegistrar(communicationMode, tentacleSettings, context.ForceRegistration);
 
         var backend = new LocalScriptService();
 
@@ -67,17 +67,27 @@ public sealed class LinuxTentacleFlavor : ITentacleFlavor
     /// that field as the "already registered" marker would silently skip
     /// registration, leaving the Server unaware of the Tentacle and all
     /// poll connections rejected.
+    ///
+    /// <para><paramref name="forceRegistration"/> bypasses the skip path —
+    /// set by <c>RegisterCommand</c> when the operator passes
+    /// <c>--force</c>. Catches the operator-impact gap where re-registering
+    /// to update roles / environment / api-key was silently no-op'd
+    /// (caught by Linux C3h E2E first runner; documented in the spawned
+    /// production-fix task).</para>
     /// </summary>
     private static ITentacleRegistrar ResolveRegistrar(
-        TentacleCommunicationMode mode, TentacleSettings settings)
+        TentacleCommunicationMode mode, TentacleSettings settings, bool forceRegistration)
     {
         var alreadyRegistered = settings.Registered.Equals("true", StringComparison.OrdinalIgnoreCase);
 
-        if (alreadyRegistered)
+        if (alreadyRegistered && !forceRegistration)
         {
-            Log.Information("Tentacle already registered (Registered=true), skipping re-registration");
+            Log.Information("Tentacle already registered (Registered=true), skipping re-registration. Pass --force to re-register against the server (e.g. to update roles/environment/api-key).");
             return new NoOpRegistrar(settings);
         }
+
+        if (alreadyRegistered && forceRegistration)
+            Log.Information("--force passed: bypassing 'already registered' skip and re-registering");
 
         // Listening mode without credentials → can't self-register; this tentacle must
         // either be pre-registered via the UI or the operator needs to run `register`


### PR DESCRIPTION
## Summary

- **Production fix**: `register` silently no-ops when `Tentacle:Registered=true` was previously persisted, breaking operators who re-run register to update roles / environment / api-key.
- **Fix**: add opt-in `--force` flag. When passed, `LinuxTentacleFlavor.ResolveRegistrar` bypasses the skip path and actually POSTs to the server.
- **Backward compat preserved**: default behavior unchanged. `systemd run` keeps the skip (correct for boot-time idempotency).

## Why this matters

Caught by Linux C3h E2E (PR #250 iteration 3). Operator-impact: every fleet-automation pipeline that re-applies `register` for role updates was thinking it succeeded but the server's machine record stayed stale.

## Files changed

| File | Change |
|---|---|
| `Abstractions/TentacleFlavorModels.cs` | Add `ForceRegistration` bool to `TentacleFlavorContext` |
| `Flavors/LinuxTentacle/LinuxTentacleFlavor.cs` | `ResolveRegistrar` takes `forceRegistration` parameter; skips the skip when true |
| `Commands/RegisterCommand.cs` | Add `ExtractForceFlag` helper; thread `--force` through `TentacleFlavorContext` |

## Test plan

- [x] `dotnet build` green
- [ ] CI: existing 172 E2E tests still pass (C3h's NoOp pin uses log-line prefix that's unchanged by my new wording)
- [ ] Future: tighten C3h to also pin `--force` actually triggers a real second register (separate follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)