### PR TITLE
Fix package-version dropdown hiding fresh versions behind lex-sort + take

### DIFF
--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/ExternalFeedPackageVersionService.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/ExternalFeedPackageVersionService.cs
@@ -24,7 +24,13 @@ public class ExternalFeedPackageVersionService(
         if (strategy == null)
             return new SearchFeedPackageVersionsResponseData { Versions = [] };
 
-        var versions = await strategy.ListVersionsAsync(feed, packageId, take, ct).ConfigureAwait(false);
+        // Strategy returns ALL upstream versions (paginated, capped at the
+        // enumeration sanity limit). PackageVersionFilter is the SINGLE point of
+        // filter + semver sort + take, so a newly-pushed version that's lex-late
+        // upstream (e.g. 1.1.0 when 1.0.3-8 lex-sorts before it) still surfaces
+        // in the dropdown. See IPackageVersionStrategy doc for why take was
+        // removed from the strategy contract.
+        var versions = await strategy.ListVersionsAsync(feed, packageId, ct).ConfigureAwait(false);
 
         versions = PackageVersionFilter.Apply(versions, includePreRelease, filter, take);
 

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/DockerPackageVersionStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/DockerPackageVersionStrategy.cs
@@ -11,9 +11,19 @@ public class DockerPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
     internal static readonly Uri DockerHubRegistryBaseUri = new("https://registry-1.docker.io/v2/");
 
+    /// <summary>
+    /// Tags-per-page hint asked of the registry. The reference distribution
+    /// (and most clones — Harbor, ECR, GHCR) honour <c>?n=N</c> up to ~100; some
+    /// implementations cap silently below that. We then follow the
+    /// <c>Link: &lt;url&gt;; rel="next"</c> header until exhaustion or the
+    /// enumeration sanity cap is hit. Asking for the largest reasonable page
+    /// minimises round-trips for typical feeds.
+    /// </summary>
+    internal const int MaxTagsPerPage = 100;
+
     public bool CanHandle(string feedType) => DockerRegistryAuthHelper.IsContainerRegistryFeed(new ExternalFeed { FeedType = feedType });
 
-    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, int take, CancellationToken ct)
+    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(packageId)) return [];
 
@@ -22,54 +32,81 @@ public class DockerPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
         var v2Base = ResolveRegistryV2Base(baseUri);
         var repo = IsDockerHub(baseUri) && !packageId.Contains('/') ? $"library/{packageId}" : packageId;
 
-        return await ListRegistryTagsAsync(feed, v2Base, repo, take, ct).ConfigureAwait(false);
+        return await ListRegistryTagsAsync(feed, v2Base, repo, ct).ConfigureAwait(false);
     }
 
-    private async Task<List<string>> ListRegistryTagsAsync(ExternalFeed feed, Uri v2Base, string repo, int take, CancellationToken ct)
+    /// <summary>
+    /// Page the registry's tags/list endpoint via RFC 5988 <c>rel="next"</c>
+    /// links, accumulating into a single list. On a 401 challenge for the first
+    /// page we upgrade to a bearer token (for Docker Hub / GHCR / ECR-style
+    /// servers) and retry the same URL; the bearer is then reused for every
+    /// subsequent page. Stops at <see cref="PackageVersionEnumerationCap"/>.
+    /// </summary>
+    private async Task<List<string>> ListRegistryTagsAsync(ExternalFeed feed, Uri v2Base, string repo, CancellationToken ct)
     {
-        var tagsUrl = $"{v2Base.ToString().TrimEnd('/')}/{repo}/tags/list";
+        var firstPageUrl = new Uri($"{v2Base.ToString().TrimEnd('/')}/{repo}/tags/list?n={MaxTagsPerPage}");
+        var cap = PackageVersionEnumerationCap.Resolve();
 
-        var headers = BuildAuthHeaders(feed);
-        var client = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
+        var accumulated = new List<string>();
+        var currentUri = firstPageUrl;
+        string bearerToken = null;
 
-        using var response = await client.GetAsync(tagsUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
-
-        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        while (currentUri != null && accumulated.Count < cap)
         {
-            var bearerResult = await TryListWithBearerTokenAsync(feed, tagsUrl, response, repo, take, ct).ConfigureAwait(false);
+            var headers = BuildAuthHeaders(feed, bearerToken);
+            var client = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
 
-            if (bearerResult != null) return bearerResult;
+            using var response = await client.GetAsync(currentUri.ToString(), HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized && bearerToken == null)
+            {
+                // Only the first-page 401 triggers a bearer upgrade. Mid-pagination
+                // 401s are treated as terminal — we surface what we have rather
+                // than silently looping while a token expires.
+                bearerToken = await TryUpgradeToBearerAsync(feed, response, repo, ct).ConfigureAwait(false);
+
+                if (bearerToken == null) return accumulated;
+
+                continue;
+            }
+
+            if (!response.IsSuccessStatusCode) return accumulated;
+
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            AppendTags(accumulated, ParseRegistryTags(json), cap);
+
+            if (accumulated.Count >= cap) return accumulated;
+
+            if (!LinkHeaderParser.TryGetNextUri(response, currentUri, out var nextUri))
+                return accumulated;
+
+            currentUri = nextUri;
         }
 
-        if (!response.IsSuccessStatusCode) return [];
-
-        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-
-        return ParseRegistryTags(json, take);
+        return accumulated;
     }
 
-    private async Task<List<string>> TryListWithBearerTokenAsync(ExternalFeed feed, string tagsUrl, HttpResponseMessage challengeResponse, string repo, int take, CancellationToken ct)
+    private static void AppendTags(List<string> accumulated, List<string> page, int cap)
+    {
+        foreach (var tag in page)
+        {
+            if (accumulated.Count >= cap) return;
+
+            accumulated.Add(tag);
+        }
+    }
+
+    private async Task<string> TryUpgradeToBearerAsync(ExternalFeed feed, HttpResponseMessage challengeResponse, string repo, CancellationToken ct)
     {
         var scope = $"repository:{repo}:pull";
 
         if (!DockerRegistryAuthHelper.TryBuildDockerTokenEndpoint(challengeResponse, scope, out var tokenEndpoint))
             return null;
 
-        var tokenResult = await RequestBearerTokenAsync(feed, tokenEndpoint, ct).ConfigureAwait(false);
+        var (success, token) = await RequestBearerTokenAsync(feed, tokenEndpoint, ct).ConfigureAwait(false);
 
-        if (!tokenResult.Success) return null;
-
-        var client = httpClientFactory.CreateClient(timeout: Timeout);
-        using var request = new HttpRequestMessage(HttpMethod.Get, tagsUrl);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenResult.Token);
-
-        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
-
-        if (!response.IsSuccessStatusCode) return null;
-
-        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-
-        return ParseRegistryTags(json, take);
+        return success ? token : null;
     }
 
     private async Task<(bool Success, string Token)> RequestBearerTokenAsync(ExternalFeed feed, Uri tokenEndpoint, CancellationToken ct)
