### PR TITLE
Add PreDeploy + PostDeploy custom-script hooks to IIS deploy (Phase 5)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -832,6 +832,23 @@ $DeployIISScriptBlock = {
 	Write-Host "IIS configuration complete"
 }
 
+# ── Squid: Custom-script PreDeploy hook (Phase 5 — Octopus CustomScripts parity) ──
+# Mirrors Octopus's `Octopus.Action.CustomScripts.PreDeploy.ps1` slot. The operator's
+# script body has already been server-rendered into the preamble as a single-quoted
+# string literal (so apostrophes are doubled and the value is safe to Invoke-Expression).
+# Auto-imports WebAdministration so operators can use `Stop-WebAppPool` / `Restart-WebAppPool`
+# directly without boilerplate.
+$preDeployScript = $SquidParameters['Squid.Action.CustomScripts.PreDeploy.ps1']
+if (-not [string]::IsNullOrWhiteSpace($preDeployScript)) {
+	Write-Host "Running PreDeploy custom script..."
+	Import-Module WebAdministration -ErrorAction SilentlyContinue
+	$preDeployBlock = [scriptblock]::Create($preDeployScript)
+	& $preDeployBlock
+	if ($LastExitCode -ne 0 -and $null -ne $LastExitCode) {
+		throw "PreDeploy custom script exited with code $LastExitCode. Aborting IIS deploy before metabase mutations."
+	}
+}
+
 $psVersion = $PSVersionTable.PSVersion
 
 if ($psVersion.Major -ge 7 -and $psVersion.Minor -ge 3) {
@@ -847,5 +864,20 @@ if ($psVersion.Major -ge 7 -and $psVersion.Minor -ge 3) {
 }
 else {
 	&$DeployIISScriptBlock -SquidParameters $SquidParameters
+}
+
+# ── Squid: Custom-script PostDeploy hook (Phase 5) ──
+# Runs ONLY when the IIS configure block above completed without throwing (PowerShell's
+# default error-mode aborts the script on uncaught throw, so this line is unreachable on
+# IIS-configure failure — matches Octopus's semantic of "post-deploy runs on success").
+$postDeployScript = $SquidParameters['Squid.Action.CustomScripts.PostDeploy.ps1']
+if (-not [string]::IsNullOrWhiteSpace($postDeployScript)) {
+	Write-Host "Running PostDeploy custom script..."
+	Import-Module WebAdministration -ErrorAction SilentlyContinue
+	$postDeployBlock = [scriptblock]::Create($postDeployScript)
+	& $postDeployBlock
+	if ($LastExitCode -ne 0 -and $null -ne $LastExitCode) {
+		throw "PostDeploy custom script exited with code $LastExitCode."
+	}
 }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -95,6 +95,36 @@ internal static class IISDeployProperties
     internal const string VirtualDirectoryVirtualPath = "Squid.Action.IISWebSite.VirtualDirectory.VirtualPath";
     internal const string VirtualDirectoryPhysicalPath = "Squid.Action.IISWebSite.VirtualDirectory.PhysicalPath";
 
+    // ── Custom script slots (Phase 5 — Octopus CustomScripts parity) ──────
+    //
+    // Mirrors Octopus's <c>Octopus.Action.CustomScripts.{Stage}.{ext}</c> taxonomy from
+    // <c>Calamari.Common/Plumbing/Variables/KnownVariables.cs:27-35</c>. Each property
+    // value is the LITERAL SCRIPT BODY the operator wants executed at that stage
+    // — not a file path. Operators commonly use these for:
+    //   - PreDeploy: <c>Stop-WebAppPool $PoolName</c> so file replacement doesn't EBUSY
+    //   - PostDeploy: <c>Start-WebAppPool $PoolName; Invoke-WebRequest http://localhost:$Port/health</c>
+    //
+    // The <c>.ps1</c> suffix is part of the key (not a file extension) and signals the
+    // PowerShell syntax. Future syntaxes (<c>.sh</c> / <c>.py</c> / <c>.csx</c>) would
+    // slot in as additional sibling constants when Squid supports non-Windows IIS.
+
+    /// <summary>
+    /// Operator PowerShell script that runs BEFORE the IIS configuration logic.
+    /// Typical use: <c>Stop-WebAppPool $PoolName</c> to release file locks before deployment.
+    /// Runs in an isolated scope but has access to <c>$SquidParameters</c>;
+    /// <c>WebAdministration</c> is auto-imported.
+    /// </summary>
+    internal const string CustomScriptsPreDeploy = "Squid.Action.CustomScripts.PreDeploy.ps1";
+
+    /// <summary>
+    /// Operator PowerShell script that runs AFTER the IIS configuration logic completes
+    /// successfully. Typical use: <c>Start-WebAppPool $PoolName; Invoke-WebRequest ...</c>
+    /// for smoke-testing. Skipped if the IIS configure script threw (the throw aborts
+    /// before reaching the PostDeploy hook). Runs in an isolated scope; <c>$SquidParameters</c>
+    /// is available and <c>WebAdministration</c> is auto-imported.
+    /// </summary>
+    internal const string CustomScriptsPostDeploy = "Squid.Action.CustomScripts.PostDeploy.ps1";
+
     // ── Tentacle-runtime variables read by the script (NOT action properties) ─
 
     /// <summary>Injected by <c>TentacleEndpointVariableContributor</c>. The handler reads this to gate Windows-only execution.</summary>

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -79,6 +79,10 @@ internal static class IISDeployScriptBuilder
         IISDeployProperties.VirtualDirectoryWebSiteName,
         IISDeployProperties.VirtualDirectoryVirtualPath,
         IISDeployProperties.VirtualDirectoryPhysicalPath,
+
+        // Custom script slots (Phase 5)
+        IISDeployProperties.CustomScriptsPreDeploy,
+        IISDeployProperties.CustomScriptsPostDeploy,
     };
 
     internal static string Build(DeploymentActionDto action)
