### PR TITLE
1.6.6 hardening follow-up: copy-ctor drift detector + doc fixes + stale test fix

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.cs
@@ -103,15 +103,29 @@ public sealed partial class ExecuteStepsPhase(
     /// <summary>
     /// Maximum attempts for <see cref="PersistCheckpointAsync"/> before
     /// escalating to <c>Log.Error</c> and proceeding without checkpoint
-    /// persistence. 3 attempts with exponential backoff (200ms / 600ms
-    /// / 1800ms) covers transient DB hiccups (connection blip, brief
-    /// lock contention) without delaying steady-state deploys noticeably.
+    /// persistence. With 3 attempts there are 2 inter-attempt backoffs
+    /// (the final attempt's failure is the terminal log, not a wait).
+    /// See <see cref="CheckpointPersistInitialDelay"/> for the actual
+    /// sleep durations. Covers transient DB hiccups (connection blip,
+    /// brief lock contention) without delaying steady-state deploys
+    /// noticeably.
     /// </summary>
     internal const int CheckpointPersistMaxAttempts = 3;
 
     /// <summary>
-    /// Initial delay for the checkpoint-persist retry. Doubles on each
-    /// subsequent attempt; cumulative wait under the cap is ~2.6 s.
+    /// Initial backoff after the first failed persist. Subsequent
+    /// backoffs are computed as <c>previous × 3</c> (cubic-style
+    /// exponential — the test harness pins this multiplier).
+    ///
+    /// <para>With <see cref="CheckpointPersistMaxAttempts"/>=3 the
+    /// actual sequence the loop applies is:</para>
+    /// <list type="bullet">
+    ///   <item>after attempt 1 fails → wait 200ms</item>
+    ///   <item>after attempt 2 fails → wait 600ms</item>
+    ///   <item>after attempt 3 fails → terminal Log.Error (no wait)</item>
+    /// </list>
+    ///
+    /// <para>Total backoff in the all-fail case: ~800 ms.</para>
     /// </summary>
     internal static readonly TimeSpan CheckpointPersistInitialDelay = TimeSpan.FromMilliseconds(200);
 
@@ -286,25 +300,12 @@ public sealed partial class ExecuteStepsPhase(
         // Already encrypted (e.g. resumed-and-rewritten path) — don't re-wrap.
         if (variableEncryptionService.IsValidEncryptedValue(v.Value)) return v;
 
-        // Clone instead of mutating the source — _ctx.Variables is read by
-        // downstream batches and downstream readers expect plaintext.
-        return new VariableDto
-        {
-            Id = v.Id,
-            VariableSetId = v.VariableSetId,
-            Name = v.Name,
-            Value = variableEncryptionService.EncryptAsync(v.Value, _ctx.ServerTaskId),
-            Description = v.Description,
-            Type = v.Type,
-            IsSensitive = v.IsSensitive,
-            SortOrder = v.SortOrder,
-            LastModifiedDate = v.LastModifiedDate,
-            LastModifiedBy = v.LastModifiedBy,
-            PromptLabel = v.PromptLabel,
-            PromptDescription = v.PromptDescription,
-            PromptRequired = v.PromptRequired,
-            Scopes = v.Scopes
-        };
+        // Clone via the copy-constructor — pre-existing manual field-by-field
+        // copy was fragile against future VariableDto field additions (silent
+        // loss with no compiler warning). The copy-ctor is pinned by
+        // VariableDtoCopyConstructorTests so a missing field assignment fails
+        // unit tests at PR review, not in production checkpoint round-trips.
+        return new VariableDto(v) { Value = variableEncryptionService.EncryptAsync(v.Value, _ctx.ServerTaskId) };
     }
 
     private void ApplyBatchResults(IEnumerable<StepExecutionResult> results)

--- a/src/Squid.Message/Models/Deployments/Variable/VariableDto.cs
+++ b/src/Squid.Message/Models/Deployments/Variable/VariableDto.cs
@@ -6,6 +6,50 @@ namespace Squid.Message.Models.Deployments.Variable;
 
 public class VariableDto
 {
+    /// <summary>Default constructor — required for JSON deserialization.</summary>
+    public VariableDto() { }
+
+    /// <summary>
+    /// Copy-constructor — preserves every field of <paramref name="other"/>.
+    /// Used by paths that need to mutate exactly one field on a clone without
+    /// aliasing the source instance (e.g. <c>ExecuteStepsPhase.EncryptIfSensitive</c>
+    /// produces an encrypted-Value clone for the checkpoint JSON without
+    /// rewriting the live <c>_ctx.Variables</c> entry).
+    ///
+    /// <para><b>Future-proof by design</b>: future fields added to this DTO
+    /// flow through this ctor automatically <i>only if a contributor adds
+    /// the assignment here</i>. The reflection-based drift detector
+    /// <c>VariableDtoCopyConstructorTests.CopyConstructor_PreservesAllPublicProperties</c>
+    /// fails on the first missing assignment so the omission is caught at
+    /// PR review, not silently in production.</para>
+    ///
+    /// <para><b>Scopes is a shallow copy</b>: the cloned instance shares
+    /// the same <see cref="VariableScopeDto"/> list reference as
+    /// <paramref name="other"/>. Callers that need an independent list must
+    /// reassign <c>Scopes = new List&lt;VariableScopeDto&gt;(other.Scopes)</c>
+    /// post-clone. The encrypt-for-checkpoint use case doesn't mutate Scopes
+    /// so the shared reference is safe.</para>
+    /// </summary>
+    public VariableDto(VariableDto other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        Id = other.Id;
+        VariableSetId = other.VariableSetId;
+        Name = other.Name;
+        Value = other.Value;
+        Description = other.Description;
+        Type = other.Type;
+        IsSensitive = other.IsSensitive;
+        SortOrder = other.SortOrder;
+        LastModifiedDate = other.LastModifiedDate;
+        LastModifiedBy = other.LastModifiedBy;
+        PromptLabel = other.PromptLabel;
+        PromptDescription = other.PromptDescription;
+        PromptRequired = other.PromptRequired;
+        Scopes = other.Scopes;
+    }
+
     public int Id { get; set; }
 
     public int VariableSetId { get; set; }

--- a/tests/Squid.UnitTests/Services/Deployments/Checkpoints/CheckpointPersistRetryTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Checkpoints/CheckpointPersistRetryTests.cs
@@ -184,6 +184,10 @@ public sealed class CheckpointPersistRetryTests
         var transportRegistry = new Mock<ITransportRegistry>();
         transportRegistry.Setup(r => r.Resolve(It.IsAny<CommunicationStyle>())).Returns(transport);
 
+        var encryption = new Mock<Squid.Core.Services.Security.IVariableEncryptionService>();
+        encryption.Setup(e => e.IsValidEncryptedValue(It.IsAny<string>())).Returns(false);
+        encryption.Setup(e => e.EncryptAsync(It.IsAny<string>(), It.IsAny<int>())).Returns<string, int>((v, _) => v);
+
         var phase = new ExecuteStepsPhase(
             actionHandlerRegistry: registry,
             lifecycle: lifecycle,
@@ -194,7 +198,8 @@ public sealed class CheckpointPersistRetryTests
             externalFeedDataProvider: new Mock<Squid.Core.Services.Deployments.ExternalFeeds.IExternalFeedDataProvider>().Object,
             packageAcquisitionService: new Mock<Squid.Core.Services.DeploymentExecution.Packages.IPackageAcquisitionService>().Object,
             serviceMessageParser: new ServiceMessageParser(),
-            intentRendererRegistry: Squid.UnitTests.Services.Deployments.Execution.Rendering.TestIntentRendererRegistry.Create());
+            intentRendererRegistry: Squid.UnitTests.Services.Deployments.Execution.Rendering.TestIntentRendererRegistry.Create(),
+            variableEncryptionService: encryption.Object);
 
         var ctx = new DeploymentTaskContext
         {

--- a/tests/Squid.UnitTests/Services/Deployments/Variables/VariableDtoCopyConstructorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Variables/VariableDtoCopyConstructorTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Shouldly;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Variable;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Variables;
+
+/// <summary>
+/// Drift detector for <see cref="VariableDto"/>'s copy-constructor.
+///
+/// <para><b>Why this test exists</b>: pre-fix, <c>ExecuteStepsPhase.EncryptIfSensitive</c>
+/// hand-copied 14 fields from a <see cref="VariableDto"/> source into a new
+/// instance with an encrypted Value. Future fields added to
+/// <see cref="VariableDto"/> would silently NOT be copied — no compiler
+/// warning, no test failure, just a silent loss in checkpoint round-trips.
+/// The same fragility applies to any other code path that clones the DTO.</para>
+///
+/// <para><b>The fix</b>: <see cref="VariableDto.VariableDto(VariableDto)"/>
+/// copy-constructor centralises the field-by-field copy. The reflection-based
+/// test below enumerates EVERY public read-write property on the DTO and
+/// asserts the copy preserves it. When a contributor adds a new property,
+/// they get one of two outcomes:
+/// <list type="bullet">
+///   <item>They updated the copy-ctor → this test passes silently.</item>
+///   <item>They forgot → this test fails with a message naming the missing
+///         property and pointing at the copy-ctor as the fix site.</item>
+/// </list>
+/// This is the "drift detector" pattern from <c>~/.claude/CLAUDE.md</c> Rule
+/// 12.5 applied to a copy-constructor.</para>
+///
+/// <para>Note on Scopes: the copy-ctor does a <i>shallow</i> copy of the
+/// <c>Scopes</c> list (shares reference). The shallow-copy assertion in this
+/// test is intentional — callers that need an independent list must reassign
+/// post-clone, and the doc-comment on the ctor flags that contract.</para>
+/// </summary>
+public sealed class VariableDtoCopyConstructorTests
+{
+    [Fact]
+    public void CopyConstructor_NullSource_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new VariableDto(null));
+    }
+
+    [Fact]
+    public void CopyConstructor_PreservesAllPublicProperties()
+    {
+        // Distinct, type-appropriate, non-default values for every R+W
+        // property. Reflection-driven so future fields are auto-checked.
+        var original = MakeFullyPopulatedDto();
+
+        var copy = new VariableDto(original);
+
+        var failures = new List<string>();
+        foreach (var prop in WritableProperties())
+        {
+            var originalValue = prop.GetValue(original);
+            var copyValue = prop.GetValue(copy);
+
+            if (!Equals(originalValue, copyValue))
+            {
+                failures.Add(
+                    $"property '{prop.Name}' (type {prop.PropertyType.Name}): " +
+                    $"original={Render(originalValue)} copy={Render(copyValue)}. " +
+                    $"FIX: add `{prop.Name} = other.{prop.Name};` to VariableDto's copy-constructor.");
+            }
+        }
+
+        failures.ShouldBeEmpty(
+            customMessage: "Copy-constructor missed " + failures.Count + " field(s):\n  • " +
+                          string.Join("\n  • ", failures));
+    }
+
+    [Fact]
+    public void CopyConstructor_ScopesIsSharedReference_DocumentedShallowCopyContract()
+    {
+        // Documented behaviour: Scopes is shallow-copied. If you change the
+        // ctor to deep-copy, update the doc-comment AND this test.
+        var original = MakeFullyPopulatedDto();
+
+        var copy = new VariableDto(original);
+
+        copy.Scopes.ShouldBeSameAs(original.Scopes,
+            customMessage: "VariableDto copy-ctor documents shallow copy of Scopes. " +
+                          "If you change to deep-copy, update both the doc-comment AND this test.");
+    }
+
+    [Fact]
+    public void CopyConstructor_SourceMutationAfterClone_DoesNotAffectClone_ForValueTypes()
+    {
+        // Sanity: scalar fields are independent after copy. Only the Scopes
+        // list reference is shared (covered by the test above).
+        var original = MakeFullyPopulatedDto();
+        var copy = new VariableDto(original);
+
+        var originalName = copy.Name;
+        var originalValue = copy.Value;
+        var originalIsSensitive = copy.IsSensitive;
+
+        original.Name = "mutated-after-clone";
+        original.Value = "different-value";
+        original.IsSensitive = !original.IsSensitive;
+
+        copy.Name.ShouldBe(originalName);
+        copy.Value.ShouldBe(originalValue);
+        copy.IsSensitive.ShouldBe(originalIsSensitive);
+    }
+
+    [Fact]
+    public void CopyConstructor_AllowsValueOverrideViaObjectInitializer()
+    {
+        // The encrypt-for-checkpoint use case writes
+        // `new VariableDto(v) { Value = encryptedText }` — confirm the
+        // initializer-after-ctor pattern works as expected.
+        var original = MakeFullyPopulatedDto();
+
+        var copy = new VariableDto(original) { Value = "OVERRIDE" };
+
+        copy.Value.ShouldBe("OVERRIDE");
+        copy.Name.ShouldBe(original.Name);   // every other field still preserved
+        copy.IsSensitive.ShouldBe(original.IsSensitive);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static IEnumerable<PropertyInfo> WritableProperties()
+    {
+        return typeof(VariableDto)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(p => p.CanRead && p.CanWrite);
+    }
+
+    private static VariableDto MakeFullyPopulatedDto()
+    {
+        var dto = new VariableDto();
+
+        foreach (var prop in WritableProperties())
+        {
+            var value = MakeDistinctValueFor(prop);
+            prop.SetValue(dto, value);
+        }
+
+        return dto;
+    }
+
+    private static object MakeDistinctValueFor(PropertyInfo prop)
+    {
+        var t = prop.PropertyType;
+
+        // Use the property name where possible to make failure messages
+        // informative (e.g. "Description" got "test-description").
+        if (t == typeof(string)) return $"test-{prop.Name.ToLowerInvariant()}";
+        if (t == typeof(int)) return 42;
+        if (t == typeof(int?)) return (int?)17;
+        if (t == typeof(bool)) return true;
+        if (t == typeof(DateTimeOffset)) return new DateTimeOffset(2026, 5, 10, 12, 34, 56, TimeSpan.Zero);
+        if (t == typeof(VariableType)) return VariableType.String;
+        if (t == typeof(List<VariableScopeDto>)) return new List<VariableScopeDto> { new() };
+
+        throw new InvalidOperationException(
+            $"VariableDtoCopyConstructorTests: add a MakeDistinctValueFor case for type {t.FullName} " +
+            $"(needed for new property {prop.Name}). This is a one-line addition; the new field is " +
+            $"otherwise auto-covered by the drift detector.");
+    }
+
+    private static string Render(object value) =>
+        value switch
+        {
+            null => "null",
+            string s => $"\"{s}\"",
+            _ => value.ToString()
+        };
+}


### PR DESCRIPTION
## Summary

Three follow-ups from the P0 deep code review (PRs #285-#288), plus a broken-main fix surfaced during review:

1. **`VariableDto` copy-constructor + reflection-based drift detector** — replaces the fragile 14-field manual clone in `ExecuteStepsPhase.EncryptIfSensitive`. Future field additions to `VariableDto` are caught by the drift detector at PR review, not silently in production checkpoint round-trips.

2. **P0-5 doc-code drift fix (no behaviour change)** — the comment said "doubles" but the code uses `× 3`. The doc also claimed "cumulative ~2.6s" but only ~800ms of backoff actually applies with MaxAttempts=3. Doc now states the exact sequence (200ms → 600ms → terminal-error).

3. **Stale-test fix from #288 merge-order** — `CheckpointPersistRetryTests` (added by #288) was branched before #286 merged. The squash-merge produced no conflict because the test file had no overlap with #286's changes, BUT the test's `new ExecuteStepsPhase(...)` call was missing the `IVariableEncryptionService` param. **main has been failing to build since #288 merged** — this PR is the fix.

## Test plan

- [x] `VariableDtoCopyConstructorTests`: 5 cases
  - `CopyConstructor_NullSource_Throws`
  - `CopyConstructor_PreservesAllPublicProperties` — reflection-based drift detector
  - `CopyConstructor_ScopesIsSharedReference_DocumentedShallowCopyContract` — pins the documented shallow-copy contract for Scopes
  - `CopyConstructor_SourceMutationAfterClone_DoesNotAffectClone_ForValueTypes`
  - `CopyConstructor_AllowsValueOverrideViaObjectInitializer` — confirms `new VariableDto(v) { Value = ... }` works for the encrypt-for-checkpoint use case
- [x] `CheckpointPersistRetryTests` 6/6 pass after stale-test fix
- [x] Full unit suite: 5129/5129

## Why this PR before 1.6.6 release

1. main is broken right now (build error from stale test) — nobody can sync
2. P0-3's silent-clone fragility is the kind of bug that ships and bites in 6 months
3. P0-5's doc-code drift sets a bad precedent (test passed because the doc claim 200ms/600ms cumulative ≥700ms happened to align with `× 3`'s actual 800ms)

All three are small, focused, and well-tested. Should land before 1.6.6 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)