@@ -93,8 +130,11 @@ public class DockerPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
         return string.IsNullOrWhiteSpace(token) ? (false, null) : (true, token);
     }
 
-    private static Dictionary<string, string> BuildAuthHeaders(ExternalFeed feed)
+    private static Dictionary<string, string> BuildAuthHeaders(ExternalFeed feed, string bearerToken)
     {
+        if (!string.IsNullOrEmpty(bearerToken))
+            return new Dictionary<string, string> { ["Authorization"] = $"Bearer {bearerToken}" };
+
         if (!DockerRegistryAuthHelper.HasCredentials(feed)) return null;
 
         var encoded = DockerRegistryAuthHelper.ToBasicAuthValue(feed.Username, feed.Password);
@@ -113,7 +153,15 @@ public class DockerPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
         baseUri.Host.Contains("docker.io", StringComparison.OrdinalIgnoreCase) ||
         baseUri.Host.Contains("docker.com", StringComparison.OrdinalIgnoreCase);
 
-    internal static List<string> ParseRegistryTags(string json, int take)
+    /// <summary>
+    /// Pure parser for one tags/list page. NO truncation here — pre-sort
+    /// truncation was the cause of a real production bug where a freshly pushed
+    /// <c>1.1.0</c> never appeared in dropdowns because Docker registries return
+    /// tags in lexicographic order and 30 lex-earlier <c>1.0.x-N</c> tags filled
+    /// the cap before semver sort. Ordering and take are now exclusively in
+    /// <see cref="PackageVersionFilter.Apply"/>.
+    /// </summary>
+    internal static List<string> ParseRegistryTags(string json)
     {
         try
         {
@@ -130,8 +178,6 @@ public class DockerPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
                 if (item.ValueKind != JsonValueKind.String) continue;
 
                 result.Add(item.GetString());
-
-                if (result.Count >= take) break;
             }
 
             return result;

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/GitHubPackageVersionStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/GitHubPackageVersionStrategy.cs
@@ -8,24 +8,67 @@ public class GitHubPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// GitHub Releases API per-page maximum. Asking for the largest page minimises
+    /// round-trips for typical feeds; pagination via RFC 5988 Link header
+    /// (<c>rel="next"</c>) covers feeds that exceed 100 releases.
+    /// </summary>
+    internal const int MaxReleasesPerPage = 100;
+
     public bool CanHandle(string feedType) =>
         !string.IsNullOrWhiteSpace(feedType) && feedType.Contains("GitHub", StringComparison.OrdinalIgnoreCase);
 
-    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, int take, CancellationToken ct)
+    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(packageId)) return [];
 
-        var url = $"https://api.github.com/repos/{packageId}/releases?per_page={take}";
+        var firstPageUrl = new Uri($"https://api.github.com/repos/{packageId}/releases?per_page={MaxReleasesPerPage}");
         var headers = BuildHeaders(feed);
         var client = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
 
-        using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        return await PaginateReleasesAsync(client, firstPageUrl, ct).ConfigureAwait(false);
+    }
 
