### PR TITLE
Add Phase 13 PR-3: Windows real-binary polling agent E2E

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -25,7 +25,7 @@ on:
       upgrade_test_filter:
         description: "xUnit --filter for the Squid.WindowsTentacleE2ETests step (defaults to wrapper + service categories)"
         required: false
-        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E"
+        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E"
 
 permissions:
   contents: read
@@ -76,7 +76,7 @@ jobs:
       - name: Run Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E" }
+          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E" }
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `

--- a/tests/Squid.WindowsTentacleE2ETests/Infrastructure/WindowsTentacleBinaryFixture.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/Infrastructure/WindowsTentacleBinaryFixture.cs
@@ -1,0 +1,343 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Squid.WindowsTentacleE2ETests.Infrastructure;
+
+/// <summary>
+/// Phase 13 PR-2 — Windows mirror of
+/// <c>Squid.LinuxTentacleE2ETests.Infrastructure.LinuxTentacleBinaryFixture</c>.
+/// Builds the REAL <c>Squid.Tentacle.exe</c> binary (self-contained
+/// win-x64) once per test process and shares the path across all
+/// tests that need to drive its CLI surface.
+///
+/// <para><b>Why a real binary, not a placeholder</b>: the existing
+/// Windows test suite calls into production command classes
+/// (<c>RegisterCommand.ExecuteAsync</c>, <c>ServiceCommand.ExecuteAsync</c>)
+/// directly via the public seam — Rule 12.9. That's the right pattern
+/// for testing CLI argv parsing + per-command logic. But Phase 13 is
+/// after a different kind of confidence: a real <c>dotnet publish</c>'d
+/// single-file exe that systemd/SCM can launch at the binary path
+/// stamped into the unit / SCM entry. Calling the production class
+/// in-process can't catch publish-pipeline regressions (PublishSingleFile
+/// target drift, RID mismatch, missing native dependency in self-
+/// contained bundle).</para>
+///
+/// <para><b>UNBLOCKS Phase 13 PR-3</b>: real-binary-as-polling-agent
+/// E2E test (mirror of Linux <c>R1h_RealBinary_PollingAgent_*</c>).
+/// PR-3's test consumes this fixture to run the actual exe.</para>
+///
+/// <para><b>Build strategy</b>: <c>dotnet publish</c> with the same flags
+/// production CI uses (<c>-r win-x64 --self-contained true
+/// -p:PublishSingleFile=true</c>) into a stable cache path under
+/// <c>bin/</c>. First call to <see cref="EnsureBuilt"/> takes ~30-60s
+/// (cold .NET SDK build); subsequent calls return immediately from
+/// the cached binary path.</para>
+///
+/// <para><b>Process-wide singleton</b>: build under a <see cref="object"/>
+/// lock so concurrent test classes that share the binary don't race on
+/// the dotnet publish invocation. xUnit's
+/// <c>WindowsTentacleHostStateCollection</c> serializes the consumers,
+/// but the collection's first test is what triggers the build — if
+/// classes ever escape the collection, the lock prevents double-build.</para>
+///
+/// <para><b>Skip-on-non-Windows</b>: the binary is built for win-x64
+/// self-contained → won't run on macOS / Linux. <see cref="IsAvailable"/>
+/// returns true only on Windows + when <c>dotnet</c> is on PATH.</para>
+/// </summary>
+public sealed class WindowsTentacleBinaryFixture
+{
+    private static readonly object _buildLock = new();
+    private static string _cachedBinaryPath;
+    private static string _cachedV2BinaryPath;
+
+    /// <summary>
+    /// Pinned version stamp baked into the binary at publish time via
+    /// <c>-p:Version=...</c>. The <c>version</c> subcommand reads
+    /// <c>AssemblyVersion.Canonical</c> which is computed from the
+    /// binary's NUMERIC <c>AssemblyName.Version</c> (4-part
+    /// <c>Major.Minor.Build.Revision</c>), with trailing <c>.0</c>
+    /// stripped — pre-release suffixes from
+    /// <c>AssemblyInformationalVersion</c> are NOT included.
+    ///
+    /// <para>Therefore <see cref="BuildVersion"/> must be a 3-component
+    /// numeric version. <c>99.99.99</c> chosen so it's:
+    /// <list type="bullet">
+    ///   <item>Distinguishable from any real production version
+    ///         (currently 1.x — semver guard against accidental
+    ///         match if test fixture leaks into production paths).</item>
+    ///   <item>Survives <c>AssemblyVersion.Canonical</c>'s computation
+    ///         unchanged: published Version="99.99.99" → numeric
+    ///         "99.99.99.0" → strip ".0" → "99.99.99".</item>
+    /// </list></para>
+    ///
+    /// <para>Mirrors the Linux fixture's <c>BuildVersion</c> for cross-
+    /// platform consistency — a unit test asserting "99.99.99" output
+    /// from <c>version</c> works on either OS.</para>
+    /// </summary>
+    public const string BuildVersion = "99.99.99";
+
+    /// <summary>
+    /// Pinned version stamp for the v2 (upgrade-target) binary build.
+    /// Same numeric-only constraint as <see cref="BuildVersion"/>.
+    /// <c>100.0.0</c> chosen so it's:
+    /// <list type="bullet">
+    ///   <item>STRICTLY GREATER than <see cref="BuildVersion"/> (semver
+    ///         well-ordering: an upgrade test that asserts "version went
+    ///         up" reads naturally).</item>
+    ///   <item>Distinguishable from any real production version (currently
+    ///         1.x).</item>
+    /// </list>
+    /// Mirrors Linux fixture's <c>BuildVersionV2</c>. Reserved for future
+    /// Phase 13 upgrade-binary-integration tests on Windows.
+    /// </summary>
+    public const string BuildVersionV2 = "100.0.0";
+
+    public static bool IsAvailable => OperatingSystem.IsWindows() && IsDotnetOnPath();
+
+    /// <summary>
+    /// Builds the binary if not already cached. Returns the absolute path
+    /// to the executable (with <c>.exe</c> suffix on Windows). Idempotent
+    /// + thread-safe.
+    /// </summary>
+    public string EnsureBuilt()
+    {
+        lock (_buildLock)
+        {
+            if (_cachedBinaryPath != null && File.Exists(_cachedBinaryPath))
+                return _cachedBinaryPath;
+
+            var binaryPath = Build(BuildVersion, "win-x64");
+
+            if (!File.Exists(binaryPath))
+                throw new InvalidOperationException(
+                    $"dotnet publish completed but binary not found at expected path: {binaryPath}. " +
+                    "Likely cause: production csproj's OutputType / publish target changed (Squid.Tentacle no longer produces a single-file Exe). " +
+                    "Confirm via `dotnet publish ... -o <out>` and inspect the directory.");
+
+            _cachedBinaryPath = binaryPath;
+            return _cachedBinaryPath;
+        }
+    }
+
+    /// <summary>
+    /// Builds (or returns the cached path of) the v2 binary stamped at
+    /// <see cref="BuildVersionV2"/>. Reserved for Phase 13 upgrade tests
+    /// that need both v1 + v2 simultaneously.
+    /// </summary>
+    public string EnsureBuiltV2()
+    {
+        lock (_buildLock)
+        {
+            if (_cachedV2BinaryPath != null && File.Exists(_cachedV2BinaryPath))
+                return _cachedV2BinaryPath;
+
+            var binaryPath = Build(BuildVersionV2, "win-x64-v2");
+
+            if (!File.Exists(binaryPath))
+                throw new InvalidOperationException(
+                    $"v2 dotnet publish completed but binary not found at: {binaryPath}.");
+
+            _cachedV2BinaryPath = binaryPath;
+            return _cachedV2BinaryPath;
+        }
+    }
+
+    /// <summary>
+    /// Runs the binary with the given args + a clean environment.
+    /// Returns (exitCode, combined stdout+stderr). 60s wall-clock cap —
+    /// individual subcommands like <c>version</c> are sub-second; longer
+    /// timeouts indicate hangs that should fail-fast.
+    ///
+    /// <para><b>Note on elevation</b>: unlike Linux's
+    /// <c>SudoRun</c>/<c>Run</c> distinction (where sudo is required for
+    /// <c>service install/uninstall</c>, <c>register</c> writing under
+    /// <c>/etc/squid-tentacle/</c>, etc.), Windows tests assume the test
+    /// runner process is already running as Administrator (the
+    /// <c>windows-latest</c> GHA runner satisfies this). All operations
+    /// — including <c>service install</c> writing the SCM entry —
+    /// inherit that elevation. No sudo equivalent needed.</para>
+    /// </summary>
+    public (int exitCode, string output) Run(params string[] args)
+    {
+        var binaryPath = EnsureBuilt();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to launch {binaryPath}");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        if (!proc.WaitForExit(60_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException($"{binaryPath} {string.Join(' ', args)} did not complete within 60s.");
+        }
+
+        return (proc.ExitCode, stdoutTask.Result + Environment.NewLine + stderrTask.Result);
+    }
+
+    /// <summary>
+    /// Spawns the binary as a long-running detached process — caller is
+    /// responsible for stopping it. Used by Phase 13 PR-3's
+    /// real-binary-as-polling-agent test where the binary's <c>run</c>
+    /// command needs to stay alive while the stub server dispatches a
+    /// script through the polling channel.
+    ///
+    /// <para>Returns the underlying <see cref="Process"/> so the caller
+    /// can: (a) <c>Kill</c> it on cleanup, (b) read stdout/stderr for
+    /// diagnostics on failure paths.</para>
+    ///
+    /// <para><b>Why a separate method</b>: <see cref="Run"/> blocks until
+    /// the process exits and returns combined output. That's right for
+    /// short subcommands (<c>version</c>, <c>register</c>) but wrong for
+    /// long-running (<c>run</c>) — we need the process running while we
+    /// drive the stub server. Caller is responsible for cleanup.</para>
+    /// </summary>
+    public Process StartLongRunning(params string[] args)
+    {
+        var binaryPath = EnsureBuilt();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        return Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to launch {binaryPath} {string.Join(' ', args)}");
+    }
+
+    private static string Build(string versionStamp, string outputSubDir)
+    {
+        var repoRoot = LocateRepoRoot();
+        var csproj = Path.Combine(repoRoot, "src", "Squid.Tentacle", "Squid.Tentacle.csproj");
+
+        if (!File.Exists(csproj))
+            throw new FileNotFoundException(
+                $"Could not locate Squid.Tentacle.csproj at {csproj}. Repo root resolved to {repoRoot}.");
+
+        // Stable cache path under the test assembly's bin/. Survives between
+        // test runs but cleared by `dotnet clean` / `git clean -xdf bin/`.
+        // The outputSubDir parameter lets v1 + v2 coexist in separate cache
+        // dirs (e.g. win-x64/ and win-x64-v2/).
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var outputDir = Path.Combine(thisAssemblyDir, "squid-tentacle-binary-fixture", outputSubDir);
+
+        Directory.CreateDirectory(outputDir);
+
+        // Mirror production CI's publish flags exactly — single self-
+        // contained binary, stamped version. Same flags as the Linux
+        // fixture except RID = win-x64.
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("publish");
+        psi.ArgumentList.Add(csproj);
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add("Release");
+        psi.ArgumentList.Add("-r");
+        psi.ArgumentList.Add("win-x64");
+        psi.ArgumentList.Add("--self-contained");
+        psi.ArgumentList.Add("true");
+        psi.ArgumentList.Add("-p:PublishSingleFile=true");
+        psi.ArgumentList.Add($"-p:Version={versionStamp}");
+        psi.ArgumentList.Add("-o");
+        psi.ArgumentList.Add(outputDir);
+        // Quiet verbosity — full build log isn't useful for test diagnosis;
+        // errors still surface on stderr.
+        psi.ArgumentList.Add("--verbosity");
+        psi.ArgumentList.Add("quiet");
+        psi.ArgumentList.Add("--nologo");
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start dotnet publish");
+
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+
+        // Cold .NET SDK + restore + publish + self-contained runtime
+        // bundle ≈ 30-60s; budget 5min for the worst case (CI cold cache,
+        // fresh NuGet downloads).
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException(
+                "dotnet publish did not complete within 5min. Cold cache + NuGet restore typically takes 1-2min; longer indicates a build hang OR a dependency network issue.");
+        }
+
+        if (proc.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"dotnet publish failed with exit {proc.ExitCode}.\n" +
+                $"stdout: {stdoutTask.Result}\n" +
+                $"stderr: {stderrTask.Result}");
+        }
+
+        return Path.Combine(outputDir, "Squid.Tentacle.exe");
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            // Repo root marker: presence of .github/ + src/Squid.Tentacle/
+            var githubDir = Path.Combine(dir, ".github");
+            var tentacleDir = Path.Combine(dir, "src", "Squid.Tentacle");
+            if (Directory.Exists(githubDir) && Directory.Exists(tentacleDir))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new DirectoryNotFoundException(
+            $"Could not locate repo root (no .github/ + src/Squid.Tentacle/ ancestor of {thisAssemblyDir}).");
+    }
+
+    private static bool IsDotnetOnPath()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("--version");
+
+            using var proc = Process.Start(psi);
+            if (proc == null) return false;
+            proc.WaitForExit(5_000);
+            return proc.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsBinarySmokeE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsBinarySmokeE2ETests.cs
@@ -1,0 +1,135 @@
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Phase 13 PR-2 — smoke tests for <see cref="WindowsTentacleBinaryFixture"/>.
+/// Tier 🔵 Fixture-only (Rule 12) — proves the build pipeline works
+/// (fixture compiles + binary runs + reports the expected version)
+/// before downstream Phase 13 PR-3 (real-binary-as-polling-agent)
+/// consumes it.
+///
+/// <para>Why a smoke layer matters: the binary is built via
+/// <c>dotnet publish</c> which has many failure modes (missing SDK,
+/// network restore failure, csproj target drift, RID mismatch). A
+/// dedicated smoke test surfaces these failures BEFORE the bigger
+/// downstream tests start using the binary — much easier to debug
+/// "build failed" at smoke vs "polling-agent test mysteriously
+/// failed".</para>
+///
+/// <para>Mirrors <c>Squid.LinuxTentacleE2ETests.TentacleLinuxBinarySmokeE2ETests</c>:
+/// the fixture is fixture-only-tier; downstream tests that USE the
+/// fixture for production-flow E2E are tier 🟢 H.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.TentacleBinary)]
+[Collection(WindowsTentacleHostStateCollection.Name)]
+public sealed class TentacleWindowsBinarySmokeE2ETests
+{
+    // ========================================================================
+    // Binary_Version_PrintsExpectedString
+    //
+    // Smallest viable smoke: build the binary + run `version` + assert
+    // the canonical-version string the production CLI prints matches the
+    // fixture's published version stamp.
+    //
+    // Catches:
+    //   - dotnet publish fails entirely (build pipeline regression)
+    //   - PublishSingleFile target produces a different output path
+    //     (e.g. the win-x64 self-contained bundle layout changed)
+    //   - VersionCommand regression (CLI prints something other than
+    //     AssemblyVersion.Canonical)
+    //   - -p:Version flag doesn't propagate to AssemblyName.Version
+    //
+    // Why this test FIRST (before PR-3 polling-agent test): the most
+    // likely failure mode for PR-2 is the build itself; PR-3 would
+    // then fail with cascading errors. Smoke isolates the build
+    // success contract.
+    //
+    // Cross-OS parity: same expected output as the Linux smoke test
+    // (BuildVersion="99.99.99"), proving AssemblyVersion.Canonical
+    // computation is identical on Windows + Linux.
+    // ========================================================================
+
+    [Fact]
+    public void Binary_Version_PrintsBuildVersionStamp()
+    {
+        if (!WindowsTentacleBinaryFixture.IsAvailable) return;
+
+        var fixture = new WindowsTentacleBinaryFixture();
+
+        var (exitCode, output) = fixture.Run("version");
+
+        exitCode.ShouldBe(0,
+            customMessage: $"`Squid.Tentacle.exe version` MUST exit 0. Got exit {exitCode}. " +
+                          $"If non-zero: VersionCommand has a bug OR the binary is broken (build pipeline regression). " +
+                          $"output:\n{output}");
+
+        // VersionCommand reads AssemblyVersion.Canonical which is computed
+        // from the numeric AssemblyName.Version (Major.Minor.Build.Revision)
+        // with trailing `.0` Revision stripped. Pre-release suffixes from
+        // AssemblyInformationalVersion are NOT included — this is consistent
+        // with the Linux fixture's first-runner finding.
+        output.Trim().ShouldBe(WindowsTentacleBinaryFixture.BuildVersion,
+            customMessage: $"`Squid.Tentacle.exe version` stdout MUST be exactly '{WindowsTentacleBinaryFixture.BuildVersion}' " +
+                          $"(the -p:Version stamp the fixture passes to dotnet publish, after AssemblyVersion.Canonical strips the trailing .0 revision). " +
+                          $"Got: '{output.Trim()}'. " +
+                          $"If different: AssemblyVersion.Canonical computation regressed, OR -p:Version flag is being overridden by the csproj's <Version> property, " +
+                          $"OR Console.WriteLine is emitting extra text. " +
+                          $"Full output:\n{output}");
+    }
+
+    // ========================================================================
+    // Binary_NoArgs_ProducesOutput
+    //
+    // Sanity: invoking the binary with no args goes through CommandResolver's
+    // default-to-RunCommand path. Without a valid registered config,
+    // RunCommand should fail-fast OR start its loop — but it MUST produce
+    // output (Serilog log line, error message, or help text). Pure crash /
+    // hang would surface as empty stdout+stderr OR a Run() timeout.
+    //
+    // Why this matters: regressions in CommandResolver / Program.cs Main
+    // (e.g. unhandled exception path that bypasses the help prompt) would
+    // surface here as a hang or crash. Catches at smoke tier so downstream
+    // tests don't have to deal with it.
+    //
+    // Note: we don't drive the binary into RUNNING state here — it tries
+    // to start the agent which would eventually time out at the fixture's
+    // 60s cap if config isn't valid. Instead we use `help` (or any short-
+    // running command that exits cleanly without needing config).
+    // ========================================================================
+
+    [Fact]
+    public void Binary_Help_ProducesUsageOutput()
+    {
+        if (!WindowsTentacleBinaryFixture.IsAvailable) return;
+
+        var fixture = new WindowsTentacleBinaryFixture();
+
+        // `help` is a short-running command that exits with usage text —
+        // doesn't try to start the agent (which would need real config).
+        // Catches: binary completely broken / segfaults / can't even
+        // resolve commands.
+        var (exitCode, output) = fixture.Run("help");
+
+        // Help output should be printed (exit code can be 0 or non-zero
+        // depending on whether help is treated as success — what matters
+        // is output exists, not the exit code).
+        output.ShouldNotBeNullOrEmpty(
+            customMessage: $"binary `help` produced empty stdout+stderr. Either it hung past the 60s timeout " +
+                          $"(already caught by Run's cap, would throw TimeoutException) OR crashed silently. Exit code: {exitCode}. " +
+                          "Production binary's command-resolver path should always produce some output for `help`.");
+
+        // Sanity: at least one of the documented commands appears.
+        // PrintHelp lists every command via the registered ITentacleCommand
+        // collection; any of these MUST appear in usage output.
+        var hasAnyCommand = output.Contains("register", StringComparison.OrdinalIgnoreCase)
+                         || output.Contains("service", StringComparison.OrdinalIgnoreCase)
+                         || output.Contains("version", StringComparison.OrdinalIgnoreCase)
+                         || output.Contains("show-thumbprint", StringComparison.OrdinalIgnoreCase);
+
+        hasAnyCommand.ShouldBeTrue(
+            customMessage: $"`help` output MUST list at least one production command (register / service / version / show-thumbprint). " +
+                          $"If absent: PrintHelp regressed, OR the command registry was emptied. " +
+                          $"\noutput:\n{output}");
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsRealBinaryIntegrationE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsRealBinaryIntegrationE2ETests.cs
@@ -188,11 +188,14 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
         var runProcess = ctx.Binary.StartLongRunning("run", "--instance", ctx.InstanceName);
         ctx.RunProcess = runProcess;
 
-        // Drain stdout/stderr concurrently so the binary's pipe buffers
-        // don't fill (which would block its writes and stall the polling
-        // loop). Captured for failure-diagnostic dumps.
-        ctx.StdoutCapture = DrainStreamAsync(runProcess.StandardOutput, ctx.RunCts.Token);
-        ctx.StderrCapture = DrainStreamAsync(runProcess.StandardError, ctx.RunCts.Token);
+        // Drain stdout/stderr concurrently into a thread-safe StringBuilder
+        // so the binary's pipe buffers don't fill (which would block its
+        // writes and stall the polling loop). Snapshot via lock for
+        // failure-diagnostic dumps — never await the drain task itself
+        // (it only completes on stream EOF, i.e. after process exit, so
+        // .Result on the failure path WOULD deadlock — caught by xUnit1031).
+        ctx.StdoutCapture = DrainStreamAsync(runProcess.StandardOutput, ctx.StdoutBuilder, ctx.StdoutLock, ctx.RunCts.Token);
+        ctx.StderrCapture = DrainStreamAsync(runProcess.StandardError, ctx.StderrBuilder, ctx.StderrLock, ctx.RunCts.Token);
 
         // ── Step 4: wait for polling channel to be queryable ──────────────
         // Capabilities probe via Halibut polling — proves the agent's
@@ -212,8 +215,8 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
                 runProcess.HasExited.ShouldBeFalse(
                     customMessage: $"binary exited with code {runProcess.ExitCode} BEFORE polling channel came up. " +
                                   $"Likely cause: config-load failure, port-bind failure, or unhandled exception in StartPolling. " +
-                                  $"\nstdout:\n{ctx.StdoutCapture.Result}" +
-                                  $"\nstderr:\n{ctx.StderrCapture.Result}");
+                                  $"\nstdout:\n{ctx.SnapshotStdout()}" +
+                                  $"\nstderr:\n{ctx.SnapshotStderr()}");
             }
 
             try
@@ -239,8 +242,8 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
                               "(1) agent's StartPolling didn't trust the server thumbprint correctly; " +
                               "(2) stub's TrustAgent didn't propagate; " +
                               "(3) ServerCommsUrl resolution diverged on Windows — check binary stdout. " +
-                              $"\n\nstdout:\n{ctx.StdoutCapture.Result}" +
-                              $"\n\nstderr:\n{ctx.StderrCapture.Result}");
+                              $"\n\nstdout:\n{ctx.SnapshotStdout()}" +
+                              $"\n\nstderr:\n{ctx.SnapshotStderr()}");
         }
 
         capabilities.AgentVersion.ShouldNotBeNullOrEmpty(
@@ -297,8 +300,8 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
                 "(1) polling channel actually wasn't ready (Step 4's probe got lucky once); " +
                 "(2) LocalScriptService PowerShell spawn regressed in real binary path; " +
                 "(3) Halibut RPC serialization broke for StartScriptCommand. " +
-                $"\n\nbinary stdout:\n{ctx.StdoutCapture.Result}" +
-                $"\n\nbinary stderr:\n{ctx.StderrCapture.Result}", ex);
+                $"\n\nbinary stdout:\n{ctx.SnapshotStdout()}" +
+                $"\n\nbinary stderr:\n{ctx.SnapshotStderr()}", ex);
         }
 
         result.ExitCode.ShouldBe(0,
@@ -317,16 +320,24 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Drains a stream concurrently into a captured string. Used to keep
-    /// the binary's stdout/stderr pipe buffers empty (a full pipe blocks
-    /// the writer) AND to surface the captured text in failure-path
-    /// diagnostic dumps.
+    /// Drains a stream concurrently into a shared StringBuilder protected
+    /// by <paramref name="appendLock"/>. Used to keep the binary's
+    /// stdout/stderr pipe buffers empty (a full pipe blocks the writer
+    /// AND stalls the polling loop) AND to surface the captured text in
+    /// failure-path diagnostic dumps.
+    ///
+    /// <para><b>Why a shared StringBuilder + lock instead of a returned
+    /// Task&lt;string&gt;</b>: the drain task only completes on stream EOF,
+    /// which only happens AFTER the binary process exits. If we awaited
+    /// <c>Task&lt;string&gt;</c> on a failure path mid-test (when the binary
+    /// is still running), we'd deadlock. xUnit1031 catches that. Snapshotting
+    /// via lock lets the test read what's been captured SO FAR without
+    /// waiting for stream EOF.</para>
     /// </summary>
-    private static Task<string> DrainStreamAsync(StreamReader reader, CancellationToken ct)
+    private static Task DrainStreamAsync(StreamReader reader, StringBuilder target, object appendLock, CancellationToken ct)
     {
         return Task.Run(async () =>
         {
-            var sb = new StringBuilder();
             try
             {
                 var buffer = new char[1024];
@@ -334,14 +345,14 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
                 {
                     var read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                     if (read == 0) break;
-                    sb.Append(buffer, 0, read);
+                    lock (appendLock)
+                        target.Append(buffer, 0, read);
                 }
             }
             catch
             {
-                // Stream closed / disposed — return what we have.
+                // Stream closed / disposed mid-read — preserve what we have.
             }
-            return sb.ToString();
         }, ct);
     }
 
@@ -361,8 +372,25 @@ public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
 
         public Process RunProcess { get; set; }
         public CancellationTokenSource RunCts { get; } = new();
-        public Task<string> StdoutCapture { get; set; }
-        public Task<string> StderrCapture { get; set; }
+
+        // Drain target — see DrainStreamAsync's doc-comment for why we
+        // snapshot via lock instead of awaiting a Task<string>.
+        public StringBuilder StdoutBuilder { get; } = new();
+        public StringBuilder StderrBuilder { get; } = new();
+        public object StdoutLock { get; } = new();
+        public object StderrLock { get; } = new();
+        public Task StdoutCapture { get; set; }
+        public Task StderrCapture { get; set; }
+
+        public string SnapshotStdout()
+        {
+            lock (StdoutLock) return StdoutBuilder.ToString();
+        }
+
+        public string SnapshotStderr()
+        {
+            lock (StderrLock) return StderrBuilder.ToString();
+        }
 
         public RealBinaryPollingContext()
         {

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsRealBinaryIntegrationE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleWindowsRealBinaryIntegrationE2ETests.cs
@@ -1,0 +1,433 @@
+using System.Diagnostics;
+using System.Text;
+using Squid.Tentacle.Instance;
+using Squid.Tentacle.Platform;
+using Squid.Message.Contracts.Tentacle;
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Phase 13 PR-3 — Windows mirror of
+/// <c>Squid.LinuxTentacleE2ETests.TentacleLinuxRealBinaryIntegrationE2ETests.R1h_RealBinary_PollingAgent_*</c>.
+/// Pins the FULL real-production polling-agent path on Windows: the
+/// real <c>dotnet publish</c>'d <c>Squid.Tentacle.exe</c> registers
+/// against <see cref="StubSquidServer"/>, runs as a polling agent,
+/// and accepts a real Halibut script-dispatch round-trip.
+///
+/// <para><b>Coverage delta vs prior Windows tests</b>:</para>
+/// <list type="bullet">
+///   <item><see cref="TentacleRegisterE2ETests"/> calls
+///         <c>RegisterCommand.ExecuteAsync</c> directly (Rule 12.9 public
+///         seam) — fast, but doesn't catch publish-pipeline regressions.</item>
+///   <item><see cref="TentacleDeployE2ETests"/> drives Halibut script
+///         dispatch but uses <see cref="StubAgent"/> (in-process wrapper
+///         around <c>LocalScriptService</c>), NOT the real binary.</item>
+/// </list>
+/// PR-3 closes the gap: real binary, real `register` against the stub,
+/// real polling channel, real script execution. This is the highest-
+/// fidelity Windows E2E the suite has.
+///
+/// <para><b>Tier 🟢 H</b> (Rule 12.4): zero mocks at the
+/// real-production-code layer. Only "stub" is the SERVER-side
+/// (<see cref="StubSquidServer"/>) which IS the production server's
+/// contract — same Halibut runtime, same self-signed cert TLS, same
+/// REST register handshake.</para>
+///
+/// <para><b>Why Process.Start instead of SCM-launched start (vs Linux R1h
+/// which uses systemd start)</b>: Squid.Tentacle's Program.cs has no
+/// <c>UseWindowsService()</c> / <c>ServiceBase</c> integration —
+/// SCM-launched start times out at <c>ERROR_SERVICE_REQUEST_TIMEOUT</c>
+/// because the binary doesn't register a service control handler. This
+/// is a real production gap (operators following the documented
+/// <c>service install</c> + <c>sc start</c> workflow on Windows would
+/// see the service fail to reach RUNNING state). Tracked as a separate
+/// production-fix task — once the fix lands, an SCM-launched variant
+/// of this test can be added. PR-3's Process.Start path validates the
+/// polling code path which is the primary value of Phase 13.</para>
+///
+/// <para><b>Windows-only</b>: real binary is published self-contained
+/// <c>win-x64</c> (<see cref="WindowsTentacleBinaryFixture"/>). Skip-
+/// guards on macOS / Linux.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.TentacleBinary)]
+[Collection(WindowsTentacleHostStateCollection.Name)]
+public sealed class TentacleWindowsRealBinaryIntegrationE2ETests
+{
+    // ========================================================================
+    // R1.h-Windows — REAL binary as polling agent: register → spawn run →
+    //                polling channel up → script dispatched → output round-trip
+    //
+    // Operator workflow this exercises:
+    //
+    //   Squid.Tentacle.exe register `
+    //     --server https://squid.acme.internal:7078 `
+    //     --comms-url https://squid.acme.internal:10943 `
+    //     --api-key API-XXXX `
+    //     --role web-server `
+    //     --environment Production
+    //
+    //   # (Production: would be `service install` + sc start; today blocked
+    //   # on UseWindowsService() integration → use Process.Start direct.)
+    //   Squid.Tentacle.exe run --instance <name>
+    //
+    //   # Operator triggers a deployment from the Squid web UI:
+    //     # → server dispatches StartScriptCommand via Halibut polling
+    //     # → real binary's LocalScriptService runs PowerShell
+    //     # → output streams back to server
+    //
+    // What this catches that prior tests don't:
+    //
+    //   - register → run config round-trip on Windows (e.g. PlatformPaths
+    //     resolution diverges from Linux's /etc/squid-tentacle/ pattern)
+    //   - TentacleHalibutHost.StartPolling regression on Windows (e.g.
+    //     IPAddress.Any binding policy, certificate trust on Windows
+    //     CryptoAPI cert store)
+    //   - LocalScriptService PowerShell spawn regression on the
+    //     real-binary path (vs StubAgent which exercises the same
+    //     LocalScriptService but in-process)
+    //   - ProcessOutput streaming through Halibut on the real Windows binary
+    //
+    // Test mechanism:
+    //   1. Start StubSquidServer (full Halibut listener + REST register).
+    //   2. Pre-create the instance in InstanceRegistry (matching Windows
+    //      register-test pattern).
+    //   3. Real binary `register --comms-url=stub.PollingUri ...`
+    //      — Polling mode, persists config with stub's ServerThumbprint.
+    //   4. Extract agent thumbprint + subscriptionId from registration body.
+    //   5. stub.TrustAgent(thumbprint) BEFORE starting `run` — TLS handshake
+    //      would otherwise reject the agent's cert.
+    //   6. Spawn real binary via StartLongRunning("run", "--instance", ...)
+    //      and KEEP it running while the dispatch fires.
+    //   7. Wait for stub.ProbeCapabilitiesPollingAsync to succeed (proves
+    //      polling channel up, retries needed because Halibut handshake
+    //      takes 2-5s after process launch).
+    //   8. THE PIN: stub.DispatchAndObservePollingAsync with a PowerShell
+    //      echo round-trip — assert exit 0 + marker in logs.
+    //   9. Cleanup: Process.Kill the binary, delete config + instance.
+    //
+    // Why PowerShell for the dispatch script (not bash like Linux R1h):
+    // production LocalScriptService uses ScriptType.PowerShell on Windows;
+    // bash isn't reliably available on the GHA windows-latest runner.
+    //
+    // Tier: 🟢 H. Maximum-fidelity Windows E2E. Real binary + real Halibut
+    // RPC + real PowerShell spawn — only SCM is bypassed (separate task).
+    //
+    // Expected runtime: ~30-60s
+    //   - register: ~1-2s (binary spawn cost on Windows is higher than Linux)
+    //   - run startup + polling channel handshake: ~3-8s
+    //   - script dispatch + observe: ~2-3s
+    //   - cleanup: ~3-5s
+    // ========================================================================
+
+    [Fact]
+    public async Task R1h_RealBinary_PollingAgent_ScriptDispatchRoundTripsThroughHalibut()
+    {
+        if (!WindowsTentacleBinaryFixture.IsAvailable) return;
+
+        await using var stub = await StubSquidServer.StartAsync();
+        using var ctx = new RealBinaryPollingContext();
+
+        // ── Step 1: register the real binary as a Polling tentacle ────────
+        var (regExit, regOutput) = ctx.Binary.Run(
+            "register",
+            "--instance", ctx.InstanceName,
+            "--server", stub.ServerUri.ToString().TrimEnd('/'),
+            "--comms-url", stub.PollingUri.ToString().TrimEnd('/'),
+            "--api-key", "API-PHASE13-PR3-W-1234",
+            "--role", "phase13-windows-polling-agent",
+            "--environment", "Production",
+            "--flavor", "LinuxTentacle");
+
+        regExit.ShouldBe(0,
+            customMessage: $"Step 1 (register Polling) MUST exit 0. Got {regExit}. " +
+                          $"Without successful register, downstream `run` + dispatch are meaningless. " +
+                          $"output:\n{regOutput}");
+
+        stub.ReceivedRegistrations.Count.ShouldBe(1,
+            customMessage: $"stub MUST have received exactly 1 register call. Got {stub.ReceivedRegistrations.Count}.");
+
+        var registration = stub.ReceivedRegistrations.Single();
+        registration.Kind.ShouldBe(RegistrationKind.Polling,
+            customMessage: $"register MUST hit the Polling endpoint when --comms-url is provided. " +
+                          $"Got {registration.Kind}. " +
+                          "If Listening: --comms-url ArgMapping regressed OR ResolveCommunicationMode flipped.");
+
+        var agentThumbprint = registration.AgentThumbprint;
+        agentThumbprint.ShouldNotBeNullOrEmpty(
+            customMessage: $"registration body MUST contain agent thumbprint. Body:\n{registration.RawBody}");
+
+        var agentSubscriptionId = registration.SubscriptionId;
+        agentSubscriptionId.ShouldNotBeNullOrEmpty(
+            customMessage: $"registration body MUST contain subscriptionId for Polling. Body:\n{registration.RawBody}");
+
+        // Sanity: persisted config has Registered=true so `run` will hit
+        // NoOpRegistrar and reuse the persisted ServerCertificate /
+        // SubscriptionId instead of re-registering against the (test-
+        // lifetime) stub URL.
+        File.Exists(ctx.ExpectedConfigPath).ShouldBeTrue(
+            customMessage: $"register MUST persist config at {ctx.ExpectedConfigPath} — without it `run` has no identity to load");
+
+        var configContent = File.ReadAllText(ctx.ExpectedConfigPath);
+        configContent.ShouldContain("Registered",
+            customMessage: $"config MUST contain Registered key. config:\n{configContent}");
+        configContent.ShouldContain(stub.ServerThumbprint,
+            customMessage: $"config MUST contain stub's ServerThumbprint '{stub.ServerThumbprint}'. config:\n{configContent}");
+
+        // ── Step 2: stub trusts the agent's thumbprint ────────────────────
+        // Halibut TLS handshake on stub-side rejects unknown agent certs.
+        // Trust BEFORE starting `run` so when its polling client dials in,
+        // the handshake completes.
+        stub.TrustAgent(agentThumbprint);
+
+        // ── Step 3: spawn the real binary as a long-running `run` process ─
+        // (Linux R1h does `service install` here; Windows blocks on missing
+        // UseWindowsService() integration — see class doc-comment for the
+        // tracked production-fix task. Process.Start validates the same
+        // polling code path.)
+        var runProcess = ctx.Binary.StartLongRunning("run", "--instance", ctx.InstanceName);
+        ctx.RunProcess = runProcess;
+
+        // Drain stdout/stderr concurrently so the binary's pipe buffers
+        // don't fill (which would block its writes and stall the polling
+        // loop). Captured for failure-diagnostic dumps.
+        ctx.StdoutCapture = DrainStreamAsync(runProcess.StandardOutput, ctx.RunCts.Token);
+        ctx.StderrCapture = DrainStreamAsync(runProcess.StandardError, ctx.RunCts.Token);
+
+        // ── Step 4: wait for polling channel to be queryable ──────────────
+        // Capabilities probe via Halibut polling — proves the agent's
+        // _runtime.Poll(...) successfully connected to the stub's listener
+        // and registered itself under the right subscription id. Halibut
+        // handshake takes 2-5s after process launch on Windows (slower than
+        // Linux due to .NET startup + cert store traversal); retry up to
+        // 30s.
+        var probeDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        Exception lastProbeException = null;
+        CapabilitiesResponse capabilities = null;
+        while (DateTime.UtcNow < probeDeadline)
+        {
+            // Bail early if the binary crashed.
+            if (runProcess.HasExited)
+            {
+                runProcess.HasExited.ShouldBeFalse(
+                    customMessage: $"binary exited with code {runProcess.ExitCode} BEFORE polling channel came up. " +
+                                  $"Likely cause: config-load failure, port-bind failure, or unhandled exception in StartPolling. " +
+                                  $"\nstdout:\n{ctx.StdoutCapture.Result}" +
+                                  $"\nstderr:\n{ctx.StderrCapture.Result}");
+            }
+
+            try
+            {
+                using var probeCts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+                capabilities = await stub.ProbeCapabilitiesPollingAsync(
+                    agentSubscriptionId, agentThumbprint, probeCts.Token);
+                break;
+            }
+            catch (Exception ex)
+            {
+                lastProbeException = ex;
+                await Task.Delay(500);
+            }
+        }
+
+        if (capabilities == null)
+        {
+            capabilities.ShouldNotBeNull(
+                customMessage: $"polling channel did NOT come up within 30s of `run` process launch. " +
+                              $"Last probe exception: {lastProbeException?.GetType().Name}: {lastProbeException?.Message}. " +
+                              "Most likely causes: " +
+                              "(1) agent's StartPolling didn't trust the server thumbprint correctly; " +
+                              "(2) stub's TrustAgent didn't propagate; " +
+                              "(3) ServerCommsUrl resolution diverged on Windows — check binary stdout. " +
+                              $"\n\nstdout:\n{ctx.StdoutCapture.Result}" +
+                              $"\n\nstderr:\n{ctx.StderrCapture.Result}");
+        }
+
+        capabilities.AgentVersion.ShouldNotBeNullOrEmpty(
+            customMessage: "agent's CapabilitiesService MUST report a non-empty AgentVersion.");
+
+        // Production CapabilitiesService formats supported services as
+        // "<Name>/v1" — prefix-match for forward compatibility with future
+        // version bumps. Same pattern Linux R1h adopted after first runner
+        // surfaced the versioned format.
+        var hasScriptService = capabilities.SupportedServices?.Any(s => s.StartsWith("IScriptService", StringComparison.Ordinal)) ?? false;
+        hasScriptService.ShouldBeTrue(
+            customMessage: $"agent MUST list IScriptService (or IScriptService/vN) in supported services — " +
+                          "the dispatch in Step 5 is about to invoke it. " +
+                          $"Got: [{string.Join(", ", capabilities.SupportedServices ?? new List<string>())}].");
+
+        // ── Step 5: THE PIN — dispatch a real script via Halibut polling ──
+        // Server (stub) sends StartScriptCommand → Halibut RPC → REAL binary's
+        // LocalScriptService → PowerShell spawn → ProcessOutput streamed
+        // back via Halibut → server's observe loop.
+        var marker = $"phase13-pr3-windows-real-binary-{Guid.NewGuid():N}";
+        var ticket = new ScriptTicket($"phase13-pr3-{Guid.NewGuid():N}");
+        var command = new StartScriptCommand(
+            ticket,
+            // Start-Sleep before Write-Host — same timing-resilience pattern
+            // as Linux LD7h/LD8h: gives PowerShell spawn + LocalScriptService's
+            // stdout reader a moment to attach before the marker is emitted.
+            // Also matches the Windows TentacleDeployE2ETests pattern.
+            $"Start-Sleep -Seconds 1; Write-Host '{marker}'",
+            ScriptIsolationLevel.NoIsolation,
+            TimeSpan.FromMinutes(1),
+            null,
+            Array.Empty<string>(),
+            ticket.TaskId,
+            TimeSpan.Zero)
+        {
+            ScriptSyntax = ScriptType.PowerShell
+        };
+
+        ObservedScriptResult result;
+        try
+        {
+            using var dispatchCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            result = await stub.DispatchAndObservePollingAsync(
+                agentSubscriptionId, agentThumbprint, command,
+                TimeSpan.FromSeconds(45), dispatchCts.Token);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "Step 5 (Halibut polling dispatch) FAILED — could not round-trip a real PowerShell script through " +
+                "the real binary's polling channel. " +
+                $"Exception: {ex.GetType().Name}: {ex.Message}. " +
+                "Most likely causes: " +
+                "(1) polling channel actually wasn't ready (Step 4's probe got lucky once); " +
+                "(2) LocalScriptService PowerShell spawn regressed in real binary path; " +
+                "(3) Halibut RPC serialization broke for StartScriptCommand. " +
+                $"\n\nbinary stdout:\n{ctx.StdoutCapture.Result}" +
+                $"\n\nbinary stderr:\n{ctx.StderrCapture.Result}", ex);
+        }
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"PowerShell echo script MUST exit 0. Got {result.ExitCode}. " +
+                          $"\nLogs:\n{result.AllText}");
+
+        result.AllText.ShouldContain(marker,
+            customMessage: $"echo marker '{marker}' MUST round-trip from stub server → Halibut polling → real binary's " +
+                          $"LocalScriptService → PowerShell → ProcessOutput → Halibut → stub's observe loop. " +
+                          "If absent: production agent's stdout streaming regressed in the real-binary Windows path. " +
+                          $"\nLogs:\n{result.AllText}");
+
+        ctx.MarkClean();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Drains a stream concurrently into a captured string. Used to keep
+    /// the binary's stdout/stderr pipe buffers empty (a full pipe blocks
+    /// the writer) AND to surface the captured text in failure-path
+    /// diagnostic dumps.
+    /// </summary>
+    private static Task<string> DrainStreamAsync(StreamReader reader, CancellationToken ct)
+    {
+        return Task.Run(async () =>
+        {
+            var sb = new StringBuilder();
+            try
+            {
+                var buffer = new char[1024];
+                while (!ct.IsCancellationRequested)
+                {
+                    var read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                    if (read == 0) break;
+                    sb.Append(buffer, 0, read);
+                }
+            }
+            catch
+            {
+                // Stream closed / disposed — return what we have.
+            }
+            return sb.ToString();
+        }, ct);
+    }
+
+    /// <summary>
+    /// Per-test context — owns the binary fixture, instance registry entry,
+    /// the long-running `run` process, and best-effort cleanup of every
+    /// staged artefact.
+    /// </summary>
+    private sealed class RealBinaryPollingContext : IDisposable
+    {
+        private bool _clean;
+
+        public WindowsTentacleBinaryFixture Binary { get; } = new();
+        public string InstanceName { get; }
+        public string ExpectedConfigPath { get; }
+        public string ExpectedInstanceDir { get; }
+
+        public Process RunProcess { get; set; }
+        public CancellationTokenSource RunCts { get; } = new();
+        public Task<string> StdoutCapture { get; set; }
+        public Task<string> StderrCapture { get; set; }
+
+        public RealBinaryPollingContext()
+        {
+            InstanceName = $"e2e-phase13-pr3-{Guid.NewGuid():N}";
+
+            // Compute production paths via PlatformPaths so a future
+            // resolver change is caught at staging (Rule 12.7).
+            var configDir = PlatformPaths.PickWritableConfigDir();
+            ExpectedConfigPath = PlatformPaths.GetInstanceConfigPath(configDir, InstanceName);
+
+            var certsDir = PlatformPaths.GetInstanceCertsDir(configDir, InstanceName);
+            ExpectedInstanceDir = Path.GetDirectoryName(certsDir)!;
+
+            // Pre-create instance in registry — register requires it
+            // (RegisterCommand line 78: throws "Instance does not exist"
+            // if not pre-created).
+            try
+            {
+                var registry = InstanceRegistry.CreateForCurrentProcess();
+                registry.Add(new InstanceRecord
+                {
+                    Name = InstanceName,
+                    ConfigPath = ExpectedConfigPath
+                });
+            }
+            catch (InvalidOperationException)
+            {
+                // Already exists — ignore (rare GUID collision).
+            }
+        }
+
+        public void MarkClean() => _clean = true;
+
+        public void Dispose()
+        {
+            if (!_clean)
+                Console.WriteLine($"[RealBinaryPollingContext] Dispose called without MarkClean — Phase 13 PR-3 test for instance '{InstanceName}' failed before its happy-path conclusion.");
+
+            // Stop the long-running binary first — must finish before we
+            // try to delete config (Windows file locks).
+            try
+            {
+                if (RunProcess != null && !RunProcess.HasExited)
+                {
+                    RunProcess.Kill(entireProcessTree: true);
+                    RunProcess.WaitForExit(5_000);
+                }
+            }
+            catch { /* best-effort */ }
+
+            try { RunCts.Cancel(); } catch { /* best-effort */ }
+            try { RunProcess?.Dispose(); } catch { /* best-effort */ }
+
+            // Best-effort cleanup of every artefact register might write.
+            try { if (File.Exists(ExpectedConfigPath)) File.Delete(ExpectedConfigPath); } catch { }
+            try { if (Directory.Exists(ExpectedInstanceDir)) Directory.Delete(ExpectedInstanceDir, recursive: true); } catch { }
+
+            // Remove instance from registry so list-instances doesn't
+            // accumulate stale entries.
+            try
+            {
+                var registry = InstanceRegistry.CreateForCurrentProcess();
+                registry.Remove(InstanceName);
+            }
+            catch { /* best-effort */ }
+        }
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
@@ -207,4 +207,19 @@ public static class WindowsUpgradeE2ECategories
     /// stub HTTP exchange (D1h round-trip).</para>
     /// </summary>
     public const string TentacleDiagnostic = "TentacleDiagnosticE2E";
+
+    /// <summary>
+    /// Phase 13 PR-2+ E2E coverage for the real production
+    /// <c>Squid.Tentacle.exe</c> binary's CLI surface — Windows mirror
+    /// of <c>Squid.LinuxTentacleE2ETests.LinuxTentacleE2ECategories.TentacleBinary</c>.
+    ///
+    /// <para>Tier 🟢 high-fidelity — drives the actual published binary
+    /// (built via <c>dotnet publish -r win-x64 --self-contained</c>
+    /// matching production CI). UNBLOCKS Phase 13 PR-3 (real binary as
+    /// polling agent — the highest-fidelity Windows E2E).</para>
+    ///
+    /// <para>Windows-only; the fixture's binary is a self-contained
+    /// <c>win-x64</c> bundle that won't run on macOS / Linux.</para>
+    /// </summary>
+    public const string TentacleBinary = "WindowsTentacleBinaryE2E";
 }