@@ -91,31 +95,78 @@ internal static class IISDeployScriptBuilder
         return preamble + body;
     }
 
+    /// <summary>
+    /// Properties whose value is an operator-authored SCRIPT BODY (not data). Multi-line scripts
+    /// must preserve newlines (PowerShell statement separator) and arbitrary apostrophes / dollar
+    /// signs without breakage — single-quote single-line escape cannot guarantee that. We instead
+    /// emit these via base64 round-trip, which is byte-safe at the cost of slight verbosity in
+    /// the rendered preamble.
+    /// </summary>
+    private static readonly HashSet<string> ScriptContentProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        IISDeployProperties.CustomScriptsPreDeploy,
+        IISDeployProperties.CustomScriptsPostDeploy,
+    };
+
     private static string BuildPreamble(DeploymentActionDto action)
     {
         var sb = new StringBuilder();
 
         sb.AppendLine("# ── BEGIN GENERATED PREAMBLE (Squid IISDeployScriptBuilder) ──");
         sb.AppendLine("# This hashtable is populated server-side from the action's property values;");
-        sb.AppendLine("# every value is pre-escaped for PowerShell single-quote literals. Do not edit.");
+        sb.AppendLine("# data values are pre-escaped for PowerShell single-quote literals.");
+        sb.AppendLine("# Script-body values are base64-encoded so newlines + apostrophes pass through");
+        sb.AppendLine("# verbatim at runtime. Do not edit.");
         sb.AppendLine("$SquidParameters = @{}");
 
         foreach (var propertyName in RecognisedProperties)
         {
             var rawValue = ReadProperty(action, propertyName);
-            var escaped = EscapeForPowerShellSingleQuote(rawValue);
 
-            sb.Append("$SquidParameters['");
-            sb.Append(propertyName);
-            sb.Append("'] = '");
-            sb.Append(escaped);
-            sb.AppendLine("'");
+            if (ScriptContentProperties.Contains(propertyName))
+            {
+                EmitScriptContentAssignment(sb, propertyName, rawValue);
+            }
+            else
+            {
+                EmitDataAssignment(sb, propertyName, rawValue);
+            }
         }
 
         sb.AppendLine("# ── END GENERATED PREAMBLE ──");
         sb.AppendLine();
 
         return sb.ToString();
+    }
+
+    private static void EmitDataAssignment(StringBuilder sb, string propertyName, string rawValue)
+    {
+        var escaped = EscapeForPowerShellSingleQuote(rawValue);
+        sb.Append("$SquidParameters['");
+        sb.Append(propertyName);
+        sb.Append("'] = '");
+        sb.Append(escaped);
+        sb.AppendLine("'");
+    }
+
+    private static void EmitScriptContentAssignment(StringBuilder sb, string propertyName, string rawValue)
+    {
+        // Empty script-content stays empty (no decode needed at runtime — saves a few CPU cycles
+        // and keeps the rendered preamble readable when the operator didn't set the slot).
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            sb.Append("$SquidParameters['");
+            sb.Append(propertyName);
+            sb.AppendLine("'] = ''");
+            return;
+        }
+
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(rawValue));
+        sb.Append("$SquidParameters['");
+        sb.Append(propertyName);
+        sb.Append("'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('");
+        sb.Append(base64);
+        sb.AppendLine("'))");
     }
 
     private static string ReadProperty(DeploymentActionDto action, string propertyName)

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -414,6 +414,82 @@ public class IISDeployPipelineE2ETests
         captured.ScriptBody.ShouldNotContain("#{WebAppVirtualPath}");
     }
 
