### PR TITLE
Fix Tentacle: add UseWindowsService() so SCM-launched start works on Windows

### DIFF
--- a/src/Squid.Tentacle/Core/TentacleEntry.cs
+++ b/src/Squid.Tentacle/Core/TentacleEntry.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.Configuration;
+using Squid.Tentacle.Commands;
+using Squid.Tentacle.Configuration;
+using Squid.Tentacle.Instance;
+using Serilog;
+
+namespace Squid.Tentacle.Core;
+
+/// <summary>
+/// The shared command-dispatch entry-point used by BOTH the console
+/// (interactive CLI) launch path AND the Windows SCM-launched service
+/// path. Extracted from <c>Program.cs</c> so SCM mode can run the same
+/// command pipeline under a host-managed cancellation token (so SCM's
+/// Stop signal cleanly cancels the run).
+///
+/// <para><b>Why a separate entry method (vs leaving the body in
+/// Program.cs)</b>: SCM mode wraps the run in
+/// <see cref="Microsoft.Extensions.Hosting.IHost"/> with
+/// <see cref="Microsoft.Extensions.Hosting.WindowsServices.WindowsServiceLifetime"/>
+/// — that lifetime owns the cancellation token and triggers it on SCM
+/// Stop. The host-controlled CT is what we thread into command execution
+/// so a service-stop request actually drains in-flight work cleanly.
+/// Leaving the body inline in Program.cs would force every SCM-aware
+/// branch to duplicate it.</para>
+///
+/// <para><b>Behavior is byte-identical between paths</b>: the same
+/// CommandResolver, the same config-loading order, the same exception
+/// handling. The only difference is which CT cancellation source
+/// (Console.CancelKeyPress vs SCM-Stop) drives the token.</para>
+/// </summary>
+public static class TentacleEntry
+{
+    /// <summary>
+    /// The build-in command set the binary supports. Kept as a static
+    /// property (vs constructed in Program.cs) so the SCM-detection seam
+    /// can resolve the route without re-instantiating the command list.
+    /// </summary>
+    public static ITentacleCommand[] BuildCommands() =>
+    [
+        new RunCommand(),
+        new ShowThumbprintCommand(),
+        new ShowConfigCommand(),
+        new CheckServicesCommand(),
+        new NewCertificateCommand(),
+        new RegisterCommand(),
+        new ServiceCommand(),
+        new CreateInstanceCommand(),
+        new ListInstancesCommand(),
+        new DeleteInstanceCommand(),
+        new VersionCommand()
+    ];
+
+    /// <summary>
+    /// The shared run-the-command-pipeline body. Identical to what
+    /// Program.cs previously did inline — extracted so SCM mode can call
+    /// it with the host-managed CT.
+    /// </summary>
+    /// <param name="args">CLI args as received from Main / Host.</param>
+    /// <param name="ct">Cancellation token (from Console.CancelKeyPress
+    /// in console mode; from <see cref="Microsoft.Extensions.Hosting.WindowsServices.WindowsServiceLifetime"/>
+    /// in SCM mode).</param>
+    /// <returns>Process exit code.</returns>
+    public static async Task<int> RunAsync(string[] args, CancellationToken ct)
+    {
+        var commands = BuildCommands();
+
+        try
+        {
+            var route = CommandResolver.Resolve(commands, args);
+
+            if (route.HelpRequested)
+            {
+                PrintHelp(commands);
+                return 0;
+            }
+
+            if (route.UnknownCommand != null)
+            {
+                Console.Error.WriteLine($"Unknown command: {route.UnknownCommand}");
+                PrintHelp(commands);
+                return 1;
+            }
+
+            // Extract --instance NAME (the instance-aware commands need to know which config to load
+            // and which certs dir to use). Remove it from the arg array before the rest of the pipeline
+            // sees it, so ConfigurationBuilder.AddCommandLine doesn't choke on an unknown key.
+            var (instanceName, argsAfterInstance) = InstanceSelector.ExtractInstanceArg(route.RemainingArgs);
+
+            var configBuilder = new ConfigurationBuilder();
+
+            // Priority (low → high): per-instance config.json → appsettings.json → env vars → CLI args.
+            // This lets `register` persist to the config file and `systemd run` / `sc start` pick it up,
+            // while still allowing env vars / CLI args to override for debugging or Docker-style launches.
+            var instanceConfigPath = TryGetInstanceConfigPath(instanceName);
+            if (instanceConfigPath != null)
+                configBuilder.AddJsonFile(instanceConfigPath, optional: true, reloadOnChange: false);
+
+            configBuilder.AddJsonFile("appsettings.json", optional: true);
+            configBuilder.AddEnvironmentVariables();
+            configBuilder.AddCommandLine(argsAfterInstance);
+
+            var config = configBuilder.Build();
+
+            return await route.Command.ExecuteAsync(route.RemainingArgs, config, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Information("Squid Tentacle shutdown requested");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "Squid Tentacle terminated unexpectedly");
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Pure SCM-detection seam: should we hand off to
+    /// <see cref="Microsoft.Extensions.Hosting.WindowsServices.WindowsServiceLifetime"/>
+    /// before running the command pipeline?
+    ///
+    /// <para>True when ALL of:
+    /// <list type="bullet">
+    ///   <item>Running on Windows</item>
+    ///   <item>Process was launched by SCM (per
+    ///         <c>WindowsServiceHelpers.IsWindowsService()</c> — checks
+    ///         the parent process is <c>services.exe</c>)</item>
+    ///   <item>The CLI command being invoked is the long-running
+    ///         <c>run</c> command (other commands like <c>register</c>,
+    ///         <c>service install</c>, <c>show-thumbprint</c> are short-
+    ///         lived and don't need SCM lifetime)</item>
+    /// </list></para>
+    ///
+    /// <para><b>Why isolate the check</b>: lets unit tests verify the
+    /// detection logic on any platform without needing a real SCM. The
+    /// <paramref name="isLaunchedBySCM"/> parameter is the seam — production
+    /// passes <c>WindowsServiceHelpers.IsWindowsService</c>; tests pass
+    /// a deterministic predicate.</para>
+    /// </summary>
+    public static bool ShouldRunUnderScm(string[] args, bool isWindows, Func<bool> isLaunchedBySCM)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(isLaunchedBySCM);
+
+        if (!isWindows) return false;
+
+        // Resolve the command without side effects so we can short-circuit
+        // for non-`run` invocations (registry queries, sc.exe one-shots
+        // like service install, show-config, etc.). Those commands are
+        // sub-second; no SCM lifetime needed.
+        var commands = BuildCommands();
+        var route = CommandResolver.Resolve(commands, args);
+        if (route.Command is not RunCommand) return false;
+
+        return isLaunchedBySCM();
+    }
+
+    private static string TryGetInstanceConfigPath(string instanceName)
+    {
+        try
+        {
+            var record = InstanceSelector.Resolve(instanceName);
+            return new TentacleConfigFile(record.ConfigPath).Exists() ? record.ConfigPath : null;
+        }
+        catch
+        {
+            // Instance lookup failures are non-fatal at startup — commands that actually need
+            // an instance (register, run) will fail with a clear error later.
+            return null;
+        }
+    }
+
+    private static void PrintHelp(ITentacleCommand[] commands)
+    {
+        Console.WriteLine("Squid Tentacle — Deployment Agent");
+        Console.WriteLine();
+        Console.WriteLine("Usage: squid-tentacle <command> [--instance NAME] [options]");
+        Console.WriteLine();
+        Console.WriteLine("Commands:");
+
+        foreach (var cmd in commands)
+            Console.WriteLine($"  {cmd.Name,-20} {cmd.Description}");
+
+        Console.WriteLine($"  {"help",-20} Show this help message");
+        Console.WriteLine();
+        Console.WriteLine("Instance management (multiple Tentacles on one host):");
+        Console.WriteLine("  squid-tentacle create-instance --instance production");
+        Console.WriteLine("  squid-tentacle list-instances");
+        Console.WriteLine("  squid-tentacle delete-instance --instance production");
+        Console.WriteLine();
+        Console.WriteLine("Install + register + run (typical flow):");
+        Console.WriteLine("  squid-tentacle register --server URL --api-key KEY --role R --environment E");
+        Console.WriteLine("  sudo squid-tentacle service install");
+        Console.WriteLine();
+        Console.WriteLine("Configuration sources (low → high): instance config → appsettings.json → env (Tentacle__Key) → CLI (--Tentacle:Key=V)");
+    }
+}

--- a/src/Squid.Tentacle/Core/TentacleScmHostedService.cs
+++ b/src/Squid.Tentacle/Core/TentacleScmHostedService.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace Squid.Tentacle.Core;
+
+/// <summary>
+/// <see cref="BackgroundService"/> that runs the
+/// <see cref="TentacleEntry.RunAsync"/> command pipeline under
+/// <see cref="Microsoft.Extensions.Hosting.WindowsServices.WindowsServiceLifetime"/>.
+/// Used ONLY when SCM launches the binary
+/// (<see cref="TentacleEntry.ShouldRunUnderScm"/> returns true).
+///
+/// <para><b>The lifetime contract</b>: when the service binary is started
+/// by SCM:
+/// <list type="number">
+///   <item><c>WindowsServiceLifetime</c> calls <c>StartServiceCtrlDispatcher</c>
+///         + registers the SCM control handler. SCM transitions to
+///         <c>START_PENDING</c>.</item>
+///   <item>Host build completes; <c>WindowsServiceLifetime.OnStarted</c>
+///         fires; SCM transitions to <c>RUNNING</c>.</item>
+///   <item>This service's <see cref="ExecuteAsync"/> runs in the
+///         background. It calls <c>TentacleEntry.RunAsync</c> with
+///         <paramref name="stoppingToken"/> as the CT.</item>
+///   <item>When SCM sends Stop (operator runs <c>sc stop</c>, host
+///         reboots, etc.), <c>WindowsServiceLifetime</c> cancels the
+///         host's CT, which in turn cancels <paramref name="stoppingToken"/>.
+///         <c>TentacleEntry.RunAsync</c> sees the cancellation, the
+///         agent's polling loop drains in-flight work cleanly, and
+///         <see cref="ExecuteAsync"/> returns.</item>
+///   <item>Host shutdown completes; SCM transitions to <c>STOPPED</c>.</item>
+/// </list></para>
+///
+/// <para><b>Argument propagation</b>: the args passed to <c>Main</c>
+/// (e.g. <c>["run", "--instance", "production"]</c> from the SCM-
+/// installed unit's <c>binPath</c>) are captured at construction so
+/// <c>ExecuteAsync</c> can pass them verbatim to
+/// <c>TentacleEntry.RunAsync</c>.</para>
+///
+/// <para><b>Exit code propagation</b>: the host doesn't return an exit
+/// code from <c>RunAsync</c> directly. We capture the result of
+/// <c>TentacleEntry.RunAsync</c> in <see cref="LastExitCode"/> so
+/// <c>Program.cs</c>'s SCM branch can return it. Default is 0 — set on
+/// successful drain; non-zero only if the command pipeline itself
+/// returned non-zero (which would be unusual for <c>run</c> since it's
+/// long-running).</para>
+/// </summary>
+public sealed class TentacleScmHostedService : BackgroundService
+{
+    private readonly string[] _args;
+    private readonly IHostApplicationLifetime _lifetime;
+
+    public TentacleScmHostedService(string[] args, IHostApplicationLifetime lifetime)
+    {
+        _args = args ?? throw new ArgumentNullException(nameof(args));
+        _lifetime = lifetime ?? throw new ArgumentNullException(nameof(lifetime));
+    }
+
+    /// <summary>
+    /// Captured exit code from the command pipeline. Read by
+    /// <c>Program.cs</c>'s SCM branch after the host returns. Default 0
+    /// (treated as success on clean shutdown).
+    /// </summary>
+    public int LastExitCode { get; private set; }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Log.Information("Squid Tentacle launched under SCM lifetime — args: [{Args}]",
+            string.Join(", ", _args));
+
+        try
+        {
+            LastExitCode = await TentacleEntry.RunAsync(_args, stoppingToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "Squid Tentacle SCM-hosted service crashed");
+            LastExitCode = 1;
+        }
+        finally
+        {
+            // Trigger host shutdown so SCM transitions out of RUNNING
+            // even if the command pipeline finished early (e.g. `run`
+            // exited cleanly without a Stop signal — uncommon for the
+            // long-running run command but possible for malformed
+            // configs that fail-fast).
+            _lifetime.StopApplication();
+        }
+    }
+}

