### PR TITLE
Add authentication toggles to IIS deploy step (Phase 3)

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -69,16 +69,22 @@ jobs:
             --filter $filter `
             --logger "console;verbosity=normal"
 
-      - name: Install IIS feature (Web-WebServer + Management tools)
+      - name: Install IIS feature (Web-WebServer + auth modules + Management tools)
         # Required by Category=IISDeployE2E. Other categories don't need IIS but installing it
         # is cheap on `windows-latest` (~1m) and idempotent, so we always install rather than
         # gating on category. The IIS tests themselves probe `Get-WindowsFeature Web-WebServer`
         # before exercising the metabase so a future split into category-conditional install
         # is mechanical.
+        #
+        # Auth modules (Phase 3): `Web-Basic-Auth` and `Web-Windows-Auth` are NOT part of the
+        # base `Web-WebServer` install. Without them, `appcmd.exe set config /section:basicAuthentication`
+        # fails with "the configuration section 'basicAuthentication' cannot be read because it
+        # is missing a section declaration" — same for windowsAuthentication. Anonymous auth
+        # comes with the base install.
         shell: pwsh
         run: |
-          Install-WindowsFeature -Name Web-WebServer,Web-Mgmt-Console -IncludeManagementTools
-          Get-WindowsFeature Web-WebServer | Format-Table -Property Name, InstallState, DisplayName
+          Install-WindowsFeature -Name Web-WebServer,Web-Mgmt-Console,Web-Basic-Auth,Web-Windows-Auth -IncludeManagementTools
+          Get-WindowsFeature Web-WebServer, Web-Basic-Auth, Web-Windows-Auth | Format-Table -Property Name, InstallState, DisplayName
 
       - name: Restore Squid.WindowsTentacleE2ETests
         shell: pwsh

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -207,6 +207,87 @@ public class IISDeployPipelineE2ETests
         captured.ScriptBody.ShouldNotContain("#{CertThumbprint}");
     }
 
+    // ── Authentication toggle variable substitution (Phase 3) ─────────────
+
+    [Theory]
+    [InlineData("TentaclePolling", "True", "False", "True")]      // anonymous + windows, no basic
+    [InlineData("TentacleListening", "False", "True", "False")]   // basic only
+    public async Task FullPipeline_AuthFlagsReferenceSquidVariables_AllThreeAreResolvedBeforeDispatch(
+        string communicationStyle, string anonValue, string basicValue, string windowsValue)
+    {
+        // Realistic operator workflow: auth posture differs between environments
+        // (dev: anonymous-only; staging/prod: windows-auth required). Operators store
+        // the per-environment flag values as Squid variables and reference them in
+        // the action properties via `#{AnonEnabled}` etc. The pipeline's
+        // `ExpandActionProperties` stage MUST resolve all three before the builder
+        // serialises — otherwise the agent's appcmd call gets `/enabled:#{AnonEnabled}`
+        // and IIS rejects with "the value '#{AnonEnabled}' is not valid for property 'enabled'".
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteInternalAsync(
+            communicationStyle,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "AuthSite",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "AuthSite-Pool",
+                ["Squid.Action.IISWebSite.EnableAnonymousAuthentication"] = "#{AnonEnabled}",
+                ["Squid.Action.IISWebSite.EnableBasicAuthentication"] = "#{BasicEnabled}",
+                ["Squid.Action.IISWebSite.EnableWindowsAuthentication"] = "#{WindowsEnabled}"
+            },
+            variables: new[]
+            {
+                ("AnonEnabled", anonValue, false),
+                ("BasicEnabled", basicValue, false),
+                ("WindowsEnabled", windowsValue, false)
+            }).ConfigureAwait(false);
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        captured.ScriptBody.ShouldContain(
+            $"$SquidParameters['Squid.Action.IISWebSite.EnableAnonymousAuthentication'] = '{anonValue}'",
+            customMessage:
+                "Anonymous auth flag didn't resolve through variable substitution. " +
+                "If this fails the agent's appcmd call sees a literal '#{AnonEnabled}' and IIS rejects. " +
+                "Captured body around that line:\n" +
+                ExtractAroundProperty(captured.ScriptBody, "EnableAnonymousAuthentication"));
+
+        captured.ScriptBody.ShouldContain(
+            $"$SquidParameters['Squid.Action.IISWebSite.EnableBasicAuthentication'] = '{basicValue}'");
+        captured.ScriptBody.ShouldContain(
+            $"$SquidParameters['Squid.Action.IISWebSite.EnableWindowsAuthentication'] = '{windowsValue}'");
+
+        // Defence-in-depth: none of the three #{...} placeholders survive into the script body.
+        captured.ScriptBody.ShouldNotContain("#{AnonEnabled}");
+        captured.ScriptBody.ShouldNotContain("#{BasicEnabled}");
+        captured.ScriptBody.ShouldNotContain("#{WindowsEnabled}");
+    }
+
+    /// <summary>
+    /// Grabs the line containing the named property (if any) + one above for context.
+    /// Helps narrow a failed Should-contain assertion to the specific area without
+    /// dumping the entire 850+-line rendered script into the test output.
+    /// </summary>
+    private static string ExtractAroundProperty(string scriptBody, string propertyToken)
+    {
+        var lines = scriptBody.Split('\n');
+        var idx = Array.FindIndex(lines, l => l.Contains(propertyToken, StringComparison.Ordinal));
+
+        if (idx < 0) return "(property token not found anywhere in script body)";
+
+        var from = Math.Max(0, idx - 1);
+        var to = Math.Min(lines.Length - 1, idx + 1);
+
+        return string.Join("\n", lines[from..(to + 1)]);
+    }
+
     // ── Theory matrix coverage of Tentacle communication-style dispatch ───
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -251,6 +251,85 @@ public class IISDeployScriptBuilderTests
         assignmentLine.ShouldNotContain("\n");
     }
 