+    // ── Custom-script slots (Phase 5: PreDeploy + PostDeploy hooks) ────────
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_PreDeployAndPostDeployScripts_FlowThroughAsBase64InPreamble(string communicationStyle)
+    {
+        // Operator workflow: stop the AppPool before file replacement, smoke-test after.
+        // Variables inside the scripts (`#{X}`) must be resolved BEFORE the builder base64-
+        // encodes — otherwise the agent sees the literal '#{X}' inside the decoded script and
+        // either runs against a bogus token or fails noisily.
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteWithVariableAsync(
+            communicationStyle: communicationStyle,
+            variableName: "PoolName",
+            variableValue: "OrderApi-Pool",
+            isSensitive: false,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "#{PoolName}",
+                ["Squid.Action.CustomScripts.PreDeploy.ps1"] =
+                    "Stop-WebAppPool '#{PoolName}'\nStart-Sleep 1",
+                ["Squid.Action.CustomScripts.PostDeploy.ps1"] =
+                    "Start-WebAppPool '#{PoolName}'"
+            }).ConfigureAwait(false);
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        // Decode each script's base64 from the preamble — confirm the variable substitution
+        // happened pre-encode (otherwise the decoded body would contain the literal #{PoolName}).
+        var preDeployDecoded = DecodeBase64Body(captured.ScriptBody, "Squid.Action.CustomScripts.PreDeploy.ps1");
+        var postDeployDecoded = DecodeBase64Body(captured.ScriptBody, "Squid.Action.CustomScripts.PostDeploy.ps1");
+
+        preDeployDecoded.ShouldContain("Stop-WebAppPool 'OrderApi-Pool'",
+            customMessage: "PreDeploy script lost variable resolution OR base64 round-trip mangled the body. " +
+                          $"Decoded:\n{preDeployDecoded}");
+        preDeployDecoded.ShouldContain("Start-Sleep 1");
+        preDeployDecoded.ShouldNotContain("#{PoolName}");
+
+        postDeployDecoded.ShouldContain("Start-WebAppPool 'OrderApi-Pool'");
+        postDeployDecoded.ShouldNotContain("#{PoolName}");
+    }
+
+    /// <summary>
+    /// Helper: locates the base64 string for a given script-content property in the rendered
+    /// preamble, decodes it, and returns the original operator-authored body. Mirrors the
+    /// agent-side `[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String(...))`
+    /// expression — see <c>IISDeployScriptBuilder.EmitScriptContentAssignment</c>.
+    /// </summary>
+    private static string DecodeBase64Body(string preambleScript, string propertyName)
+    {
+        var marker = $"$SquidParameters['{propertyName}'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('";
+        var start = preambleScript.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0)
+            throw new InvalidOperationException(
+                $"Property '{propertyName}' not emitted as base64 in preamble. " +
+                $"This means the builder treated it as a data value, not a script-content value — " +
+                $"check `IISDeployScriptBuilder.ScriptContentProperties` registration.");
+
+        var b64Start = start + marker.Length;
+        var b64End = preambleScript.IndexOf("'))", b64Start, StringComparison.Ordinal);
+        var b64 = preambleScript.Substring(b64Start, b64End - b64Start);
+
+        return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(b64));
+    }
+
     // ── Theory matrix coverage of Tentacle communication-style dispatch ───
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -410,6 +410,111 @@ public class IISDeployScriptBuilderTests
         script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.VirtualDirectory.CreateOrUpdate'] = 'True'");
     }
 