--- a/src/Squid.Tentacle/Program.cs
+++ b/src/Squid.Tentacle/Program.cs
@@ -1,7 +1,7 @@
-using Microsoft.Extensions.Configuration;
-using Squid.Tentacle.Commands;
-using Squid.Tentacle.Configuration;
-using Squid.Tentacle.Instance;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.WindowsServices;
+using Squid.Tentacle.Core;
 using Serilog;
 using Serilog.Events;
 
@@ -35,115 +35,76 @@ Log.Logger = new LoggerConfiguration()
         outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
     .CreateLogger();
 
-var commands = new ITentacleCommand[]
-{
-    new RunCommand(),
-    new ShowThumbprintCommand(),
-    new ShowConfigCommand(),
-    new CheckServicesCommand(),
-    new NewCertificateCommand(),
-    new RegisterCommand(),
-    new ServiceCommand(),
-    new CreateInstanceCommand(),
-    new ListInstancesCommand(),
-    new DeleteInstanceCommand(),
-    new VersionCommand()
-};
-
 try
 {
-    var route = CommandResolver.Resolve(commands, args);
+    // SCM-detection branch — when launched by Windows SCM (`sc start`),
+    // hand off to the host pipeline so SCM's StartServiceCtrlDispatcher
+    // contract is honored. Without this, SCM-launched start times out
+    // at ERROR_SERVICE_REQUEST_TIMEOUT after 30s because the binary
+    // never registers a service control handler. See
+    // TentacleEntry.ShouldRunUnderScm + TentacleScmHostedService for
+    // the full SCM lifetime story.
+    //
+    // Console mode (interactive CLI, register, service install, etc.)
+    // — including SSH-launched `run` for systemd's ExecStart on Linux
+    // — falls through to the existing Console-CT path below.
+    if (TentacleEntry.ShouldRunUnderScm(args, OperatingSystem.IsWindows(), WindowsServiceHelpers.IsWindowsService))
+        return await RunUnderScmLifetimeAsync(args).ConfigureAwait(false);
 
-    if (route.HelpRequested)
-    {
-        PrintHelp(commands);
-        return 0;
-    }
+    // Console mode — existing flow. Console.CancelKeyPress + ProcessExit
+    // drive the CT so Ctrl-C on an interactive run + systemd stop on
+    // Linux both trigger graceful drain.
+    using var consoleCts = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) => { e.Cancel = true; consoleCts.Cancel(); };
+    AppDomain.CurrentDomain.ProcessExit += (_, _) => consoleCts.Cancel();
 
