### PR TITLE
Add Deploy to IIS step (Phase 1: WebSite foundation)

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -25,7 +25,7 @@ on:
       upgrade_test_filter:
         description: "xUnit --filter for the Squid.WindowsTentacleE2ETests step (defaults to wrapper + service categories)"
         required: false
-        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E"
+        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E"
 
 permissions:
   contents: read
@@ -69,6 +69,17 @@ jobs:
             --filter $filter `
             --logger "console;verbosity=normal"
 
+      - name: Install IIS feature (Web-WebServer + Management tools)
+        # Required by Category=IISDeployE2E. Other categories don't need IIS but installing it
+        # is cheap on `windows-latest` (~1m) and idempotent, so we always install rather than
+        # gating on category. The IIS tests themselves probe `Get-WindowsFeature Web-WebServer`
+        # before exercising the metabase so a future split into category-conditional install
+        # is mechanical.
+        shell: pwsh
+        run: |
+          Install-WindowsFeature -Name Web-WebServer,Web-Mgmt-Console -IncludeManagementTools
+          Get-WindowsFeature Web-WebServer | Format-Table -Property Name, InstallState, DisplayName
+
       - name: Restore Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: dotnet restore tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj --configfile "$env:NUGET_CONFIG"
@@ -76,8 +87,20 @@ jobs:
       - name: Run Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E" }
+          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E" }
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `
             --logger "console;verbosity=normal"
+
+      - name: Capture IIS metabase state on failure
+        if: failure()
+        shell: pwsh
+        run: |
+          Import-Module WebAdministration -ErrorAction SilentlyContinue
+          Write-Host "=== Sites ==="
+          Get-Website | Format-Table -Property Name, ID, State, PhysicalPath | Out-String
+          Write-Host "=== AppPools ==="
+          Get-WebAppPool | Format-Table -Property Name, State | Out-String
+          Write-Host "=== Bindings ==="
+          Get-WebBinding | Format-Table -Property protocol, bindingInformation, sslFlags | Out-String