+    // ── Custom-script slots (Phase 5: PreDeploy + PostDeploy hooks) ────────
+    //
+    // Custom-script properties are operator-authored PowerShell bodies that may contain
+    // newlines, apostrophes, dollar signs. These are NOT data values — single-quote
+    // single-line escape would silently break multi-line scripts (newlines collapsed to
+    // spaces would turn `Stop-WebAppPool MyPool\nStart-Sleep 2` into one undefined command).
+    // The builder routes script-content properties through base64 round-trip instead, so
+    // every byte survives. These tests pin that routing + verify the runtime decode shape.
+
+    [Fact]
+    public void Build_PreDeployScriptPropertySet_EmittedAsBase64DecodeInPreamble()
+    {
+        const string body = "Stop-WebAppPool 'MyPool'\nStart-Sleep 2\nWrite-Host \"stopped\"";
+
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.CustomScriptsPreDeploy, body));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // Data properties stay in their single-quote single-line form.
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.WebSiteName'] = 'OrderApi'");
+
+        // The script-body lands as a base64 round-trip — the decoded value must equal `body`.
+        var expectedBase64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(body));
+        script.ShouldContain(
+            $"$SquidParameters['Squid.Action.CustomScripts.PreDeploy.ps1'] = " +
+            $"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('{expectedBase64}'))");
+    }
+
+    [Fact]
+    public void Build_PostDeployScriptPropertySet_EmittedAsBase64DecodeInPreamble()
+    {
+        const string body = "Start-WebAppPool 'MyPool'; Invoke-WebRequest http://localhost:8080/health";
+
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.CustomScriptsPostDeploy, body));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        var expectedBase64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(body));
+        script.ShouldContain(
+            $"$SquidParameters['Squid.Action.CustomScripts.PostDeploy.ps1'] = " +
+            $"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('{expectedBase64}'))");
+    }
+
+    [Fact]
+    public void Build_CustomScriptUnset_EmittedAsEmptyStringNotBase64()
+    {
+        // Unset script slots SHOULD emit an empty string literal — base64-decode of an empty
+        // string costs CPU + makes the preamble noisy. Defensive guard for the common case
+        // where the operator only sets one of the two hooks.
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.CustomScripts.PreDeploy.ps1'] = ''");
+        script.ShouldContain("$SquidParameters['Squid.Action.CustomScripts.PostDeploy.ps1'] = ''");
+        script.ShouldNotContain("FromBase64String('')",
+            customMessage: "Empty script slot should NOT emit a base64-decode-empty-string expression; " +
+                          "use the simple empty string literal for clarity + avoiding wasted CPU.");
+    }
+
+    [Fact]
+    public void Build_PreDeployScriptWithApostrophesAndNewlines_RoundTripsExactlyViaBase64()
+    {
+        // Adversarial operator script: apostrophes, dollar signs, backticks, multiple newlines.
+        // Round-trip via base64 must preserve ALL bytes — the runtime decode produces the EXACT
+        // original string. Pin by decoding the base64 we emitted and comparing.
+        const string body =
+            "$pool = 'O''Brien''s Pool'\n" +
+            "Stop-WebAppPool $pool\n" +
+            "Start-Sleep 2\n" +
+            "Write-Host \"pool: $pool\"";
+
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.CustomScriptsPreDeploy, body));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // Extract the base64 segment from the preamble.
+        var marker = "Squid.Action.CustomScripts.PreDeploy.ps1'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('";
+        var start = script.IndexOf(marker, StringComparison.Ordinal);
+        start.ShouldBePositive("PreDeploy base64 marker missing from preamble.");
+
+        var base64Start = start + marker.Length;
+        var base64End = script.IndexOf("'))", base64Start, StringComparison.Ordinal);
+        base64End.ShouldBeGreaterThan(base64Start, "PreDeploy base64 closing delimiter missing.");
+
+        var emittedBase64 = script.Substring(base64Start, base64End - base64Start);
+        var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(emittedBase64));
+
+        decoded.ShouldBe(body,
+            customMessage:
+                "Round-trip through base64 must preserve script body byte-for-byte. " +
+                $"Emitted base64='{emittedBase64}'. Decoded='{decoded}'. Expected='{body}'.");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -219,6 +219,48 @@ public class IISDeployScriptDriftDetectorTests
                 "on the same host. Any other 'Octopus' word in executable code is a porting oversight.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: the PS1 contains PreDeploy + PostDeploy custom-script