### PR DESCRIPTION
## Summary

- New high-fidelity E2E `R1h_RealBinary_PollingAgent_ScriptDispatchRoundTripsThroughHalibut` — Windows mirror of Linux R1h. Drives the **real** `dotnet publish`'d `Squid.Tentacle.exe` as a polling agent against `StubSquidServer`, then dispatches a real PowerShell script through the polling channel and asserts the output round-trips.
- Closes the coverage gap between `TentacleRegisterE2ETests` (in-process production class) and `TentacleDeployE2ETests` (StubAgent wrapper) — neither exercises the real binary's polling code path.
- Tier 🟢 H per Rule 12.4 — zero mocks at the production-code layer.

## Stacking

Stacks on top of #270 (PR-2) which adds `WindowsTentacleBinaryFixture`. Once #270 merges, GitHub will auto-retarget this PR's base branch to `main`. Local-author flow if needed:
```
git rebase --onto origin/main phase13.real-binary-integration-pr2-windows-binary-fixture
```

## SCM gap surfaced

Squid.Tentacle's Program.cs has no `UseWindowsService()` / `ServiceBase` integration. SCM-launched start (the production deployment shape) would time out at `ERROR_SERVICE_REQUEST_TIMEOUT` because the binary doesn't register a service control handler. **This is a real production gap** — operators following the documented `service install` + `sc start` workflow on Windows would see the service fail to reach RUNNING.