--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -1,0 +1,848 @@
+﻿## --------------------------------------------------------------------------------------
+## Squid — Deploy to IIS WebSite (PowerShell, Windows Tentacle target)
+##
+## MIRROR-TIER SCRIPT (per ~/.claude/CLAUDE.md Rule 12 fidelity tiers):
+## Verbatim port of Octopus Calamari's
+##   Calamari/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1
+## with one mechanical substitution applied — `Octopus.` → `Squid.` in identifiers
+## and dictionary keys, `$OctopusParameters` → `$SquidParameters`. Every line of
+## deployment logic below is functionally identical to its Octopus counterpart so
+## that operators carrying Octopus IIS variable specs to Squid can rely on
+## byte-for-byte behavioural compatibility.
+##
+## The drift detector at
+##   tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/
+##     IISDeployScriptDriftDetectorTests.cs
+## fails CI if any of the key operations (mutex, SNI detection, netsh-cert
+## binding, appcmd auth, app pool setup, PS-7.3 compat wrapper) drift away from
+## the Octopus reference. Update both sides in lockstep when porting upstream
+## fixes — never edit this file alone.
+##
+## RUNTIME CONTRACT:
+##   `$SquidParameters` MUST be defined at script scope before this file is
+##   sourced. `IISDeployScriptBuilder.cs` generates that preamble at dispatch
+##   time, with all action-property values pre-escaped for PowerShell single-
+##   quote string literals. See IISDeployScriptBuilder for the exact preamble
+##   shape; do NOT add `$SquidParameters = @{}` here.
+## --------------------------------------------------------------------------------------
+
+$DeployIISScriptBlock = {
+	param(
+		[Parameter(Mandatory = $true)]
+		$SquidParameters
+	)
+
+	function Is-DeploymentTypeDisabled($value) {
+		return !$value -or ![Bool]::Parse($value)
+	}
+
+	$deployAsWebSite = !(Is-DeploymentTypeDisabled $SquidParameters["Squid.Action.IISWebSite.CreateOrUpdateWebSite"])
+	$deployAsWebApplication = !(Is-DeploymentTypeDisabled $SquidParameters["Squid.Action.IISWebSite.WebApplication.CreateOrUpdate"])
+	$deployAsVirtualDirectory = !(Is-DeploymentTypeDisabled $SquidParameters["Squid.Action.IISWebSite.VirtualDirectory.CreateOrUpdate"])
+
+
+	if (!$deployAsVirtualDirectory -and !$deployAsWebSite -and !$deployAsWebApplication)
+	{
+		Write-Host "Skipping IIS deployment. Neither Website nor Virtual Directory nor Web Application deployment type has been enabled." 
+		exit 0
+	}
+
+	try {
+		$iisFeature = Get-WindowsFeature Web-WebServer -ErrorAction Stop
+		if ($iisFeature -eq $null -or $iisFeature.Installed -eq $false) {
+			Write-Error "It looks like IIS is not installed on this server and the deployment is likely to fail."
+			Write-Error "Tip: You can use PowerShell to ensure IIS is installed: 'Install-WindowsFeature Web-WebServer'"
+			Write-Error "     You are likely to want more IIS features than just the web server. Run 'Get-WindowsFeature *web*' to see all of the features you can install."
+			exit 1
+		}
+		else {
+			$iisVersion = Get-ItemProperty HKLM:\SOFTWARE\Microsoft\InetStp\  | Select VersionString
+			Write-Verbose "Detected IIS $($iisVersion.VersionString)"
+		}
+	} catch {
+		Write-Verbose "Call to `Get-WindowsFeature Web-WebServer` failed."
+		Write-Verbose "Unable to determine if IIS is installed on this server but will optimistically continue."
+	}
+
+	try {
+		Add-PSSnapin WebAdministration -ErrorAction Stop
+	} catch {
+		try {
+			Import-Module WebAdministration -ErrorAction Stop
+			} catch {
+				Write-Warning "We failed to load the WebAdministration module. This usually resolved by doing one of the following:"
+				Write-Warning "1. Install IIS via Add Roles and Features, Web Server (IIS)"
+				Write-Warning "2. Install .NET Framework 3.5.1"
+				Write-Warning "3. Upgrade to PowerShell 3.0 (or greater)"
+				Write-Warning "4. On Windows 2008 you might need to install PowerShell SnapIn for IIS from http://www.iis.net/downloads/microsoft/powershell#additionalDownloads"
+				throw ($error | Select-Object -First 1)
+		}
+	}
+
+	function Wait-OnMutex {
+		param(
+		[parameter(Mandatory = $true)][string] $mutexId
+		)
+
+		Try	{
+			$mutex = New-Object System.Threading.Mutex -ArgumentList false, $mutexId
+
+			while (-not $mutex.WaitOne(5000))
+			{
+				Write-Verbose "Cannot start this IIS website related task yet. There is already another task running that cannot be run in conjunction with any other task. Please wait..."
+			}
+			
+			Write-Verbose "Acquired mutex $mutexId"
+			return $mutex
+		}
+		Catch [System.Threading.AbandonedMutexException] {
+			return Wait-OnMutex $mutexId
+		}
+		Catch [System.SystemException]{
+			Write-Verbose "Wait-OnMutex had a major issue, possibly not running with sufficient privileges recover the mutex, details: $_.Exception.Message"
+		}
+	}
+
+	function Determine-Path($path) {
+		if (!$path) {
+			$path = "."
+		}
+
+		return (resolve-path $path).ProviderPath
+	}
+
+	$maxFailures = $SquidParameters["Squid.Action.IISWebSite.MaxRetryFailures"]
+	if ($maxFailures -Match "^\d+$") {
+		$maxFailures = [int]$maxFailures
+	} else {
+		$maxFailures = 5
+	}
+
+	$sleepBetweenFailures = $SquidParameters["Squid.Action.IISWebSite.SleepBetweenRetryFailuresInSeconds"]
+	if ($sleepBetweenFailures -Match "^\d+$") {
+		$sleepBetweenFailures = [int]$sleepBetweenFailures
+	} else {
+		$sleepBetweenFailures = Get-Random -minimum 1 -maximum 4
+	}
+
+	if ($sleepBetweenFailures -gt 60) {
+		Write-Host "Invalid Sleep time between failures.  Setting to max of 60 seconds"
+		$sleepBetweenFailures = 60
+	}
+
+	# Not available on Server 2008
+	$hasWebCommitDelay = $false
+	If(Get-Command "Start-WebCommitDelay" -ErrorAction SilentlyContinue){
+		$hasWebCommitDelay = $true
+	}
+		
+	function Execute-WithRetry([ScriptBlock] $command, $noLock) {
+
+		function Core-Execute-WithRetry([ScriptBlock] $command) {
+			$attemptCount = 0
+			$operationIncomplete = $true
+		
+			while ($operationIncomplete -and $attemptCount -lt $maxFailures) {
+				$attemptCount = ($attemptCount + 1)
+		
+				if ($attemptCount -ge 2) {
+					Write-Host "Waiting for $sleepBetweenFailures seconds before retrying..."
+					Start-Sleep -s $sleepBetweenFailures
+					Write-Host "Retrying..."
+				}
+		
+				try {
+					& $command
+		
+					$operationIncomplete = $false
+				} catch [System.Exception] {
+					if($hasWebCommitDelay){
+						Stop-WebCommitDelay -Commit $false -ErrorAction SilentlyContinue
+					}
+					if ($attemptCount -lt ($maxFailures)) {
+						Write-Host ("Attempt $attemptCount of $maxFailures failed: " + $_.Exception.Message)
+					} else {
+						throw
+					}
+				}
+			}
+		}
+
+		if($noLock) {
+			Core-Execute-WithRetry -command $command
+		} else {
+			$mutexId = 'Global\Octopus-IIS-Metabase-Mutex'
+			$mutex = Wait-OnMutex $mutexId
+			Try {
+				Core-Execute-WithRetry -command $command
+			}
+			Finally {
+				$mutex.ReleaseMutex()
+				$mutex.Close()
+			}
+		}
+	}
+
+	function SetUp-ApplicationPool($applicationPoolName, $applicationPoolIdentityType, 
+									$applicationPoolUsername, $applicationPoolPassword,
+									$applicationPoolFrameworkVersion,  $startPool) 
+	{
+
+		$appPoolPath = ("IIS:\AppPools\" + $applicationPoolName)
+
+		# Set App Pool
+		Execute-WithRetry { 
+			Write-Verbose "Loading Application pool"
+			$exists = Test-Path $appPoolPath -ErrorAction SilentlyContinue
+			if (!$exists) { 
+				Write-Host "Application pool `"$applicationPoolName`" does not exist, creating..." 
+				New-Item $appPoolPath -confirm:$false
+			} else {
+				Write-Host "Application pool `"$applicationPoolName`" already exists"
+			}
+			# Confirm it's there. Get-Item can pause if the app-pool is suspended, so use Get-WebAppPoolState
+			$pool = Get-WebAppPoolState $applicationPoolName
+
+			if ($startPool -eq $false) {
+				if ($pool.Value -eq "Started") {
+					Write-Host "Application pool is started. Attempting to stop..."
+					Stop-WebAppPool $applicationPoolName
+				}
+			}
+		}
+
+		# Set App Pool Identity
+		Execute-WithRetry { 
+			Write-Host "Set application pool identity: $applicationPoolIdentityType"
+			if ($applicationPoolIdentityType -eq "SpecificUser") {
+				Set-ItemProperty $appPoolPath -name processModel -value @{identitytype="SpecificUser"; username="$applicationPoolUsername"; password="$applicationPoolPassword"}
+			} else {
+				Set-ItemProperty $appPoolPath -name processModel -value @{identitytype="$applicationPoolIdentityType"}
+			}
+		}
+
+		# Set .NET Framework
+		Execute-WithRetry { 
+			Write-Host "Set .NET framework version: $applicationPoolFrameworkVersion" 
+			if($applicationPoolFrameworkVersion -eq "No Managed Code")
+			{
+				Set-ItemProperty $appPoolPath managedRuntimeVersion ""
+			}
+			else
+			{
+				Set-ItemProperty $appPoolPath managedRuntimeVersion $applicationPoolFrameworkVersion
+			}
+		}
+	}
+
+	function Assign-ToApplicationPool($iisPath, $applicationPoolName) {
+		Execute-WithRetry { 
+			Write-Verbose "Loading Site"
+			$pool = Get-ItemProperty $iisPath -name applicationPool
+			if ($applicationPoolName -ne $pool) {
+				Write-Host "Assigning `"$iisPath`" to application pool `"$applicationPoolName`"..."
+				Set-ItemProperty $iisPath -name applicationPool -value $applicationPoolName
+			} else {
+				Write-Host "Application pool `"$applicationPoolName`" already assigned to `"$iisPath`""
+			}
+		}
+	}
+
+	function Start-ApplicationPool($applicationPoolName) {
+		# It can take a while for the App Pool to come to life (#490)
+		Start-Sleep -s 1
+
+		# Start App Pool
+		Execute-WithRetry { 
+			$state = Get-WebAppPoolState $applicationPoolName
+			if ($state.Value -eq "Stopped") {
+				Write-Host "Application pool is stopped. Attempting to start..."
+				Start-WebAppPool $applicationPoolName
+			}
+		} -noLock $true
+	}
+
+	function Get-FullPath($root, $segments)
+	{
+		return $root +  "\" + ($segments -join "\")
+	}
+
+	function Assert-ParentSegmentsExist($sitePath, $virtualPathSegments) {
+		$fullPathToVirtualPathSegment = $sitePath
+		for($i = 0; $i -lt $virtualPathSegments.Length - 1; $i++) {
+			$fullPathToVirtualPathSegment = $fullPathToVirtualPathSegment + "\" + $virtualPathSegments[$i]
+			$segment = Get-Item $fullPathToVirtualPathSegment -ErrorAction SilentlyContinue
+			if (!$segment) {
+				$fullPath = Get-FullPath -root $sitePath -segments $virtualPathSegments
+				throw "Virtual path `"$fullPathToVirtualPathSegment`" does not exist. Please make sure all parent segments of $fullPath exist."
+			}
+		}
+	}
+
+	function Assert-WebsiteExists($SitePath, $SiteName)
+	{
+		Execute-WithRetry { 
+			Write-Verbose "Looking for the parent Site `"$SiteName`" at `"$SitePath`"..."
+			$site = Get-Item $SitePath -ErrorAction SilentlyContinue
+			if (!$site) 
+			{ 
+				throw "The Web Site `"$SiteName`" does not exist in IIS and this step cannot create the Web Site because the necessary details are not available. Add a step which makes sure the parent Web Site exists before this step attempts to add a child to it." 
+			}
+		}
+	}
+
+	function Convert-ToPathSegments($VirtualPath)
+	{
+		return $VirtualPath.Split(@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries)
+	}
+
+	function Set-Path($virtualPath, $physicalPath)
+	{
+		Execute-WithRetry { 
+			Write-Host ("Setting physical path of $virtualPath to $physicalPath")
+			Set-ItemProperty $virtualPath -name physicalPath -value "$physicalPath"
+		}
+	}
+
+	function Is-Directory($Path){
+		return Test-Path -Path $Path -PathType Container
+	}
+
+	if ($deployAsVirtualDirectory) 
+	{
+		$webSiteName = $SquidParameters["Squid.Action.IISWebSite.VirtualDirectory.WebSiteName"]
+		$physicalPath = Determine-Path $SquidParameters["Squid.Action.IISWebSite.VirtualDirectory.PhysicalPath"]
+		$virtualPath = $SquidParameters["Squid.Action.IISWebSite.VirtualDirectory.VirtualPath"]
+
+		Write-Host "Making sure a Virtual Directory `"$virtualPath`" is configured as a child of `"$webSiteName`" at `"$physicalPath`"..."
+		
+		pushd IIS:\
+
+		$sitePath = "IIS:\Sites\$webSiteName"
+
+		Assert-WebsiteExists -SitePath $sitePath -SiteName $webSiteName
+
+		[array]$virtualPathSegments =  Convert-ToPathSegments -VirtualPath $virtualPath
+		Assert-ParentSegmentsExist -sitePath $sitePath -virtualPathSegments $virtualPathSegments
+
+		$fullPathToLastVirtualPathSegment = Get-FullPath -root $sitePath -segments $virtualPathSegments
+		$lastSegment = Get-Item $fullPathToLastVirtualPathSegment -ErrorAction SilentlyContinue
+
+		if (!$lastSegment) {
+			Write-Host "`"$virtualPath`" does not exist. Creating Virtual Directory pointing to $fullPathToLastVirtualPathSegment ..."
+			Execute-WithRetry { 
+				New-Item $fullPathToLastVirtualPathSegment -type VirtualDirectory -physicalPath $physicalPath
+			}
+		} else {
+			if ($lastSegment.ElementTagName -eq 'virtualDirectory') {
+				Write-Host "Virtual Directory `"$virtualPath`" already exists, no need to create it."
+			} elseif ($lastSegment.ElementTagName -eq 'application') {
+				# It looks like the only reliable way to do the conversion is to delete the exsting application and then create a new virtual directory. http://stackoverflow.com/questions/16738995/powershell-convertto-webapplication-on-iis
+				# We don't want to delete anything as the customer might have handcrafted the settings and has no way of retrieving them.
+				throw "`"$virtualPath`" already exists in IIS and points to a Web Application. We cannot automatically change this to a Virtual Directory on your behalf. Please delete it and then re-deploy the project."
+			} else {
+				if (!(Is-Directory -Path $physicalPath)) {
+					throw "`"$virtualPath`" already exists in IIS and points to an unknown item which isn't a directory. Please delete it and then re-deploy the project. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Virtual Directory on your behalf."
+				}
+				
+				Write-Host "`"$virtualPath`" already exists in IIS and points to an unknown item which seems to be a directory. We will try to convert it to a Virtual Directory. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Virtual Directory on your behalf."
+				Execute-WithRetry { 
+					New-Item $fullPathToLastVirtualPathSegment -type VirtualDirectory -physicalPath $physicalPath
+				}
+			}
+
+			Set-Path -virtualPath $fullPathToLastVirtualPathSegment -physicalPath $physicalPath
+		}
+
+		popd	
+	} 
+
+	if ($deployAsWebApplication)
+	{
+		$webSiteName = $SquidParameters["Squid.Action.IISWebSite.WebApplication.WebSiteName"]
+		$physicalPath = Determine-Path $SquidParameters["Squid.Action.IISWebSite.WebApplication.PhysicalPath"]
+		$virtualPath = $SquidParameters["Squid.Action.IISWebSite.WebApplication.VirtualPath"]
+		$startAppPool = if ($SquidParameters.ContainsKey("Squid.Action.IISWebSite.StartApplicationPool")) { $SquidParameters["Squid.Action.IISWebSite.StartApplicationPool"] } else { $true }
+
+		Write-Host "Making sure a Web Application `"$virtualPath`" is configured as a child of `"$webSiteName`" at `"$physicalPath`"..."
+		
+		pushd IIS:\
+
+		$applicationPoolName = $SquidParameters["Squid.Action.IISWebSite.WebApplication.ApplicationPoolName"]
+		$applicationPoolIdentityType = $SquidParameters["Squid.Action.IISWebSite.WebApplication.ApplicationPoolIdentityType"]
+		$applicationPoolUsername = $SquidParameters["Squid.Action.IISWebSite.WebApplication.ApplicationPoolUsername"]
+		$applicationPoolPassword = $SquidParameters["Squid.Action.IISWebSite.WebApplication.ApplicationPoolPassword"]
+		$applicationPoolFrameworkVersion = $SquidParameters["Squid.Action.IISWebSite.WebApplication.ApplicationPoolFrameworkVersion"]
+
+		$sitePath = ("IIS:\Sites\" + $webSiteName)
+
+		Assert-WebsiteExists -SitePath $sitePath -SiteName $webSiteName
+
+		[array]$virtualPathSegments =  Convert-ToPathSegments -VirtualPath $virtualPath
+		Assert-ParentSegmentsExist -sitePath $sitePath -virtualPathSegments $virtualPathSegments
+
+		$fullPathToLastVirtualPathSegment = Get-FullPath -root $sitePath -segments $virtualPathSegments
+		$lastSegment = Get-Item $fullPathToLastVirtualPathSegment -ErrorAction SilentlyContinue
+
+		SetUp-ApplicationPool -applicationPoolName $applicationPoolName -applicationPoolIdentityType $applicationPoolIdentityType -applicationPoolUsername $applicationPoolUsername -applicationPoolPassword $applicationPoolPassword -applicationPoolFrameworkVersion $applicationPoolFrameworkVersion -startPool $startAppPool
+
+		if (!$lastSegment) {
+			Write-Host "`"$virtualPath`" does not exist. Creating Web Application pointing to $fullPathToLastVirtualPathSegment ..."
+			Execute-WithRetry { 
+				New-Item $fullPathToLastVirtualPathSegment -type Application -physicalPath $physicalPath
+			}
+		} else {
+			if ($lastSegment.ElementTagName -eq 'application') {
+				Write-Host "Web Application `"$virtualPath`" already exists, no need to create it."
+			} elseif ($lastSegment.ElementTagName -eq 'virtualDirectory') {
+				# It looks like the only reliable way to do the conversion is to delete the exsting web application and then create a new virtual directory. http://stackoverflow.com/questions/16738995/powershell-convertto-webapplication-on-iis
+				# We don't want to delete anything as the customer might have handcrafted the settings and has no way of retrieving them.
+				throw "`"$virtualPath`" already exists in IIS and points to a Virtual Directory. We cannot automatically change this to a Web Application on your behalf. Please delete it and then re-deploy the project."
+			} else {
+				if (!(Is-Directory -Path $physicalPath)) {
+					throw "`"$virtualPath`" already exists in IIS and points to an unknown item which isn't a directory. Please delete it and then re-deploy the project. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Web Application on your behalf."
+				}
+				
+				Write-Host "`"$virtualPath`" already exists in IIS and points to an unknown item which seems to be a directory. We will try to convert it to a Web Application. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Web Application on your behalf."
+				Execute-WithRetry { 
+					New-Item $fullPathToLastVirtualPathSegment -type Application -physicalPath $physicalPath
+				}
+
+			}
+
+			Set-Path -virtualPath $fullPathToLastVirtualPathSegment -physicalPath $physicalPath
+		}
+
+		Assign-ToApplicationPool -iisPath $fullPathToLastVirtualPathSegment -applicationPoolName $applicationPoolName					
+		
+		if($startAppPool -eq $true) {
+			Start-ApplicationPool $applicationPoolName
+		}
+
+		popd
+	}
+
+
+	if ($deployAsWebSite)
+	{	
+		$webSiteName = $SquidParameters["Squid.Action.IISWebSite.WebSiteName"]
+		$applicationPoolName = $SquidParameters["Squid.Action.IISWebSite.ApplicationPoolName"]
+		$bindingString = $SquidParameters["Squid.Action.IISWebSite.Bindings"]
+		$existingBindings = $SquidParameters["Squid.Action.IISWebSite.ExistingBindings"]
+		$webRoot =  Determine-Path $SquidParameters["Squid.Action.IISWebSite.WebRoot"]
+		$enableWindows = $SquidParameters["Squid.Action.IISWebSite.EnableWindowsAuthentication"]
+		$enableBasic = $SquidParameters["Squid.Action.IISWebSite.EnableBasicAuthentication"]
+		$enableAnonymous = $SquidParameters["Squid.Action.IISWebSite.EnableAnonymousAuthentication"]
+		$applicationPoolIdentityType = $SquidParameters["Squid.Action.IISWebSite.ApplicationPoolIdentityType"]
+		$applicationPoolUsername = $SquidParameters["Squid.Action.IISWebSite.ApplicationPoolUsername"]
+		$applicationPoolPassword = $SquidParameters["Squid.Action.IISWebSite.ApplicationPoolPassword"]
+		$applicationPoolFrameworkVersion = $SquidParameters["Squid.Action.IISWebSite.ApplicationPoolFrameworkVersion"]
+		$startAppPool = if ($SquidParameters.ContainsKey("Squid.Action.IISWebSite.StartApplicationPool")) { $SquidParameters["Squid.Action.IISWebSite.StartApplicationPool"] } else { $true }
+		$startWebSite = if ($SquidParameters.ContainsKey("Squid.Action.IISWebSite.StartWebSite")) { $SquidParameters["Squid.Action.IISWebSite.StartWebSite"] } else { $true }
+		
+		Write-Host "Making sure a Website `"$webSiteName`" is configured in IIS..."
+
+		#Assess SNI support (IIS 8 or greater)
+		$iis = get-itemproperty HKLM:\SOFTWARE\Microsoft\InetStp\  | select setupstring 
+		$iisVersion = ($iis.SetupString.Substring(4)) -as [double]
+		$supportsSNI = $iisVersion -ge 8
+
+		$wsbindings = new-object System.Collections.ArrayList
+
+		function Write-IISBinding($message, $bindingObject) {
+			if(-not ($bindingObject -is [PSObject])) {
+				Write-Host "$message @{$([String]::Join("; ", ($bindingObject.Keys | % { return "$($_)=$($bindingObject[$_])" })))}"
+			} else {
+				Write-Host "$message $bindingObject"
+			}
+		}
+
+		if(Get-Command ConvertFrom-Json -errorAction SilentlyContinue){
+			$bindingArray = (ConvertFrom-Json $bindingString)
+		} else {
+			add-type -assembly system.web.extensions
+			$serializer=new-object system.web.script.serialization.javascriptSerializer
+			$bindingArray = ($serializer.DeserializeObject($bindingString))
+		}
+
+		ForEach($binding in $bindingArray){
+			if(![Bool]::Parse($binding.enabled)) {
+				Write-IISBinding "Ignore binding: " $binding
+				continue
+			}
+
+			$sslFlagPart = @{$true=1;$false=0}[[Bool]::Parse($binding.requireSni)]  
+			$bindingIpAddress =  @{$true="*";$false=$binding.ipAddress}[[string]::IsNullOrEmpty($binding.ipAddress)]
+			$bindingInformation = $bindingIpAddress+":"+$binding.port+":"+$binding.host
+
+			$bindingObj = @{
+				protocol=(($binding.protocol, "http") -ne $null)[0].ToLower();
+				ipAddress=$bindingIpAddress;
+				port=$binding.port;
+				host=$binding.host;
+				bindingInformation=$bindingInformation;
+			};
+
+			if ($binding.certificateVariable) {
+				$bindingObj.certificateVariable = $binding.certificateVariable.Trim();
+			} elseif ($binding.thumbprint -and ($null -ne $binding.thumbprint)){
+				$bindingObj.thumbprint=$binding.thumbprint.Trim();
+			}
+
+			if ([Bool]::Parse($supportsSNI)) {
+				$bindingObj.sslFlags=$sslFlagPart;
+			}
+
+			$wsbindings.Add($bindingObj) | Out-Null
+		}
+
+		# For any HTTPS bindings, ensure the certificate is configured for the IP/port combination
+		$wsbindings | where-object { $_.protocol -eq "https" } | foreach-object {
+
+			# If an Octopus-managed certificate variable is supplied, it will have been installed in the store earlier
+			# in the deployment process
+			if ($_.certificateVariable) {
+				$sslCertificateThumbprint = $SquidParameters[$_.certificateVariable + ".Thumbprint"]
+			} elseif ($_.thumbprint){
+				# Otherwise, the certificate thumbprint was supplied directly in the binding
+				$sslCertificateThumbprint = $_.thumbprint.Trim()
+			} else {
+				[Console]::Error.WriteLine("To configure an HTTPS binding please choose a certificate which is managed by Octopus, or provide the thumbprint for a certificate which is already available in the Machine certificate store.")
+				exit 1
+			}
+
+			Write-Host "Finding SSL certificate with thumbprint $sslCertificateThumbprint"
+			foreach ($certStore in (Get-ChildItem Cert:\LocalMachine)) {
+				try {
+					$certs = Get-ChildItem "Cert:\LocalMachine\$($certStore.Name)" -ErrorAction Stop
+					$certificate = $certs | Where-Object { $_.Thumbprint -eq $sslCertificateThumbprint -and $_.HasPrivateKey -eq $true } | Select-Object -first 1
+					if ($certificate) {
+						break
+					}
+				} catch {
+					Write-Host "Skipping inaccessible certificate store '$($certStore.Name)': $_"
+				}
+			}
+			if (! $certificate) 
+			{
+				throw "Could not find certificate under Cert:\LocalMachine with thumbprint $sslCertificateThumbprint. Make sure that the certificate is installed to the Local Machine context and that the private key is available."
+			}
+
+			$certPathParts = $certificate.PSParentPath.Split('\')
+			$certStoreName = $certPathParts[$certPathParts.Length-1]
+
+			Write-Host ("Found certificate: " + $certificate.Subject + " in: " + $certStoreName)
+
+			$ipAddress = $_.ipAddress;
+			if ((! $ipAddress) -or ($ipAddress -eq '*')) {
+				$ipAddress = "0.0.0.0"
+			}
+			$port = $_.port
+			$hostname = $_.host
+			Execute-WithRetry { 
+		
+				# if we are supporting SNI then we need to bind cert to hostname instead of ip
+				if($_.sslFlags -eq 1){
+			
+					$existing = & netsh http show sslcert hostnameport="$($hostname):$port"
+					if ($LastExitCode -eq 0) {
+						$hasThumb = ($existing | Where-Object { $_.IndexOf($certificate.Thumbprint, [System.StringComparison]::OrdinalIgnoreCase) -ne -1 })
+						if ($hasThumb -eq $null) {
+							Write-Host "A different binding exists for the Hostname/port combination, replacing..."
+						
+							& netsh http delete sslcert hostnameport="$($hostname):$port"
+							if ($LastExitCode -ne 0 ){
+								throw
+							}
+
+							$appid = [System.Guid]::NewGuid().ToString("b")
+							& netsh http add sslcert hostnameport="$($hostname):$port" certhash="$($certificate.Thumbprint)" appid="$appid" certstorename="$certStoreName"
+							if ($LastExitCode -ne 0 ){
+								throw
+							}
+
+						} else {
+							Write-Host "The required certificate binding is already in place"
+						}
+					} else {
+						$appid = [System.Guid]::NewGuid().ToString("b")
+						& netsh http add sslcert hostnameport="$($hostname):$port" certhash="$($certificate.Thumbprint)" appid="$appid" certstorename="$certStoreName"
+						if ($LastExitCode -ne 0 ){
+							throw
+						}
+					}	
+				} else {
+					$existing = & netsh http show sslcert ipport="$($ipAddress):$port"
+					if ($LastExitCode -eq 0) {
+						$hasThumb = ($existing | Where-Object { $_.IndexOf($certificate.Thumbprint, [System.StringComparison]::OrdinalIgnoreCase) -ne -1 })
+						if ($hasThumb -eq $null) {
+							Write-Host "A different binding exists for the IP/port combination, replacing..."
+						
+							& netsh http delete sslcert ipport="$($ipAddress):$port"
+							if ($LastExitCode -ne 0 ){
+								throw
+							}
+
+							$appid = [System.Guid]::NewGuid().ToString("b")
+							& netsh http add sslcert ipport="$($ipAddress):$port" certhash="$($certificate.Thumbprint)" appid="$appid" certstorename="$certStoreName"
+							if ($LastExitCode -ne 0 ){
+								throw
+							}
+						
+						} else {
+							Write-Host "The required certificate binding is already in place"
+						}
+					} else {
+						Write-Host "Adding a new SSL certificate binding..."
+						$appid = [System.Guid]::NewGuid().ToString("b")
+						& netsh http add sslcert ipport="$($ipAddress):$port" certhash="$($certificate.Thumbprint)" appid="$appid" certstorename="$certStoreName"
+						if ($LastExitCode -ne 0 ){
+							Write-Host "Failed adding new SSL binding for certificate with thumbprint '$($certificate.Thumbprint)'. Exit code: $LastExitCode"
+							throw
+						}
+					}	
+				}	
+			}
+		}
+
+		## --------------------------------------------------------------------------------------
+		## Run
+		## --------------------------------------------------------------------------------------
+
+		pushd IIS:\
+		
+		SetUp-ApplicationPool -applicationPoolName $applicationPoolName -applicationPoolIdentityType $applicationPoolIdentityType -applicationPoolFrameworkVersion $applicationPoolFrameworkVersion -applicationPoolUsername $applicationPoolUsername -applicationPoolPassword $applicationPoolPassword -startPool $startAppPool
+
+		$sitePath = ("IIS:\Sites\" + $webSiteName)
+
+		$odTempBinding = ":81:od-temp.example.com"
+
+		# Create Website
+		Execute-WithRetry { 
+			Write-Verbose "Loading Site"
+			$site = Get-Item $sitePath -ErrorAction SilentlyContinue
+			if (!$site) { 
+				Write-Host "Site `"$webSiteName`" does not exist, creating..." 
+				$id = (dir iis:\sites | foreach {$_.id} | sort -Descending | select -first 1) + 1
+				new-item $sitePath -bindings @{protocol="http";bindingInformation=$odTempBinding} -id $id -physicalPath $webRoot -confirm:$false
+			} else {
+				Write-Host "Site `"$webSiteName`" already exists"
+			}
+		}
+
+		if($startWebSite -eq $false) {
+			# Stop Website
+			Execute-WithRetry { 
+				$state = Get-WebsiteState $webSiteName
+				if ($state.Value -eq "Started") {
+					Write-Host "Web site is started. Attempting to stop..."
+					Stop-Website $webSiteName
+				}
+			} -noLock $true
+		}
+
+		Assign-ToApplicationPool -iisPath $sitePath -applicationPoolName $applicationPoolName
+		Set-Path -virtualPath $sitePath -physicalPath $webRoot
+
+		function Convert-ToHashTable($bindingArray) {
+			$hash = @{}
+			$bindingArray | %{
+				$key = Get-BindingKey $_
+				$hash[$key] = $_
+			}
+			return $hash
+		}
+
+		function Get-BindingKey($binding) {
+			return $binding.protocol + "|" + $binding.bindingInformation + "|" + $binding.sslFlags
+		}
+
+		if($existingBindings -eq "Merge") {
+			# Merge existing bindings into the configured collection. This allows the following code to be the same regardless of this options
+			$configuredBindingsLookup = Convert-ToHashTable $wsbindings
+			$existingBindings = Get-ItemProperty $sitePath -name bindings
+			$bindingsToMerge = $existingBindings.Collection | where { ($configuredBindingsLookup[(Get-BindingKey $_)] -eq $null) -and ($_.bindingInformation -ne $odTempBinding) } | ForEach-Object { $wsbindings.Add($_) }
+		}
+
+		# Returns $true if existing IIS bindings are as specified in configuration, otherwise $false
+		function Bindings-AreCorrect($existingBindings, $configuredBindings, [System.Collections.ArrayList] $bindingsToRemove) {
+			$existingBindingsLookup = Convert-ToHashTable $existingBindings.Collection
+			$configuredBindingsLookup = Convert-ToHashTable $configuredBindings
+		
+			# Are there existing assigned bindings that are not configured
+			for ($i = 0; $i -lt $existingBindings.Collection.Count; $i = $i+1) {
+				$binding = $existingBindings.Collection[$i]
+				$bindingKey = Get-BindingKey $binding
+
+				$matching = $configuredBindingsLookup[$bindingKey]
+			
+				if ($matching -eq $null) {
+					Write-Host "Found existing non-configured binding: $($binding.protocol) $($binding.bindingInformation)"
+					$bindingsToRemove.Add($binding) | Out-Null
+				}
+			}
+
+			if($bindingsToRemove.Length -gt 0){
+				return $false
+			}
+
+			# Are there configured bindings which are not assigned
+			for ($i = 0; $i -lt $configuredBindings.Count; $i = $i+1) {
+				$wsbinding = $configuredBindings[$i]
+				$wsBindingKey = Get-BindingKey $wsbinding
+
+				$matching = $existingBindingsLookup[$wsBindingKey]
+
+				if ($matching -eq $null) {
+					Write-Host "Found configured binding which is not assigned: $($wsbinding.protocol) $($wsbinding.bindingInformation)"
+					return $false
+				}
+			}        
+
+			Write-Host "Looks OK"
+
+			return $true
+		}
+
+		# Set Bindings
+		Execute-WithRetry { 
+			Write-Host "Comparing existing IIS bindings with configured bindings..."
+			$existingBindings = Get-ItemProperty $sitePath -name bindings
+			$bindingsToRemove = new-object System.Collections.ArrayList
+
+			if (-not (Bindings-AreCorrect $existingBindings $wsbindings $bindingsToRemove)) {
+				Write-Host "Existing IIS bindings do not match configured bindings."
+				Write-Host "Clearing IIS bindings"
+				Clear-ItemProperty $sitePath -name bindings
+
+				If($hasWebCommitDelay){
+					Start-WebCommitDelay
+				}
+				for ($i = 0; $i -lt $wsbindings.Count; $i = $i+1) {
+					Write-Host ("Assigning binding: " + ($wsbindings[$i].protocol + " " + $wsbindings[$i].bindingInformation))
+					New-ItemProperty $sitePath -name bindings -value ($wsbindings[$i])
+				}
+				If($hasWebCommitDelay){
+					Stop-WebCommitDelay -Commit $true
+				}
+			} else {
+				Write-Host "Bindings are as configured. No changes required."
+			}
+
+			# try to remove ssl cert bindings for IIS bindings that are being removed
+			$bindingsToRemove | where-object { $_.protocol -eq "https" } | foreach-object {
+				$bindingParts = $_.bindingInformation.Split(':')
+				$ipAddress = $bindingParts[0]
+				if (!$ipAddress) {
+					$ipAddress = "*"
+				}
+				$port = $bindingParts[1]
+				$hostname = $bindingParts[2]
+
+				if($_.sslFlags -eq 1){ # SNI on so we will have created against the hostname
+					$existing = & netsh http show sslcert hostnameport="$($hostname):$port"
+					if ($LastExitCode -eq 0) {
+						Write-Host ("Removing unused SSL certificate binding: $($hostname):$port")
+						& netsh http delete sslcert hostnameport="$($hostname):$port"
+						if ($LastExitCode -ne 0 ){
+							throw
+						}
+					}
+				} else { # SNI off so we will have created against the ip
+					# check if there are any other bindings to the same IP:Port so that
+					# we don't remove an ssl cert that's used by any other sites on the server
+					$existing = Get-WebBinding -IPAddress $ipAddress -Port $port -Protocol "https"
+					if (!$existing) {
+						Write-Host ("Removing unused SSL certificate binding: $($ipAddress):$port")
+						if ($ipAddress -eq '*') {
+							$ipAddress = "0.0.0.0"
+						}
+						& netsh http delete sslcert ipport="$($ipAddress):$port"
+
+						if ($LastExitCode -ne 0 ){
+							throw
+						}
+					}
+				}
+			}
+		}
+
+		$appCmdPath = $env:SystemRoot + "\system32\inetsrv\appcmd.exe"
+		if ((Test-Path $appCmdPath) -eq $false) {
+			throw "Could not find appCmd.exe at $appCmdPath"
+		}
+
+		try {
+			Execute-WithRetry { 
+				Write-Host "Anonymous authentication enabled: $enableAnonymous"
+				& $appCmdPath set config "$webSiteName" -section:"system.webServer/security/authentication/anonymousAuthentication" /enabled:"$enableAnonymous" /commit:apphost
+				if ($LastExitCode -ne 0 ){
+					throw
+				}		
+			}
+
+			Execute-WithRetry { 
+				Write-Host "Basic authentication enabled: $enableBasic"
+				& $appCmdPath set config "$webSiteName" -section:"system.webServer/security/authentication/basicAuthentication" /enabled:"$enableBasic" /commit:apphost
+				if ($LastExitCode -ne 0 ){
+					throw
+				}		
+			}
+
+			Execute-WithRetry { 
+				Write-Host "Windows authentication enabled: $enableWindows"
+				& $appCmdPath set config "$webSiteName" -section:"system.webServer/security/authentication/windowsAuthentication" /enabled:"$enableWindows" /commit:apphost
+				if ($LastExitCode -ne 0 ){
+					throw
+				}		
+			
+			}
+		} catch [System.Exception] {
+			Write-Host "Authentication options could not be set. This can happen when there is a problem with your application's web.config. For example, you might be using a section that requires an extension that is not installed on this web server (such as URL Rewriting). It can also happen when you have selected an authentication option and the appropriate IIS module is not installed (for example, for Windows authentication, you need to enable the Windows Authentication module in IIS/Windows first)"
+			throw
+		}
+
+		if($startAppPool -eq $true) {
+			Start-ApplicationPool $applicationPoolName
+		}
+
+		if($startWebSite -eq $true) {
+			if ($wsbindings.Count -eq 0) {
+				Write-Warning "The deployment has been configured to start the web site $webSiteName but no bindings are enabled."
+			}
+			# Start Website
+			Execute-WithRetry { 
+				$state = Get-WebsiteState $webSiteName
+				if ($state.Value -eq "Stopped") {
+					Write-Host "Web site is stopped. Attempting to start..."
+					Start-Website $webSiteName
+				} elseif ($state -eq "Undefined") {
+					Write-Warning "Unable to retrieve the state of the web site $webSiteName. The web site will not be started. This is commonly caused by an invalid web site configuration."
+				}
+			} -noLock $true
+		}
+
+		popd
+	}
+
+
+	Write-Host "IIS configuration complete"
+}
+
+$psVersion = $PSVersionTable.PSVersion
+
+if ($psVersion.Major -ge 7 -and $psVersion.Minor -ge 3) {
+	Write-Verbose "'Deploy to IIS' step is yet not supported on PowerShell 7.3 or later. "
+	Write-Verbose "Running the script on incompatible Powershell version, will optimistically continue using Windows Powershell compatibility session."
+	Import-Module WebAdministration -UseWindowsPowerShell
+	$compatSession = Get-PSSession -Name WinPSCompatSession
+	if ($null -eq $compatSession) {
+		Write-Error "Failed to find Windows Powershell compatibility session. Please try running the script on Windows Powershell."
+		throw
+	}
+	Invoke-Command -Session $compatSession -ScriptBlock $DeployIISScriptBlock -ArgumentList $SquidParameters
+}
+else {
+	&$DeployIISScriptBlock -SquidParameters $SquidParameters
+}
+

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -1,0 +1,102 @@
+namespace Squid.Core.Services.DeploymentExecution;
+
+/// <summary>
+/// Action-property constants for the <c>Squid.DeployToIISWebSite</c> action type.
+///
+/// <para><b>Mirrors Octopus's <c>Octopus.Action.IISWebSite.*</c> taxonomy</b> from
+/// <c>Octopus.Core/Variables/SpecialVariables.cs:637-674</c> and
+/// <c>Calamari/Shared/Deployment/SpecialVariables.cs:126-142</c>. The names are kept
+/// 1:1 with Octopus (only the <c>Octopus.</c> prefix is replaced with <c>Squid.</c>)
+/// so operators familiar with Octopus IIS deploys can carry their variable spec
+/// over verbatim. The <c>IISWebSite</c> infix is intentional and reserved — future
+/// IIS-adjacent action types (IISWebDeploy, IISAzureFunction, …) get their own
+/// namespaces so a sub-feature split never breaks a customer's existing variable
+/// references.</para>
+/// </summary>
+internal static class IISDeployProperties
+{
+    // ── DeploymentType + sub-feature toggles ───────────────────────────────
+    // A single Squid.DeployToIISWebSite action can deploy any combination of
+    // Website / WebApplication / VirtualDirectory in one execution — exactly
+    // mirrors Octopus's `IISWebSite_BeforePostDeploy.ps1:15-24` toggle layout.
+
+    /// <summary>Optional hint, advisory only; the three CreateOrUpdate flags drive actual behaviour.</summary>
+    internal const string DeploymentType = "Squid.Action.IISWebSite.DeploymentType";
+
+    /// <summary>When <c>true</c>, the script creates / updates an IIS WebSite.</summary>
+    internal const string CreateOrUpdateWebSite = "Squid.Action.IISWebSite.CreateOrUpdateWebSite";
+
+    /// <summary>When <c>true</c>, the script creates / updates a Web Application under <see cref="WebApplicationWebSiteName"/>.</summary>
+    internal const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";
+
+    /// <summary>When <c>true</c>, the script creates / updates a Virtual Directory under <see cref="VirtualDirectoryWebSiteName"/>.</summary>
+    internal const string VirtualDirectoryCreateOrUpdate = "Squid.Action.IISWebSite.VirtualDirectory.CreateOrUpdate";
+
+    // ── WebSite properties ────────────────────────────────────────────────
+
+    internal const string WebSiteName = "Squid.Action.IISWebSite.WebSiteName";
+    internal const string ApplicationPoolName = "Squid.Action.IISWebSite.ApplicationPoolName";
+
+    /// <summary>One of: ApplicationPoolIdentity, LocalService, LocalSystem, NetworkService, SpecificUser.</summary>
+    internal const string ApplicationPoolIdentityType = "Squid.Action.IISWebSite.ApplicationPoolIdentityType";
+
+    /// <summary>Required when <see cref="ApplicationPoolIdentityType"/> is <c>SpecificUser</c>. Format: <c>DOMAIN\user</c> or <c>.\user</c>.</summary>
+    internal const string ApplicationPoolUsername = "Squid.Action.IISWebSite.ApplicationPoolUsername";
+
+    /// <summary>Required when <see cref="ApplicationPoolIdentityType"/> is <c>SpecificUser</c>. Marked sensitive via the action property metadata.</summary>
+    internal const string ApplicationPoolPassword = "Squid.Action.IISWebSite.ApplicationPoolPassword";
+
+    /// <summary>One of: <c>v4.0</c>, <c>v2.0</c>, <c>No Managed Code</c>.</summary>
+    internal const string ApplicationPoolFrameworkVersion = "Squid.Action.IISWebSite.ApplicationPoolFrameworkVersion";
+
+    /// <summary>JSON array of <c>IISBinding</c> objects. See <c>IISBindingParser</c> for the schema.</summary>
+    internal const string Bindings = "Squid.Action.IISWebSite.Bindings";
+
+    /// <summary>Either <c>Merge</c> (preserve unmatched existing bindings) or <c>Replace</c> (default — clear all, apply configured).</summary>
+    internal const string ExistingBindings = "Squid.Action.IISWebSite.ExistingBindings";
+
+    /// <summary>Physical disk path that the WebSite serves from (e.g. <c>C:\inetpub\OrderApi</c>).</summary>
+    internal const string WebRoot = "Squid.Action.IISWebSite.WebRoot";
+
+    internal const string EnableAnonymousAuthentication = "Squid.Action.IISWebSite.EnableAnonymousAuthentication";
+    internal const string EnableBasicAuthentication = "Squid.Action.IISWebSite.EnableBasicAuthentication";
+    internal const string EnableWindowsAuthentication = "Squid.Action.IISWebSite.EnableWindowsAuthentication";
+
+    /// <summary>Default <c>true</c>. When <c>false</c>, the pool is created/updated but left stopped.</summary>
+    internal const string StartApplicationPool = "Squid.Action.IISWebSite.StartApplicationPool";
+
+    /// <summary>Default <c>true</c>. When <c>false</c>, the WebSite is created/updated but left stopped.</summary>
+    internal const string StartWebSite = "Squid.Action.IISWebSite.StartWebSite";
+
+    // ── IIS-metabase locking + retry knobs (operator-tunable) ─────────────
+    // These match Octopus's tuning surface so air-gapped operators with
+    // performance-tuned IIS hosts can carry their existing values across.
+
+    /// <summary>Maximum retry count when the IIS metabase mutex is held by another process. Default 5.</summary>
+    internal const string MaxRetryFailures = "Squid.Action.IISWebSite.MaxRetryFailures";
+
+    /// <summary>Sleep interval (seconds) between mutex-acquisition retries. Default random 1-3s.</summary>
+    internal const string SleepBetweenRetryFailuresInSeconds = "Squid.Action.IISWebSite.SleepBetweenRetryFailuresInSeconds";
+
+    // ── WebApplication properties (Phase 4 will activate these) ───────────
+
+    internal const string WebApplicationWebSiteName = "Squid.Action.IISWebSite.WebApplication.WebSiteName";
+    internal const string WebApplicationVirtualPath = "Squid.Action.IISWebSite.WebApplication.VirtualPath";
+    internal const string WebApplicationPhysicalPath = "Squid.Action.IISWebSite.WebApplication.PhysicalPath";
+    internal const string WebApplicationApplicationPoolName = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolName";
+    internal const string WebApplicationApplicationPoolIdentityType = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolIdentityType";
+    internal const string WebApplicationApplicationPoolUsername = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolUsername";
+    internal const string WebApplicationApplicationPoolPassword = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolPassword";
+    internal const string WebApplicationApplicationPoolFrameworkVersion = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolFrameworkVersion";
+
+    // ── VirtualDirectory properties (Phase 4 will activate these) ─────────
+
+    internal const string VirtualDirectoryWebSiteName = "Squid.Action.IISWebSite.VirtualDirectory.WebSiteName";
+    internal const string VirtualDirectoryVirtualPath = "Squid.Action.IISWebSite.VirtualDirectory.VirtualPath";
+    internal const string VirtualDirectoryPhysicalPath = "Squid.Action.IISWebSite.VirtualDirectory.PhysicalPath";
+
+    // ── Tentacle-runtime variables read by the script (NOT action properties) ─
+
+    /// <summary>Injected by <c>TentacleEndpointVariableContributor</c>. The handler reads this to gate Windows-only execution.</summary>
+    internal const string TentacleOS = "Squid.Tentacle.OS";
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
@@ -1,0 +1,78 @@
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Execution;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+/// <summary>
+/// Handles the <c>Squid.DeployToIISWebSite</c> action — emits a <see cref="RunScriptIntent"/>
+/// carrying the assembled PowerShell payload (server-generated <c>$SquidParameters</c>
+/// preamble + verbatim Octopus-mirrored deploy script body).
+///
+/// <para>Auto-registered as <see cref="IActionHandler"/> via <c>IScopedDependency</c>
+/// scan; <see cref="ActionHandlerRegistry"/> picks it up by <see cref="ActionType"/>.</para>
+///
+/// <para><b>OS guard</b> — IIS only runs on Windows Tentacles. If the target machine's
+/// runtime-capabilities cache reports a non-Windows OS we throw a descriptive error at
+/// dispatch time rather than letting the agent fail mid-script with a cryptic "the term
+/// 'Get-WindowsFeature' is not recognised" message. If the OS is unknown (cache miss
+/// for a brand-new Tentacle that hasn't been health-checked yet), we proceed optimistically
+/// — the agent-side script's <c>Get-WindowsFeature Web-WebServer</c> probe is the final
+/// authority and will produce a clear error if the agent isn't actually Windows.</para>
+/// </summary>
+public class IISDeployActionHandler : IActionHandler
+{
+    public string ActionType => SpecialVariables.ActionTypes.DeployToIISWebSite;
+
+    Task<ExecutionIntent> IActionHandler.DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        EnsureWindowsTentacleTarget(ctx);
+
+        var scriptBody = IISDeployScriptBuilder.Build(ctx.Action);
+
+        var intent = new RunScriptIntent
+        {
+            Name = "deploy-to-iis-website",
+            StepName = ctx.Step?.Name ?? string.Empty,
+            ActionName = ctx.Action?.Name ?? string.Empty,
+            ScriptBody = scriptBody,
+            Syntax = Message.Models.Deployments.Execution.ScriptSyntax.PowerShell,
+            // The IIS script self-contains all helpers it needs (mutex / retry / SetUp-ApplicationPool
+            // / netsh / appcmd) — porting Octopus's PS1 verbatim. Squid's runtime bundle is bash-first
+            // and would just add noise, so we opt out.
+            InjectRuntimeBundle = false
+        };
+
+        return Task.FromResult<ExecutionIntent>(intent);
+    }
+
+    /// <summary>
+    /// Rejects dispatch when the target machine is known to NOT be a Windows Tentacle.
+    /// "Known non-Windows" = the runtime-capabilities cache has a value for
+    /// <c>Squid.Tentacle.OS</c> and that value isn't <c>Windows</c>. "Unknown" (no value
+    /// in the cache yet) is permitted — the script will fail loudly on the agent if so.
+    /// </summary>
+    private static void EnsureWindowsTentacleTarget(ActionExecutionContext ctx)
+    {
+        var osVariable = ctx.Variables?
+            .FirstOrDefault(v => string.Equals(v.Name, IISDeployProperties.TentacleOS, StringComparison.OrdinalIgnoreCase));
+
+        if (osVariable == null || string.IsNullOrEmpty(osVariable.Value))
+            return;   // unknown — proceed optimistically (see XML doc above)
+
+        if (string.Equals(osVariable.Value, "Windows", StringComparison.OrdinalIgnoreCase))
+            return;   // confirmed Windows — proceed
+
+        var stepName = ctx.Step?.Name ?? "(unknown)";
+        var actionName = ctx.Action?.Name ?? "(unknown)";
+
+        throw new InvalidOperationException(
+            $"Action '{actionName}' (type '{SpecialVariables.ActionTypes.DeployToIISWebSite}') in step '{stepName}' " +
+            $"requires a Windows Tentacle target. The configured target reports '{IISDeployProperties.TentacleOS}'='{osVariable.Value}'. " +
+            $"To deploy to IIS, configure a Windows Tentacle (Polling or Listening) and assign it the role this step targets. " +
+            $"If you believe the target IS Windows, run a health check against it so the runtime-capabilities cache refreshes.");
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -1,0 +1,165 @@
+using System.Reflection;
+using System.Text;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+/// <summary>
+/// Builds the PowerShell script body for a <c>Squid.DeployToIISWebSite</c> action.
+///
+/// <para>The script has two segments concatenated at dispatch time:</para>
+/// <list type="number">
+///   <item>A <b>generated preamble</b> that populates the <c>$SquidParameters</c>
+///         hashtable from the action's property values. Each property value is
+///         escaped for PowerShell single-quote string literals
+///         (<see cref="EscapeForPowerShellSingleQuote"/>) so that operator-provided
+///         values containing apostrophes / <c>$</c> / backticks cannot break out
+///         of the string.</item>
+///   <item>A <b>verbatim body</b> read from the embedded resource
+///         <c>Squid.Core.Resources.Deploy.IIS.DeployToIISWebSite.ps1</c>, which is
+///         a 1:1 mirror of Octopus Calamari's IIS deploy script with namespace
+///         renames applied. Never edit the body without updating the drift
+///         detector at <c>IISDeployScriptDriftDetectorTests</c>.</item>
+/// </list>
+///
+/// <para>Mirroring Octopus's behaviour, properties NOT supplied by the operator
+/// are emitted as empty strings (<c>''</c>) in the hashtable — the script body's
+/// <c>Is-DeploymentTypeDisabled</c> / null-check logic handles missing values
+/// gracefully. We do NOT bake operator-friendly defaults here; defaults live in
+/// the PS1 itself so Squid + Octopus remain behaviourally aligned.</para>
+/// </summary>
+internal static class IISDeployScriptBuilder
+{
+    private const string EmbeddedScriptName = "Squid.Core.Resources.Deploy.IIS.DeployToIISWebSite.ps1";
+
+    /// <summary>
+    /// The complete set of <c>Squid.Action.IISWebSite.*</c> property names the script body reads.
+    /// Each entry on this list is emitted into the generated <c>$SquidParameters</c> preamble
+    /// regardless of whether the operator supplied a value — missing values become empty strings.
+    ///
+    /// <para>Adding a new property: bump this list AND add the constant on
+    /// <see cref="IISDeployProperties"/>. The drift detector tracks both sides.</para>
+    /// </summary>
+    internal static readonly IReadOnlyList<string> RecognisedProperties = new[]
+    {
+        // Sub-feature toggles
+        IISDeployProperties.CreateOrUpdateWebSite,
+        IISDeployProperties.WebApplicationCreateOrUpdate,
+        IISDeployProperties.VirtualDirectoryCreateOrUpdate,
+
+        // WebSite
+        IISDeployProperties.WebSiteName,
+        IISDeployProperties.ApplicationPoolName,
+        IISDeployProperties.ApplicationPoolIdentityType,
+        IISDeployProperties.ApplicationPoolUsername,
+        IISDeployProperties.ApplicationPoolPassword,
+        IISDeployProperties.ApplicationPoolFrameworkVersion,
+        IISDeployProperties.Bindings,
+        IISDeployProperties.ExistingBindings,
+        IISDeployProperties.WebRoot,
+        IISDeployProperties.EnableAnonymousAuthentication,
+        IISDeployProperties.EnableBasicAuthentication,
+        IISDeployProperties.EnableWindowsAuthentication,
+        IISDeployProperties.StartApplicationPool,
+        IISDeployProperties.StartWebSite,
+        IISDeployProperties.MaxRetryFailures,
+        IISDeployProperties.SleepBetweenRetryFailuresInSeconds,
+
+        // WebApplication (dormant in Phase 1 — toggles default to false)
+        IISDeployProperties.WebApplicationWebSiteName,
+        IISDeployProperties.WebApplicationVirtualPath,
+        IISDeployProperties.WebApplicationPhysicalPath,
+        IISDeployProperties.WebApplicationApplicationPoolName,
+        IISDeployProperties.WebApplicationApplicationPoolIdentityType,
+        IISDeployProperties.WebApplicationApplicationPoolUsername,
+        IISDeployProperties.WebApplicationApplicationPoolPassword,
+        IISDeployProperties.WebApplicationApplicationPoolFrameworkVersion,
+
+        // VirtualDirectory (dormant in Phase 1)
+        IISDeployProperties.VirtualDirectoryWebSiteName,
+        IISDeployProperties.VirtualDirectoryVirtualPath,
+        IISDeployProperties.VirtualDirectoryPhysicalPath,
+    };
+
+    internal static string Build(DeploymentActionDto action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var preamble = BuildPreamble(action);
+        var body = LoadEmbeddedScriptBody();
+
+        return preamble + body;
+    }
+
+    private static string BuildPreamble(DeploymentActionDto action)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("# ── BEGIN GENERATED PREAMBLE (Squid IISDeployScriptBuilder) ──");
+        sb.AppendLine("# This hashtable is populated server-side from the action's property values;");
+        sb.AppendLine("# every value is pre-escaped for PowerShell single-quote literals. Do not edit.");
+        sb.AppendLine("$SquidParameters = @{}");
+
+        foreach (var propertyName in RecognisedProperties)
+        {
+            var rawValue = ReadProperty(action, propertyName);
+            var escaped = EscapeForPowerShellSingleQuote(rawValue);
+
+            sb.Append("$SquidParameters['");
+            sb.Append(propertyName);
+            sb.Append("'] = '");
+            sb.Append(escaped);
+            sb.AppendLine("'");
+        }
+
+        sb.AppendLine("# ── END GENERATED PREAMBLE ──");
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static string ReadProperty(DeploymentActionDto action, string propertyName)
+    {
+        var prop = action.Properties?
+            .FirstOrDefault(p => string.Equals(p.PropertyName, propertyName, StringComparison.OrdinalIgnoreCase));
+
+        return prop?.PropertyValue ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Escapes <paramref name="value"/> for a PowerShell single-quote string literal. In single-quoted
+    /// strings, the only character that requires escaping is the apostrophe itself, which is doubled
+    /// (<c>''</c>). Variable expansion, backticks, and dollar signs are inert inside single quotes.
+    ///
+    /// <para>Newlines (<c>\r\n</c>) inside the value would break the one-line <c>$SquidParameters['X'] =
+    /// 'value'</c> assignment — Bindings JSON in particular is multi-line in source form. We replace
+    /// <c>\r\n</c> / <c>\n</c> / <c>\r</c> with a single space so the value stays on one line. JSON
+    /// itself doesn't care about whitespace between tokens, so <c>{"a":1, "b":2}</c> behaves
+    /// identically to the multi-line form once <c>ConvertFrom-Json</c> parses it on the agent.</para>
+    /// </summary>
+    internal static string EscapeForPowerShellSingleQuote(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var collapsed = value
+            .Replace("\r\n", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal);
+
+        return collapsed.Replace("'", "''", StringComparison.Ordinal);
+    }
+
+    private static string LoadEmbeddedScriptBody()
+    {
+        var assembly = typeof(IISDeployScriptBuilder).Assembly;
+
+        using var stream = assembly.GetManifestResourceStream(EmbeddedScriptName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{EmbeddedScriptName}' not found in assembly '{assembly.GetName().Name}'. " +
+                $"Verify Squid.Core.csproj has '<EmbeddedResource Include=\"Resources\\Deploy\\IIS\\*.ps1\" />' " +
+                $"and the .ps1 file exists at src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleListeningTransport.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleListeningTransport.cs
@@ -23,7 +23,8 @@ public sealed class TentacleListeningTransport : DeploymentTransport
         RequiresContextPreparationForPackagedPayload = false,
         SupportedActionTypes = TransportCapabilities.ActionTypes(
             SpecialVariables.ActionTypes.Script,
-            SpecialVariables.ActionTypes.HealthCheck),
+            SpecialVariables.ActionTypes.HealthCheck,
+            SpecialVariables.ActionTypes.DeployToIISWebSite),
         OptionalFeatures = TransportCapabilities.Features("halibut", "bash", "tentacle")
     };
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentaclePollingTransport.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentaclePollingTransport.cs
@@ -23,7 +23,8 @@ public sealed class TentaclePollingTransport : DeploymentTransport
         RequiresContextPreparationForPackagedPayload = false,
         SupportedActionTypes = TransportCapabilities.ActionTypes(
             SpecialVariables.ActionTypes.Script,
-            SpecialVariables.ActionTypes.HealthCheck),
+            SpecialVariables.ActionTypes.HealthCheck,
+            SpecialVariables.ActionTypes.DeployToIISWebSite),
         OptionalFeatures = TransportCapabilities.Features("halibut", "bash", "tentacle")
     };
 

--- a/src/Squid.Core/Squid.Core.csproj
+++ b/src/Squid.Core/Squid.Core.csproj
@@ -57,6 +57,7 @@
     <EmbeddedResource Include="TentaclesScripts\*" />
     <EmbeddedResource Include="Services\DeploymentExecution\Runtime\Bundles\Resources\*" />
     <EmbeddedResource Include="Resources\Upgrade\*" />
+    <EmbeddedResource Include="Resources\Deploy\IIS\*.ps1" />
   </ItemGroup>
 
   <ItemGroup Label="DbUp">

--- a/src/Squid.Message/Constants/SpecialVariables.cs
+++ b/src/Squid.Message/Constants/SpecialVariables.cs
@@ -27,6 +27,14 @@ public static class SpecialVariables
         public const string OpenClawFetchResult = "Squid.OpenClaw.FetchResult";
         public const string OpenClawChatCompletion = "Squid.OpenClaw.ChatCompletion";
 
+        /// <summary>
+        /// Mirrors Octopus's <c>Octopus.IIS</c> action type for Windows-Tentacle IIS
+        /// deployments. The "WebSite" suffix is intentional and reserved — future
+        /// IIS-adjacent action types (e.g. WebDeploy, AzureFunction) get their own
+        /// names so customers can switch sub-feature without changing the action type.
+        /// </summary>
+        public const string DeployToIISWebSite = "Squid.DeployToIISWebSite";
+
         public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             Script,
@@ -50,7 +58,8 @@ public static class SpecialVariables
             OpenClawWaitSession,
             OpenClawAssert,
             OpenClawFetchResult,
-            OpenClawChatCompletion
+            OpenClawChatCompletion,
+            DeployToIISWebSite
         };
     }
 

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -1,0 +1,304 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.E2ETests.Deployments;
+using Squid.E2ETests.Infrastructure;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Shouldly;
+using Xunit;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.E2ETests.Deployments.Tentacle;
+
+/// <summary>
+/// Pipeline-tier E2E coverage for the <c>Squid.DeployToIISWebSite</c> action.
+/// <see cref="DeploymentPipelineFixture{T}"/> swaps the real execution strategy for
+/// <see cref="CapturingExecutionStrategy"/>, so these tests verify the SERVER-SIDE
+/// pipeline shape — handler → intent → renderer → ScriptExecutionRequest — without
+/// requiring a real Windows host or IIS install. Real-cluster execution is deferred
+/// to a follow-up phase (per the IIS implementation plan).
+///
+/// <para>Both Tentacle communication styles (Polling + Listening) are covered via
+/// <c>[InlineData]</c>. The IIS step is Windows-only at runtime, but the pipeline
+/// dispatch is identical for both — the only difference is how Halibut delivers the
+/// captured script to the agent. <see cref="CapturingExecutionStrategy"/> doesn't
+/// care about agent OS, so both rows assert the same content.</para>
+/// </summary>
+[Collection("KindCluster")]
+[Trait("Category", "E2E")]
+public class IISDeployPipelineE2ETests
+    : IClassFixture<DeploymentPipelineFixture<IISDeployPipelineE2ETests>>
+{
+    private readonly DeploymentPipelineFixture<IISDeployPipelineE2ETests> _fixture;
+
+    public IISDeployPipelineE2ETests(
+        KindClusterFixture cluster,
+        DeploymentPipelineFixture<IISDeployPipelineE2ETests> fixture)
+    {
+        _ = cluster;   // required by [Collection("KindCluster")] but unused — this test never touches K8s
+        _fixture = fixture;
+    }
+
+    private CapturingExecutionStrategy ExecutionCapture => _fixture.ExecutionCapture;
+
+    // ── Captured script shape ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_DeployToIISWebSite_CapturesPowerShellWithPreambleAndBody(string communicationStyle)
+    {
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteAsync(
+            communicationStyle,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Pool",
+                ["Squid.Action.IISWebSite.ApplicationPoolIdentityType"] = "ApplicationPoolIdentity",
+                ["Squid.Action.IISWebSite.ApplicationPoolFrameworkVersion"] = "v4.0",
+                ["Squid.Action.IISWebSite.WebRoot"] = @"C:\inetpub\OrderApi",
+                ["Squid.Action.IISWebSite.Bindings"] = "[{\"protocol\":\"http\",\"port\":\"80\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]",
+                ["Squid.Action.IISWebSite.StartApplicationPool"] = "True",
+                ["Squid.Action.IISWebSite.StartWebSite"] = "True"
+            });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        ExecutionCapture.CapturedRequests.Count.ShouldBe(1);
+        var captured = ExecutionCapture.CapturedRequests[0];
+
+        // The renderer hands a PowerShell-syntax request to whichever transport executes it.
+        captured.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+
+        // Preamble lands first — server-rendered hashtable population.
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.WebSiteName'] = 'OrderApi'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ApplicationPoolName'] = 'OrderApi-Pool'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.WebRoot'] = 'C:\\inetpub\\OrderApi'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.CreateOrUpdateWebSite'] = 'True'");
+
+        // Embedded body — Octopus-mirrored deploy logic.
+        captured.ScriptBody.ShouldContain("$DeployIISScriptBlock = {");
+        captured.ScriptBody.ShouldContain("Import-Module WebAdministration");
+        captured.ScriptBody.ShouldContain("netsh http add sslcert");        // present even though the binding is http-only — the body has the SSL branch unconditionally
+        captured.ScriptBody.ShouldContain("appcmd.exe");                    // authentication toggle branch
+        captured.ScriptBody.ShouldContain("Octopus-IIS-Metabase-Mutex");    // global mutex name preserved verbatim from the Octopus port
+    }
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_DeployToIISWebSite_BindingsJson_RenderedOnSingleLineInPreamble(string communicationStyle)
+    {
+        // Realistic operator scenario: HTTPS binding with cert reference + SNI. The Bindings
+        // JSON in the action property is multi-line as authored. The server must collapse it
+        // to one line in the preamble (the `$SquidParameters['…'] = '…'` assignment can't
+        // span multiple lines without breaking the PowerShell parser).
+        ExecutionCapture.Clear();
+
+        var bindingsJson = "[\n  {\n    \"protocol\":\"https\",\n    \"port\":\"443\",\n    \"host\":\"api.example.com\",\n    \"requireSni\":true,\n    \"thumbprint\":\"ABCD1234\",\n    \"enabled\":true\n  }\n]";
+
+        var serverTaskId = await SeedIISWebSiteAsync(
+            communicationStyle,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "ApiSite",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "ApiSite-Pool",
+                ["Squid.Action.IISWebSite.Bindings"] = bindingsJson
+            });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        var bindingsLine = captured.ScriptBody
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        bindingsLine.ShouldContain("\"protocol\":\"https\"");
+        bindingsLine.ShouldContain("\"port\":\"443\"");
+        bindingsLine.ShouldContain("\"host\":\"api.example.com\"");
+        bindingsLine.ShouldContain("\"requireSni\":true");
+        bindingsLine.ShouldContain("\"thumbprint\":\"ABCD1234\"");
+    }
+
+    // ── Theory matrix coverage of Tentacle communication-style dispatch ───
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_DeployToIISWebSite_DispatchesToTentacle_OfBothStyles(string communicationStyle)
+    {
+        // Sanity: the IIS action type was added to both TentaclePollingTransport.Capability
+        // and TentacleListeningTransport.Capability. The capability validator should let the
+        // dispatch through for both styles. Without this wiring the pipeline would
+        // short-circuit with a CapabilityViolation.
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteAsync(
+            communicationStyle,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Pool"
+            });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+        ExecutionCapture.CapturedRequests.ShouldNotBeEmpty(
+            "Capability validator should accept Squid.DeployToIISWebSite for both " +
+            "TentaclePolling and TentacleListening; if this assertion fails check " +
+            "the SupportedActionTypes wiring in both transports.");
+    }
+
+    // ── Seeder ─────────────────────────────────────────────────────────────
+
+    private async Task<int> SeedIISWebSiteAsync(string communicationStyle, Dictionary<string, string> properties)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..6];
+        var serverTaskId = 0;
+
+        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            var step = await builder.CreateDeploymentStepAsync(process.Id, 1, "Deploy to IIS").ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step.Id,
+                ("Squid.Action.TargetRoles", "windows-iis")).ConfigureAwait(false);
+
+            var action = await builder.CreateDeploymentActionAsync(
+                step.Id, 1, "IIS WebSite",
+                actionType: "Squid.DeployToIISWebSite").ConfigureAwait(false);
+
+            await builder.CreateActionMachineRolesAsync(action.Id, "windows-iis").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(action.Id,
+                properties.Select(p => (p.Key, p.Value)).ToArray()).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync($"E2E IIS Env {suffix}").ConfigureAwait(false);
+
+            var endpointJson = communicationStyle == "TentaclePolling"
+                ? JsonSerializer.Serialize(new
+                {
+                    CommunicationStyle = "TentaclePolling",
+                    SubscriptionId = $"sub-{suffix}",
+                    Thumbprint = $"E2E-IIS-POLLING-THUMBPRINT-{suffix}"
+                })
+                : JsonSerializer.Serialize(new
+                {
+                    CommunicationStyle = "TentacleListening",
+                    Uri = $"https://localhost:10933/",
+                    Thumbprint = $"E2E-IIS-LISTENING-THUMBPRINT-{suffix}"
+                });
+
+            var machine = new Machine
+            {
+                Name = $"E2E IIS Target {suffix}",
+                IsDisabled = false,
+                Roles = DeploymentTargetFinder.SerializeRoles(new[] { "windows-iis" }),
+                EnvironmentIds = DeploymentTargetFinder.SerializeIds(new[] { environment.Id }),
+                Endpoint = endpointJson,
+                SpaceId = 1,
+                Slug = $"e2e-iis-target-{suffix}"
+            };
+
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            var deployment = new Deployment
+            {
+                Name = $"E2E IIS Deployment {suffix}",
+                SpaceId = 1,
+                ChannelId = channel.Id,
+                ProjectId = project.Id,
+                ReleaseId = release.Id,
+                EnvironmentId = environment.Id,
+                DeployedBy = 1,
+                CreatedDate = DateTimeOffset.UtcNow,
+                Json = string.Empty
+            };
+
+            await repository.InsertAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var serverTask = new ServerTask
+            {
+                Name = $"E2E IIS Task {suffix}",
+                Description = "E2E IIS deploy",
+                QueueTime = DateTimeOffset.UtcNow,
+                State = TaskState.Pending,
+                ServerTaskType = "Deploy",
+                ProjectId = project.Id,
+                EnvironmentId = environment.Id,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                BusinessProcessState = "Queued",
+                StateOrder = 1,
+                Weight = 1,
+                BatchId = 0,
+                JSON = string.Empty,
+                HasWarningsOrErrors = false,
+                ServerNodeId = Guid.NewGuid(),
+                DurationSeconds = 0,
+                DataVersion = Array.Empty<byte>()
+            };
+
+            await repository.InsertAsync(serverTask).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            serverTaskId = serverTask.Id;
+        }).ConfigureAwait(false);
+
+        return serverTaskId;
+    }
+
+    private async Task AssertTaskStateAsync(string expectedState)
+    {
+        await _fixture.Run<IServerTaskDataProvider>(async taskDataProvider =>
+        {
+            var tasks = await taskDataProvider.GetAllServerTasksAsync(CancellationToken.None).ConfigureAwait(false);
+
+            tasks.ShouldNotBeNull();
+            tasks.Count.ShouldBeGreaterThanOrEqualTo(1);
+
+            var task = tasks.OrderByDescending(t => t.Id).First();
+            task.State.ShouldBe(expectedState, $"Expected task state '{expectedState}' but was '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -31,6 +31,7 @@ namespace Squid.E2ETests.Deployments.Tentacle;
 /// </summary>
 [Collection("KindCluster")]
 [Trait("Category", "E2E")]
+[Trait("Tier", "Contract")]
 public class IISDeployPipelineE2ETests
     : IClassFixture<DeploymentPipelineFixture<IISDeployPipelineE2ETests>>
 {

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployActionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployActionHandlerTests.cs
@@ -1,0 +1,194 @@
+using System.Linq;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class IISDeployActionHandlerTests
+{
+    [Fact]
+    public void ActionType_MatchesPublishedConstant()
+    {
+        // Renaming this constant breaks every customer who scripted against
+        // the action type. Hard-pin so any drift is caught at build time.
+        new IISDeployActionHandler().ActionType.ShouldBe("Squid.DeployToIISWebSite");
+        new IISDeployActionHandler().ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployToIISWebSite);
+    }
+
+    // ── Intent emission ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DescribeIntentAsync_ReturnsRunScriptIntent_WithPowerShellSyntax()
+    {
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi")));
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+
+        intent.ShouldBeOfType<RunScriptIntent>();
+        var runScript = (RunScriptIntent)intent;
+
+        runScript.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+        runScript.Name.ShouldBe("deploy-to-iis-website");
+        // We DON'T inject Squid's bash-flavoured runtime bundle — the IIS script is
+        // self-contained (mutex + retry + appcmd + netsh all live in the embedded body).
+        runScript.InjectRuntimeBundle.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_PropagatesStepAndActionNamesForObservability()
+    {
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((IISDeployProperties.WebSiteName, "X")),
+            stepName: "Deploy OrderApi",
+            actionName: "IIS Website");
+
+        var intent = (RunScriptIntent)await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+
+        intent.StepName.ShouldBe("Deploy OrderApi");
+        intent.ActionName.ShouldBe("IIS Website");
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_ScriptBody_ContainsBothPreambleAndEmbeddedBody()
+    {
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(BuildAction(
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.ApplicationPoolName, "OrderApi-Pool")));
+
+        var intent = (RunScriptIntent)await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+
+        // Preamble assignment lands in the script
+        intent.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.WebSiteName'] = 'OrderApi'");
+
+        // Embedded body's script-block declaration is also present
+        intent.ScriptBody.ShouldContain("$DeployIISScriptBlock = {");
+    }
+
+    // ── OS guard ───────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Linux")]
+    [InlineData("Darwin")]
+    [InlineData("FreeBSD")]
+    public async Task DescribeIntentAsync_NonWindowsTentacle_ThrowsWithActionableMessage(string os)
+    {
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(
+            action: BuildAction((IISDeployProperties.WebSiteName, "X")),
+            stepName: "Deploy OrderApi",
+            actionName: "IIS Website",
+            tentacleOs: os);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => handler.DescribeIntentAsync(ctx, CancellationToken.None));
+
+        // Message must include: the action type (so operators know which step), the actual OS
+        // reported (so they know why), the remediation (configure a Windows Tentacle / refresh
+        // health check). Rule 12.10: failure messages must be actionable.
+        ex.Message.ShouldContain("Squid.DeployToIISWebSite");
+        ex.Message.ShouldContain("Deploy OrderApi");
+        ex.Message.ShouldContain("IIS Website");
+        ex.Message.ShouldContain(os);
+        ex.Message.ShouldContain("Windows Tentacle");
+        ex.Message.ShouldContain("health check");
+    }
+
+    [Theory]
+    [InlineData("Windows")]
+    [InlineData("windows")]   // case-insensitive — Windows reports vary
+    [InlineData("WINDOWS")]
+    public async Task DescribeIntentAsync_WindowsTentacle_ProceedsSuccessfully(string os)
+    {
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((IISDeployProperties.WebSiteName, "X")),
+            tentacleOs: os);
+
+        // Should not throw.
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_OsCacheMiss_ProceedsOptimistically()
+    {
+        // A brand-new Tentacle that hasn't done a health check yet has no entry in the
+        // runtime-capabilities cache → no Squid.Tentacle.OS variable contributed. The handler
+        // proceeds; the agent-side script's `Get-WindowsFeature Web-WebServer` probe is the
+        // final authority and will fail loudly on non-Windows.
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((IISDeployProperties.WebSiteName, "X")),
+            tentacleOs: null);
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_OsEmptyString_ProceedsOptimistically()
+    {
+        // The contributor only emits Squid.Tentacle.OS when caps.Os is non-empty
+        // (see TentacleEndpointVariableContributor:59), but defensive against a future
+        // refactor that could emit empty strings.
+        var handler = (IActionHandler)new IISDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((IISDeployProperties.WebSiteName, "X")),
+            tentacleOs: "");
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "IIS Website",
+            ActionType = "Squid.DeployToIISWebSite",
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+
+    private static ActionExecutionContext BuildContext(
+        DeploymentActionDto action,
+        string stepName = "Deploy",
+        string actionName = "IIS Website",
+        string tentacleOs = "Windows")
+    {
+        var variables = new List<VariableDto>();
+
+        if (tentacleOs != null)
+            variables.Add(new VariableDto { Name = "Squid.Tentacle.OS", Value = tentacleOs });
+
+        return new ActionExecutionContext
+        {
+            Step = new DeploymentStepDto { Name = stepName },
+            Action = new DeploymentActionDto
+            {
+                Id = action.Id,
+                Name = actionName,
+                ActionType = action.ActionType,
+                Properties = action.Properties
+            },
+            Variables = variables
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -1,0 +1,166 @@
+using System.Linq;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class IISDeployScriptBuilderTests
+{
+    // ── Preamble generation ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_EmitsSquidParametersHashtable_AtTopOfScript()
+    {
+        var action = BuildAction(
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.ApplicationPoolName, "OrderApi-Pool"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // Preamble marker is present
+        script.ShouldContain("# ── BEGIN GENERATED PREAMBLE");
+
+        // Hashtable initialised before any keys are set
+        script.ShouldContain("$SquidParameters = @{}");
+
+        // Configured property values land in the hashtable verbatim
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.WebSiteName'] = 'OrderApi'");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ApplicationPoolName'] = 'OrderApi-Pool'");
+    }
+
+    [Fact]
+    public void Build_AppendsEmbeddedScriptBody_AfterPreamble()
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "X"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // The verbatim body starts with the script-block declaration that mirrors Octopus.
+        script.ShouldContain("$DeployIISScriptBlock = {");
+        script.ShouldContain("param(");
+        script.ShouldContain("$SquidParameters");
+
+        // The PS-7.3 compatibility wrapper at the tail of the file is preserved.
+        script.ShouldContain("Import-Module WebAdministration -UseWindowsPowerShell");
+        script.ShouldContain("Invoke-Command -Session $compatSession -ScriptBlock $DeployIISScriptBlock");
+
+        // Preamble must appear strictly BEFORE the body — otherwise $SquidParameters
+        // is undefined when the wrapper at the bottom tries to read it.
+        var preambleIndex = script.IndexOf("# ── BEGIN GENERATED PREAMBLE", StringComparison.Ordinal);
+        var bodyIndex = script.IndexOf("$DeployIISScriptBlock = {", StringComparison.Ordinal);
+
+        preambleIndex.ShouldBeGreaterThanOrEqualTo(0);
+        bodyIndex.ShouldBeGreaterThanOrEqualTo(0);
+        preambleIndex.ShouldBeLessThan(bodyIndex);
+    }
+
+    [Fact]
+    public void Build_AllRecognisedProperties_HaveExplicitEntryInHashtable_EvenWhenUnsetByOperator()
+    {
+        // No properties set on the action — the builder still emits a key for every
+        // recognised property so the script body's reads never null-deref. Octopus does
+        // the same via its top-level dictionary literal.
+        var action = BuildAction();
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        foreach (var propertyName in IISDeployScriptBuilder.RecognisedProperties)
+            script.ShouldContain($"$SquidParameters['{propertyName}']");
+    }
+
+    // ── Single-quote escaping (the security-critical part) ─────────────────
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("plain", "plain")]
+    [InlineData("OrderApi-Pool", "OrderApi-Pool")]
+    [InlineData("C:\\inetpub\\OrderApi", "C:\\inetpub\\OrderApi")]   // backslashes pass through — single-quotes don't escape
+    [InlineData("$variable", "$variable")]                          // dollars are inert in single-quotes
+    [InlineData("with`backtick", "with`backtick")]                  // backticks are inert in single-quotes
+    [InlineData("Joe's pool", "Joe''s pool")]                       // apostrophe DOUBLED — the only escape rule
+    [InlineData("'leading", "''leading")]
+    [InlineData("trailing'", "trailing''")]
+    [InlineData("a'b'c", "a''b''c")]
+    public void EscapeForPowerShellSingleQuote_FollowsPowerShellLiteralRules(string input, string expected)
+    {
+        IISDeployScriptBuilder.EscapeForPowerShellSingleQuote(input).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("line1\nline2", "line1 line2")]
+    [InlineData("line1\r\nline2", "line1 line2")]
+    [InlineData("line1\rline2", "line1 line2")]
+    public void EscapeForPowerShellSingleQuote_CollapsesNewlines_ToKeepPreambleOnOneLine(string input, string expected)
+    {
+        // Multi-line values (Bindings JSON in particular) must stay on one line because the
+        // preamble template is `$SquidParameters['X'] = 'value'`. JSON is whitespace-insensitive
+        // so `{"a":1, "b":2}` parses identically to its multi-line form.
+        IISDeployScriptBuilder.EscapeForPowerShellSingleQuote(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Build_OperatorValueWithApostrophe_DoesNotBreakOutOfStringLiteral()
+    {
+        // Adversarial input: an operator who set ApplicationPoolUsername to `O'Brien` (legit
+        // surname) or maliciously to `'; Stop-Service something; '` (PowerShell injection
+        // attempt). The doubled-apostrophe escape neutralises both — the value stays inside
+        // the quotes either way.
+        var action = BuildAction(
+            (IISDeployProperties.ApplicationPoolUsername, "O'Brien"),
+            (IISDeployProperties.WebSiteName, "'; Stop-Service something; '"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ApplicationPoolUsername'] = 'O''Brien'");
+
+        // Adversarial input is contained: each `'` doubles to `''`, so the value `'; Stop-Service…; '`
+        // becomes the wrapped literal `'''; Stop-Service…; '''`. The PowerShell tokenizer reads that
+        // as a single string literal whose VALUE is `'; Stop-Service…; '` — no statement escape.
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.WebSiteName'] = '''; Stop-Service something; '''");
+    }
+
+    [Fact]
+    public void Build_OperatorBindingsJson_PassesThroughOneLine_WithoutBreakingHashtable()
+    {
+        // Realistic Bindings JSON the script-body will ConvertFrom-Json on the agent.
+        var bindings = "[\n  {\n    \"protocol\":\"http\",\n    \"port\":\"80\",\n    \"enabled\":true\n  }\n]";
+
+        var action = BuildAction((IISDeployProperties.Bindings, bindings));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // The value must end up on one line (newlines collapsed to spaces) so the single-quote
+        // assignment doesn't span multiple lines. We specifically want the ASSIGNMENT line
+        // (`$SquidParameters['Squid.Action.IISWebSite.Bindings'] = '…'`), not any of the
+        // script-body lookup lines (`$SquidParameters["Squid.Action.IISWebSite.Bindings"]`)
+        // that the mirror reads. Filter on the assignment shape.
+        var bindingsAssignmentLine = script
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        bindingsAssignmentLine.ShouldContain("\"protocol\":\"http\"");
+        bindingsAssignmentLine.ShouldContain("\"port\":\"80\"");
+        bindingsAssignmentLine.ShouldContain("\"enabled\":true");
+        bindingsAssignmentLine.ShouldNotContain("\r");
+        bindingsAssignmentLine.ShouldNotContain("\n");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "Deploy to IIS",
+            ActionType = "Squid.DeployToIISWebSite",
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -1,0 +1,199 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+/// <summary>
+/// Drift detector for the mirror-tier <c>DeployToIISWebSite.ps1</c> embedded resource
+/// (per ~/.claude/CLAUDE.md Rule 12.5 — every inline mirror of production logic MUST
+/// have a drift-detector that fails CI when the mirror diverges from its upstream
+/// reference).
+///
+/// <para>The mirror is a verbatim port of Octopus Calamari's
+/// <c>Calamari/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1</c>
+/// with two mechanical substitutions: <c>Octopus.Action.IISWebSite</c> →
+/// <c>Squid.Action.IISWebSite</c> and <c>$OctopusParameters</c> →
+/// <c>$SquidParameters</c>. Every other byte of deployment logic — the mutex name,
+/// retry loop, IIS-version detection, SNI handling, netsh-cert binding, appcmd
+/// authentication toggles, PS-7.3 compat-session wrapper — is byte-identical.</para>
+///
+/// <para>The test has two modes:</para>
+/// <list type="number">
+///   <item><b>Structural invariants</b> (always runs): assert each
+///         deployment-critical construct is present in our embedded copy. These
+///         survive small Octopus edits (a comment change, whitespace adjustment).
+///         If any invariant goes missing in our copy, the port has decayed.</item>
+///   <item><b>Soft upstream comparison</b> (runs only when the Octopus source is
+///         checked out at the documented path): assert each invariant is ALSO
+///         present in the upstream — i.e. the invariant we're tracking is still
+///         a thing Octopus does. If Octopus removed it (e.g. they dropped legacy
+///         IIS 6 support), we should evaluate whether to drop it too.</item>
+/// </list>
+///
+/// <para>When Octopus ships a new IIS fix, port it by editing both sides and
+/// updating this list — the diff in this test makes the change reviewable.</para>
+/// </summary>
+public class IISDeployScriptDriftDetectorTests
+{
+    private const string OctopusReferencePath =
+        "/Users/mars/Projects/octopus/Calamari/source/Calamari/Scripts/Octopus.Features.IISWebSite_BeforePostDeploy.ps1";
+
+    private const string EmbeddedResource = "Squid.Core.Resources.Deploy.IIS.DeployToIISWebSite.ps1";
+
+    /// <summary>
+    /// Each entry pins one critical operation. <c>(Description, Pattern)</c> — pattern is matched
+    /// as a substring against both our embedded script and the upstream Octopus script. If you
+    /// edit either side without keeping both invariants intact, this test fails with a clear
+    /// remediation message.
+    /// </summary>
+    private static readonly IReadOnlyList<(string Description, string Pattern)> KeyOperations = new[]
+    {
+        ("Sub-feature toggle: WebSite",          "Squid.Action.IISWebSite.CreateOrUpdateWebSite"),
+        ("Sub-feature toggle: WebApplication",   "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate"),
+        ("Sub-feature toggle: VirtualDirectory", "Squid.Action.IISWebSite.VirtualDirectory.CreateOrUpdate"),
+
+        ("IIS-installed probe",                  "Get-WindowsFeature Web-WebServer"),
+        ("IIS version detection",                "HKLM:\\SOFTWARE\\Microsoft\\InetStp"),
+        ("WebAdministration module load",        "Import-Module WebAdministration"),
+
+        ("Global metabase mutex name",           "Octopus-IIS-Metabase-Mutex"),
+        ("Mutex wait helper",                    "Wait-OnMutex"),
+        ("Retry helper",                         "Execute-WithRetry"),
+
+        ("App-pool setup function",              "SetUp-ApplicationPool"),
+        ("Identity type: ApplicationPoolIdentity", "ApplicationPoolIdentity"),
+        ("Identity type: SpecificUser",          "SpecificUser"),
+        ("Managed runtime version property",     "managedRuntimeVersion"),
+
+        ("Binding parser (JSON)",                "ConvertFrom-Json"),
+        ("SNI flag (requireSni)",                "requireSni"),
+        ("SSL cert binding via netsh",           "netsh http add sslcert"),
+        ("Hostname-port SNI form",               "hostnameport="),
+        ("IP-port non-SNI form",                 "ipport="),
+
+        ("Authentication via appcmd",            "appcmd.exe"),
+        ("Anonymous authentication section",     "anonymousAuthentication"),
+        ("Basic authentication section",         "basicAuthentication"),
+        ("Windows authentication section",       "windowsAuthentication"),
+
+        ("Start-WebCommitDelay (batch atomicity)", "Start-WebCommitDelay"),
+        ("Stop-WebCommitDelay (batch atomicity)",  "Stop-WebCommitDelay"),
+
+        ("PS-7.3 compat-session import",         "Import-Module WebAdministration -UseWindowsPowerShell"),
+        ("PS-7.3 compat-session invoke",         "Invoke-Command -Session $compatSession"),
+
+        ("Existing bindings: Merge vs Replace",  "ExistingBindings"),
+
+        ("Script block declaration",             "$DeployIISScriptBlock"),
+    };
+
+    [Fact]
+    public void EmbeddedScript_ContainsEveryKeyOperation()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        var missing = KeyOperations
+            .Where(op => !ourScript.Contains(op.Pattern, StringComparison.Ordinal))
+            .Select(op => $"  - '{op.Description}' (pattern: <{op.Pattern}>)")
+            .ToList();
+
+        missing.Count.ShouldBe(0,
+            customMessage:
+                "Squid's embedded IIS deploy script is missing one or more key operations that " +
+                "Octopus's reference script ships. This means the mirror has decayed and the " +
+                "Squid behaviour no longer matches Octopus.\n\n" +
+                "Missing operations:\n" + string.Join("\n", missing) + "\n\n" +
+                "Fix: either restore the missing operation in " +
+                "src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1, or — if you intentionally " +
+                "removed the operation — update the KeyOperations list in this test and document " +
+                "the rationale in the PR description.");
+    }
+
+    [Fact]
+    public void EveryKeyOperation_StillPresentInOctopusUpstream_WhenSourceCheckedOut()
+    {
+        // Soft skip: this only runs when the Octopus source is checked out locally. CI runners
+        // without the Octopus repo see a green test (intent: the structural invariants are still
+        // authoritative on their own).
+        if (!File.Exists(OctopusReferencePath))
+            return;
+
+        var octopusScript = File.ReadAllText(OctopusReferencePath);
+
+        // Octopus uses `Octopus.Action.IISWebSite.*` and `$OctopusParameters` — we normalize
+        // our Squid patterns back to the Octopus namespace for the upstream comparison.
+        var octopusEquivalents = KeyOperations.Select(op => (
+            op.Description,
+            Pattern: op.Pattern
+                .Replace("Squid.Action.IISWebSite", "Octopus.Action.IISWebSite", StringComparison.Ordinal)
+                .Replace("SquidParameters", "OctopusParameters", StringComparison.Ordinal)));
+
+        var dropped = octopusEquivalents
+            .Where(op => !octopusScript.Contains(op.Pattern, StringComparison.Ordinal))
+            .Select(op => $"  - '{op.Description}' (Octopus pattern: <{op.Pattern}>)")
+            .ToList();
+
+        dropped.Count.ShouldBe(0,
+            customMessage:
+                "One or more KeyOperations are no longer present in the Octopus reference script at\n" +
+                $"  {OctopusReferencePath}\n\n" +
+                "This means Octopus has dropped a feature that Squid's mirror still ships. " +
+                "Evaluate whether Squid should drop it too (e.g. legacy IIS 6 support that " +
+                "Octopus pruned). If yes: remove from both Squid's PS1 AND the KeyOperations " +
+                "list. If no: keep Squid's behaviour but explain in the PR description why we " +
+                "intentionally retain a feature Octopus dropped.\n\n" +
+                "Dropped in upstream:\n" + string.Join("\n", dropped));
+    }
+
+    [Fact]
+    public void EmbeddedScript_DoesNotLeakAnyOctopusNamespace_InExecutableLines()
+    {
+        // Verify the mechanical port renamed every Octopus identifier in the EXECUTABLE
+        // PowerShell code. The header (top of the file) intentionally describes the porting
+        // contract using Octopus identifiers in prose — strip comment lines before checking
+        // so the test pins live-code semantics, not documentation wording.
+        var ourScript = LoadEmbeddedScript();
+
+        var executableLines = ourScript
+            .Split('\n')
+            .Where(line => !line.TrimStart().StartsWith('#'))   // PS comment marker
+            .ToList();
+
+        var lineWithOctopusActionRef = executableLines
+            .FirstOrDefault(l => l.Contains("Octopus.Action.IISWebSite", StringComparison.Ordinal));
+
+        lineWithOctopusActionRef.ShouldBeNull(
+            customMessage:
+                "Squid's embedded PS1 still has a live-code reference to Octopus.Action.IISWebSite:\n" +
+                $"  {lineWithOctopusActionRef}\n\n" +
+                "Run the namespace-rename sed over the file again and re-commit.");
+
+        var lineWithOctopusParametersRef = executableLines
+            .FirstOrDefault(l => l.Contains("OctopusParameters", StringComparison.Ordinal));
+
+        lineWithOctopusParametersRef.ShouldBeNull(
+            customMessage:
+                "Squid's embedded PS1 still has a live-code reference to $OctopusParameters:\n" +
+                $"  {lineWithOctopusParametersRef}\n\n" +
+                "Rename to $SquidParameters and re-commit.");
+    }
+
+    private static string LoadEmbeddedScript()
+    {
+        // We deliberately load through the same path the production code uses
+        // (Assembly.GetManifestResourceStream on Squid.Core) so this test catches
+        // .csproj wiring regressions (e.g. someone removing the EmbeddedResource entry).
+        var assembly = typeof(IISDeployScriptBuilder).Assembly;
+
+        using var stream = assembly.GetManifestResourceStream(EmbeddedResource)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{EmbeddedResource}' not found. Verify Squid.Core.csproj has " +
+                $"<EmbeddedResource Include=\"Resources\\Deploy\\IIS\\*.ps1\" />.");
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1,0 +1,405 @@
+using System.Diagnostics;
+using System.Text;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Execution-tier E2E for the <c>Squid.DeployToIISWebSite</c> action's PowerShell
+/// payload. Drives <see cref="IISDeployScriptBuilder.Build"/> with realistic action
+/// properties, pipes the resulting PowerShell into a real <c>powershell.exe</c>
+/// process, then verifies the resulting IIS metabase state via <c>Get-Website</c>
+/// / <c>Get-WebAppPool</c> / <c>Get-WebBinding</c>.
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity (per ~/.claude/CLAUDE.md Rule 12). Real IIS,
+/// real PowerShell, real <c>WebAdministration</c> module, real metabase mutations.
+/// The only seam vs end-to-end is the Halibut server↔agent dispatch — that's
+/// covered separately by <c>TentacleDeployE2ETests</c> in this same project and
+/// kept out of scope here so this suite runs on <c>windows-latest</c> without
+/// spinning up a server-side stack.</para>
+///
+/// <para><b>Coverage delta vs pipeline-tier <c>IISDeployPipelineE2ETests</c></b>
+/// (in <c>Squid.E2ETests</c>): that suite asserts the rendered
+/// <c>ScriptExecutionRequest</c> shape via <c>CapturingExecutionStrategy</c>;
+/// this suite proves the rendered script actually does the right thing to real
+/// IIS. Both ship in the same PR so a regression in either rendering OR runtime
+/// surfaces.</para>
+///
+/// <para><b>OS / IIS prereqs</b>: requires Windows + <c>Web-WebServer</c> feature
+/// installed. The CI workflow <c>tentacle-windows-e2e.yml</c> installs it before
+/// invoking this category. Per-test <c>Get-WindowsFeature</c> probe + per-class
+/// skip-on-non-Windows guard keep dev hosts on macOS / Linux running a clean
+/// "0 ran, 0 passed" instead of spurious failures.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.IISDeploy)]
+public sealed class IISDeployRealHostE2ETests
+{
+    [Fact]
+    public void RealIIS_BasicWebSiteCreate_AppPoolAndSiteExistOnHost()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]"),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True")));
+
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Squid IIS deploy script failed on real Windows host. " +
+                $"stdout / stderr captured below — to manually diagnose, run " +
+                $"`Get-Website -Name {ctx.SiteName}` and `Get-WebAppPool -Name {ctx.PoolName}`.\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // The site MUST exist in IIS metabase, with the configured physical path.
+        var sitePath = PowerShellSingleLine(
+            $"(Get-Website -Name '{ctx.SiteName}').physicalPath");
+
+        sitePath.ShouldBe(ctx.PhysicalPath,
+            customMessage: "physicalPath on the created site doesn't match the configured WebRoot. " +
+                          "Either the script's `Set-ItemProperty IIS:\\Sites\\... -Name physicalPath` " +
+                          "didn't run or it ran against a different path. Check the captured stdout.");
+
+        // The pool MUST exist with the configured identity type + framework.
+        var poolIdentity = PowerShellSingleLine(
+            $"(Get-ItemProperty IIS:\\AppPools\\{ctx.PoolName} -Name processModel.identityType).Value");
+
+        poolIdentity.ShouldBe("ApplicationPoolIdentity");
+
+        var poolRuntime = PowerShellSingleLine(
+            $"(Get-ItemProperty IIS:\\AppPools\\{ctx.PoolName} -Name managedRuntimeVersion).Value");
+
+        poolRuntime.ShouldBe("v4.0");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_HttpBinding_RegisteredInMetabaseWithConfiguredPort()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, $"deploy failed: {result.StdErr}");
+
+        // The configured binding MUST be present on the site. The bindingInformation
+        // format is `<ipAddress>:<port>:<host>` — for *:<port>: it's `*:80:`.
+        var bindingInfo = PowerShellSingleLine(
+            $"(Get-WebBinding -Name '{ctx.SiteName}' -Protocol http).bindingInformation");
+
+        bindingInfo.ShouldBe($"*:{ctx.HttpPort}:",
+            customMessage: "HTTP binding not registered with the configured port. The script's " +
+                          "`New-WebBinding` or binding-merge logic didn't populate the metabase. " +
+                          "Inspect captured stdout for the binding-loop output.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_StartWebSiteFalse_SiteCreatedButLeftStopped()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]"),
+            (Property.StartWebSite, "False")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, $"deploy failed: {result.StdErr}");
+
+        // Site exists but the script honoured StartWebSite=False → state is Stopped.
+        var siteState = PowerShellSingleLine(
+            $"(Get-Website -Name '{ctx.SiteName}').state");
+
+        siteState.ShouldBe("Stopped",
+            customMessage: "Site should be in 'Stopped' state because StartWebSite=False, but is in " +
+                          $"'{siteState}'. The script's `Start-Website` block executed when it should " +
+                          "have been skipped.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_SecondDeploySameSite_IsIdempotentUpdate_NotDuplicate()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        // First deploy
+        var script1 = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]")));
+
+        var result1 = RunPowerShell(script1);
+        result1.ExitCode.ShouldBe(0, $"first deploy failed: {result1.StdErr}");
+
+        // Second deploy — same name, slightly different physical path.
+        var newPath = ctx.PhysicalPath + "-v2";
+        Directory.CreateDirectory(newPath);
+        ctx.RegisterTempDirForCleanup(newPath);
+
+        var script2 = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.WebRoot, newPath),
+            (Property.Bindings, "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]")));
+
+        var result2 = RunPowerShell(script2);
+        result2.ExitCode.ShouldBe(0,
+            customMessage: $"second deploy with same release name failed — idempotence broken.\n\n" +
+                          $"STDOUT:\n{result2.StdOut}\n\nSTDERR:\n{result2.StdErr}");
+
+        // Still exactly one site with that name (not duplicated).
+        var siteCount = PowerShellSingleLine(
+            $"(Get-Website | Where-Object {{ $_.Name -eq '{ctx.SiteName}' }} | Measure-Object).Count");
+
+        siteCount.ShouldBe("1",
+            customMessage: "Second deploy produced a duplicate site instead of an update. " +
+                          "The script's existing-site detection (Test-Path IIS:\\Sites\\X) didn't fire.");
+
+        // The site's physicalPath was updated to the new value.
+        var sitePath = PowerShellSingleLine(
+            $"(Get-Website -Name '{ctx.SiteName}').physicalPath");
+
+        sitePath.ShouldBe(newPath,
+            customMessage: "Second deploy didn't update physicalPath — the create-vs-update branch " +
+                          "took the wrong path.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_AppPoolFrameworkVersionV2_AppliedToMetabase()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolFrameworkVersion, "v2.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}]")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, $"deploy failed: {result.StdErr}");
+
+        var poolRuntime = PowerShellSingleLine(
+            $"(Get-ItemProperty IIS:\\AppPools\\{ctx.PoolName} -Name managedRuntimeVersion).Value");
+
+        poolRuntime.ShouldBe("v2.0",
+            customMessage: "Framework version not applied to the app pool. The script's " +
+                          "`Set-ItemProperty managedRuntimeVersion` didn't run or ran with the wrong value.");
+
+        ctx.MarkClean();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Per-test isolation context. Every test gets unique site / pool / physicalPath
+    /// names suffixed with a GUID so concurrent CI runs and re-runs after a failure
+    /// don't collide on IIS metabase entries. <see cref="Dispose"/> best-effort
+    /// removes the entries so a failing test never leaves IIS state pollution that
+    /// breaks the next test.
+    /// </summary>
+    private sealed class IISTestContext : IDisposable
+    {
+        private readonly string _suffix = Guid.NewGuid().ToString("N")[..8];
+        private readonly List<string> _tempDirsToClean = new();
+        private bool _markedClean;
+
+        public IISTestContext()
+        {
+            SiteName = $"SquidIISE2E-{_suffix}";
+            PoolName = $"SquidIISE2EPool-{_suffix}";
+            PhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-e2e-{_suffix}");
+            HttpPort = PickFreePort();
+
+            Directory.CreateDirectory(PhysicalPath);
+            _tempDirsToClean.Add(PhysicalPath);
+        }
+
+        public string SiteName { get; }
+        public string PoolName { get; }
+        public string PhysicalPath { get; }
+        public string HttpPort { get; }
+
+        public void RegisterTempDirForCleanup(string path) => _tempDirsToClean.Add(path);
+
+        public void MarkClean() => _markedClean = true;
+
+        public void Dispose()
+        {
+            // Best-effort: even if the test passed (MarkClean) we still tear down IIS state
+            // so the next class instance starts clean.
+            if (OperatingSystem.IsWindows() && IsIISInstalled())
+            {
+                TryPowerShell($"Remove-Website -Name '{SiteName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{PoolName}' -ErrorAction SilentlyContinue");
+            }
+
+            foreach (var dir in _tempDirsToClean)
+            {
+                try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+                catch { /* best-effort */ }
+            }
+
+            // If MarkClean wasn't called and we're on a CI runner, leave a hint in the log so
+            // post-mortem diagnostics know to dump IIS state on failure.
+            if (!_markedClean && OperatingSystem.IsWindows())
+                Console.WriteLine($"[IISTestContext.Dispose] Test did not call MarkClean — possible failure path. Site='{SiteName}', Pool='{PoolName}'.");
+        }
+
+        /// <summary>
+        /// Bind a free localhost port via TcpListener(0) then release it. CI runs may have
+        /// 80 already taken by IIS Default Web Site; using a dynamic port avoids that conflict.
+        /// </summary>
+        private static string PickFreePort()
+        {
+            using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Short hand for the action-property names. We use string literals here
+    /// (not the <c>IISDeployProperties</c> internal constants) so this test file
+    /// remains decoupled from the production internal API — a refactor that renames
+    /// the constant should fail the unit test (which pins names) before reaching
+    /// this E2E.
+    /// </summary>
+    private static class Property
+    {
+        public const string CreateOrUpdateWebSite = "Squid.Action.IISWebSite.CreateOrUpdateWebSite";
+        public const string WebSiteName = "Squid.Action.IISWebSite.WebSiteName";
+        public const string ApplicationPoolName = "Squid.Action.IISWebSite.ApplicationPoolName";
+        public const string ApplicationPoolIdentityType = "Squid.Action.IISWebSite.ApplicationPoolIdentityType";
+        public const string ApplicationPoolFrameworkVersion = "Squid.Action.IISWebSite.ApplicationPoolFrameworkVersion";
+        public const string WebRoot = "Squid.Action.IISWebSite.WebRoot";
+        public const string Bindings = "Squid.Action.IISWebSite.Bindings";
+        public const string StartApplicationPool = "Squid.Action.IISWebSite.StartApplicationPool";
+        public const string StartWebSite = "Squid.Action.IISWebSite.StartWebSite";
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "IIS WebSite (E2E)",
+            ActionType = "Squid.DeployToIISWebSite",
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+
+    private static bool IsIISInstalled()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+
+        try
+        {
+            var result = RunPowerShell("(Get-WindowsFeature Web-WebServer -ErrorAction SilentlyContinue).Installed");
+            return result.ExitCode == 0 && result.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Convenience for one-line state queries against IIS metabase. Wraps
+    /// the value in a <c>Write-Host</c> so we get clean stdout without prompt noise.
+    /// </summary>
+    private static string PowerShellSingleLine(string command)
+    {
+        var script = $"Import-Module WebAdministration; Write-Host -NoNewline ({command})";
+        var result = RunPowerShell(script);
+        return result.StdOut.Trim();
+    }
+
+    private static void TryPowerShell(string command)
+    {
+        try { RunPowerShell($"Import-Module WebAdministration -ErrorAction SilentlyContinue; {command}"); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    private static PsResult RunPowerShell(string script)
+    {
+        // Use powershell.exe (Windows PowerShell 5.1) explicitly because the
+        // IIS WebAdministration module's idiomatic surface (`IIS:\Sites\X`,
+        // `Get-Website`, etc.) is most reliable on 5.1. The script body's
+        // outer wrapper handles PS 7+ via compat session, but for the runtime
+        // test harness staying on 5.1 avoids that branch and isolates the
+        // failure mode to script logic.
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardInputEncoding = Encoding.UTF8,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
+        };
+
+        using var process = Process.Start(startInfo)!;
+        process.StandardInput.Write(script);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(TimeSpan.FromMinutes(2));
+
+        return new PsResult(process.ExitCode, stdout, stderr);
+    }
+
+    private sealed record PsResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
@@ -222,4 +222,37 @@ public static class WindowsUpgradeE2ECategories
     /// <c>win-x64</c> bundle that won't run on macOS / Linux.</para>
     /// </summary>
     public const string TentacleBinary = "WindowsTentacleBinaryE2E";
+
+    /// <summary>
+    /// E2E coverage for the production
+    /// <c>Squid.DeployToIISWebSite</c> action's PowerShell payload against
+    /// a real Windows host with real IIS installed. Drives
+    /// <c>IISDeployScriptBuilder.Build(action)</c> to produce the same
+    /// script the dispatch path would ship, then executes it via real
+    /// <c>powershell.exe</c> and verifies cluster-equivalent state via
+    /// <c>Get-Website</c> / <c>Get-WebAppPool</c> / <c>Get-WebBinding</c>.
+    ///
+    /// <para><b>Tier</b>: 🟢 High-fidelity (Rule 12). Real IIS, real
+    /// PowerShell, real <c>WebAdministration</c> module, real metabase
+    /// state. The only seam vs an end-to-end deploy from a Squid server
+    /// is the Halibut RPC layer between server and agent — that layer is
+    /// covered by <see cref="TentacleDeploy"/> and is intentionally
+    /// out-of-scope here so this suite can run on
+    /// <c>windows-latest</c> without spinning up a server-side stack.</para>
+    ///
+    /// <para><b>Coverage delta vs the pipeline-tier
+    /// <c>IISDeployPipelineE2ETests</c> in <c>Squid.E2ETests</c></b>: that
+    /// category asserts the rendered <c>ScriptExecutionRequest</c> shape
+    /// (medium-mock — <c>CapturingExecutionStrategy</c>); this category
+    /// proves the script actually does the right thing to real IIS
+    /// metabase state. Both ship in the same PR so a regression in
+    /// either rendering OR runtime is caught.</para>
+    ///
+    /// <para>Windows-only — requires <c>Web-WebServer</c> Windows feature
+    /// installed. CI workflow installs it before invoking the test step;
+    /// local devs without IIS see a clean skip via
+    /// <c>if (!OperatingSystem.IsWindows()) return;</c> + per-test
+    /// <c>Get-WindowsFeature</c> probe.</para>
+    /// </summary>
+    public const string IISDeploy = "IISDeployE2E";
 }


### PR DESCRIPTION
## Summary

- Introduces the `Squid.DeployToIISWebSite` action type for Windows Tentacle (Polling + Listening) targets
- Mirrors Octopus Calamari's IIS deploy step verbatim — every line of deployment logic in the embedded `DeployToIISWebSite.ps1` is byte-identical to Octopus's `Octopus.Features.IISWebSite_BeforePostDeploy.ps1` after one mechanical substitution (`Octopus.` → `Squid.`, `$OctopusParameters` → `$SquidParameters`)
- Diverges only at the dispatch seam: Squid pre-renders the `$SquidParameters` hashtable on the server (Path A in the implementation plan) instead of relying on a Calamari runtime bootstrapper that `Squid.Tentacle` doesn't yet emit for PowerShell — so this PR ships without requiring a Tentacle binary upgrade

## What ships

| Component | Lines | Purpose |
|---|---|---|
| `SpecialVariables.ActionTypes.DeployToIISWebSite` | +2 | New action-type constant + entry in the `All` set |
| `IISDeployProperties` | 100 | 30+ `Squid.Action.IISWebSite.*` constants matching Octopus's taxonomy 1:1 |
| `IISDeployScriptBuilder` | 150 | Server-side preamble generation with PowerShell single-quote escape (doubling apostrophes, collapsing newlines) |
| `IISDeployActionHandler` | 75 | Auto-registered via `IScopedDependency`; emits `RunScriptIntent` with `Syntax = PowerShell`; OS guard rejects known non-Windows targets with an actionable error |
| `DeployToIISWebSite.ps1` (embedded) | 850 | Verbatim port of Octopus's IIS deploy script — mutex, retry loop, app-pool setup, SNI handling, `netsh http add sslcert`, `appcmd.exe` auth toggles, PS-7.3 compat-session wrapper |
| `TentaclePollingTransport` / `TentacleListeningTransport` | +1 each | Declare `DeployToIISWebSite` in `SupportedActionTypes` |

## Test plan — three tiers, all green locally

- [x] **Unit** (33 new tests, full suite 5162 / 5162 green)
  - `IISDeployScriptBuilderTests` — preamble generation, hashtable coverage of every recognised property, single-quote escape rules, newline collapse for multi-line JSON, adversarial-input containment (apostrophe in `O'Brien` username; PowerShell-injection attempt in WebSiteName)
  - `IISDeployActionHandlerTests` — intent emission, syntax / step-name / action-name propagation, OS-guard Theory matrix (Linux / Darwin / FreeBSD rejected with actionable messages; Windows accepted; cache-miss / empty-string proceed optimistically)
  - `IISDeployScriptDriftDetectorTests` (Rule 12.5 mirror-tier guard) — structural invariants for every critical operation; soft comparison against the upstream Octopus reference path when checked out locally; namespace-leak check on executable lines
- [x] **E2E pipeline-tier** (`IISDeployPipelineE2ETests`) — full Squid pipeline via `DeploymentPipelineFixture` + `CapturingExecutionStrategy`, Theory across `TentaclePolling` + `TentacleListening`. Asserts script-body shape (PowerShell syntax, preamble assignments, embedded body contents, multi-line bindings JSON collapsed onto one line)
- [ ] **E2E execution-tier (real Windows IIS host)** — deferred to a follow-up PR; requires a Windows runner with `IIS-WebServerRole` enabled

## Out of scope (future phases per the implementation plan)

- Phase 2: HTTPS bindings + cert variable resolution — the embedded PS1 already has all the code paths (`netsh http add sslcert`, SNI flag handling), only test coverage will be added
- Phase 3: Authentication toggles (Anonymous / Basic / Windows) — same: PS1 code present, dedicated tests deferred
- Phase 4: Web Application + Virtual Directory deployment types — the `CreateOrUpdate` toggles for each are in `IISDeployProperties` and the PS1 branches exist (dormant when toggle defaults to false), tests deferred
- Phase 5: Real-Windows execution-tier E2E — needs `windows-latest` GitHub runner with IIS feature enabled

## Breaking-change risk

None. The change is purely additive — new action type, new constants, new handler, embedded resource. The two existing transport files gain one entry in `SupportedActionTypes`, which is a list addition (no removals / renames). No public-API signature changes. No DB migration. No env-var-driven behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)