### PR TITLE
P0-1: Reject empty/whitespace ScriptBody in RunScriptActionHandler

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Handlers/RunScriptActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Handlers/RunScriptActionHandler.cs
@@ -1,4 +1,5 @@
 using Squid.Core.Extensions;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.DeploymentExecution.Intents;
 using Squid.Message.Constants;
@@ -15,12 +16,32 @@ public class RunScriptActionHandler : IActionHandler
     /// Produces a <see cref="RunScriptIntent"/> with <c>InjectRuntimeBundle = true</c> so the
     /// runtime bundle (<c>set_squidvariable</c>, <c>new_squidartifact</c>,
     /// <c>fail_step</c>) is always injected by the renderer.
+    ///
+    /// <para><b>P0-1 fix</b> — validates that <see cref="SpecialVariables.Action.ScriptBody"/>
+    /// is non-blank. The pre-fix behaviour silently emitted an empty intent and let the shell
+    /// execute a no-op script (<c>set -e</c> immediate exit), reporting success. That hid
+    /// misconfigured steps where an operator forgot to fill in the script — the deploy was
+    /// "✅ green" while doing nothing, and downstream steps that read output variables saw
+    /// stale / missing values and produced subtle bugs in production.</para>
+    ///
+    /// <para>The planner stub at <c>DeploymentPlanner.BuildStubIntent</c> intentionally uses
+    /// an empty body and is NOT routed through this method — it only goes through capability
+    /// validation, never execution.</para>
     /// </summary>
     Task<ExecutionIntent> IActionHandler.DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(ctx);
 
-        var scriptBody = ctx.Action?.GetProperty(SpecialVariables.Action.ScriptBody) ?? string.Empty;
+        var scriptBody = ctx.Action?.GetProperty(SpecialVariables.Action.ScriptBody);
+
+        if (string.IsNullOrWhiteSpace(scriptBody))
+            throw new DeploymentValidationException(
+                $"RunScript action '{ctx.Action?.Name ?? "(unknown)"}' in step '{ctx.Step?.Name ?? "(unknown)"}' " +
+                $"has an empty or whitespace-only ScriptBody. " +
+                $"This usually means the step's script field was left blank during configuration. " +
+                $"Set the '{SpecialVariables.Action.ScriptBody}' property to a non-empty script, " +
+                $"or remove this action / disable this step if it is no longer needed.");
+
         var syntax = ScriptSyntaxHelper.ResolveSyntax(ctx.Action);
 
         var intent = new RunScriptIntent

--- a/tests/Squid.UnitTests/Services/Deployments/Handlers/RunScriptActionHandlerDescribeIntentTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Handlers/RunScriptActionHandlerDescribeIntentTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Intents;
 using Squid.Message.Constants;
@@ -97,8 +98,24 @@ public class RunScriptActionHandlerDescribeIntentTests
         intent.ScriptBody.ShouldBe("kubectl apply -f deployment.yaml");
     }
 
+    // ── P0-1 — empty / whitespace ScriptBody must NOT silently pass ──────────
+    //
+    // Pre-fix: the handler emitted an empty intent and the renderer wrote a
+    // shell script with no commands; the agent ran `set -e` and exited 0;
+    // step marked "success"; downstream steps proceeded despite the
+    // configuration error. Operators reported "deploy says green but
+    // nothing actually happened" — silent no-op was a real production bug.
+    //
+    // Post-fix: any empty / whitespace-only / missing ScriptBody throws
+    // DeploymentValidationException with an actionable message that names
+    // both the action and the step.
+    //
+    // The planner's `BuildStubIntent` (DeploymentPlanner.cs:367) intentionally
+    // builds a RunScriptIntent with empty body for capability validation —
+    // that path doesn't go through DescribeIntentAsync, so it is unaffected.
+
     [Fact]
-    public async Task DescribeIntentAsync_MissingScriptBody_EmitsEmptyString()
+    public async Task DescribeIntentAsync_MissingScriptBodyProperty_Throws()
     {
         var action = new DeploymentActionDto
         {
@@ -108,13 +125,41 @@ public class RunScriptActionHandlerDescribeIntentTests
         };
         var ctx = new ActionExecutionContext
         {
-            Step = new DeploymentStepDto { Name = "Empty" },
+            Step = new DeploymentStepDto { Name = "Empty Step" },
             Action = action
         };
 
+        var ex = await Should.ThrowAsync<DeploymentValidationException>(
+            () => ((IActionHandler)_handler).DescribeIntentAsync(ctx, CancellationToken.None));
+
+        ex.Message.ShouldContain("no-script", customMessage: "exception MUST name the offending action so operators can find it in the UI");
+        ex.Message.ShouldContain("Empty Step", customMessage: "exception MUST name the offending step");
+        ex.Message.ShouldContain("ScriptBody", customMessage: "exception MUST name the property that needs filling so the message is actionable");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    [InlineData("   \t \n  ")]
+    public async Task DescribeIntentAsync_BlankScriptBody_Throws(string blank)
+    {
+        var ctx = CreateContext(scriptBody: blank);
+
+        await Should.ThrowAsync<DeploymentValidationException>(
+            () => ((IActionHandler)_handler).DescribeIntentAsync(ctx, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_NonBlankWithLeadingWhitespace_DoesNotThrow()
+    {
+        // "   echo hi" is valid — only fully-blank bodies fail.
+        var ctx = CreateContext(scriptBody: "   echo hi");
+
         var intent = (RunScriptIntent)await ((IActionHandler)_handler).DescribeIntentAsync(ctx, CancellationToken.None);
 
-        intent.ScriptBody.ShouldBe(string.Empty);
+        intent.ScriptBody.ShouldBe("   echo hi");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- **Real production risk**: pre-fix, a misconfigured RunScript step with blank ScriptBody silently passed — the handler defaulted to `string.Empty`, the agent ran `set -e` and exited 0, the step marked success, downstream steps proceeded with stale/missing output variables. Operators reported "deploy says green but nothing happened."
- **Fix**: `DescribeIntentAsync` now throws `DeploymentValidationException` with an actionable message naming the action, step, and property when ScriptBody is null / empty / whitespace-only.
- **Planner unaffected**: `DeploymentPlanner.BuildStubIntent` (line 367) intentionally builds an empty-body intent for capability validation; that path doesn't go through `DescribeIntentAsync`.

## Test plan

- [x] Unit (RunScriptActionHandlerDescribeIntentTests): 22/22 — including new theory `DescribeIntentAsync_BlankScriptBody_Throws` over `""`, `" "`, `"\t"`, `"\n"`, mixed
- [x] Pinned message contract: exception MUST contain action name + step name + `ScriptBody` property name (so operators can find the offending step in the UI)
- [x] Full unit suite: 5114/5114 pass
- [x] Replaced the buggy-pinning `_MissingScriptBody_EmitsEmptyString` test that codified the silent-pass behaviour
- [x] Verified `_NonBlankWithLeadingWhitespace_DoesNotThrow` — `"   echo hi"` still valid, only fully-blank fails

## Rollback

Single-file revert; no schema or DI surface changed. Existing deploys with empty ScriptBody will now fail-fast at execution rather than silently no-op — this IS the intended behaviour change. Operators with such deploys will see a clear error message and a fix-it path. Document this as a behaviour change in 1.6.6 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)