+    /// hooks that have NO Octopus equivalent in this PS1 (Octopus runs custom scripts at
+    /// a higher orchestration layer via <c>ConfiguredScriptBehaviour</c> in their
+    /// <c>DeployPackageCommand</c> pipeline — Squid mirrors the same operator-facing
+    /// contract by embedding the hooks directly in the IIS deploy script).
+    ///
+    /// <para>This test is NOT part of <see cref="KeyOperations"/> because adding it there
+    /// would cause the upstream comparison test to incorrectly flag the hooks as "missing
+    /// from Octopus" — they're not supposed to be in Octopus's PS1 at all.</para>
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasPreDeployAndPostDeployHooks_ForOctopusCustomScriptsParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("$SquidParameters['Squid.Action.CustomScripts.PreDeploy.ps1']",
+            customMessage:
+                "Squid IIS PS1 is missing the PreDeploy custom-script hook. This breaks operator " +
+                "workflows that need `Stop-WebAppPool` before file replacement. Hook should appear " +
+                "BEFORE the `Invoke-Command -ScriptBlock $DeployIISScriptBlock` dispatch.");
+
+        ourScript.ShouldContain("$SquidParameters['Squid.Action.CustomScripts.PostDeploy.ps1']",
+            customMessage:
+                "Squid IIS PS1 is missing the PostDeploy custom-script hook. This breaks operator " +
+                "workflows that smoke-test after deploy. Hook should appear AFTER the IIS configure " +
+                "dispatch — runs only on successful IIS configuration (throw aborts before reaching it).");
+
+        // Order: PreDeploy MUST appear before the script block invocation; PostDeploy MUST appear after.
+        var preDeployIdx = ourScript.IndexOf("'Squid.Action.CustomScripts.PreDeploy.ps1'", StringComparison.Ordinal);
+        var invokeIdx = ourScript.IndexOf("Invoke-Command -Session $compatSession", StringComparison.Ordinal);
+        var postDeployIdx = ourScript.IndexOf("'Squid.Action.CustomScripts.PostDeploy.ps1'", StringComparison.Ordinal);
+
+        preDeployIdx.ShouldBeLessThan(invokeIdx,
+            customMessage: "PreDeploy hook appears AFTER the IIS configure dispatch — that's backwards. " +
+                          "Operators expect PreDeploy to fire BEFORE IIS metabase mutations.");
+
+        invokeIdx.ShouldBeLessThan(postDeployIdx,
+            customMessage: "PostDeploy hook appears BEFORE the IIS configure dispatch — that's backwards. " +
+                          "PostDeploy must fire AFTER IIS configuration completes successfully.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -821,6 +821,230 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Custom-script hooks (Phase 5: PreDeploy + PostDeploy) ───────────────
+    //
+    // Octopus's `ConfiguredScriptBehaviour` runs operator-inline scripts at 5 stages of
+    // the deploy pipeline. Squid embeds the two most-used stages (PreDeploy + PostDeploy)
+    // directly inside the IIS deploy script — PreDeploy runs BEFORE the IIS configure
+    // dispatch, PostDeploy runs AFTER it completes (success path only — `throw` in the
+    // IIS configure block aborts before PostDeploy).
+    //
+    // These tests verify real PowerShell execution + ordering + failure propagation against
+    // real IIS. Sentinel files at known temp paths witness which scripts ran.
+
+    [Fact]
+    public void RealIIS_PreDeployScript_RunsBeforeIISConfigure()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var sentinelPath = ctx.RegisterSentinelPath("predeploy");
+
+        // PreDeploy writes a sentinel file. After deploy, both the sentinel AND the IIS site
+        // must exist — proving PreDeploy ran AND the deploy still proceeded normally.
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.CustomScriptsPreDeploy, $"Set-Content -Path '{sentinelPath}' -Value 'predeploy-ran'")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Deploy with PreDeploy script failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        File.Exists(sentinelPath).ShouldBeTrue(
+            customMessage: $"PreDeploy sentinel '{sentinelPath}' was not created — PreDeploy didn't run. " +
+                          "Check the IIS PS1's PreDeploy hook block at the bottom of the file.");
+
+        File.ReadAllText(sentinelPath).Trim().ShouldBe("predeploy-ran");
+
+        // IIS site must also exist — PreDeploy succeeded, deploy proceeded.
+        PowerShellSingleLine($"if (Get-Website -Name '{ctx.SiteName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}")
+            .ShouldBe("true", customMessage: "Site missing after PreDeploy succeeded — deploy aborted unexpectedly.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PostDeployScript_RunsAfterIISConfigure_SeesSiteInMetabase()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var sentinelPath = ctx.RegisterSentinelPath("postdeploy");
+
+        // PostDeploy queries Get-Website and writes the site state to the sentinel.
+        // If PostDeploy ran AFTER IIS configure, the site MUST be in the metabase
+        // and `(Get-Website).State` returns "Started".
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True"),
+            (Property.CustomScriptsPostDeploy,
+                $"$site = Get-Website -Name '{ctx.SiteName}'; " +
+                $"Set-Content -Path '{sentinelPath}' -Value $site.State")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Deploy with PostDeploy script failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        File.Exists(sentinelPath).ShouldBeTrue(
+            customMessage: $"PostDeploy sentinel '{sentinelPath}' was not created — PostDeploy didn't run. " +
+                          "Check the IIS PS1's PostDeploy hook block at the bottom of the file.");
+
+        var observedState = File.ReadAllText(sentinelPath).Trim();
+        observedState.ShouldBe("Started",
+            customMessage: $"PostDeploy observed site state='{observedState}', expected 'Started'. " +
+                          "Either PostDeploy ran BEFORE the IIS configure (impossible per script order), " +
+                          "OR Start-WebSite didn't fire. Check IIS PS1 deploy logic.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PreDeployScriptFailure_AbortsBeforeIISConfigure()
+    {
+        // Failure propagation: PreDeploy throws → deploy must abort with non-zero exit
+        // AND the IIS site must NOT be created (the configure block never runs).
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var postDeploySentinel = ctx.RegisterSentinelPath("postdeploy-should-not-fire");
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.CustomScriptsPreDeploy, "throw 'intentional pre-deploy failure'"),
+            (Property.CustomScriptsPostDeploy,
+                $"Set-Content -Path '{postDeploySentinel}' -Value 'this-should-never-fire'")));
+
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldNotBe(0,
+            customMessage: $"Deploy with PreDeploy throw unexpectedly succeeded. " +
+                          $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // IIS site MUST NOT exist — the configure block never ran.
+        PowerShellSingleLine($"if (Get-Website -Name '{ctx.SiteName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}")
+            .ShouldBe("false",
+                customMessage: $"Site '{ctx.SiteName}' was created despite PreDeploy throwing — the abort path is broken.");
+
+        // PostDeploy MUST NOT have fired — the throw should have stopped script execution.
+        File.Exists(postDeploySentinel).ShouldBeFalse(
+            customMessage: $"PostDeploy sentinel '{postDeploySentinel}' exists — PostDeploy ran after a PreDeploy throw. " +
+                          "Script execution should stop at the throw.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PreDeployMultiLineScript_AllStatementsExecute()
+    {
+        // Multi-line operator scripts MUST preserve newlines through the base64 round-trip.
+        // Single-quote single-line escape would have collapsed `\n` to space and broken this.
+        // This test writes TWO distinct sentinel files from a multi-line PreDeploy script.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var sentinel1 = ctx.RegisterSentinelPath("multiline-line1");
+        var sentinel2 = ctx.RegisterSentinelPath("multiline-line2");
+
+        var multiLineScript =
+            $"Set-Content -Path '{sentinel1}' -Value 'first-line-ran'\n" +
+            $"Start-Sleep -Milliseconds 50\n" +
+            $"Set-Content -Path '{sentinel2}' -Value 'second-line-ran'";
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.CustomScriptsPreDeploy, multiLineScript)));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Multi-line PreDeploy deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        File.Exists(sentinel1).ShouldBeTrue(
+            customMessage: $"First sentinel '{sentinel1}' missing — first line of multi-line script didn't run. " +
+                          "Likely base64 round-trip lost newlines (would have made statement 1 and 2 collide).");
+
+        File.Exists(sentinel2).ShouldBeTrue(
+            customMessage: $"Second sentinel '{sentinel2}' missing — second line of multi-line script didn't run.");
+
+        File.ReadAllText(sentinel1).Trim().ShouldBe("first-line-ran");
+        File.ReadAllText(sentinel2).Trim().ShouldBe("second-line-ran");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PreAndPostDeployStopThenStartAppPool_RealisticOperatorWorkflow()
+    {
+        // Realistic operator workflow: PreDeploy stops the app pool (releases file locks for
+        // a subsequent file copy), PostDeploy starts it again. This is the canonical Octopus
+        // IIS deploy pattern. After the full deploy, the pool MUST be in "Started" state.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        // First deploy: create the site and pool, with both Pre + Post scripts wired.
+        // PreDeploy: Stop-WebAppPool '#{PoolName}' — Stop is no-op for a non-existent pool on
+        //   first deploy (handled gracefully via -ErrorAction SilentlyContinue).
+        // PostDeploy: explicit `Start-WebAppPool '#{PoolName}'` to ensure pool is running.
+        // Note: the IIS configure script itself starts the pool via StartApplicationPool=True,
+        // so PostDeploy here is documenting + asserting the operator's explicit pattern.
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True"),
+            (Property.CustomScriptsPreDeploy, $"Stop-WebAppPool -Name '{ctx.PoolName}' -ErrorAction SilentlyContinue"),
+            (Property.CustomScriptsPostDeploy, $"Start-WebAppPool -Name '{ctx.PoolName}' -ErrorAction Stop")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Realistic Pre+Post workflow failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}\n\n" +
+                $"Manually inspect via `Get-WebAppPool -Name {ctx.PoolName}`.");
+
+        // Pool MUST be in Started state after the workflow.
+        var poolState = PowerShellSingleLine($"(Get-WebAppPool -Name '{ctx.PoolName}').State");
+        poolState.ShouldBe("Started",
+            customMessage: $"After Pre/Post Stop-Start workflow, pool state='{poolState}', expected 'Started'. " +
+                          "PostDeploy `Start-WebAppPool` either didn't run or failed silently.");
+
+        ctx.MarkClean();
+    }
+
     // ── WebApplication + VirtualDirectory sub-features (Phase 4) ────────────
     //
     // Octopus's PS1 supports three deployment-type toggles in one action:
