### PR TITLE
Add HTTPS bindings to IIS deploy step (Phase 2)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -342,10 +342,10 @@ $DeployIISScriptBlock = {
 				throw "`"$virtualPath`" already exists in IIS and points to a Web Application. We cannot automatically change this to a Virtual Directory on your behalf. Please delete it and then re-deploy the project."
 			} else {
 				if (!(Is-Directory -Path $physicalPath)) {
-					throw "`"$virtualPath`" already exists in IIS and points to an unknown item which isn't a directory. Please delete it and then re-deploy the project. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Virtual Directory on your behalf."
+					throw "`"$virtualPath`" already exists in IIS and points to an unknown item which isn't a directory. Please delete it and then re-deploy the project. If you specified a custom Physical Path that targets this location, switch back to the default location and let Squid update the Physical Path of the Virtual Directory on your behalf."
 				}
-				
-				Write-Host "`"$virtualPath`" already exists in IIS and points to an unknown item which seems to be a directory. We will try to convert it to a Virtual Directory. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Virtual Directory on your behalf."
+
+				Write-Host "`"$virtualPath`" already exists in IIS and points to an unknown item which seems to be a directory. We will try to convert it to a Virtual Directory. If you specified a custom Physical Path that targets this location, switch back to the default location and let Squid update the Physical Path of the Virtual Directory on your behalf."
 				Execute-WithRetry { 
 					New-Item $fullPathToLastVirtualPathSegment -type VirtualDirectory -physicalPath $physicalPath
 				}
@@ -400,10 +400,10 @@ $DeployIISScriptBlock = {
 				throw "`"$virtualPath`" already exists in IIS and points to a Virtual Directory. We cannot automatically change this to a Web Application on your behalf. Please delete it and then re-deploy the project."
 			} else {
 				if (!(Is-Directory -Path $physicalPath)) {
-					throw "`"$virtualPath`" already exists in IIS and points to an unknown item which isn't a directory. Please delete it and then re-deploy the project. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Web Application on your behalf."
+					throw "`"$virtualPath`" already exists in IIS and points to an unknown item which isn't a directory. Please delete it and then re-deploy the project. If you specified a custom Physical Path that targets this location, switch back to the default location and let Squid update the Physical Path of the Web Application on your behalf."
 				}
-				
-				Write-Host "`"$virtualPath`" already exists in IIS and points to an unknown item which seems to be a directory. We will try to convert it to a Web Application. If you used the Custom Installation Directory feature to target this path we recommend removing the Custom Installation Directory feature, instead allowing Octopus to unpack the files into the default location and update the Physical Path of the Web Application on your behalf."
+
+				Write-Host "`"$virtualPath`" already exists in IIS and points to an unknown item which seems to be a directory. We will try to convert it to a Web Application. If you specified a custom Physical Path that targets this location, switch back to the default location and let Squid update the Physical Path of the Web Application on your behalf."
 				Execute-WithRetry { 
 					New-Item $fullPathToLastVirtualPathSegment -type Application -physicalPath $physicalPath
 				}
@@ -499,15 +499,18 @@ $DeployIISScriptBlock = {
 		# For any HTTPS bindings, ensure the certificate is configured for the IP/port combination
 		$wsbindings | where-object { $_.protocol -eq "https" } | foreach-object {
 
-			# If an Octopus-managed certificate variable is supplied, it will have been installed in the store earlier
-			# in the deployment process
+			# Squid certificate-variable system (forward-compatible with future phases): when the binding
+			# references a named variable, the script reads its sibling ".Thumbprint" property from
+			# $SquidParameters. Until the cert-variable feature ships, operators use the direct
+			# `thumbprint` field on the binding, which points at a cert already installed in
+			# LocalMachine\My on the target Tentacle.
 			if ($_.certificateVariable) {
 				$sslCertificateThumbprint = $SquidParameters[$_.certificateVariable + ".Thumbprint"]
 			} elseif ($_.thumbprint){
 				# Otherwise, the certificate thumbprint was supplied directly in the binding
 				$sslCertificateThumbprint = $_.thumbprint.Trim()
 			} else {
-				[Console]::Error.WriteLine("To configure an HTTPS binding please choose a certificate which is managed by Octopus, or provide the thumbprint for a certificate which is already available in the Machine certificate store.")
+				[Console]::Error.WriteLine("To configure an HTTPS binding, provide the `thumbprint` field on the binding pointing at a certificate already installed in LocalMachine\My on the target Tentacle.")
 				exit 1
 			}
 

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -141,6 +141,72 @@ public class IISDeployPipelineE2ETests
         bindingsLine.ShouldContain("\"thumbprint\":\"ABCD1234\"");
     }
 
+    // ── Variable substitution on HTTPS cert thumbprint (Phase 2) ──────────
+
+    [Theory]
+    [InlineData("TentaclePolling", false)]    // plaintext Squid variable
+    [InlineData("TentaclePolling", true)]     // sensitive Squid variable (encrypted at rest)
+    [InlineData("TentacleListening", false)]
+    [InlineData("TentacleListening", true)]
+    public async Task FullPipeline_HttpsBindingThumbprintReferencesSquidVariable_IsResolvedBeforeDispatch(
+        string communicationStyle, bool isSensitive)
+    {
+        // Realistic operator workflow: cert thumbprint stored as a Squid variable
+        // (so it can rotate without re-editing every deploy spec). Bindings JSON
+        // references it via `#{CertThumbprint}`. The pipeline's
+        // `ExpandActionProperties` stage MUST resolve the reference BEFORE the
+        // builder serialises the JSON into the preamble — otherwise the agent
+        // sees a literal `#{CertThumbprint}` and `Get-ChildItem Cert:\LocalMachine\My`
+        // throws an unfindable-thumbprint error.
+        //
+        // Sensitive flag exercised: sensitive variables go through the encrypted
+        // `sensitiveVariables.json` channel on the agent but must still resolve
+        // their value at expansion time on the server. Theory pins both shapes.
+        ExecutionCapture.Clear();
+
+        const string resolvedThumbprint = "ABCDEF0123456789ABCDEF0123456789ABCDEF01";
+
+        var serverTaskId = await SeedIISWebSiteWithVariableAsync(
+            communicationStyle,
+            variableName: "CertThumbprint",
+            variableValue: resolvedThumbprint,
+            isSensitive: isSensitive,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi-Https",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Https-Pool",
+                ["Squid.Action.IISWebSite.Bindings"] =
+                    "[{\"protocol\":\"https\",\"port\":\"443\",\"host\":\"\"," +
+                    "\"ipAddress\":\"*\",\"thumbprint\":\"#{CertThumbprint}\"," +
+                    "\"requireSni\":false,\"enabled\":true}]"
+            });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        var bindingsLine = captured.ScriptBody
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        bindingsLine.ShouldContain($"\"thumbprint\":\"{resolvedThumbprint}\"",
+            customMessage:
+                "Variable substitution didn't resolve #{CertThumbprint} before the builder serialised. " +
+                "If this assertion fails the agent will see a literal '#{CertThumbprint}' string and " +
+                "fail with `Could not find certificate under Cert:\\LocalMachine with thumbprint #{CertThumbprint}`. " +
+                "Check the order of `ExpandActionProperties` vs the handler's `DescribeIntentAsync` call " +
+                $"in DeploymentTaskExecutor.Execute.cs. Captured assignment:\n  {bindingsLine}");
+
+        // Defence-in-depth: the unresolved template must NOT remain anywhere in the script body.
+        captured.ScriptBody.ShouldNotContain("#{CertThumbprint}");
+    }
+
     // ── Theory matrix coverage of Tentacle communication-style dispatch ───
 
     [Theory]
@@ -177,7 +243,27 @@ public class IISDeployPipelineE2ETests
 
     // ── Seeder ─────────────────────────────────────────────────────────────
 
-    private async Task<int> SeedIISWebSiteAsync(string communicationStyle, Dictionary<string, string> properties)
+    private Task<int> SeedIISWebSiteWithVariableAsync(
+        string communicationStyle, string variableName, string variableValue,
+        bool isSensitive, Dictionary<string, string> properties)
+    {
+        // Thin overload: forwards to the main seeder with a single-entry variable list.
+        // Kept separate so the existing tests (no variables) don't have to thread a
+        // null/empty list through their call sites.
+        return SeedIISWebSiteInternalAsync(
+            communicationStyle, properties,
+            variables: new[] { (variableName, variableValue, isSensitive) });
+    }
+
+    private Task<int> SeedIISWebSiteAsync(string communicationStyle, Dictionary<string, string> properties)
+    {
+        return SeedIISWebSiteInternalAsync(communicationStyle, properties, variables: null);
+    }
+
+    private async Task<int> SeedIISWebSiteInternalAsync(
+        string communicationStyle,
+        Dictionary<string, string> properties,
+        (string Name, string Value, bool IsSensitive)[]? variables)
     {
         var suffix = Guid.NewGuid().ToString("N")[..6];
         var serverTaskId = 0;
@@ -189,6 +275,10 @@ public class IISDeployPipelineE2ETests
             var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
             var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
             await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            if (variables != null)
+                foreach (var v in variables)
+                    await builder.CreateVariableAsync(variableSet.Id, v.Name, v.Value, isSensitive: v.IsSensitive).ConfigureAwait(false);
 
             var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
             await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -149,6 +149,108 @@ public class IISDeployScriptBuilderTests
         bindingsAssignmentLine.ShouldNotContain("\n");
     }
 
+    // ── HTTPS bindings (Phase 2) ───────────────────────────────────────────
+    //
+    // The builder treats the Bindings string as opaque JSON — these tests pin the contract
+    // that operator-supplied HTTPS payloads survive the escape pipeline byte-for-byte so
+    // the agent-side ConvertFrom-Json + netsh-cert-binding paths receive exactly what the
+    // operator configured.
+
+    [Fact]
+    public void Build_HttpsBindingWithDirectThumbprint_FlowsThroughAssignmentLine()
+    {
+        // Direct-thumbprint path: the operator points at a cert already installed in
+        // LocalMachine\My on the target Tentacle. This is the only HTTPS path Squid
+        // supports in Phase 2 (Squid cert-variable system is future work).
+        const string thumbprint = "ABCDEF0123456789ABCDEF0123456789ABCDEF01";
+        var bindings =
+            "[{\"protocol\":\"https\",\"port\":\"443\",\"host\":\"\",\"ipAddress\":\"*\"," +
+            $"\"thumbprint\":\"{thumbprint}\",\"requireSni\":false,\"enabled\":true}}]";
+
+        var action = BuildAction((IISDeployProperties.Bindings, bindings));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        var assignmentLine = script
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        assignmentLine.ShouldContain("\"protocol\":\"https\"");
+        assignmentLine.ShouldContain($"\"thumbprint\":\"{thumbprint}\"");
+        assignmentLine.ShouldContain("\"requireSni\":false");
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("false")]
+    public void Build_HttpsBinding_RequireSniFlag_PreservedVerbatim(string sniFlag)
+    {
+        // The PS1 reads `$binding.requireSni` and the SNI/non-SNI branch picks
+        // `netsh http add sslcert hostnameport=…` vs `ipport=…`. The builder must
+        // not silently coerce the flag — Theory pins both values.
+        var bindings =
+            "[{\"protocol\":\"https\",\"port\":\"443\",\"host\":\"orders.example.com\"," +
+            "\"thumbprint\":\"ABCDEF0123456789ABCDEF0123456789ABCDEF01\"," +
+            $"\"requireSni\":{sniFlag},\"enabled\":true}}]";
+
+        var action = BuildAction((IISDeployProperties.Bindings, bindings));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var assignmentLine = script
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        assignmentLine.ShouldContain($"\"requireSni\":{sniFlag}");
+    }
+
+    [Fact]
+    public void Build_HttpsBindingWithCertificateVariableReference_PassesThroughForFutureCertVariableSystem()
+    {
+        // Forward-compat: the PS1's HTTPS path supports `$binding.certificateVariable`
+        // which the script resolves by reading `$SquidParameters[<varname>.Thumbprint]`.
+        // Squid's cert-variable system isn't shipped yet, but the binding shape must
+        // round-trip cleanly so when it does ship there's no plumbing rewrite needed.
+        var bindings =
+            "[{\"protocol\":\"https\",\"port\":\"443\",\"host\":\"\",\"ipAddress\":\"*\"," +
+            "\"certificateVariable\":\"OrderApiCert\",\"requireSni\":false,\"enabled\":true}]";
+
+        var action = BuildAction((IISDeployProperties.Bindings, bindings));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var assignmentLine = script
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        assignmentLine.ShouldContain("\"certificateVariable\":\"OrderApiCert\"");
+    }
+
+    [Fact]
+    public void Build_MixedHttpAndHttpsBindings_BothLandInSingleAssignmentLine()
+    {
+        // A common production layout: port 80 redirects to port 443. The Bindings JSON
+        // is one array with both entries; the builder must keep them on a single line.
+        var bindings =
+            "[" +
+            "{\"protocol\":\"http\",\"port\":\"80\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}," +
+            "{\"protocol\":\"https\",\"port\":\"443\",\"host\":\"\",\"ipAddress\":\"*\"," +
+            "\"thumbprint\":\"ABCDEF0123456789ABCDEF0123456789ABCDEF01\"," +
+            "\"requireSni\":false,\"enabled\":true}" +
+            "]";
+
+        var action = BuildAction((IISDeployProperties.Bindings, bindings));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var assignmentLine = script
+            .Split('\n')
+            .Single(l => l.Contains("$SquidParameters['Squid.Action.IISWebSite.Bindings'] ="));
+
+        assignmentLine.ShouldContain("\"protocol\":\"http\"");
+        assignmentLine.ShouldContain("\"protocol\":\"https\"");
+        assignmentLine.ShouldContain("\"port\":\"80\"");
+        assignmentLine.ShouldContain("\"port\":\"443\"");
+        assignmentLine.ShouldNotContain("\n");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -181,6 +181,44 @@ public class IISDeployScriptDriftDetectorTests
                 "Rename to $SquidParameters and re-commit.");
     }
 