-        if (!response.IsSuccessStatusCode) return [];
+    /// <summary>
+    /// Follow GitHub's RFC 5988 Link header until exhaustion or the enumeration
+    /// sanity cap. GitHub returns releases newest-first; pagination preserves
+    /// that order so a fresh release at position 1 surfaces even on huge repos.
+    /// </summary>
+    private static async Task<List<string>> PaginateReleasesAsync(HttpClient client, Uri firstPageUrl, CancellationToken ct)
+    {
+        var cap = PackageVersionEnumerationCap.Resolve();
+        var accumulated = new List<string>();
+        var currentUri = firstPageUrl;
 
-        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        while (currentUri != null && accumulated.Count < cap)
+        {
+            using var response = await client.GetAsync(currentUri.ToString(), HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
 
-        return ParseReleases(json);
+            if (!response.IsSuccessStatusCode) return accumulated;
+
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            AppendReleases(accumulated, ParseReleases(json), cap);
+
+            if (accumulated.Count >= cap) return accumulated;
+
+            if (!LinkHeaderParser.TryGetNextUri(response, currentUri, out var nextUri))
+                return accumulated;
+
+            currentUri = nextUri;
+        }
+
+        return accumulated;
+    }
+
+    private static void AppendReleases(List<string> accumulated, List<string> page, int cap)
+    {
+        foreach (var release in page)
+        {
+            if (accumulated.Count >= cap) return;
+
+            accumulated.Add(release);
+        }
     }
 
     private static Dictionary<string, string> BuildHeaders(ExternalFeed feed)
@@ -42,6 +85,11 @@ public class GitHubPackageVersionStrategy(ISquidHttpClientFactory httpClientFact
         return headers;
     }
 
+    /// <summary>
+    /// Pure parser for one releases-page response body. Order preserved as
+    /// returned by GitHub (newest first). NO truncation — pagination + take
+    /// happen in <see cref="PaginateReleasesAsync"/> + <see cref="PackageVersionFilter.Apply"/>.
+    /// </summary>
     internal static List<string> ParseReleases(string json)
     {
         try

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/HelmPackageVersionStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/HelmPackageVersionStrategy.cs
@@ -10,7 +10,7 @@ public class HelmPackageVersionStrategy(ISquidHttpClientFactory httpClientFactor
     public bool CanHandle(string feedType) =>
         !string.IsNullOrWhiteSpace(feedType) && feedType.Contains("Helm", StringComparison.OrdinalIgnoreCase);
 
-    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, int take, CancellationToken ct)
+    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(packageId)) return [];
 
@@ -26,7 +26,7 @@ public class HelmPackageVersionStrategy(ISquidHttpClientFactory httpClientFactor
 
         var yaml = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
 
-        return ParseChartVersions(yaml, packageId, take);
+        return ParseChartVersions(yaml, packageId, PackageVersionEnumerationCap.Resolve());
     }
 
     private static Dictionary<string, string> BuildAuthHeaders(ExternalFeed feed)
@@ -40,12 +40,16 @@ public class HelmPackageVersionStrategy(ISquidHttpClientFactory httpClientFactor
     }
 
     /// <summary>
-    /// Parses Helm index.yaml to extract chart versions.
-    /// Handles both compact format ("- version: X") and standard format
-    /// where version is a standalone property at the entry indent level.
-    /// Ignores nested version fields (e.g. inside dependencies).
+    /// Parses Helm <c>index.yaml</c> to extract chart versions for the named
+    /// chart. Helm repos serve a single index file (no pagination), so the
+    /// <paramref name="enumerationCap"/> only protects against pathologically
+    /// long indexes — under any reasonable repo it's never reached.
+    ///
+    /// <para>Handles both compact format (<c>- version: X</c>) and standard
+    /// format where <c>version</c> is a standalone property at the entry indent
+    /// level. Ignores nested version fields (e.g. inside <c>dependencies</c>).</para>
     /// </summary>
-    internal static List<string> ParseChartVersions(string yaml, string chartName, int take)
+    internal static List<string> ParseChartVersions(string yaml, string chartName, int enumerationCap)
     {
         var versions = new List<string>();
         var inEntries = false;
@@ -98,7 +102,7 @@ public class HelmPackageVersionStrategy(ISquidHttpClientFactory httpClientFactor
             if (!string.IsNullOrWhiteSpace(versionValue))
                 versions.Add(versionValue);
 
-            if (versions.Count >= take) break;
+            if (versions.Count >= enumerationCap) break;
         }
 
         return versions;

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/IPackageVersionStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/IPackageVersionStrategy.cs
@@ -2,9 +2,34 @@ using Squid.Core.Persistence.Entities.Deployments;
 
 namespace Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
 
+/// <summary>
+/// Per-feed-type strategy that lists raw versions discoverable from upstream.
+///
+/// <para><b>No <c>take</c> on the contract</b>: previous design passed a take limit
+/// down into each strategy, but that caused a real production bug — the truncation
+/// happened BEFORE <see cref="PackageVersionFilter"/> sorted by semver, so a
+/// freshly pushed <c>1.1.0</c> was hidden behind 30 lex-sorted <c>1.0.x-N</c>
+/// tags (Docker registries return tags in lexicographic order, where
+/// <c>1.0.3-8</c> sorts before <c>1.1.0</c> because <c>0 &lt; 1</c> at the third
+/// character). Strategies now return ALL versions discoverable via upstream
+/// pagination, and <see cref="PackageVersionFilter.Apply"/> is the single point
+/// of filter+sort+take.</para>
+///
+/// <para><b>Sanity cap via <see cref="PackageVersionEnumerationCap"/></b>: each
+/// implementation MUST enforce the cap (default 5000) to prevent OOM on
+/// pathological feeds. Operators with legitimately larger feeds override via
+/// <c>SQUID_PACKAGE_VERSION_MAX_ENUMERATE</c>.</para>
+/// </summary>
 public interface IPackageVersionStrategy : IScopedDependency
 {
     bool CanHandle(string feedType);
 
-    Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, int take, CancellationToken ct);
+    /// <summary>
+    /// Returns ALL versions for the given package as they appear upstream, up to
+    /// the enumeration sanity cap. Order is upstream-native (lexicographic for
+    /// Docker, date-descending for GitHub, file-order for Helm). The caller —
+    /// <c>ExternalFeedPackageVersionService</c> via <see cref="PackageVersionFilter.Apply"/>
+    /// — is responsible for filter, semver sort, and take.
+    /// </summary>
+    Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, CancellationToken ct);
 }

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/LinkHeaderParser.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/LinkHeaderParser.cs
@@ -1,0 +1,132 @@
+namespace Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+
+/// <summary>
+/// RFC 5988 Link-header parser, focused on the <c>rel="next"</c> form used by
+/// paginated registry / API endpoints (Docker registry v2 tags/list, GitHub
+/// Releases, Helm OCI manifest list).
+///
+/// <para><b>Format</b>: a single Link header may contain multiple links, comma-
+/// separated, each <c>&lt;url&gt;; rel="next"</c>. Whitespace between segments is
+/// allowed. Relative URLs in the header are resolved against the request URL
+/// per RFC 3986. Absolute URLs are used verbatim.</para>
+///
+/// <para><b>Why a shared helper</b>: both Docker and GitHub use Link headers but
+/// each strategy's auth flow is bespoke (Docker bearer-token retry, GitHub PAT).
+/// Extracting only the *parsing* into a pure helper avoids duplicating the regex
+/// + URL-resolution logic across strategies; each strategy's pagination loop
+/// stays inline so its auth context is obvious to a reader.</para>
+/// </summary>
+internal static class LinkHeaderParser
+{
+    /// <summary>
+    /// Tries to extract the next-page URI from an HTTP response's Link header.
+    /// </summary>
+    /// <param name="response">The HTTP response just received.</param>
+    /// <param name="requestUri">
+    /// The URI of the request that produced <paramref name="response"/>. Used to
+    /// resolve relative Link header URLs (Docker registry returns relative paths
+    /// like <c>/v2/repo/tags/list?n=100&amp;last=tag</c>; GitHub returns absolute).
+    /// </param>
+    /// <param name="nextUri">The resolved absolute next-page URI, when found.</param>
+    /// <returns>True if a <c>rel="next"</c> link was found; false otherwise.</returns>
+    public static bool TryGetNextUri(HttpResponseMessage response, Uri requestUri, out Uri nextUri)
+    {
+        nextUri = null;
+
+        if (response == null || requestUri == null) return false;
+
+        if (!response.Headers.TryGetValues("Link", out var values)) return false;
+
+        // Multiple Link headers may concatenate; join then split on `,` (commas
+        // inside angle brackets aren't permitted by RFC, so a plain split is safe).
+        var combined = string.Join(",", values);
+
+        foreach (var segment in combined.Split(','))
+        {
+            if (!TryParseSegment(segment, out var url, out var rel)) continue;
+
+            if (!string.Equals(rel, "next", StringComparison.OrdinalIgnoreCase)) continue;
+
+            return TryResolveAbsolute(url, requestUri, out nextUri);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Pure parser for a single Link header segment. Exposed for unit testing
+    /// edge cases (whitespace variants, missing rel, malformed urls) without
+    /// having to construct an HttpResponseMessage.
+    /// </summary>
+    internal static bool TryParseSegment(string segment, out string url, out string rel)
+    {
+        url = null;
+        rel = null;
+
+        if (string.IsNullOrWhiteSpace(segment)) return false;
+
+        var trimmed = segment.Trim();
+
+        var openBracket = trimmed.IndexOf('<');
+        var closeBracket = trimmed.IndexOf('>');
+
+        if (openBracket < 0 || closeBracket <= openBracket) return false;
+
+        url = trimmed.Substring(openBracket + 1, closeBracket - openBracket - 1).Trim();
+
+        if (string.IsNullOrWhiteSpace(url)) return false;
+
+        rel = ExtractRel(trimmed[(closeBracket + 1)..]);
+
+        return true;
+    }
+
+    private static string ExtractRel(string parameters)
+    {
+        // Find `rel=` parameter; value may be quoted or bare.
+        const string relMarker = "rel=";
+
+        var idx = parameters.IndexOf(relMarker, StringComparison.OrdinalIgnoreCase);
+
+        if (idx < 0) return null;
+
+        var valueStart = idx + relMarker.Length;
+
+        if (valueStart >= parameters.Length) return null;
+
+        var rest = parameters[valueStart..].TrimStart();
+
+        if (rest.Length == 0) return null;
+
+        if (rest[0] == '"')
+        {
+            var endQuote = rest.IndexOf('"', 1);
+            return endQuote > 0 ? rest.Substring(1, endQuote - 1) : null;
+        }
+
+        // Bare token — until `;` or `,` or whitespace
+        var end = rest.IndexOfAny([';', ',', ' ', '\t']);
+
+        return end > 0 ? rest[..end] : rest;
+    }
+
+    private static bool TryResolveAbsolute(string url, Uri requestUri, out Uri absolute)
+    {
+        // The (baseUri, relativeUri) overload handles BOTH cases:
+        //   • Absolute URL string → result = the absolute URI (baseUri ignored)
+        //   • Relative URL string → result = baseUri.Scheme://baseUri.Authority/<relative>
+        // Verifying IsAbsoluteUri afterwards guards against the .NET quirk where
+        // some malformed inputs produce a relative result without scheme/host —
+        // observed e.g. with `/v2/...` strings on certain frameworks. Returning
+        // false in that case lets the caller treat the link as missing.
+        if (!Uri.TryCreate(requestUri, url, out absolute)) return false;
+
+        if (!absolute.IsAbsoluteUri || string.IsNullOrEmpty(absolute.Host))
+        {
+            absolute = null;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/PackageVersionEnumerationCap.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/PackageVersionEnumerationCap.cs
@@ -1,0 +1,46 @@
+namespace Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+
+/// <summary>
+/// Sanity cap on how many versions a single <see cref="IPackageVersionStrategy"/>
+/// will pull from upstream during one <c>ListVersionsAsync</c> call.
+///
+/// <para><b>Why this exists</b>: strategies now follow pagination links until the
+/// source is exhausted (Docker registry Link header, GitHub Releases Link header).
+/// A pathological feed (e.g. an internal mirror that mirrors millions of tags from
+/// upstream registries) could otherwise OOM the API process by streaming tags
+/// indefinitely. The cap is the upstream-fetch ceiling — the per-call <c>take</c>
+/// the operator passes in is applied AFTER semver sort by
+/// <see cref="PackageVersionFilter.Apply"/>, so the cap doesn't change what the
+/// user sees in the dropdown unless their target version is past the cap.</para>
+///
+/// <para><b>Default 5000</b>: an order of magnitude above any package's typical
+/// release history (Docker Hub's nginx has ~3000 tags as the largest practical
+/// example), but well below the ~50–100K threshold where memory pressure becomes
+/// a concern (each tag string is ~32 bytes; 5000 × 32 = 160 KB per call).</para>
+///
+/// <para><b>Operator escape hatch</b> (Rule 8): air-gapped operators with private
+/// mirrors that legitimately have higher tag counts can override via
+/// <c>SQUID_PACKAGE_VERSION_MAX_ENUMERATE</c> env var. Reads on each call so a
+/// restart isn't needed to bump the cap mid-incident.</para>
+/// </summary>
+public static class PackageVersionEnumerationCap
+{
+    /// <summary>Default sanity cap. See class doc for rationale.</summary>
+    public const int Default = 5000;
+
+    /// <summary>Env var name. Pinned by unit test (Rule 8).</summary>
+    public const string MaxItemsEnvVar = "SQUID_PACKAGE_VERSION_MAX_ENUMERATE";
+
+    /// <summary>
+    /// Read the effective cap. Returns <see cref="Default"/> unless the env var is
+    /// set to a positive integer.
+    /// </summary>
+    public static int Resolve()
+    {
+        var raw = Environment.GetEnvironmentVariable(MaxItemsEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return Default;
+
+        return int.TryParse(raw, out var parsed) && parsed > 0 ? parsed : Default;
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/DockerPackageVersionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/DockerPackageVersionStrategyTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
 using Squid.Core.Services.Http;
 
@@ -40,7 +41,7 @@ public class DockerPackageVersionStrategyTests
             }
             """;
 
-        var result = DockerPackageVersionStrategy.ParseRegistryTags(json, 100);
+        var result = DockerPackageVersionStrategy.ParseRegistryTags(json);
 
         result.Count.ShouldBe(4);
         result.ShouldContain("latest");
@@ -53,7 +54,7 @@ public class DockerPackageVersionStrategyTests
     {
         var json = """{"tags": ["1.0.0", "1.0.1-rc1", "1.0.1-beta.2", "2.0.0-alpha", "latest"]}""";
 
-        var result = DockerPackageVersionStrategy.ParseRegistryTags(json, 100);
+        var result = DockerPackageVersionStrategy.ParseRegistryTags(json);
 
         result.Count.ShouldBe(5);
         result.ShouldContain("1.0.1-rc1");
@@ -61,14 +62,27 @@ public class DockerPackageVersionStrategyTests
         result.ShouldContain("2.0.0-alpha");
     }
 
+    /// <summary>
+    /// Inverted version of the deleted "ShouldRespectTakeLimit" test. The new
+    /// contract: the parser returns ALL tags from the page payload — semver sort
+    /// + take is the orchestrator's job (<see cref="PackageVersionFilter.Apply"/>).
+    /// If this fails it likely means someone re-introduced pre-sort truncation
+    /// here, which would re-open the production bug where freshly pushed lex-late
+    /// versions (e.g. 1.1.0 after 1.0.3-8) never appear in the dropdown.
+    /// </summary>
     [Fact]
-    public void ParseRegistryTags_ShouldRespectTakeLimit()
+    public void ParseRegistryTags_ShouldReturnAllTagsFromPage_NoTruncation()
     {
-        var json = """{"tags": ["v1", "v2", "v3", "v4", "v5"]}""";
+        // 50 tags — well over any historical pre-sort take=30 limit.
+        var tags = string.Join(",", Enumerable.Range(0, 50).Select(i => $"\"v{i}\""));
+        var json = $"{{\"tags\": [{tags}]}}";
 
-        var result = DockerPackageVersionStrategy.ParseRegistryTags(json, 3);
+        var result = DockerPackageVersionStrategy.ParseRegistryTags(json);
 
-        result.Count.ShouldBe(3);
+        result.Count.ShouldBe(50,
+            customMessage: "Parser MUST return all tags — order + take belong to PackageVersionFilter.Apply. " +
+                          "If this fails, the production bug 'freshly pushed 1.1.0 hidden behind 30 lex-earlier " +
+                          "1.0.x-N tags' has been re-introduced.");
     }
 
     [Fact]
@@ -76,12 +90,20 @@ public class DockerPackageVersionStrategyTests
     {
         var json = """{"name": "my-app"}""";
 
-        DockerPackageVersionStrategy.ParseRegistryTags(json, 100).ShouldBeEmpty();
+        DockerPackageVersionStrategy.ParseRegistryTags(json).ShouldBeEmpty();
     }
 
     [Fact]
     public void ParseRegistryTags_InvalidJson_ReturnsEmpty()
     {
-        DockerPackageVersionStrategy.ParseRegistryTags("bad", 100).ShouldBeEmpty();
+        DockerPackageVersionStrategy.ParseRegistryTags("bad").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MaxTagsPerPage_IsAt100()
+    {
+        // Pinned: per Docker registry v2 spec the per-page upper bound is ~100;
+        // changing this affects round-trip count for every Docker feed in production.
+        DockerPackageVersionStrategy.MaxTagsPerPage.ShouldBe(100);
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/ExternalFeedPackageVersionServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/ExternalFeedPackageVersionServiceTests.cs
@@ -21,7 +21,7 @@ public class ExternalFeedPackageVersionServiceTests
     {
         var feed = new ExternalFeed { Id = 1, FeedType = "Docker", FeedUri = "https://registry.example.com" };
         _dataProvider.Setup(x => x.GetFeedByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(feed);
-        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "nginx", 30, It.IsAny<CancellationToken>()))
+        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "nginx", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["1.25.4", "1.25.3", "latest"]);
 
         var sut = CreateSut();
@@ -29,8 +29,8 @@ public class ExternalFeedPackageVersionServiceTests
         var result = await sut.ListVersionsAsync(1, "nginx", 30, true, null, CancellationToken.None);
 
         result.Versions.Count.ShouldBe(3);
-        _dockerStrategy.Verify(x => x.ListVersionsAsync(feed, "nginx", 30, It.IsAny<CancellationToken>()), Times.Once);
-        _helmStrategy.Verify(x => x.ListVersionsAsync(It.IsAny<ExternalFeed>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _dockerStrategy.Verify(x => x.ListVersionsAsync(feed, "nginx", It.IsAny<CancellationToken>()), Times.Once);
+        _helmStrategy.Verify(x => x.ListVersionsAsync(It.IsAny<ExternalFeed>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ExternalFeedPackageVersionServiceTests
     {
         var feed = new ExternalFeed { Id = 1, FeedType = "Docker", FeedUri = "https://registry.example.com" };
         _dataProvider.Setup(x => x.GetFeedByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(feed);
-        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", 30, It.IsAny<CancellationToken>()))
+        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["7.2.4", "7.2.4-rc1", "7.2.3", "7.2.3-beta.2", "7.2.2", "latest"]);
 
         var sut = CreateSut();
@@ -94,7 +94,7 @@ public class ExternalFeedPackageVersionServiceTests
     {
         var feed = new ExternalFeed { Id = 1, FeedType = "Docker", FeedUri = "https://registry.example.com" };
         _dataProvider.Setup(x => x.GetFeedByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(feed);
-        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", 30, It.IsAny<CancellationToken>()))
+        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["7.2.4", "7.2.4-rc1", "7.2.3-beta.2", "latest"]);
 
         var sut = CreateSut();
@@ -109,7 +109,7 @@ public class ExternalFeedPackageVersionServiceTests
     {
         var feed = new ExternalFeed { Id = 1, FeedType = "Docker", FeedUri = "https://registry.example.com" };
         _dataProvider.Setup(x => x.GetFeedByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(feed);
-        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", 30, It.IsAny<CancellationToken>()))
+        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["7.2.4", "7.2.3", "7.0.15", "6.2.14", "latest"]);
 
         var sut = CreateSut();
@@ -124,7 +124,7 @@ public class ExternalFeedPackageVersionServiceTests
     {
         var feed = new ExternalFeed { Id = 1, FeedType = "Docker", FeedUri = "https://registry.example.com" };
         _dataProvider.Setup(x => x.GetFeedByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(feed);
-        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", 30, It.IsAny<CancellationToken>()))
+        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "redis", It.IsAny<CancellationToken>()))
             .ReturnsAsync(["6.2.14", "7.0.15", "7.2.4", "7.2.3"]);
 
         var sut = CreateSut();
@@ -135,6 +135,54 @@ public class ExternalFeedPackageVersionServiceTests
         result.Versions[1].ShouldBe("7.2.3");
         result.Versions[2].ShouldBe("7.0.15");
         result.Versions[3].ShouldBe("6.2.14");
+    }
+
+    /// <summary>
+    /// Pinned regression for the real production bug: a user pushed Docker image
+    /// <c>1.1.0</c> after a long history of <c>1.0.x-N</c> tags. Docker registries
+    /// return tags lex-sorted, so <c>1.0.3-8</c> sorts before <c>1.1.0</c> (the
+    /// '0' at the third character is less than '1'). With the old contract the
+    /// strategy truncated to 30 tags BEFORE semver sort — the user's freshly
+    /// pushed <c>1.1.0</c> was never seen.
+    ///
+    /// <para>Pre-fix: the strategy received <c>take=30</c> and stopped reading
+    /// tags at position 30; <c>1.1.0</c> at position 31 was lost. Post-fix:
+    /// strategy returns ALL 32 tags, PackageVersionFilter sorts by semver, take
+    /// keeps the top 30 — <c>1.1.0</c> sits at position #1.</para>
+    /// </summary>
+    [Fact]
+    public async Task ListVersionsAsync_ShouldNotHideNewerVersionBehindLexSort()
+    {
+        var feed = new ExternalFeed { Id = 1, FeedType = "Docker", FeedUri = "https://registry.example.com" };
+        _dataProvider.Setup(x => x.GetFeedByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(feed);
+
+        // Mimic the user's actual feed: 31 tags ending at "1.0.3-8" (lex-late-but-
+        // semver-old) plus the freshly pushed "1.1.0". The strategy returns them
+        // in lex order — exactly what `/v2/.../tags/list` produces.
+        var lexOrderedTags = new List<string>
+        {
+            "1.0.0", "1.0.1", "1.0.1-1", "1.0.1-2", "1.0.2", "1.0.2-1", "1.0.2-2",
+            "1.0.2-3", "1.0.2-4", "1.0.2-5", "1.0.2-6", "1.0.2-7", "1.0.2-8",
+            "1.0.2-9", "1.0.3", "1.0.3-1", "1.0.3-2", "1.0.3-3", "1.0.3-4",
+            "1.0.3-5", "1.0.3-6", "1.0.3-7", "1.0.3-8", "1.0.3-9", "1.0.3-10",
+            "1.0.3-11", "1.0.3-12", "1.0.3-13", "1.0.3-14", "1.0.3-15", "1.0.3-16",
+            "1.1.0"
+        };
+
+        _dockerStrategy.Setup(x => x.ListVersionsAsync(feed, "web", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lexOrderedTags);
+
+        var sut = CreateSut();
+
+        var result = await sut.ListVersionsAsync(1, "web", 30, includePreRelease: true, filter: null, CancellationToken.None);
+
+        result.Versions.Count.ShouldBe(30);
+        result.Versions[0].ShouldBe("1.1.0",
+            customMessage: "Top result MUST be 1.1.0 — the strategy now returns ALL upstream tags " +
+                          "and PackageVersionFilter applies semver sort BEFORE take. " +
+                          "If this fails: someone re-introduced pre-sort truncation in the " +
+                          "strategy or service. See ExternalFeedPackageVersionService for the " +
+                          "correct order: ListVersionsAsync(no take) → PackageVersionFilter.Apply(take).");
     }
 
     private ExternalFeedPackageVersionService CreateSut()

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/GitHubPackageVersionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/GitHubPackageVersionStrategyTests.cs
@@ -53,4 +53,14 @@ public class GitHubPackageVersionStrategyTests
     {
         GitHubPackageVersionStrategy.ParseReleases("bad json").ShouldBeEmpty();
     }
+
+    [Fact]
+    public void MaxReleasesPerPage_IsAt100()
+    {
+        // Pinned: GitHub's REST API caps per_page at 100. Lowering this would
+        // multiply round-trips for every GitHub feed; raising it past 100 would
+        // be silently capped server-side. The pagination loop relies on this
+        // being the GitHub-supported maximum.
+        GitHubPackageVersionStrategy.MaxReleasesPerPage.ShouldBe(100);
+    }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/HelmPackageVersionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/HelmPackageVersionStrategyTests.cs
@@ -5,6 +5,8 @@ namespace Squid.UnitTests.Services.Deployments.ExternalFeeds;
 
 public class HelmPackageVersionStrategyTests
 {
+    private const int LargeEnumerationCap = 10_000;
+
     [Theory]
     [InlineData("Helm", true)]
     [InlineData("Helm Feed", true)]
@@ -36,7 +38,7 @@ public class HelmPackageVersionStrategyTests
             generated: "2026-01-01T00:00:00Z"
             """;
 
-        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", 100);
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", LargeEnumerationCap);
 
         result.Count.ShouldBe(3);
         result[0].ShouldBe("1.2.0");
@@ -55,7 +57,7 @@ public class HelmPackageVersionStrategyTests
                 - version: "2.0.0"
             """;
 
-        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", 100);
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", LargeEnumerationCap);
 
         result.Count.ShouldBe(1);
         result[0].ShouldBe("1.0.0");
@@ -70,11 +72,18 @@ public class HelmPackageVersionStrategyTests
                 - version: "2.0.0"
             """;
 
-        HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", 100).ShouldBeEmpty();
+        HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", LargeEnumerationCap).ShouldBeEmpty();
     }
 
+    /// <summary>
+    /// Inverted version of the old "ShouldRespectTakeLimit" test. The cap is now
+    /// a SANITY ceiling (default 5000), not a per-call take. Helm index.yaml is
+    /// served as a single file with no pagination, so all chart versions in the
+    /// file are returned (up to the cap). Filter+sort+take happen downstream in
+    /// <see cref="PackageVersionFilter.Apply"/>.
+    /// </summary>
     [Fact]
-    public void ParseChartVersions_ShouldRespectTakeLimit()
+    public void ParseChartVersions_ShouldReturnAllVersions_BelowCap()
     {
         var yaml = """
             entries:
@@ -84,7 +93,30 @@ public class HelmPackageVersionStrategyTests
                 - version: "1.0.0"
             """;
 
-        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", 2);
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", LargeEnumerationCap);
+
+        result.Count.ShouldBe(3,
+            customMessage: "Parser MUST return all chart versions — order + take belong to " +
+                          "PackageVersionFilter.Apply. The cap parameter is a sanity ceiling " +
+                          "(default 5000) for OOM protection, not a per-call take.");
+    }
+
+    [Fact]
+    public void ParseChartVersions_RespectsEnumerationCap_ForSafetyOnPathologicalIndex()
+    {
+        // Defense-in-depth: a malicious / corrupt index with millions of versions
+        // must not OOM the parser. Cap at 2 here to make the limit observable.
+        var yaml = """
+            entries:
+              nginx:
+                - version: "5.0.0"
+                - version: "4.0.0"
+                - version: "3.0.0"
+                - version: "2.0.0"
+                - version: "1.0.0"
+            """;
+
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "nginx", enumerationCap: 2);
 
         result.Count.ShouldBe(2);
     }
@@ -98,7 +130,7 @@ public class HelmPackageVersionStrategyTests
                 - version: 0.1.0
             """;
 
-        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "mychart", 100);
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "mychart", LargeEnumerationCap);
 
         result.Count.ShouldBe(1);
         result[0].ShouldBe("0.1.0");
@@ -113,7 +145,7 @@ public class HelmPackageVersionStrategyTests
                 - version: "1.0.0"
             """;
 
-        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "mychart", 100);
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "mychart", LargeEnumerationCap);
 
         result.Count.ShouldBe(1);
     }
@@ -151,7 +183,7 @@ public class HelmPackageVersionStrategyTests
             generated: "2026-03-26T07:20:46Z"
             """;
 
-        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "openclaw", 100);
+        var result = HelmPackageVersionStrategy.ParseChartVersions(yaml, "openclaw", LargeEnumerationCap);
 
         result.Count.ShouldBe(3);
         result[0].ShouldBe("1.5.7");
@@ -176,8 +208,8 @@ public class HelmPackageVersionStrategyTests
             generated: "2026-01-01T00:00:00Z"
             """;
 
-        var resultA = HelmPackageVersionStrategy.ParseChartVersions(yaml, "chartA", 100);
-        var resultB = HelmPackageVersionStrategy.ParseChartVersions(yaml, "chartB", 100);
+        var resultA = HelmPackageVersionStrategy.ParseChartVersions(yaml, "chartA", LargeEnumerationCap);
+        var resultB = HelmPackageVersionStrategy.ParseChartVersions(yaml, "chartB", LargeEnumerationCap);
 
         resultA.Count.ShouldBe(2);
         resultA[0].ShouldBe("1.0.0");

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/LinkHeaderParserTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/LinkHeaderParserTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Net.Http;
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+
+namespace Squid.UnitTests.Services.Deployments.ExternalFeeds;
+
+/// <summary>
+/// Pure parser unit tests for <see cref="LinkHeaderParser"/>.
+///
+/// <para>The Link header drives pagination for both Docker registry v2 (relative
+/// URLs) and GitHub Releases (absolute URLs). A regression in this parser would
+/// silently truncate every paginated feed back to a single page — the exact
+/// shape of the bug we just fixed in <see cref="DockerPackageVersionStrategy"/>.</para>
+/// </summary>
+public class LinkHeaderParserTests
+{
+    private static readonly Uri RequestUri = new("https://registry.example.com/v2/repo/tags/list?n=100");
+
+    [Fact]
+    public void TryGetNextUri_NullResponse_ReturnsFalse()
+    {
+        LinkHeaderParser.TryGetNextUri(null, RequestUri, out var next).ShouldBeFalse();
+        next.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetNextUri_NoLinkHeader_ReturnsFalse()
+    {
+        using var response = new HttpResponseMessage();
+
+        LinkHeaderParser.TryGetNextUri(response, RequestUri, out var next).ShouldBeFalse();
+        next.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetNextUri_AbsoluteUrl_GitHubStyle()
+    {
+        using var response = new HttpResponseMessage();
+        response.Headers.Add(
+            "Link",
+            "<https://api.github.com/repos/foo/bar/releases?page=2&per_page=100>; rel=\"next\", " +
+            "<https://api.github.com/repos/foo/bar/releases?page=5&per_page=100>; rel=\"last\"");
+
+        LinkHeaderParser.TryGetNextUri(response, RequestUri, out var next).ShouldBeTrue();
+        next.ToString().ShouldBe("https://api.github.com/repos/foo/bar/releases?page=2&per_page=100");
+    }
+
+    [Fact]
+    public void TryGetNextUri_RelativeUrl_DockerRegistryStyle()
+    {
+        // Docker reference distribution returns absolute paths relative to host;
+        // they must be resolved against the request URI.
+        using var response = new HttpResponseMessage();
+        response.Headers.Add(
+            "Link",
+            "</v2/repo/tags/list?n=100&last=v1.99.0>; rel=\"next\"");
+
+        LinkHeaderParser.TryGetNextUri(response, RequestUri, out var next).ShouldBeTrue();
+        next.Host.ShouldBe("registry.example.com");
+        next.AbsolutePath.ShouldBe("/v2/repo/tags/list");
+        next.Query.ShouldContain("last=v1.99.0");
+    }
+
+    [Fact]
+    public void TryGetNextUri_NoNextRel_OnlyPrev_ReturnsFalse()
+    {
+        using var response = new HttpResponseMessage();
+        response.Headers.Add(
+            "Link",
+            "<https://api.github.com/repos/foo/bar/releases?page=1>; rel=\"prev\"");
+
+        LinkHeaderParser.TryGetNextUri(response, RequestUri, out var next).ShouldBeFalse();
+        next.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetNextUri_RelCaseInsensitive()
+    {
+        using var response = new HttpResponseMessage();
+        response.Headers.Add(
+            "Link",
+            "<https://api.example.com/page/2>; rel=NEXT");
+
+        LinkHeaderParser.TryGetNextUri(response, RequestUri, out var next).ShouldBeTrue();
+        next.ToString().ShouldBe("https://api.example.com/page/2");
+    }
+
+    [Theory]
+    [InlineData("<https://x/2>; rel=\"next\"", "https://x/2", "next")]
+    [InlineData("  <https://x/2>;rel=\"next\"  ", "https://x/2", "next")]
+    [InlineData("<https://x/2>; rel=next", "https://x/2", "next")]
+    [InlineData("<https://x/2>; rel=next; type=\"application/json\"", "https://x/2", "next")]
+    [InlineData("<>; rel=\"next\"", null, null)]
+    [InlineData("no-brackets-here", null, null)]
+    [InlineData("", null, null)]
+    public void TryParseSegment_HandlesEdgeFormats(string segment, string expectedUrl, string expectedRel)
+    {
+        var success = LinkHeaderParser.TryParseSegment(segment, out var url, out var rel);
+
+        if (expectedUrl == null)
+        {
+            success.ShouldBeFalse();
+            return;
+        }
+
+        success.ShouldBeTrue();
+        url.ShouldBe(expectedUrl);
+        rel.ShouldBe(expectedRel);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/PackageVersionEnumerationCapTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/PackageVersionEnumerationCapTests.cs
@@ -1,0 +1,80 @@
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+
+namespace Squid.UnitTests.Services.Deployments.ExternalFeeds;
+
+/// <summary>
+/// Pin the public surface of <see cref="PackageVersionEnumerationCap"/> against
+/// accidental drift. This is a Rule 8 escape-hatch env var: changing the constant
+/// name silently breaks every air-gapped operator who pinned a private mirror's
+/// higher tag count. The literal-name pin in this test makes any rename a
+/// compile-fail-visible decision.
+/// </summary>
+public class PackageVersionEnumerationCapTests
+{
+    [Fact]
+    public void EnvVarConstantName_IsPinned()
+    {
+        // Rule 8: if you rename this, every operator who set
+        // SQUID_PACKAGE_VERSION_MAX_ENUMERATE in their environment loses their
+        // override silently. Update the docs + release notes too.
+        PackageVersionEnumerationCap.MaxItemsEnvVar.ShouldBe("SQUID_PACKAGE_VERSION_MAX_ENUMERATE");
+    }
+
+    [Fact]
+    public void Default_IsAt5000()
+    {
+        // Pinned: Docker Hub's largest practical chart (nginx) tops out around 3000
+        // tags; a 10× headroom for memory protection sits at 5000. If you bump
+        // this, audit memory profile under realistic load first.
+        PackageVersionEnumerationCap.Default.ShouldBe(5000);
+    }
+
+    [Fact]
+    public void Resolve_NoEnvVar_ReturnsDefault()
+    {
+        Environment.SetEnvironmentVariable(PackageVersionEnumerationCap.MaxItemsEnvVar, null);
+
+        try
+        {
+            PackageVersionEnumerationCap.Resolve().ShouldBe(PackageVersionEnumerationCap.Default);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(PackageVersionEnumerationCap.MaxItemsEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public void Resolve_PositiveOverride_AppliesValue()
+    {
+        Environment.SetEnvironmentVariable(PackageVersionEnumerationCap.MaxItemsEnvVar, "12345");
+
+        try
+        {
+            PackageVersionEnumerationCap.Resolve().ShouldBe(12345);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(PackageVersionEnumerationCap.MaxItemsEnvVar, null);
+        }
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("not-a-number")]
+    [InlineData(" ")]
+    public void Resolve_InvalidOrNonPositive_FallsBackToDefault(string raw)
+    {
+        Environment.SetEnvironmentVariable(PackageVersionEnumerationCap.MaxItemsEnvVar, raw);
+
+        try
+        {
+            PackageVersionEnumerationCap.Resolve().ShouldBe(PackageVersionEnumerationCap.Default);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(PackageVersionEnumerationCap.MaxItemsEnvVar, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Real bug**: a user pushed Docker image `1.1.0` after a long history of `1.0.x-N` tags; the Create-Release dropdown showed 30 versions ending at `1.0.3-8` and `1.1.0` was missing. Docker registries return tags in lexicographic order, where `1.0.3-8` sorts before `1.1.0` (`'0' < '1'` at the third character). The strategy was truncating to `take=30` BEFORE `PackageVersionFilter` sorted by semver — fresh versions past the lex-take were invisible.
- **Fix**: `IPackageVersionStrategy.ListVersionsAsync` no longer takes a `take` parameter. Strategies return ALL upstream versions (with pagination + sanity cap); `PackageVersionFilter.Apply` becomes the single point of filter + semver sort + take.
- **Scaling**: Docker + GitHub now follow RFC 5988 `Link: rel="next"` headers across pages; Helm is single-file (no pagination needed). All three strategies enforce a 5000-default enumeration cap to protect against pathological feeds, with `SQUID_PACKAGE_VERSION_MAX_ENUMERATE` env-var override (Rule 8).

## Changes

| File | Change |
|---|---|
| `IPackageVersionStrategy.cs` | Drop `take` param; doc-comment explains the production bug it fixed |
| `DockerPackageVersionStrategy.cs` | Pagination loop with sticky bearer-token upgrade on 401 — `?n=100` per page, follow Link header |
| `GitHubPackageVersionStrategy.cs` | `?per_page=100` (was `?per_page={take}`) + Link-header pagination loop |
| `HelmPackageVersionStrategy.cs` | Drop pre-sort take; cap parameter is now a sanity ceiling only |
| `ExternalFeedPackageVersionService.cs` | Calls strategy without `take`; passes `take` only to `PackageVersionFilter.Apply` |
| `LinkHeaderParser.cs` (new) | Pure RFC 5988 parser — GitHub absolute + Docker relative URLs, case-insensitive `rel`, quoted + bare values |
| `PackageVersionEnumerationCap.cs` (new) | `SQUID_PACKAGE_VERSION_MAX_ENUMERATE` env-var-pinnable cap (default 5000) |

## Test plan

- [x] Unit: 5108/5108 pass (`dotnet test tests/Squid.UnitTests/`)
- [x] User bug pinned: `ListVersionsAsync_ShouldNotHideNewerVersionBehindLexSort` (32 lex-ordered Docker tags ending at `1.1.0` → result top-of-list is `1.1.0`)
- [x] Drift pins: `MaxTagsPerPage`/`MaxReleasesPerPage` (100), `PackageVersionEnumerationCap.Default` (5000), `MaxItemsEnvVar` literal (Rule 8)
- [x] LinkHeaderParser: 13 cases covering both URL styles + edge formats
- [x] Strategy parsers inverted: each `ShouldRespectTakeLimit` test now `ShouldReturnAllTagsFromPage_NoTruncation` so re-introducing pre-sort truncation fails loudly
- [ ] Manual: verify the dropdown shows `1.1.0` at top of the user's actual web feed in staging post-deploy

## Rollout

`git revert` is clean — no schema or DI surface changed. The contract change is internal-only (`IPackageVersionStrategy`); the public `IExternalFeedPackageVersionService.ListVersionsAsync` signature is unchanged so request handlers + callers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)