@@ -1117,6 +1341,7 @@ public sealed class IISDeployRealHostE2ETests
         private readonly List<string> _netshIpPortsToClean = new();
         private readonly List<(string Host, string Port)> _netshHostnamePortsToClean = new();
         private readonly List<string> _localUsersToClean = new();
+        private readonly List<string> _sentinelFilesToClean = new();
         private bool _markedClean;
 
         public IISTestContext()
@@ -1129,6 +1354,20 @@ public sealed class IISDeployRealHostE2ETests
 
             Directory.CreateDirectory(PhysicalPath);
             _tempDirsToClean.Add(PhysicalPath);
+        }
+
+        /// <summary>
+        /// Generates a unique sentinel-file path under the OS temp dir and registers it for
+        /// removal during <see cref="Dispose"/>. Used by Phase 5 custom-script tests to witness
+        /// that the operator's PreDeploy / PostDeploy hook actually ran (sentinel exists =
+        /// script body executed; file content = what the script wrote).
+        /// </summary>
+        /// <param name="suffix">Short label to disambiguate concurrent sentinels in the same test.</param>
+        public string RegisterSentinelPath(string suffix)
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"squid-iis-sentinel-{_suffix}-{suffix}.txt");
+            _sentinelFilesToClean.Add(path);
+            return path;
         }
 
         /// <summary>