+    // ── Authentication toggles (Phase 3) ───────────────────────────────────
+    //
+    // The PS1 reads each `EnableXAuthentication` flag (lines 433-435), then
+    // runs `appcmd.exe set config <site> -section:.../XAuthentication /enabled:<value>`
+    // (lines 781/789/797). These tests pin the contract: the operator's flag
+    // value reaches the preamble byte-for-byte. The PS1's own appcmd plumbing
+    // is exercised at the real-host tier.
+
+    [Theory]
+    [InlineData("True")]
+    [InlineData("False")]
+    [InlineData("true")]                // case variants flow through verbatim — PS1 normalizes
+    [InlineData("false")]
+    public void Build_AnonymousAuthenticationFlag_PassesThroughToPreambleVerbatim(string value)
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "AuthSite"),
+            (IISDeployProperties.EnableAnonymousAuthentication, value));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain(
+            $"$SquidParameters['Squid.Action.IISWebSite.EnableAnonymousAuthentication'] = '{value}'");
+    }
+
+    [Theory]
+    [InlineData("True")]
+    [InlineData("False")]
+    public void Build_BasicAuthenticationFlag_PassesThroughToPreambleVerbatim(string value)
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "AuthSite"),
+            (IISDeployProperties.EnableBasicAuthentication, value));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain(
+            $"$SquidParameters['Squid.Action.IISWebSite.EnableBasicAuthentication'] = '{value}'");
+    }
+
+    [Theory]
+    [InlineData("True")]
+    [InlineData("False")]
+    public void Build_WindowsAuthenticationFlag_PassesThroughToPreambleVerbatim(string value)
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "AuthSite"),
+            (IISDeployProperties.EnableWindowsAuthentication, value));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain(
+            $"$SquidParameters['Squid.Action.IISWebSite.EnableWindowsAuthentication'] = '{value}'");
+    }
+
+    [Fact]
+    public void Build_AllThreeAuthFlagsSet_LandInPreambleIndependently()
+    {
+        // The three flags are emitted to the preamble independently — none of them are
+        // computed from the others. This test catches a regression where someone "helpfully"
+        // makes Anonymous default-true when Basic+Windows are false (or vice versa), which
+        // would silently change behaviour for operators relying on a specific combination.
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "MixedAuthSite"),
+            (IISDeployProperties.EnableAnonymousAuthentication, "False"),
+            (IISDeployProperties.EnableBasicAuthentication, "True"),
+            (IISDeployProperties.EnableWindowsAuthentication, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.EnableAnonymousAuthentication'] = 'False'");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.EnableBasicAuthentication'] = 'True'");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.EnableWindowsAuthentication'] = 'True'");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -443,6 +443,146 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Authentication toggles (Phase 3) ───────────────────────────────────
+    //
+    // The deploy script (PS1 lines 778-806) runs appcmd.exe three times per deploy:
+    // `appcmd set config <site> /section:.../anonymousAuthentication /enabled:<X>`
+    // and the equivalent for basic + windows. These tests verify the operator's
+    // configured flag values land in the IIS metabase, by reading back via the
+    // same appcmd tool. The Theory matrix covers the realistic combinations an
+    // operator picks (anon-only dev / windows-only enterprise / locked-down none /
+    // wide-open all-three).
+    //
+    // Skips: needs Web-Basic-Auth + Web-Windows-Auth Windows features installed.
+    // The workflow installs these; local dev hosts without them see a clean skip.
+
+    [Theory]
+    [InlineData("True", "False", "False")]    // anonymous-only (typical dev)
+    [InlineData("False", "True", "False")]    // basic-only (rare but supported)
+    [InlineData("False", "False", "True")]    // windows-only (typical enterprise intranet)
+    [InlineData("True", "True", "False")]     // anon + basic
+    [InlineData("False", "False", "False")]   // locked-down (all three explicitly off)
+    [InlineData("True", "True", "True")]      // wide-open (every method enabled)
+    public void RealIIS_AuthFlags_MetabaseReflectsConfiguredEnabledStates(
+        string anonEnabled, string basicEnabled, string windowsEnabled)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+        if (!IsIISFeatureInstalled("Web-Basic-Auth")) return;
+        if (!IsIISFeatureInstalled("Web-Windows-Auth")) return;
+
+        using var ctx = new IISTestContext();
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings,
+                "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\"," +
+                "\"ipAddress\":\"*\",\"enabled\":true}]"),
+            (Property.EnableAnonymousAuthentication, anonEnabled),
+            (Property.EnableBasicAuthentication, basicEnabled),
+            (Property.EnableWindowsAuthentication, windowsEnabled),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True")));
+
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Auth-flag deploy failed for combo (anon={anonEnabled}, basic={basicEnabled}, windows={windowsEnabled}). " +
+                $"Manually inspect via `appcmd.exe list config {ctx.SiteName} -section:system.webServer/security/authentication/anonymousAuthentication`.\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var actualAnon = ReadAuthEnabledFlag(ctx.SiteName, "anonymousAuthentication");
+        var actualBasic = ReadAuthEnabledFlag(ctx.SiteName, "basicAuthentication");
+        var actualWindows = ReadAuthEnabledFlag(ctx.SiteName, "windowsAuthentication");
+
+        // appcmd outputs `enabled="true"` / `enabled="false"` (lowercase XML attr).
+        // The operator's configured value can be "True"/"False" (PascalCase, common in Squid)
+        // or "true"/"false". Compare case-insensitively.
+        actualAnon.ToLowerInvariant().ShouldBe(anonEnabled.ToLowerInvariant(),
+            customMessage:
+                $"anonymousAuthentication.enabled in metabase doesn't match configured value. " +
+                $"Configured='{anonEnabled}', actual='{actualAnon}'. " +
+                $"This means the PS1's appcmd call for the anonymous section didn't take effect.");
+
+        actualBasic.ToLowerInvariant().ShouldBe(basicEnabled.ToLowerInvariant(),
+            customMessage:
+                $"basicAuthentication.enabled in metabase doesn't match. Configured='{basicEnabled}', actual='{actualBasic}'.");
+
+        actualWindows.ToLowerInvariant().ShouldBe(windowsEnabled.ToLowerInvariant(),
+            customMessage:
+                $"windowsAuthentication.enabled in metabase doesn't match. Configured='{windowsEnabled}', actual='{actualWindows}'.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_AuthFlag_FlipsOnRedeploy_MetabaseReflectsNewValue()
+    {
+        // Idempotence + change-detection: a redeploy with different auth flags
+        // must produce the new state, not be a no-op. This catches a regression
+        // where a future PR adds "skip if value matches" logic that doesn't account
+        // for an externally-modified config (operator manually toggled in IIS Manager).
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+        if (!IsIISFeatureInstalled("Web-Windows-Auth")) return;
+
+        using var ctx = new IISTestContext();
+
+        // Deploy 1: Anonymous on, Windows off
+        var script1 = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings,
+                "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\"," +
+                "\"ipAddress\":\"*\",\"enabled\":true}]"),
+            (Property.EnableAnonymousAuthentication, "True"),
+            (Property.EnableWindowsAuthentication, "False")));
+
+        RunPowerShell(script1).ExitCode.ShouldBe(0, "First deploy (anon=true, windows=false) must succeed.");
+
+        ReadAuthEnabledFlag(ctx.SiteName, "anonymousAuthentication").ToLowerInvariant().ShouldBe("true");
+        ReadAuthEnabledFlag(ctx.SiteName, "windowsAuthentication").ToLowerInvariant().ShouldBe("false");
+
+        // Deploy 2: Anonymous off, Windows on — opposite of Deploy 1
+        var script2 = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings,
+                "[{\"protocol\":\"http\",\"port\":\"" + ctx.HttpPort + "\",\"host\":\"\"," +
+                "\"ipAddress\":\"*\",\"enabled\":true}]"),
+            (Property.EnableAnonymousAuthentication, "False"),
+            (Property.EnableWindowsAuthentication, "True")));
+
+        var result2 = RunPowerShell(script2);
+        result2.ExitCode.ShouldBe(0,
+            customMessage: $"Redeploy (anon=false, windows=true) failed.\nSTDOUT:\n{result2.StdOut}\n\nSTDERR:\n{result2.StdErr}");
+
+        // Both flags must have FLIPPED — not just stayed at Deploy 1's values.
+        ReadAuthEnabledFlag(ctx.SiteName, "anonymousAuthentication").ToLowerInvariant().ShouldBe("false",
+            customMessage: "Redeploy with anonymous=False didn't flip the metabase from True to False. " +
+                          "The PS1 may have a `skip if already configured` regression.");
+
+        ReadAuthEnabledFlag(ctx.SiteName, "windowsAuthentication").ToLowerInvariant().ShouldBe("true",
+            customMessage: "Redeploy with windows=True didn't flip the metabase from False to True. " +
+                          "Confirm by `appcmd list config " + ctx.SiteName + " -section:system.webServer/security/authentication/windowsAuthentication` after the redeploy.");
+
+        ctx.MarkClean();
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -589,6 +729,9 @@ public sealed class IISDeployRealHostE2ETests
         public const string Bindings = "Squid.Action.IISWebSite.Bindings";
         public const string StartApplicationPool = "Squid.Action.IISWebSite.StartApplicationPool";
         public const string StartWebSite = "Squid.Action.IISWebSite.StartWebSite";