-    if (route.UnknownCommand != null)
-    {
-        Console.Error.WriteLine($"Unknown command: {route.UnknownCommand}");
-        PrintHelp(commands);
-        return 1;
-    }
-
-    // Extract --instance NAME (the instance-aware commands need to know which config to load
-    // and which certs dir to use). Remove it from the arg array before the rest of the pipeline
-    // sees it, so ConfigurationBuilder.AddCommandLine doesn't choke on an unknown key.
-    var (instanceName, argsAfterInstance) = InstanceSelector.ExtractInstanceArg(route.RemainingArgs);
-
-    var configBuilder = new ConfigurationBuilder();
-
-    // Priority (low → high): per-instance config.json → appsettings.json → env vars → CLI args.
-    // This lets `register` persist to the config file and `systemd run` pick it up, while
-    // still allowing env vars / CLI args to override for debugging or Docker-style launches.
-    var instanceConfigPath = TryGetInstanceConfigPath(instanceName);
-    if (instanceConfigPath != null)
-        configBuilder.AddJsonFile(instanceConfigPath, optional: true, reloadOnChange: false);
-
-    configBuilder.AddJsonFile("appsettings.json", optional: true);
-    configBuilder.AddEnvironmentVariables();
-    configBuilder.AddCommandLine(argsAfterInstance);
-
-    var config = configBuilder.Build();
-
-    var cts = new CancellationTokenSource();
-    Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
-    AppDomain.CurrentDomain.ProcessExit += (_, _) => cts.Cancel();
-
-    return await route.Command.ExecuteAsync(route.RemainingArgs, config, cts.Token).ConfigureAwait(false);
-}
-catch (OperationCanceledException)
-{
-    Log.Information("Squid Tentacle shutdown requested");
-    return 0;
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Squid Tentacle terminated unexpectedly");
-    return 1;
+    return await TentacleEntry.RunAsync(args, consoleCts.Token).ConfigureAwait(false);
 }
 finally
 {
     await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }
 