+    /// <summary>
+    /// Belt-and-braces follow-up to <see cref="EmbeddedScript_DoesNotLeakAnyOctopusNamespace_InExecutableLines"/>.
+    /// That test only catches the two namespace identifiers (<c>Octopus.Action.IISWebSite</c>,
+    /// <c>$OctopusParameters</c>). This test catches the broader category of operator-facing
+    /// "Octopus" brand mentions in error messages, comments, and prose that the namespace
+    /// rename misses — exactly the leaks Phase 2 cleaned up at lines 345/348/403/406/502/510
+    /// of the embedded script.
+    ///
+    /// <para>One operational literal is whitelisted: <c>Global\Octopus-IIS-Metabase-Mutex</c>.
+    /// This mutex name is shared across vendors so that an Octopus Tentacle and a Squid
+    /// Tentacle running side-by-side on the same Windows host serialize their IIS metabase
+    /// edits through one mutex instead of racing. Renaming it would break that interop.</para>
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_NoOctopusBrandInExecutableText_ExceptInteropMutexLiteral()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        // The mutex literal MUST stay byte-identical to Octopus's for cross-vendor coordination.
+        const string allowedMutexLiteral = "Octopus-IIS-Metabase-Mutex";
+
+        var leakingLine = ourScript
+            .Split('\n')
+            .Where(line => !line.TrimStart().StartsWith('#'))                   // skip PS comment lines
+            .Where(line => line.Contains("Octopus", StringComparison.OrdinalIgnoreCase))
+            .Where(line => !line.Contains(allowedMutexLiteral, StringComparison.Ordinal))
+            .FirstOrDefault();
+
+        leakingLine.ShouldBeNull(
+            customMessage:
+                "Squid's embedded PS1 has an operator-facing 'Octopus' brand reference in executable text:\n" +
+                $"  {leakingLine}\n\n" +
+                "Rename to 'Squid' (or drop the Octopus-specific feature reference entirely) and re-commit. " +
+                $"The ONLY whitelisted 'Octopus' literal is the cross-vendor mutex name " +
+                $"'{allowedMutexLiteral}' — renaming that would break interop with Octopus Tentacles " +
+                "on the same host. Any other 'Octopus' word in executable code is a porting oversight.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -232,6 +232,217 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── HTTPS binding scenarios (Phase 2) ───────────────────────────────────
+    //
+    // The deploy script's HTTPS branch (PS1 lines 499-608) reads the per-binding
+    // `thumbprint`, finds the cert in `Cert:\LocalMachine\My`, then runs
+    // `netsh http add sslcert ipport=...` (non-SNI) or `hostnameport=...` (SNI).
+    // These tests stage a real self-signed cert in the local machine store, deploy,
+    // then assert the metabase binding lands AND the netsh sslcert table shows
+    // the cert thumbprint in the expected form.
+
+    [Fact]
+    public void RealIIS_HttpsBindingNonSni_RegistersCertViaNetshIpport()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var thumbprint = ctx.StageSelfSignedCertInLocalMachineMy(dnsName: $"squid-iis-nonsni-{Guid.NewGuid():N}");
+        ctx.RegisterNetshIpPortForCleanup(ctx.HttpsPort);
+
+        var bindingsJson =
+            "[{\"protocol\":\"https\",\"port\":\"" + ctx.HttpsPort + "\",\"host\":\"\"," +
+            "\"ipAddress\":\"*\",\"thumbprint\":\"" + thumbprint + "\"," +
+            "\"requireSni\":false,\"enabled\":true}]";
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, bindingsJson),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True")));
+
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                "Squid IIS HTTPS-non-SNI deploy failed. To diagnose manually: " +
+                $"`Get-ChildItem Cert:\\LocalMachine\\My\\{thumbprint}` and " +
+                $"`netsh http show sslcert ipport=0.0.0.0:{ctx.HttpsPort}`.\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // netsh sslcert table MUST show the cert thumbprint under ipport=0.0.0.0:<port>.
+        var netshDump = RunPowerShell($"& netsh http show sslcert ipport=0.0.0.0:{ctx.HttpsPort}").StdOut;
+        netshDump.ToUpperInvariant().ShouldContain(thumbprint.ToUpperInvariant(),
+            customMessage:
+                $"netsh http show sslcert ipport=0.0.0.0:{ctx.HttpsPort} did NOT show our cert thumbprint. " +
+                $"This means either the binding wasn't created OR was created against a different port/IP. " +
+                $"Manually: `netsh http show sslcert` to dump every binding.\n\nnetsh output:\n{netshDump}");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_HttpsBindingSni_RegistersCertViaNetshHostnameport()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var hostName = $"squid-iis-sni-{Guid.NewGuid():N}.local";
+        var thumbprint = ctx.StageSelfSignedCertInLocalMachineMy(dnsName: hostName);
+        ctx.RegisterNetshHostnamePortForCleanup(hostName, ctx.HttpsPort);
+
+        var bindingsJson =
+            "[{\"protocol\":\"https\",\"port\":\"" + ctx.HttpsPort + "\",\"host\":\"" + hostName + "\"," +
+            "\"ipAddress\":\"*\",\"thumbprint\":\"" + thumbprint + "\"," +
+            "\"requireSni\":true,\"enabled\":true}]";
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, bindingsJson),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True")));
+
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                "Squid IIS HTTPS-SNI deploy failed. To diagnose manually: " +
+                $"`Get-ChildItem Cert:\\LocalMachine\\My\\{thumbprint}` and " +
+                $"`netsh http show sslcert hostnameport={hostName}:{ctx.HttpsPort}`.\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // netsh sslcert table MUST show our cert thumbprint under hostnameport=<host>:<port>.
+        var netshDump = RunPowerShell($"& netsh http show sslcert hostnameport={hostName}:{ctx.HttpsPort}").StdOut;
+        netshDump.ToUpperInvariant().ShouldContain(thumbprint.ToUpperInvariant(),
+            customMessage:
+                $"netsh http show sslcert hostnameport={hostName}:{ctx.HttpsPort} did NOT show our cert thumbprint. " +
+                $"SNI handling broken — check `$_.sslFlags -eq 1` branch in PS1 (line 548). " +
+                $"netsh output:\n{netshDump}");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_HttpsBindingWithMissingCert_FailsWithLocalMachineMyError()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        const string missingThumbprint = "FAKE0000000000000000000000000000DEADBEEF";
+
+        var bindingsJson =
+            "[{\"protocol\":\"https\",\"port\":\"" + ctx.HttpsPort + "\",\"host\":\"\"," +
+            "\"ipAddress\":\"*\",\"thumbprint\":\"" + missingThumbprint + "\"," +
+            "\"requireSni\":false,\"enabled\":true}]";
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, bindingsJson)));
+
+        var result = RunPowerShell(script);
+
+        // The script throws when the cert lookup misses; PowerShell surfaces the throw via
+        // non-zero exit + the error text we Squid-fied at line 531 of the embedded PS1.
+        result.ExitCode.ShouldNotBe(0,
+            customMessage: "Missing-cert deploy unexpectedly succeeded — the PS1's " +
+                          $"`Could not find certificate under Cert:\\LocalMachine with thumbprint` " +
+                          $"guard at line 531 is broken or wasn't reached.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var combinedOutput = result.StdOut + result.StdErr;
+        combinedOutput.ShouldContain("Could not find certificate",
+            customMessage:
+                "Cert-missing error did not contain the actionable 'Could not find certificate' phrase. " +
+                "Operators rely on grepping this exact phrase to triage. If this assertion fails, the PS1 " +
+                "error message at line 531 was renamed without updating this test.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_HttpsBindingRebindToDifferentCert_ReplacesPreviousNetshEntry()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        ctx.RegisterNetshIpPortForCleanup(ctx.HttpsPort);
+
+        var thumbprintA = ctx.StageSelfSignedCertInLocalMachineMy(dnsName: $"squid-iis-rotateA-{Guid.NewGuid():N}");
+        var thumbprintB = ctx.StageSelfSignedCertInLocalMachineMy(dnsName: $"squid-iis-rotateB-{Guid.NewGuid():N}");
+
+        thumbprintA.ShouldNotBe(thumbprintB,
+            customMessage: "Test setup expected two distinct cert thumbprints — both came back identical, " +
+                          "which would make the rebind assertion meaningless.");
+
+        // Deploy 1 — cert A
+        var script1 = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings,
+                "[{\"protocol\":\"https\",\"port\":\"" + ctx.HttpsPort + "\",\"host\":\"\"," +
+                "\"ipAddress\":\"*\",\"thumbprint\":\"" + thumbprintA + "\"," +
+                "\"requireSni\":false,\"enabled\":true}]")));
+
+        RunPowerShell(script1).ExitCode.ShouldBe(0, "First (cert A) deploy must succeed before re-bind can be tested.");
+
+        RunPowerShell($"& netsh http show sslcert ipport=0.0.0.0:{ctx.HttpsPort}").StdOut
+            .ToUpperInvariant().ShouldContain(thumbprintA.ToUpperInvariant(),
+                customMessage: "Cert A binding not present after first deploy — staging issue, not a re-bind issue.");
+
+        // Deploy 2 — cert B against the same site + port, exercising the
+        // `# A different binding exists for the IP/port combination, replacing...` branch.
+        var script2 = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings,
+                "[{\"protocol\":\"https\",\"port\":\"" + ctx.HttpsPort + "\",\"host\":\"\"," +
+                "\"ipAddress\":\"*\",\"thumbprint\":\"" + thumbprintB + "\"," +
+                "\"requireSni\":false,\"enabled\":true}]")));
+
+        var result2 = RunPowerShell(script2);
+        result2.ExitCode.ShouldBe(0,
+            customMessage: $"Re-deploy with cert B failed. STDOUT:\n{result2.StdOut}\n\nSTDERR:\n{result2.StdErr}");
+
+        var finalDump = RunPowerShell($"& netsh http show sslcert ipport=0.0.0.0:{ctx.HttpsPort}").StdOut;
+
+        finalDump.ToUpperInvariant().ShouldContain(thumbprintB.ToUpperInvariant(),
+            customMessage: "After re-deploy with cert B, netsh binding still doesn't show cert B. " +
+                          "The PS1's `netsh http delete sslcert ipport=...` + add-new path may have failed silently.");
+
+        finalDump.ToUpperInvariant().ShouldNotContain(thumbprintA.ToUpperInvariant(),
+            customMessage: "After re-deploy, the OLD cert A is still bound — re-bind replaced nothing. " +
+                          "This means cert rotation in production would leave the previous cert in place " +
+                          "even after the operator changed the thumbprint property.");
+
+        ctx.MarkClean();
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -245,6 +456,9 @@ public sealed class IISDeployRealHostE2ETests
     {
         private readonly string _suffix = Guid.NewGuid().ToString("N")[..8];
         private readonly List<string> _tempDirsToClean = new();
+        private readonly List<string> _certThumbprintsToClean = new();
+        private readonly List<string> _netshIpPortsToClean = new();
+        private readonly List<(string Host, string Port)> _netshHostnamePortsToClean = new();
         private bool _markedClean;
 
         public IISTestContext()
@@ -253,6 +467,7 @@ public sealed class IISDeployRealHostE2ETests
             PoolName = $"SquidIISE2EPool-{_suffix}";
             PhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-e2e-{_suffix}");
             HttpPort = PickFreePort();
+            HttpsPort = PickFreePort();
 
             Directory.CreateDirectory(PhysicalPath);
             _tempDirsToClean.Add(PhysicalPath);
@@ -262,8 +477,48 @@ public sealed class IISDeployRealHostE2ETests
         public string PoolName { get; }
         public string PhysicalPath { get; }
         public string HttpPort { get; }
+        public string HttpsPort { get; }
 
         public void RegisterTempDirForCleanup(string path) => _tempDirsToClean.Add(path);
+
+        /// <summary>
+        /// Imports a self-signed cert into <c>Cert:\LocalMachine\My</c> and registers the
+        /// thumbprint for removal during <see cref="Dispose"/>. Used by HTTPS binding tests
+        /// — the embedded PS1's HTTPS branch reads the cert by thumbprint from this store.
+        /// </summary>
+        /// <param name="dnsName">CN + DNS SAN on the issued cert. Use a unique value per call
+        /// so concurrent tests don't share subjects (the store is process-wide).</param>
+        /// <returns>40-char SHA-1 thumbprint of the issued cert (uppercase hex, no spaces).</returns>
+        public string StageSelfSignedCertInLocalMachineMy(string dnsName)
+        {
+            var result = RunPowerShell(
+                $"$cert = New-SelfSignedCertificate -DnsName '{dnsName}' " +
+                $"-CertStoreLocation Cert:\\LocalMachine\\My -KeyExportPolicy Exportable; " +
+                $"Write-Host -NoNewline $cert.Thumbprint");
+
+            if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.StdOut))
+                throw new InvalidOperationException(
+                    $"Failed to stage self-signed cert. ExitCode={result.ExitCode}, " +
+                    $"StdOut='{result.StdOut}', StdErr='{result.StdErr}'.");
+
+            var thumbprint = result.StdOut.Trim();
+            _certThumbprintsToClean.Add(thumbprint);
+            return thumbprint;
+        }
+
+        /// <summary>
+        /// Tells <see cref="Dispose"/> to run <c>netsh http delete sslcert ipport=0.0.0.0:{port}</c>
+        /// on teardown. Production deploys (non-SNI) leave entries in the netsh sslcert table;
+        /// CI parallelism would accumulate them otherwise.
+        /// </summary>
+        public void RegisterNetshIpPortForCleanup(string port) => _netshIpPortsToClean.Add(port);
+
+        /// <summary>
+        /// Tells <see cref="Dispose"/> to run <c>netsh http delete sslcert hostnameport={host}:{port}</c>
+        /// on teardown. Used by SNI HTTPS binding tests.
+        /// </summary>
+        public void RegisterNetshHostnamePortForCleanup(string host, string port) =>
+            _netshHostnamePortsToClean.Add((host, port));
 
         public void MarkClean() => _markedClean = true;
 