+        public const string EnableAnonymousAuthentication = "Squid.Action.IISWebSite.EnableAnonymousAuthentication";
+        public const string EnableBasicAuthentication = "Squid.Action.IISWebSite.EnableBasicAuthentication";
+        public const string EnableWindowsAuthentication = "Squid.Action.IISWebSite.EnableWindowsAuthentication";
     }
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
@@ -617,6 +760,56 @@ public sealed class IISDeployRealHostE2ETests
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Probes whether a specific Windows-feature sub-module is installed (e.g. <c>Web-Basic-Auth</c>,
+    /// <c>Web-Windows-Auth</c>). Returns false on non-Windows or if the cmdlet fails. Phase 3
+    /// auth tests use this to skip cleanly on hosts where the required IIS auth module isn't
+    /// present — `appcmd set config /section:basicAuthentication` errors out with a "section
+    /// declaration is missing" message otherwise.
+    /// </summary>
+    private static bool IsIISFeatureInstalled(string featureName)
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+
+        try
+        {
+            var result = RunPowerShell($"(Get-WindowsFeature {featureName} -ErrorAction SilentlyContinue).Installed");
+            return result.ExitCode == 0 && result.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads the <c>enabled</c> attribute of the named auth section from the site's effective
+    /// IIS config via the same <c>appcmd.exe</c> tool the PS1 used to set it. Round-tripping
+    /// through appcmd (rather than `Get-WebConfigurationProperty`) ensures we see the exact
+    /// value the deploy committed at apphost level, not an inherited/overridden one.
+    /// </summary>
+    /// <param name="siteName">IIS site name.</param>
+    /// <param name="sectionName">One of <c>anonymousAuthentication</c>, <c>basicAuthentication</c>,
+    /// <c>windowsAuthentication</c>.</param>
+    /// <returns><c>"true"</c> or <c>"false"</c> as appcmd emits them (lowercase XML attr style),
+    /// or a diagnostic string if no match.</returns>
+    private static string ReadAuthEnabledFlag(string siteName, string sectionName)
+    {
+        var ps =
+            $"$output = & \"$env:SystemRoot\\system32\\inetsrv\\appcmd.exe\" list config '{siteName}' " +
+            $"-section:system.webServer/security/authentication/{sectionName}; " +
+            $"$output | Out-String";
+        var output = RunPowerShell(ps).StdOut;
+
+        // Parse `<sectionName ... enabled="X" ... />` from the XML output.
+        var pattern = $"<{System.Text.RegularExpressions.Regex.Escape(sectionName)}\\b[^>]*\\benabled=\"(?<v>[^\"]+)\"";
+        var match = System.Text.RegularExpressions.Regex.Match(output, pattern);
+
+        return match.Success
+            ? match.Groups["v"].Value
+            : $"(no '<{sectionName} ... enabled=...' found in appcmd output: {output.Trim()})";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- The PS1 already had the appcmd.exe plumbing for the three IIS auth modes (Anonymous / Basic / Windows) — lines 433-435 read the flags, lines 778-806 commit them via `appcmd set config /section:.../XAuthentication /enabled:<value> /commit:apphost`. Phase 3 adds end-to-end coverage of the flag flow + verifies the IIS metabase actually reflects the configured state through real `appcmd list config` round-trip.
- Windows CI install step expanded to include `Web-Basic-Auth` and `Web-Windows-Auth` Windows-features. Without them, `appcmd set config /section:basicAuthentication` errors out with "the configuration section 'basicAuthentication' cannot be read because it is missing a section declaration" — Anonymous comes with the base `Web-WebServer` feature, the other two don't.

## What ships

| Component | Notes |
|---|---|
| Workflow update | `Install-WindowsFeature` now adds `Web-Basic-Auth,Web-Windows-Auth` (idempotent; adds ~1m to install step) |
| Unit tests (9 new) | Theory across true/false + case variants for each of the three flags; `Build_AllThreeAuthFlagsSet_LandInPreambleIndependently` Fact pins the independence of the three flags (guards against a regression where someone "helpfully" makes Anonymous default-true when Basic+Windows are false) |
| Pipeline-tier E2E (1 new Theory, 2 cases) | Variable substitution: action property `#{AnonEnabled}` etc. resolves to operator's variable value BEFORE the builder serialises. Defence-in-depth `ShouldNotContain("#{AnonEnabled}")` so a partial-resolution regression surfaces |
| Real-host E2E (7 new tests, 🟢 high-fidelity) | Theory across 6 realistic flag combinations (dev/enterprise/locked-down/wide-open) + idempotence-flip test (deploy 1 sets anon=true/win=false, deploy 2 flips to anon=false/win=true, both states verified via `appcmd list config`). Uses appcmd for round-trip readback (same tool the PS1 uses to set) so we see exactly the apphost-committed value, not an inherited one |

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 48 unit tests green (39 → 48, +9 auth tests)
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 16 real-host tests skip cleanly via OS guard + per-test `Web-Basic-Auth` / `Web-Windows-Auth` feature probes (9 → 16, +7 auth tests)
- [x] `dotnet build` clean across `Squid.UnitTests`, `Squid.E2ETests`, `Squid.WindowsTentacleE2ETests` — 0 errors
- [ ] CI run on `windows-latest`: install Basic+Windows auth modules, run new auth tests against real IIS, verify appcmd round-trip

## Out of scope (future phases)

- Phase 4: WebApplication + VirtualDirectory deployment types — toggles + PS1 branches exist (dormant in Phase 1+2+3), tests deferred
- Cert-variable system: Octopus-style first-class cert variables (`#{MyCert.Thumbprint}`, `#{MyCert.PfxData}`). Squid doesn't have it yet; the `certificateVariable` field in HTTPS bindings JSON is preserved as a forward-compat passthrough.

## Breaking-change risk

None. Tests are additive. Workflow change is additive (more feature installs). No public-API signatures changed. No PS1 functional change. No DB migration.