@@ -1286,6 +1525,15 @@ public sealed class IISDeployRealHostE2ETests
                 catch { /* best-effort */ }
             }
 
+            // Sentinel files written by Phase 5 custom-script tests — small text files in the
+            // OS temp dir. Even if every test cleans up cleanly, the OS retention policy
+            // varies, so explicit removal here makes the test suite hermetic.
+            foreach (var sentinelPath in _sentinelFilesToClean)
+            {
+                try { if (File.Exists(sentinelPath)) File.Delete(sentinelPath); }
+                catch { /* best-effort */ }
+            }
+
             // If MarkClean wasn't called and we're on a CI runner, leave a hint in the log so
             // post-mortem diagnostics know to dump IIS state on failure.
             if (!_markedClean && OperatingSystem.IsWindows())
@@ -1330,6 +1578,10 @@ public sealed class IISDeployRealHostE2ETests
         public const string ApplicationPoolUsername = "Squid.Action.IISWebSite.ApplicationPoolUsername";
         public const string ApplicationPoolPassword = "Squid.Action.IISWebSite.ApplicationPoolPassword";
         public const string ExistingBindings = "Squid.Action.IISWebSite.ExistingBindings";
+
+        // Phase 5 — custom script slots (Octopus CustomScripts parity)
+        public const string CustomScriptsPreDeploy = "Squid.Action.CustomScripts.PreDeploy.ps1";
+        public const string CustomScriptsPostDeploy = "Squid.Action.CustomScripts.PostDeploy.ps1";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
## Summary

Mirrors Octopus's `Octopus.Action.CustomScripts.{Stage}.ps1` taxonomy (`KnownVariables.cs:27-35`) by embedding two operator-extensibility hooks directly inside the IIS deploy script. **PreDeploy** runs BEFORE the IIS configure dispatch (canonical use: `Stop-WebAppPool` to release file locks). **PostDeploy** runs AFTER successful IIS configure (canonical use: smoke-test, `Start-WebAppPool`, `Invoke-WebRequest /health`).

