### PR TITLE
Add Phase 13 PR-2: WindowsTentacleBinaryFixture (real binary build)

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -25,7 +25,7 @@ on:
       upgrade_test_filter:
         description: "xUnit --filter for the Squid.WindowsTentacleE2ETests step (defaults to wrapper + service categories)"
         required: false
-        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E"
+        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E"
 
 permissions:
   contents: read
@@ -76,7 +76,7 @@ jobs:
       - name: Run Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E" }
+          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E" }
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `

--- a/tests/Squid.WindowsTentacleE2ETests/Infrastructure/WindowsTentacleBinaryFixture.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/Infrastructure/WindowsTentacleBinaryFixture.cs
@@ -1,0 +1,343 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Squid.WindowsTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 13 PR-2 — Windows mirror of
+/// <c>Squid.LinuxTentacleE2ETests.Infrastructure.LinuxTentacleBinaryFixture</c>.
+/// Builds the REAL <c>Squid.Tentacle.exe</c> binary (self-contained
+/// win-x64) once per test process and shares the path across all
+/// tests that need to drive its CLI surface.
+///
+/// <para><b>Why a real binary, not a placeholder</b>: the existing
+/// Windows test suite calls into production command classes
+/// (<c>RegisterCommand.ExecuteAsync</c>, <c>ServiceCommand.ExecuteAsync</c>)
+/// directly via the public seam — Rule 12.9. That's the right pattern
+/// for testing CLI argv parsing + per-command logic. But Phase 13 is
+/// after a different kind of confidence: a real <c>dotnet publish</c>'d
+/// single-file exe that systemd/SCM can launch at the binary path
+/// stamped into the unit / SCM entry. Calling the production class
+/// in-process can't catch publish-pipeline regressions (PublishSingleFile
+/// target drift, RID mismatch, missing native dependency in self-
+/// contained bundle).</para>
+///
+/// <para><b>UNBLOCKS Phase 13 PR-3</b>: real-binary-as-polling-agent
+/// E2E test (mirror of Linux <c>R1h_RealBinary_PollingAgent_*</c>).
+/// PR-3's test consumes this fixture to run the actual exe.</para>
+///
+/// <para><b>Build strategy</b>: <c>dotnet publish</c> with the same flags
+/// production CI uses (<c>-r win-x64 --self-contained true
+/// -p:PublishSingleFile=true</c>) into a stable cache path under
+/// <c>bin/</c>. First call to <see cref="EnsureBuilt"/> takes ~30-60s
+/// (cold .NET SDK build); subsequent calls return immediately from
+/// the cached binary path.</para>
+///
+/// <para><b>Process-wide singleton</b>: build under a <see cref="object"/>
+/// lock so concurrent test classes that share the binary don't race on
+/// the dotnet publish invocation. xUnit's
+/// <c>WindowsTentacleHostStateCollection</c> serializes the consumers,
+/// but the collection's first test is what triggers the build — if
+/// classes ever escape the collection, the lock prevents double-build.</para>
+///
+/// <para><b>Skip-on-non-Windows</b>: the binary is built for win-x64
+/// self-contained → won't run on macOS / Linux. <see cref="IsAvailable"/>
+/// returns true only on Windows + when <c>dotnet</c> is on PATH.</para>
+/// </summary>
+public sealed class WindowsTentacleBinaryFixture
+{
+    private static readonly object _buildLock = new();
+    private static string _cachedBinaryPath;
+    private static string _cachedV2BinaryPath;
+
+    /// <summary>
+    /// Pinned version stamp baked into the binary at publish time via
+    /// <c>-p:Version=...</c>. The <c>version</c> subcommand reads
+    /// <c>AssemblyVersion.Canonical</c> which is computed from the
+    /// binary's NUMERIC <c>AssemblyName.Version</c> (4-part
+    /// <c>Major.Minor.Build.Revision</c>), with trailing <c>.0</c>
+    /// stripped — pre-release suffixes from
+    /// <c>AssemblyInformationalVersion</c> are NOT included.
+    ///
+    /// <para>Therefore <see cref="BuildVersion"/> must be a 3-component
+    /// numeric version. <c>99.99.99</c> chosen so it's:
+    /// <list type="bullet">
+    ///   <item>Distinguishable from any real production version
+    ///         (currently 1.x — semver guard against accidental
+    ///         match if test fixture leaks into production paths).</item>
+    ///   <item>Survives <c>AssemblyVersion.Canonical</c>'s computation
+    ///         unchanged: published Version="99.99.99" → numeric
+    ///         "99.99.99.0" → strip ".0" → "99.99.99".</item>
+    /// </list></para>
+    ///
+    /// <para>Mirrors the Linux fixture's <c>BuildVersion</c> for cross-
+    /// platform consistency — a unit test asserting "99.99.99" output
+    /// from <c>version</c> works on either OS.</para>
+    /// </summary>
+    public const string BuildVersion = "99.99.99";
+
+    /// <summary>
+    /// Pinned version stamp for the v2 (upgrade-target) binary build.
+    /// Same numeric-only constraint as <see cref="BuildVersion"/>.
+    /// <c>100.0.0</c> chosen so it's:
+    /// <list type="bullet">
+    ///   <item>STRICTLY GREATER than <see cref="BuildVersion"/> (semver
+    ///         well-ordering: an upgrade test that asserts "version went
+    ///         up" reads naturally).</item>
+    ///   <item>Distinguishable from any real production version (currently
+    ///         1.x).</item>
+    /// </list>
+    /// Mirrors Linux fixture's <c>BuildVersionV2</c>. Reserved for future
+    /// Phase 13 upgrade-binary-integration tests on Windows.
+    /// </summary>
+    public const string BuildVersionV2 = "100.0.0";
+
+    public static bool IsAvailable => OperatingSystem.IsWindows() && IsDotnetOnPath();
+
+    /// <summary>
+    /// Builds the binary if not already cached. Returns the absolute path
+    /// to the executable (with <c>.exe</c> suffix on Windows). Idempotent
+    /// + thread-safe.
+    /// </summary>
+    public string EnsureBuilt()
+    {
+        lock (_buildLock)
+        {
+            if (_cachedBinaryPath != null && File.Exists(_cachedBinaryPath))
+                return _cachedBinaryPath;
+
+            var binaryPath = Build(BuildVersion, "win-x64");
+
+            if (!File.Exists(binaryPath))
+                throw new InvalidOperationException(
+                    $"dotnet publish completed but binary not found at expected path: {binaryPath}. " +
+                    "Likely cause: production csproj's OutputType / publish target changed (Squid.Tentacle no longer produces a single-file Exe). " +
+                    "Confirm via `dotnet publish ... -o <out>` and inspect the directory.");
+
+            _cachedBinaryPath = binaryPath;
+            return _cachedBinaryPath;
+        }
+    }
+
+    /// <summary>
+    /// Builds (or returns the cached path of) the v2 binary stamped at
+    /// <see cref="BuildVersionV2"/>. Reserved for Phase 13 upgrade tests
+    /// that need both v1 + v2 simultaneously.
+    /// </summary>
+    public string EnsureBuiltV2()
+    {
+        lock (_buildLock)
+        {
+            if (_cachedV2BinaryPath != null && File.Exists(_cachedV2BinaryPath))
+                return _cachedV2BinaryPath;
+
+            var binaryPath = Build(BuildVersionV2, "win-x64-v2");
+
+            if (!File.Exists(binaryPath))
+                throw new InvalidOperationException(
+                    $"v2 dotnet publish completed but binary not found at: {binaryPath}.");
+
+            _cachedV2BinaryPath = binaryPath;
+            return _cachedV2BinaryPath;
+        }
+    }
+
+    /// <summary>
+    /// Runs the binary with the given args + a clean environment.
+    /// Returns (exitCode, combined stdout+stderr). 60s wall-clock cap —
+    /// individual subcommands like <c>version</c> are sub-second; longer
+    /// timeouts indicate hangs that should fail-fast.
+    ///
+    /// <para><b>Note on elevation</b>: unlike Linux's
+    /// <c>SudoRun</c>/<c>Run</c> distinction (where sudo is required for
+    /// <c>service install/uninstall</c>, <c>register</c> writing under
+    /// <c>/etc/squid-tentacle/</c>, etc.), Windows tests assume the test
+    /// runner process is already running as Administrator (the
+    /// <c>windows-latest</c> GHA runner satisfies this). All operations
+    /// — including <c>service install</c> writing the SCM entry —
+    /// inherit that elevation. No sudo equivalent needed.</para>
+    /// </summary>
+    public (int exitCode, string output) Run(params string[] args)
+    {
+        var binaryPath = EnsureBuilt();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to launch {binaryPath}");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        if (!proc.WaitForExit(60_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException($"{binaryPath} {string.Join(' ', args)} did not complete within 60s.");
+        }
+
+        return (proc.ExitCode, stdoutTask.Result + Environment.NewLine + stderrTask.Result);
+    }
+
+    /// <summary>
+    /// Spawns the binary as a long-running detached process — caller is
+    /// responsible for stopping it. Used by Phase 13 PR-3's
+    /// real-binary-as-polling-agent test where the binary's <c>run</c>
+    /// command needs to stay alive while the stub server dispatches a
+    /// script through the polling channel.
+    ///
+    /// <para>Returns the underlying <see cref="Process"/> so the caller
+    /// can: (a) <c>Kill</c> it on cleanup, (b) read stdout/stderr for
+    /// diagnostics on failure paths.</para>
+    ///
+    /// <para><b>Why a separate method</b>: <see cref="Run"/> blocks until
+    /// the process exits and returns combined output. That's right for
+    /// short subcommands (<c>version</c>, <c>register</c>) but wrong for
+    /// long-running (<c>run</c>) — we need the process running while we
+    /// drive the stub server. Caller is responsible for cleanup.</para>
+    /// </summary>
+    public Process StartLongRunning(params string[] args)
+    {
+        var binaryPath = EnsureBuilt();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        return Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to launch {binaryPath} {string.Join(' ', args)}");
+    }
+
+    private static string Build(string versionStamp, string outputSubDir)
+    {
+        var repoRoot = LocateRepoRoot();
+        var csproj = Path.Combine(repoRoot, "src", "Squid.Tentacle", "Squid.Tentacle.csproj");
+
+        if (!File.Exists(csproj))
+            throw new FileNotFoundException(
+                $"Could not locate Squid.Tentacle.csproj at {csproj}. Repo root resolved to {repoRoot}.");
+
+        // Stable cache path under the test assembly's bin/. Survives between
+        // test runs but cleared by `dotnet clean` / `git clean -xdf bin/`.
+        // The outputSubDir parameter lets v1 + v2 coexist in separate cache
+        // dirs (e.g. win-x64/ and win-x64-v2/).
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var outputDir = Path.Combine(thisAssemblyDir, "squid-tentacle-binary-fixture", outputSubDir);
+
+        Directory.CreateDirectory(outputDir);
+
+        // Mirror production CI's publish flags exactly — single self-
+        // contained binary, stamped version. Same flags as the Linux
+        // fixture except RID = win-x64.
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("publish");
+        psi.ArgumentList.Add(csproj);
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add("Release");
+        psi.ArgumentList.Add("-r");
+        psi.ArgumentList.Add("win-x64");
+        psi.ArgumentList.Add("--self-contained");
+        psi.ArgumentList.Add("true");
+        psi.ArgumentList.Add("-p:PublishSingleFile=true");
+        psi.ArgumentList.Add($"-p:Version={versionStamp}");
+        psi.ArgumentList.Add("-o");
+        psi.ArgumentList.Add(outputDir);
+        // Quiet verbosity — full build log isn't useful for test diagnosis;
+        // errors still surface on stderr.
+        psi.ArgumentList.Add("--verbosity");
+        psi.ArgumentList.Add("quiet");
+        psi.ArgumentList.Add("--nologo");
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start dotnet publish");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        // Cold .NET SDK + restore + publish + self-contained runtime
+        // bundle ≈ 30-60s; budget 5min for the worst case (CI cold cache,
+        // fresh NuGet downloads).
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException(
+                "dotnet publish did not complete within 5min. Cold cache + NuGet restore typically takes 1-2min; longer indicates a build hang OR a dependency network issue.");
+        }
+
+        if (proc.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet publish failed with exit {proc.ExitCode}.\n" +
+                $"stdout: {stdoutTask.Result}\n" +
+                $"stderr: {stderrTask.Result}");
+        }
+
+        return Path.Combine(outputDir, "Squid.Tentacle.exe");
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            // Repo root marker: presence of .github/ + src/Squid.Tentacle/
+            var githubDir = Path.Combine(dir, ".github");
+            var tentacleDir = Path.Combine(dir, "src", "Squid.Tentacle");
+            if (Directory.Exists(githubDir) && Directory.Exists(tentacleDir))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (no .github/ + src/Squid.Tentacle/ ancestor of {thisAssemblyDir}).");
+    }
+
+    private static bool IsDotnetOnPath()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("--version");
+
+            using var proc = Process.Start(psi);
+            if (proc == null) return false;
+            proc.WaitForExit(5_000);
+            return proc.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsBinarySmokeE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsBinarySmokeE2ETests.cs
@@ -1,0 +1,135 @@
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Phase 13 PR-2 — smoke tests for <see cref="WindowsTentacleBinaryFixture"/>.
+/// Tier 🔵 Fixture-only (Rule 12) — proves the build pipeline works
+/// (fixture compiles + binary runs + reports the expected version)
+/// before downstream Phase 13 PR-3 (real-binary-as-polling-agent)
+/// consumes it.
+///
+/// <para>Why a smoke layer matters: the binary is built via
+/// <c>dotnet publish</c> which has many failure modes (missing SDK,
+/// network restore failure, csproj target drift, RID mismatch). A
+/// dedicated smoke test surfaces these failures BEFORE the bigger
+/// downstream tests start using the binary — much easier to debug
+/// "build failed" at smoke vs "polling-agent test mysteriously
+/// failed".</para>
+///
+/// <para>Mirrors <c>Squid.LinuxTentacleE2ETests.TentacleLinuxBinarySmokeE2ETests</c>:
+/// the fixture is fixture-only-tier; downstream tests that USE the
+/// fixture for production-flow E2E are tier 🟢 H.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.TentacleBinary)]
+[Collection(WindowsTentacleHostStateCollection.Name)]
+public sealed class TentacleWindowsBinarySmokeE2ETests
+{
+    // ========================================================================
+    // Binary_Version_PrintsExpectedString
+    //
+    // Smallest viable smoke: build the binary + run `version` + assert
+    // the canonical-version string the production CLI prints matches the
+    // fixture's published version stamp.
+    //
+    // Catches:
+    //   - dotnet publish fails entirely (build pipeline regression)
+    //   - PublishSingleFile target produces a different output path
+    //     (e.g. the win-x64 self-contained bundle layout changed)
+    //   - VersionCommand regression (CLI prints something other than
+    //     AssemblyVersion.Canonical)
+    //   - -p:Version flag doesn't propagate to AssemblyName.Version
+    //
+    // Why this test FIRST (before PR-3 polling-agent test): the most
+    // likely failure mode for PR-2 is the build itself; PR-3 would
+    // then fail with cascading errors. Smoke isolates the build
+    // success contract.
+    //
+    // Cross-OS parity: same expected output as the Linux smoke test
+    // (BuildVersion="99.99.99"), proving AssemblyVersion.Canonical
+    // computation is identical on Windows + Linux.
+    // ========================================================================
+
+    [Fact]
+    public void Binary_Version_PrintsBuildVersionStamp()
+    {
+        if (!WindowsTentacleBinaryFixture.IsAvailable) return;
+
+        var fixture = new WindowsTentacleBinaryFixture();
+
+        var (exitCode, output) = fixture.Run("version");
+
+        exitCode.ShouldBe(0,
+            customMessage: $"`Squid.Tentacle.exe version` MUST exit 0. Got exit {exitCode}. " +
+                          $"If non-zero: VersionCommand has a bug OR the binary is broken (build pipeline regression). " +
+                          $"output:\n{output}");
+
+        // VersionCommand reads AssemblyVersion.Canonical which is computed
+        // from the numeric AssemblyName.Version (Major.Minor.Build.Revision)
+        // with trailing `.0` Revision stripped. Pre-release suffixes from
+        // AssemblyInformationalVersion are NOT included — this is consistent
+        // with the Linux fixture's first-runner finding.
+        output.Trim().ShouldBe(WindowsTentacleBinaryFixture.BuildVersion,
+            customMessage: $"`Squid.Tentacle.exe version` stdout MUST be exactly '{WindowsTentacleBinaryFixture.BuildVersion}' " +
+                          $"(the -p:Version stamp the fixture passes to dotnet publish, after AssemblyVersion.Canonical strips the trailing .0 revision). " +
+                          $"Got: '{output.Trim()}'. " +
+                          $"If different: AssemblyVersion.Canonical computation regressed, OR -p:Version flag is being overridden by the csproj's <Version> property, " +
+                          $"OR Console.WriteLine is emitting extra text. " +
+                          $"Full output:\n{output}");
+    }
+
+    // ========================================================================
+    // Binary_NoArgs_ProducesOutput
+    //
+    // Sanity: invoking the binary with no args goes through CommandResolver's
+    // default-to-RunCommand path. Without a valid registered config,
+    // RunCommand should fail-fast OR start its loop — but it MUST produce
+    // output (Serilog log line, error message, or help text). Pure crash /
+    // hang would surface as empty stdout+stderr OR a Run() timeout.
+    //
+    // Why this matters: regressions in CommandResolver / Program.cs Main
+    // (e.g. unhandled exception path that bypasses the help prompt) would
+    // surface here as a hang or crash. Catches at smoke tier so downstream
+    // tests don't have to deal with it.
+    //
+    // Note: we don't drive the binary into RUNNING state here — it tries
+    // to start the agent which would eventually time out at the fixture's
+    // 60s cap if config isn't valid. Instead we use `help` (or any short-
+    // running command that exits cleanly without needing config).
+    // ========================================================================
+
+    [Fact]
+    public void Binary_Help_ProducesUsageOutput()
+    {
+        if (!WindowsTentacleBinaryFixture.IsAvailable) return;
+
+        var fixture = new WindowsTentacleBinaryFixture();
+
+        // `help` is a short-running command that exits with usage text —
+        // doesn't try to start the agent (which would need real config).
+        // Catches: binary completely broken / segfaults / can't even
+        // resolve commands.
+        var (exitCode, output) = fixture.Run("help");
+
+        // Help output should be printed (exit code can be 0 or non-zero
+        // depending on whether help is treated as success — what matters
+        // is output exists, not the exit code).
+        output.ShouldNotBeNullOrEmpty(
+            customMessage: $"binary `help` produced empty stdout+stderr. Either it hung past the 60s timeout " +
+                          $"(already caught by Run's cap, would throw TimeoutException) OR crashed silently. Exit code: {exitCode}. " +
+                          "Production binary's command-resolver path should always produce some output for `help`.");
+
+        // Sanity: at least one of the documented commands appears.
+        // PrintHelp lists every command via the registered ITentacleCommand
+        // collection; any of these MUST appear in usage output.
+        var hasAnyCommand = output.Contains("register", StringComparison.OrdinalIgnoreCase)
+                         || output.Contains("service", StringComparison.OrdinalIgnoreCase)
+                         || output.Contains("version", StringComparison.OrdinalIgnoreCase)
+                         || output.Contains("show-thumbprint", StringComparison.OrdinalIgnoreCase);
+
+        hasAnyCommand.ShouldBeTrue(
+            customMessage: $"`help` output MUST list at least one production command (register / service / version / show-thumbprint). " +
+                          $"If absent: PrintHelp regressed, OR the command registry was emptied. " +
+                          $"\noutput:\n{output}");
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
@@ -207,4 +207,19 @@ public static class WindowsUpgradeE2ECategories
     /// stub HTTP exchange (D1h round-trip).</para>
     /// </summary>
     public const string TentacleDiagnostic = "TentacleDiagnosticE2E";
+
+    /// <summary>
+    /// Phase 13 PR-2+ E2E coverage for the real production
+    /// <c>Squid.Tentacle.exe</c> binary's CLI surface — Windows mirror
+    /// of <c>Squid.LinuxTentacleE2ETests.LinuxTentacleE2ECategories.TentacleBinary</c>.
+    ///
+    /// <para>Tier 🟢 high-fidelity — drives the actual published binary
+    /// (built via <c>dotnet publish -r win-x64 --self-contained</c>
+    /// matching production CI). UNBLOCKS Phase 13 PR-3 (real binary as
+    /// polling agent — the highest-fidelity Windows E2E).</para>
+    ///
+    /// <para>Windows-only; the fixture's binary is a self-contained
+    /// <c>win-x64</c> bundle that won't run on macOS / Linux.</para>
+    /// </summary>
+    public const string TentacleBinary = "WindowsTentacleBinaryE2E";
 }


### PR DESCRIPTION
## Summary

- New `WindowsTentacleBinaryFixture` mirroring Linux's `LinuxTentacleBinaryFixture` — publishes real `Squid.Tentacle.exe` (self-contained `win-x64`) via `dotnet publish`, caches it, exposes `EnsureBuilt`/`EnsureBuiltV2`/`Run`/`StartLongRunning` for downstream tests
- New `TentacleWindowsBinarySmokeE2ETests` smoke layer (Tier 🔵) — pins build pipeline contract before Phase 13 PR-3 (real-binary-as-polling-agent) lands
- New `WindowsUpgradeE2ECategories.TentacleBinary = "WindowsTentacleBinaryE2E"` constant
- CI: `tentacle-windows-e2e.yml` filter now includes `WindowsTentacleBinaryE2E` so the smoke test runs on both manual + nightly + push-to-main triggers

## Why this matters

Existing Windows tests call into production command classes directly via the public seam (`RegisterCommand.ExecuteAsync`, `ServiceCommand.ExecuteAsync` — Rule 12.9). That's the right pattern for unit-of-CLI testing, but can't catch publish-pipeline regressions:

- `PublishSingleFile` target produces a different output layout
- RID drift (`win-x64` vs portable)
- Self-contained bundle missing a native dependency

Phase 13 PR-3 will be the first Windows test that needs the actual exe at the path stamped into the SCM `binPath` (mirroring Linux PR-1's systemd ExecStart pattern). The in-process production class won't suffice for that.

## Convention parity with Linux

| Aspect | Linux fixture | Windows fixture |
|---|---|---|
| `BuildVersion` | `99.99.99` | `99.99.99` (same — proves cross-OS `AssemblyVersion.Canonical` consistency) |
| `BuildVersionV2` | `100.0.0` | `100.0.0` |
| Publish flags | `-r linux-x64 --self-contained true -p:PublishSingleFile=true` | `-r win-x64 --self-contained true -p:PublishSingleFile=true` |
| `EnsureBuilt` | `bin/squid-tentacle-binary-fixture/linux-x64/Squid.Tentacle` | `bin/squid-tentacle-binary-fixture/win-x64/Squid.Tentacle.exe` |
| Cold build budget | 5 min | 5 min |

## Coverage tier

- **Fixture itself**: 🔵 Fixture-only (Rule 12)
- **Smoke tests**: 🔵 Fixture-only — proves the build pipeline works before downstream tests consume it
- **Downstream PR-3 test**: 🟢 High-fidelity (real binary + real polling channel + real script dispatch)

## Test plan

- [ ] CI on `windows-latest` runs `Category=WindowsTentacleBinaryE2E`:
  - [ ] `Binary_Version_PrintsBuildVersionStamp` passes — proves cold publish + `version` subcommand contract
  - [ ] `Binary_Help_ProducesUsageOutput` passes — sanity that Program.cs's command-resolver doesn't crash
- [x] `dotnet build tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj` — 0 errors

## Phase 13 follow-ups

- PR-3 (next): Windows real-binary as polling agent (mirror Linux R1h)
- PR-4: Keep-alive / soak — multi-second probe stability for both OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)