-static string TryGetInstanceConfigPath(string instanceName)
+static async Task<int> RunUnderScmLifetimeAsync(string[] args)
 {
-    try
+    Log.Information("SCM-launched mode detected — building host with WindowsServiceLifetime");
+
+    var builder = Host.CreateApplicationBuilder(args);
+
+    // Register WindowsServiceLifetime — IHostLifetime that:
+    //   1. Calls StartServiceCtrlDispatcher on host startup
+    //   2. Transitions SCM state machine: START_PENDING → RUNNING
+    //   3. Listens for SCM Stop signal → cancels the host's CT
+    //   4. Transitions SCM state machine: STOP_PENDING → STOPPED
+    builder.Services.AddWindowsService(options =>
     {
-        var record = InstanceSelector.Resolve(instanceName);
-        return new TentacleConfigFile(record.ConfigPath).Exists() ? record.ConfigPath : null;
-    }
-    catch
+        // Service name is set by SCM at install time (via sc.exe create
+        // --servicename). The Description here is for the host's diagnostic
+        // output only — SCM uses what's in the registry.
+        options.ServiceName = "Squid.Tentacle";
+    });
+
+    // The hosted service that runs the command pipeline under the SCM
+    // lifetime's CT. Captures the exit code on completion.
+    var hostedService = new TentacleScmHostedService(args, null!);  // Lifetime injected post-build
+    builder.Services.AddSingleton(hostedService);
+    builder.Services.AddHostedService<TentacleScmHostedService>(sp =>
     {
-        // Instance lookup failures are non-fatal at startup — commands that actually need
-        // an instance (register, run) will fail with a clear error later.
-        return null;
-    }
-}
+        // Re-construct with the resolved IHostApplicationLifetime —
+        // we couldn't resolve at AddSingleton time because the host
+        // is still being built.
+        var lifetime = sp.GetRequiredService<IHostApplicationLifetime>();
+        var configured = new TentacleScmHostedService(args, lifetime);
+        return configured;
+    });
 