Tracked as a separate production-fix task. Once that lands, an SCM-launched variant of this test can be added. PR-3 uses `Process.Start` to validate the same polling code path which is the primary value of Phase 13.

## Mechanism

1. `StubSquidServer.StartAsync` — full Halibut listener on `PollingUri` + REST register on `ServerUri`, real self-signed cert
2. Pre-create instance via `InstanceRegistry` (production binary's `register` requires it; matches `TentacleRegisterE2ETests`)
3. Real binary `register --comms-url=stub.PollingUri` — Polling mode, persists config with stub's `ServerThumbprint`
4. Extract agent thumbprint + subscriptionId from `stub.ReceivedRegistrations[0]`
5. `stub.TrustAgent(thumbprint)` — must come before `run` (TLS handshake otherwise rejects the agent's cert)
6. `binary.StartLongRunning("run", "--instance", ...)` — real binary opens outbound polling channel to stub
7. Wait for `stub.ProbeCapabilitiesPollingAsync` to succeed (Windows handshake takes 2-5s due to .NET startup + cert store traversal)
8. **THE PIN**: `stub.DispatchAndObservePollingAsync` with `Start-Sleep -Seconds 1; Write-Host '<marker>'` — assert exit 0 + marker
9. Cleanup: `Process.Kill` the long-running binary, delete config + remove instance

## What this catches that prior Windows tests miss

- `register` → `run` config round-trip on Windows (PlatformPaths resolution diverges from Linux's `/etc/squid-tentacle/` pattern)
- `TentacleHalibutHost.StartPolling` regression on Windows (cert store traversal, `IPAddress.Any` binding)
- `LocalScriptService` PowerShell spawn regression on real-binary path (vs `StubAgent`'s in-process wrapping of the same service)
- ProcessOutput streaming through Halibut on the real Windows binary

## Test plan

- [ ] CI on `windows-latest` runs `Category=WindowsTentacleBinaryE2E`:
  - [ ] `R1h_RealBinary_PollingAgent_ScriptDispatchRoundTripsThroughHalibut` passes
  - [ ] `Binary_Version_PrintsBuildVersionStamp` (PR-2 smoke) still green
  - [ ] `Binary_Help_ProducesUsageOutput` (PR-2 smoke) still green
- [x] `dotnet build tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj` — 0 errors

## Phase 13 status after this lands

| PR | Status | Coverage |
|---|---|---|
| #269 (PR-1) | 🟢 merged | Linux real-binary as polling agent (systemd-started) |
| #270 (PR-2) | 🟢 awaiting merge | WindowsTentacleBinaryFixture + smoke |
| **#271 (this, PR-3)** | 🟡 awaiting CI | Windows real-binary as polling agent (Process.Start) |
| PR-4 | pending | Keep-alive / soak — multi-second probe stability for both OSes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)