@@ -276,6 +531,19 @@ public sealed class IISDeployRealHostE2ETests
                 TryPowerShell($"Remove-Website -Name '{SiteName}' -ErrorAction SilentlyContinue");
                 TryPowerShell($"Remove-WebAppPool -Name '{PoolName}' -ErrorAction SilentlyContinue");
             }
+
+            // netsh sslcert entries — survive process exit so MUST be torn down explicitly.
+            // Best-effort: ignore errors (entry may not exist if the deploy failed pre-bind).
+            foreach (var port in _netshIpPortsToClean)
+                TryPowerShell($"& netsh http delete sslcert ipport=0.0.0.0:{port} | Out-Null");
+
+            foreach (var (host, port) in _netshHostnamePortsToClean)
+                TryPowerShell($"& netsh http delete sslcert hostnameport={host}:{port} | Out-Null");
+
+            // Cert store entries — removing the cert from the store also revokes any netsh
+            // binding (since the SHA-1 lookup misses), so order matters: netsh first, certs second.
+            foreach (var thumb in _certThumbprintsToClean)
+                TryPowerShell($"Remove-Item Cert:\\LocalMachine\\My\\{thumb} -Force -ErrorAction SilentlyContinue");
 
             foreach (var dir in _tempDirsToClean)
             {


### PR DESCRIPTION
## Summary

- HTTPS binding paths in the embedded `DeployToIISWebSite.ps1` were already byte-identical to Octopus's (`netsh http add sslcert`, SNI branch, cert-thumbprint lookup, rebind-replace logic). This PR adds test coverage at all three tiers + Squid-fies the operator-facing "Octopus" strings the namespace rename missed in Phase 1.
- Cert-variable system (Octopus-style first-class cert variables fanning out to `.Thumbprint` / `.PfxData` / `.Password`) is NOT included — Squid doesn't have it yet. The PS1's `certificateVariable` branch is preserved unchanged for forward compat; a unit test pins the passthrough shape so the future system has nothing to re-plumb. Operators in Phase 2 use the direct `thumbprint` field on the binding, pointing at a cert already installed in `LocalMachine\My` on the target Tentacle.

## What ships

| Component | Notes |
|---|---|
| `DeployToIISWebSite.ps1` Squid-fication | 6 operator-facing "Octopus" mentions (lines 345/348/403/406/502/510) → "Squid" or rewritten without the Octopus-specific feature reference. Mutex literal `Global\Octopus-IIS-Metabase-Mutex` KEPT — that's deliberate cross-vendor interop so a Squid Tentacle and an Octopus Tentacle on the same Windows host serialize their IIS metabase edits through one mutex |
| New drift-detector test | `EmbeddedScript_NoOctopusBrandInExecutableText_ExceptInteropMutexLiteral` — belt-and-braces follow-up to the namespace-leak test; catches the broader category of operator-facing brand mentions in error messages and prose |
| Unit tests for HTTPS shape | 4 new test methods + 1 Theory: thumbprint round-trip, `requireSni` flag preserved verbatim, `certificateVariable` passthrough (future-proof), mixed http+https multi-binding on single assignment line |
| Pipeline-tier E2E | Variable-substitution test: Bindings JSON with `#{CertThumbprint}` reference must be resolved by the pipeline BEFORE the builder serialises. Theory across both Tentacle styles × plaintext/sensitive variable |
| Real-host E2E (🟢 high-fidelity) | 4 new tests against real IIS on `windows-latest`: SNI binding via `netsh hostnameport=`, non-SNI via `netsh ipport=`, missing-cert error path, cert-rotation re-bind (delete-old + add-new) |

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 39 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 9 real-host tests skip cleanly via OS guard
- [x] `dotnet build` clean across `Squid.Core`, `Squid.UnitTests`, `Squid.E2ETests`, `Squid.WindowsTentacleE2ETests` — 0 errors
- [ ] CI run on `windows-latest`: confirm real-IIS HTTPS bindings land in `netsh http show sslcert` table + cert/netsh teardown via Dispose

## Out of scope (future phases)

- Phase 3: Authentication toggles (Anonymous / Basic / Windows) — PS1 `appcmd.exe` branches exist; needs dedicated E2E
- Phase 4: WebApplication + VirtualDirectory deployment types — toggles + PS1 branches exist (dormant in Phase 1+2), tests deferred
- Squid cert-variable system: when shipped, the `certificateVariable` branch lights up; the binding-JSON passthrough is already tested

## Breaking-change risk

None. The PS1 changes are operator-facing string edits (better Squid branding, no functional change). Tests are additive. No public-API signatures changed. No DB migration. No env-var-driven behaviour change.