-static void PrintHelp(ITentacleCommand[] commands)
-{
-    Console.WriteLine("Squid Tentacle — Deployment Agent");
-    Console.WriteLine();
-    Console.WriteLine("Usage: squid-tentacle <command> [--instance NAME] [options]");
-    Console.WriteLine();
-    Console.WriteLine("Commands:");
+    using var host = builder.Build();
+    await host.RunAsync().ConfigureAwait(false);
 
-    foreach (var cmd in commands)
-        Console.WriteLine($"  {cmd.Name,-20} {cmd.Description}");
-
-    Console.WriteLine($"  {"help",-20} Show this help message");
-    Console.WriteLine();
-    Console.WriteLine("Instance management (multiple Tentacles on one host):");
-    Console.WriteLine("  squid-tentacle create-instance --instance production");
-    Console.WriteLine("  squid-tentacle list-instances");
-    Console.WriteLine("  squid-tentacle delete-instance --instance production");
-    Console.WriteLine();
-    Console.WriteLine("Install + register + run (typical flow):");
-    Console.WriteLine("  squid-tentacle register --server URL --api-key KEY --role R --environment E");
-    Console.WriteLine("  sudo squid-tentacle service install");
-    Console.WriteLine();
-    Console.WriteLine("Configuration sources (low → high): instance config → appsettings.json → env (Tentacle__Key) → CLI (--Tentacle:Key=V)");
+    // Resolve the hosted service to read its captured exit code. Default
+    // 0 if the command pipeline finished cleanly via Stop signal.
+    var registeredService = host.Services.GetServices<IHostedService>()
+        .OfType<TentacleScmHostedService>()
+        .FirstOrDefault();
+    return registeredService?.LastExitCode ?? 0;
 }

--- a/src/Squid.Tentacle/Squid.Tentacle.csproj
+++ b/src/Squid.Tentacle/Squid.Tentacle.csproj
@@ -22,6 +22,27 @@
     <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <!--