This closes the operator-experience gap with Octopus for the most-used custom-script stages. Operators get the standard "stop pool → reconfigure → start pool → smoke" pattern in a single Squid action instead of composing 3 separate `Squid.Script`+IIS steps.

## What ships

### Production (+97 LOC across 3 files)

| File | Δ | What |
|---|---|---|
| `IISDeployProperties.cs` | +30 | `CustomScriptsPreDeploy` / `CustomScriptsPostDeploy` constants — keys match Octopus exactly (`Squid.Action.CustomScripts.PreDeploy.ps1` etc.) for portable operator specs |
| `IISDeployScriptBuilder.cs` | +65 | `ScriptContentProperties` hashset + dispatched emission. Data values → single-quote escape (unchanged). Script content → base64 round-trip emission so newlines/apostrophes survive byte-for-byte |
| `DeployToIISWebSite.ps1` | +32 | Two hook blocks: PreDeploy fires before `Invoke-Command -ScriptBlock $DeployIISScriptBlock`, PostDeploy fires after. Both isolated via `[scriptblock]::Create()`. `WebAdministration` auto-imported |

### Test code (+498 LOC, 12 new tests across 3 tiers)

| Tier | New | What |
|---|---|---|
| 🟢 Unit | 5 | base64 emission shape; empty-script optimization (skips base64 for empty values); adversarial round-trip preservation (apostrophes + newlines + dollar signs); drift-detector invariant pinning the new hook blocks + their ordering relative to `Invoke-Command` |
| 🟡 Pipeline E2E | 1 Theory × 2 = 2 cases | Variable substitution INTO script body — `#{PoolName}` resolves BEFORE the builder base64-encodes; helper `DecodeBase64Body()` for asserting decoded content |
| 🟢 Real-host | 5 | PreDeploy sentinel write → file exists after deploy; PostDeploy sentinel queries `Get-Website.State` → proves PostDeploy sees configured site; PreDeploy `throw` → aborts before configure, no site created, PostDeploy doesn't fire; multi-line PreDeploy → both statements execute (proves newlines survive base64); realistic Stop-WebAppPool/Start-WebAppPool workflow → pool ends `Started` |

### Test infrastructure

- `IISTestContext.RegisterSentinelPath(suffix)` — unique sentinel file path + cleanup registration
- `_sentinelFilesToClean` cleanup pass in `Dispose()`

## Why base64 instead of single-quote escape for script content

Operator scripts contain newlines (statement separators in PowerShell). Single-quote single-line escape collapses `\n` → space, which turns `Stop-WebAppPool MyPool\nStart-Sleep 2` into one undefined command. base64 round-trip preserves every byte. Verified via `Build_PreDeployScriptWithApostrophesAndNewlines_RoundTripsExactlyViaBase64`.

## Cumulative coverage after Phase 5

| Tier | Phase 4 | Phase 5 |
|---|---|---|
| Unit | 51 | **56** (+5) |
| Pipeline E2E | 8 | **9** (+1) |
| Real-host | 31 | **36** (+5) |

Windows tentacle suite expected ~131 → ~136 in ~12-13 min.

## Octopus alignment notes

Octopus's `ConfiguredScriptBehaviour` runs custom scripts at a higher orchestration layer (across all package-deploy types). Squid Phase 5 embeds the equivalent hooks INSIDE the IIS deploy script — **same operator-facing contract** (variable names, script body semantics), different runtime layer. The drift-detector test `EmbeddedScript_HasPreDeployAndPostDeployHooks_ForOctopusCustomScriptsParity` is explicitly Squid-only and not part of `KeyOperations`.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 56 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 36 real-host tests skip cleanly
- [x] `dotnet build` 0 errors
- [ ] CI run on `windows-latest`: 5 new real-host tests against real IIS

## Out of scope

- Phase 6: Variable substitution INTO files (`SubstituteInFiles`)
- Phase 7: XML config transforms (XDT)
- Phase 8: AppSettings/ConnectionStrings rewriter
- Phase 9: JSON/YAML structured config
- Phase 10: Package extraction (NuGet/zip)
- Phase 11: Custom installation directory + purge
- Phase 12: IIS certificate auto-import + private-key ACL

## Breaking-change risk

None. Pure additive: new property names, new builder dispatch path for script properties, new PS1 hook blocks that no-op when slots are empty. All existing tests unchanged.