+      Phase 13 follow-up — SCM control-handler integration.
+
+      Without this package, when SCM launches the binary via
+      `sc start squid-tentacle`, the process never calls
+      StartServiceCtrlDispatcher and SCM marks the start as
+      ERROR_SERVICE_REQUEST_TIMEOUT after 30s. Operators following the
+      documented `service install` + `sc start` workflow on Windows
+      would see the service fail to reach RUNNING state.
+
+      AddWindowsService() (called from Program.cs's SCM branch)
+      registers WindowsServiceLifetime which handles the SCM protocol:
+        START_PENDING → RUNNING → STOP_PENDING → STOPPED
+      with the SCM Stop signal triggering the host's cancellation token.
+
+      Cross-platform: package targets cross-platform (no native deps);
+      AddWindowsService() is a no-op outside Windows.
+      WindowsServiceHelpers.IsWindowsService() returns false on
+      non-Windows platforms.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.0" />

--- a/tests/Squid.Tentacle.Tests/Core/TentacleEntryTests.cs
+++ b/tests/Squid.Tentacle.Tests/Core/TentacleEntryTests.cs
@@ -1,0 +1,200 @@
+using Squid.Tentacle.Core;
+
+namespace Squid.Tentacle.Tests.Core;
+
+/// <summary>
+/// Unit tests for the SCM-detection seam in <see cref="TentacleEntry.ShouldRunUnderScm"/>.
+/// Pinned because the seam is the entry-point for the Windows-service
+/// lifetime branch — a regression here means SCM-launched start either
+/// times out (false negative: should have detected SCM but didn't) or
+/// triggers the service lifetime when it shouldn't (false positive:
+/// console-launched register / show-thumbprint hangs trying to talk
+/// to a non-existent SCM).
+///
+/// <para>The seam takes a <c>Func&lt;bool&gt;</c> for the SCM-launched
+/// check so tests can run on any platform without needing a real SCM
+/// (the production wiring passes <c>WindowsServiceHelpers.IsWindowsService</c>).</para>
+///
+/// <para>Cross-platform: these tests run identically on Windows / Linux /
+/// macOS. No skip-on-OS guards needed.</para>
+/// </summary>
+public sealed class TentacleEntryTests
+{
+    // ========================================================================
+    // ShouldRunUnderScm — false on non-Windows regardless of other inputs
+    //
+    // SCM is a Windows-only concept. Even if the seam's "is launched by
+    // SCM" predicate erroneously returned true on Linux/macOS (which it
+    // can't in production — WindowsServiceHelpers.IsWindowsService folds
+    // the Windows check in), we MUST NOT enter SCM mode. A regression
+    // here would crash AddWindowsService() at host startup on non-
+    // Windows because WindowsServiceLifetime has [SupportedOSPlatform("windows")].
+    // ========================================================================
+
+    [Fact]
+    public void ShouldRunUnderScm_NonWindows_ReturnsFalse_RegardlessOfScmPredicate()
+    {
+        var args = new[] { "run" };
+
+        // Even if the SCM predicate erroneously returns true, we're not
+        // on Windows → must short-circuit to false.
+        var result = TentacleEntry.ShouldRunUnderScm(args, isWindows: false, isLaunchedBySCM: () => true);
+
+        result.ShouldBeFalse(
+            customMessage: "ShouldRunUnderScm MUST return false on non-Windows even when the SCM predicate returns true. " +
+                          "SCM is a Windows-only concept; entering SCM mode on Linux/macOS would crash WindowsServiceLifetime " +
+                          "(which is [SupportedOSPlatform(\"windows\")]).");
+    }
+
+    // ========================================================================
+    // ShouldRunUnderScm — false when not launched by SCM (interactive console)
+    //
+    // The most common case: operator runs `Squid.Tentacle.exe register ...`
+    // from PowerShell or CMD. Even on Windows, isLaunchedBySCM=false →
+    // return false → use console flow.
+    // ========================================================================
+
+    [Fact]
+    public void ShouldRunUnderScm_WindowsConsole_NotLaunchedBySCM_ReturnsFalse()
+    {
+        var args = new[] { "run" };
+
+        var result = TentacleEntry.ShouldRunUnderScm(args, isWindows: true, isLaunchedBySCM: () => false);
+
+        result.ShouldBeFalse(
+            customMessage: "ShouldRunUnderScm MUST return false on Windows when NOT launched by SCM. " +
+                          "Interactive `Squid.Tentacle.exe run` from a terminal must use the console flow, " +
+                          "not the Windows-service host pipeline (which would fail at startup with a " +
+                          "StartServiceCtrlDispatcher error since there's no SCM connection).");
+    }
+
+    // ========================================================================
+    // ShouldRunUnderScm — false when SCM-launched but not the `run` command
+    //
+    // SCM only ever launches the binary's `run` command — that's what
+    // ServiceCommand registers in the SCM binPath. But for defense in
+    // depth (e.g. an operator manually configures SCM to run a different
+    // command), the seam short-circuits non-`run` commands so we don't
+    // wrap short-lived CLI commands in a host lifetime.
+    // ========================================================================
+
+    [Theory]
+    [InlineData("register")]
+    [InlineData("show-thumbprint")]
+    [InlineData("show-config")]
+    [InlineData("list-instances")]
+    [InlineData("create-instance")]
+    [InlineData("delete-instance")]
+    [InlineData("new-certificate")]
+    [InlineData("version")]
+    [InlineData("service")]      // service install/uninstall/start/stop
+    public void ShouldRunUnderScm_SCMLaunched_ButNotRunCommand_ReturnsFalse(string command)
+    {
+        var args = new[] { command };
+
+        var result = TentacleEntry.ShouldRunUnderScm(args, isWindows: true, isLaunchedBySCM: () => true);
+
+        result.ShouldBeFalse(
+            customMessage: $"ShouldRunUnderScm MUST return false for '{command}' even when SCM-launched. " +
+                          "Only the long-running `run` command needs WindowsServiceLifetime — short-lived " +
+                          $"commands like {command} would have their CLI summary output truncated by the " +
+                          "host's logging pipeline OR their exit code lost in the host's shutdown sequence.");
+    }
+
+    // ========================================================================
+    // ShouldRunUnderScm — TRUE when all three conditions are met
+    //
+    // The happy path: Windows + SCM-launched + `run` command → enter SCM
+    // mode. This is what enables `sc start squid-tentacle` to actually
+    // reach RUNNING state (vs the pre-fix ERROR_SERVICE_REQUEST_TIMEOUT).
+    // ========================================================================
+
+    [Fact]
+    public void ShouldRunUnderScm_WindowsSCMLaunchedRunCommand_ReturnsTrue()
+    {
+        var args = new[] { "run" };
+
+        var result = TentacleEntry.ShouldRunUnderScm(args, isWindows: true, isLaunchedBySCM: () => true);
+
+        result.ShouldBeTrue(
+            customMessage: "ShouldRunUnderScm MUST return true on Windows when SCM-launched + `run`. " +
+                          "Without this, `sc start squid-tentacle` times out at ERROR_SERVICE_REQUEST_TIMEOUT " +
+                          "after 30s because the binary never registers a service control handler.");
+    }
+
+    // ========================================================================
+    // ShouldRunUnderScm — TRUE for `run --instance NAME` (named instance)
+    //
+    // Multi-instance setups install separate SCM entries per instance
+    // (squid-tentacle, squid-tentacle-staging, etc.) where each binPath
+    // is `Squid.Tentacle.exe run --instance <name>`. The detection seam
+    // MUST handle args beyond just `run` correctly.
+    // ========================================================================
+
+    [Fact]
+    public void ShouldRunUnderScm_RunWithInstanceArg_ReturnsTrue()
+    {
+        var args = new[] { "run", "--instance", "production" };
+
+        var result = TentacleEntry.ShouldRunUnderScm(args, isWindows: true, isLaunchedBySCM: () => true);
+
+        result.ShouldBeTrue(
+            customMessage: "ShouldRunUnderScm MUST handle `run --instance NAME` (multi-instance SCM setups). " +
+                          "If false: CommandResolver doesn't recognize `run` when followed by additional args, " +
+                          "OR the seam's predicate logic short-circuited incorrectly.");
+    }
+
+    // ========================================================================
+    // ShouldRunUnderScm — argument validation (null arrays / null predicate)
+    //
+    // Defensive: nulls should produce ArgumentNullException with the
+    // parameter name, not crash with NullReferenceException deep in
+    // CommandResolver.
+    // ========================================================================
+
+    [Fact]
+    public void ShouldRunUnderScm_NullArgs_Throws()
+    {
+        Action act = () => TentacleEntry.ShouldRunUnderScm(args: null, isWindows: true, isLaunchedBySCM: () => true);
+
+        act.ShouldThrow<ArgumentNullException>().ParamName.ShouldBe("args");
+    }
+
+    [Fact]
+    public void ShouldRunUnderScm_NullPredicate_Throws()
+    {
+        Action act = () => TentacleEntry.ShouldRunUnderScm(args: new[] { "run" }, isWindows: true, isLaunchedBySCM: null);
+
+        act.ShouldThrow<ArgumentNullException>().ParamName.ShouldBe("isLaunchedBySCM");
+    }
+
+    // ========================================================================
+    // ShouldRunUnderScm — predicate is NOT called when isWindows is false
+    //
+    // Performance + defense: on non-Windows we should short-circuit
+    // before calling the predicate (which on production wraps a P/Invoke
+    // to GetCurrentProcess + parent-process check — no need to fire on
+    // Linux/macOS where the answer is structurally false anyway).
+    // ========================================================================
+
+    [Fact]
+    public void ShouldRunUnderScm_NonWindows_DoesNotInvokePredicate()
+    {
+        var predicateCalled = false;
+
+        var result = TentacleEntry.ShouldRunUnderScm(
+            args: new[] { "run" },
+            isWindows: false,
+            isLaunchedBySCM: () =>
+            {
+                predicateCalled = true;
+                return true;
+            });
+
+        result.ShouldBeFalse();
+        predicateCalled.ShouldBeFalse(
+            customMessage: "predicate MUST NOT be invoked on non-Windows — short-circuit before the call. " +
+                          "If invoked: production binary on Linux is doing a needless P/Invoke per startup " +
+                          "(WindowsServiceHelpers.IsWindowsService internally checks process handles).");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Microsoft.Extensions.Hosting.WindowsServices` integration to `Squid.Tentacle.exe` so SCM-launched start (`sc start squid-tentacle`) reaches RUNNING state
- Extracts `Program.cs`'s command-dispatch body into shared `TentacleEntry.RunAsync` so console mode + SCM mode share identical pipeline logic
- New `TentacleEntry.ShouldRunUnderScm` detection seam (16 unit-test cases) decides which mode to use
- New `TentacleScmHostedService` wraps the pipeline under `WindowsServiceLifetime` so SCM's Stop signal drains in-flight work before shutdown

## The production gap (surfaced during Phase 13 PR-3 scoping)

Pre-fix, when SCM launched the binary:
1. Process started — but `StartServiceCtrlDispatcher` was never called
2. SCM remained in `START_PENDING`
3. After 30s: `ERROR_SERVICE_REQUEST_TIMEOUT` — service marked as failed

Operators following the documented `service install` + `sc start` workflow on Windows hit this immediately. Phase 13 PR-3 sidestepped with `Process.Start` to validate the polling code path; this PR delivers the production fix.

## Post-fix SCM lifecycle

```
sc start squid-tentacle
  → WindowsServiceLifetime calls StartServiceCtrlDispatcher
  → SCM: START_PENDING → RUNNING
  → Tentacle starts polling, accepts deployments
  → ...
  → operator runs `sc stop squid-tentacle`
  → WindowsServiceLifetime cancels host CT
  → TentacleEntry.RunAsync sees CT cancellation
  → polling loop drains in-flight scripts (ShutdownDrainTimeout)
  → host disposes
  → SCM: STOP_PENDING → STOPPED
```

## Architecture

| Component | Concern |
|---|---|
| `TentacleEntry.RunAsync(args, ct)` | Shared command-dispatch pipeline (console mode + SCM mode use identical logic) |
| `TentacleEntry.ShouldRunUnderScm(args, isWindows, isLaunchedBySCM)` | Pure detection seam — `true` only when (Windows + launched-by-SCM + command-is-`run`). Predicate as `Func<bool>` so tests run on any OS |
| `TentacleScmHostedService` | `BackgroundService` running `TentacleEntry.RunAsync` under `WindowsServiceLifetime`'s CT |
| `Program.cs` SCM branch | Builds `Host` with `AddWindowsService()` + `TentacleScmHostedService` when SCM-launched; falls through to existing console flow otherwise |

## Behavior preservation

- **Console mode** (CLI invocation, `register`, `service install`, `show-thumbprint`, etc.): zero change. Same `Console.CancelKeyPress` + `ProcessExit` cancellation source, same exit codes, same Serilog output (still routed to stderr per PR #264).
- **systemd-launched mode (Linux)**: zero change. `WindowsServiceHelpers.IsWindowsService()` returns false on Linux → falls through to console flow (same as today).
- **SCM-launched mode (Windows, NEW)**: takes the SCM lifetime path. Honors Stop signal cleanly.

## Coverage

- **Unit tests** (`TentacleEntryTests.cs`): 16 cases covering
  - Non-Windows short-circuit (predicate must NOT be invoked)
  - Console mode short-circuit on Windows
  - Every non-`run` command (register, show-thumbprint, show-config, list-instances, create-instance, delete-instance, new-certificate, version, service)
  - Happy path (Windows + SCM + run)
  - Multi-instance args (`run --instance NAME`)
  - Null validation (args + predicate)
- **Cross-platform**: unit tests run identically on macOS / Linux / Windows
- **E2E variant deferred**: SCM-launched variant of `R1h-Windows` lands in a separate follow-up PR after Phase 13 PR-3 (#271) merges, so the SCM test can extend `TentacleWindowsRealBinaryIntegrationE2ETests`'s existing surface

## Test plan

- [x] `dotnet build src/Squid.Tentacle/Squid.Tentacle.csproj` — 0 errors
- [x] `dotnet test tests/Squid.Tentacle.Tests --filter TentacleEntryTests` — 16/16 passing locally
- [ ] CI: standard `Tests` workflow (Squid Tentacle Tests step) green
- [ ] CI: `Tentacle Windows E2E` workflow green — phase-13 R1h-Windows still passes (Process.Start path unchanged)

## Why this didn't surface earlier

The production binary's pre-fix behavior was: when launched directly (`./Squid.Tentacle.exe run`), it worked correctly because there's no SCM expectation. The bug only manifested when SCM (via `service install` + `sc start`) was the launcher. Existing Windows tests use a separate test-only ServiceBase-derived exe (`SquidUpgradeE2ETestService.exe`) for upgrade tests — they never spun up the real Squid.Tentacle.exe under SCM. Phase 13 PR-3 was the first attempt to do that, and it surfaced this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)