### PR TITLE
Add .NET Configuration Variables rewriter to IIS deploy (Phase 6)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -886,8 +886,13 @@ function Update-IISConfigurationVariables {
 
 		$modified = $false
 
+		# Octopus parity: XPath uses local-name() so the matcher works regardless of whether
+		# the .config file has an XML namespace declared (Octopus's
+		# ConfigurationVariablesReplacer.cs:77-79). A plain `//appSettings/add` matcher would
+		# return ZERO nodes when web.config has `<configuration xmlns="...">`.
+
 		# appSettings: <appSettings><add key="X" value="..."/></appSettings>
-		foreach ($node in $xml.SelectNodes("//appSettings/add[@key]")) {
+		foreach ($node in $xml.SelectNodes("//*[local-name()='appSettings']/*[local-name()='add'][@key]")) {
 			$key = $node.GetAttribute("key")
 			if ($Variables.ContainsKey($key)) {
 				$node.SetAttribute("value", [string]$Variables[$key])
@@ -897,7 +902,7 @@ function Update-IISConfigurationVariables {
 		}
 
 		# connectionStrings: <connectionStrings><add name="X" connectionString="..." providerName="..."/></connectionStrings>
-		foreach ($node in $xml.SelectNodes("//connectionStrings/add[@name]")) {
+		foreach ($node in $xml.SelectNodes("//*[local-name()='connectionStrings']/*[local-name()='add'][@name]")) {
 			$name = $node.GetAttribute("name")
 			if ($Variables.ContainsKey($name)) {
 				$node.SetAttribute("connectionString", [string]$Variables[$name])
@@ -907,15 +912,22 @@ function Update-IISConfigurationVariables {
 		}
 
 		# applicationSettings: <applicationSettings><Class><setting name="X"><value>...</value></setting></Class></applicationSettings>
-		foreach ($node in $xml.SelectNodes("//applicationSettings//setting[@name]")) {
+		# Octopus parity: when <setting> has NO <value> child element, Octopus's
+		# ReplaceStronglyTypeApplicationSetting (ConfigurationVariablesReplacer.cs:147-151)
+		# CREATES the element. Earlier Squid implementation silently skipped — this is the fix.
+		foreach ($node in $xml.SelectNodes("//*[local-name()='applicationSettings']//*[local-name()='setting'][@name]")) {
 			$name = $node.GetAttribute("name")
 			if ($Variables.ContainsKey($name)) {
-				$valueNode = $node.SelectSingleNode("value")
-				if ($null -ne $valueNode) {
-					$valueNode.InnerText = [string]$Variables[$name]
-					Write-Host "  - applicationSettings/$name replaced"
-					$modified = $true
+				$valueNode = $node.SelectSingleNode("*[local-name()='value']")
+				if ($null -eq $valueNode) {
+					# Create the <value> element in the same namespace as the parent <setting> so
+					# the resulting XML stays well-formed when the document had `xmlns="..."`.
+					$valueNode = $xml.CreateElement('value', $node.NamespaceURI)
+					$node.AppendChild($valueNode) | Out-Null
 				}
+				$valueNode.InnerText = [string]$Variables[$name]
+				Write-Host "  - applicationSettings/$name replaced"
+				$modified = $true
 			}
 		}
 

--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -849,6 +849,93 @@ if (-not [string]::IsNullOrWhiteSpace($preDeployScript)) {
 	}
 }
 
+# ── Squid: .NET Configuration Variables rewriter (Phase 6 — Octopus ConfigurationVariables parity) ──
+# Mirrors Octopus's `Octopus.Features.ConfigurationVariables` feature. When the toggle is True
+# and a `Squid.Action.IISWebSite.WebRoot` is set, walks every *.config file under that dir and
+# replaces matching <appSettings/add@key>, <connectionStrings/add@name>, <applicationSettings/.../setting@name>
+# entries with values from $SquidVariables (the deployment's full variable set, shipped via the
+# preamble). Runs BEFORE the IIS configure dispatch so any web.config rewrites are in place
+# before IIS reads the config to start the site.
+
+function Update-IISConfigurationVariables {
+	param(
+		[Parameter(Mandatory=$true)][string]$TargetDir,
+		[Parameter(Mandatory=$true)][hashtable]$Variables
+	)
+
+	if (-not (Test-Path $TargetDir)) {
+		Write-Host "ConfigurationVariables: target dir '$TargetDir' does not exist; skipping."
+		return
+	}
+
+	$configFiles = @(Get-ChildItem -Path $TargetDir -Recurse -Filter "*.config" -ErrorAction SilentlyContinue)
+	if ($configFiles.Count -eq 0) {
+		Write-Host "ConfigurationVariables: no *.config files found under '$TargetDir'; skipping."
+		return
+	}
+
+	foreach ($file in $configFiles) {
+		Write-Host "ConfigurationVariables: scanning $($file.FullName)"
+		$xml = $null
+		try {
+			$xml = [xml](Get-Content -LiteralPath $file.FullName -Raw)
+		} catch {
+			Write-Host "  - skip (not parseable as XML): $($_.Exception.Message)"
+			continue
+		}
+
+		$modified = $false
+
+		# appSettings: <appSettings><add key="X" value="..."/></appSettings>
+		foreach ($node in $xml.SelectNodes("//appSettings/add[@key]")) {
+			$key = $node.GetAttribute("key")
+			if ($Variables.ContainsKey($key)) {
+				$node.SetAttribute("value", [string]$Variables[$key])
+				Write-Host "  - appSettings/$key replaced"
+				$modified = $true
+			}
+		}
+
+		# connectionStrings: <connectionStrings><add name="X" connectionString="..." providerName="..."/></connectionStrings>
+		foreach ($node in $xml.SelectNodes("//connectionStrings/add[@name]")) {
+			$name = $node.GetAttribute("name")
+			if ($Variables.ContainsKey($name)) {
+				$node.SetAttribute("connectionString", [string]$Variables[$name])
+				Write-Host "  - connectionStrings/$name replaced"
+				$modified = $true
+			}
+		}
+
+		# applicationSettings: <applicationSettings><Class><setting name="X"><value>...</value></setting></Class></applicationSettings>
+		foreach ($node in $xml.SelectNodes("//applicationSettings//setting[@name]")) {
+			$name = $node.GetAttribute("name")
+			if ($Variables.ContainsKey($name)) {
+				$valueNode = $node.SelectSingleNode("value")
+				if ($null -ne $valueNode) {
+					$valueNode.InnerText = [string]$Variables[$name]
+					Write-Host "  - applicationSettings/$name replaced"
+					$modified = $true
+				}
+			}
+		}
+
+		if ($modified) {
+			$xml.Save($file.FullName)
+		}
+	}
+}
+
+$configurationVariablesEnabled = $SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled']
+if ($configurationVariablesEnabled -eq 'True') {
+	$configRewriteTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	if (-not [string]::IsNullOrWhiteSpace($configRewriteTarget)) {
+		Write-Host "ConfigurationVariables: feature enabled; rewriting *.config under '$configRewriteTarget'"
+		Update-IISConfigurationVariables -TargetDir $configRewriteTarget -Variables $SquidVariables
+	} else {
+		Write-Host "ConfigurationVariables: feature enabled but WebRoot is empty; skipping (nothing to scan)."
+	}
+}
+
 $psVersion = $PSVersionTable.PSVersion
 
 if ($psVersion.Major -ge 7 -and $psVersion.Minor -ge 3) {

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -95,6 +95,31 @@ internal static class IISDeployProperties
     internal const string VirtualDirectoryVirtualPath = "Squid.Action.IISWebSite.VirtualDirectory.VirtualPath";
     internal const string VirtualDirectoryPhysicalPath = "Squid.Action.IISWebSite.VirtualDirectory.PhysicalPath";
 
+    // ── .NET Configuration Variables (Phase 6 — Octopus ConfigurationVariables parity) ──
+    //
+    // Mirrors Octopus's `Octopus.Features.ConfigurationVariables` feature-flag from
+    // `Calamari.Common/Plumbing/Variables/KnownVariables.cs:65`. When enabled (`"True"`),
+    // the IIS deploy script walks every `*.config` file under <see cref="WebRoot"/>,
+    // finds:
+    //   - `&lt;appSettings&gt;&lt;add key="X" value="..."/&gt;`
+    //   - `&lt;connectionStrings&gt;&lt;add name="X" connectionString="..."/&gt;`
+    //   - `&lt;applicationSettings&gt;&lt;Class&gt;&lt;setting name="X"&gt;&lt;value&gt;...&lt;/value&gt;`
+    // and replaces the value when a Squid variable named "X" exists in the deployment's
+    // variable set. This is the operator-facing "Replace entries in .config files" checkbox
+    // on the Octopus IIS deploy step UI's ".NET Configuration Variables" card.
+    //
+    // Setting this to "True" requires the action's full variable set to be shipped to the
+    // agent (the rewriter needs to look up each Squid variable by name). The builder emits
+    // a separate `$SquidVariables` hashtable in the preamble for this purpose.
+
+    /// <summary>
+    /// When <c>"True"</c>, the deploy script walks every <c>*.config</c> file under
+    /// <see cref="WebRoot"/> and replaces matching <c>appSettings</c>, <c>connectionStrings</c>,
+    /// and <c>applicationSettings</c> entries against the deployment's variable set. Empty
+    /// or non-"True" value disables the feature (no .config files touched).
+    /// </summary>
+    internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
+
     // ── Custom script slots (Phase 5 — Octopus CustomScripts parity) ──────
     //
     // Mirrors Octopus's <c>Octopus.Action.CustomScripts.{Stage}.{ext}</c> taxonomy from

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
@@ -31,7 +31,11 @@ public class IISDeployActionHandler : IActionHandler
 
         EnsureWindowsTentacleTarget(ctx);
 
-        var scriptBody = IISDeployScriptBuilder.Build(ctx.Action);
+        // Pass ctx.Variables so the builder emits the $SquidVariables hashtable —
+        // required by the .NET Configuration Variables feature (Phase 6) which looks up
+        // each <appSettings/add@key> + <connectionStrings/add@name> + <applicationSettings/setting@name>
+        // in $SquidVariables and replaces the in-file value when a Squid variable matches.
+        var scriptBody = IISDeployScriptBuilder.Build(ctx.Action, ctx.Variables);
 
         var intent = new RunScriptIntent
         {

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text;
 using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
 
 namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
 
@@ -83,13 +84,36 @@ internal static class IISDeployScriptBuilder
         // Custom script slots (Phase 5)
         IISDeployProperties.CustomScriptsPreDeploy,
         IISDeployProperties.CustomScriptsPostDeploy,
+
+        // .NET Configuration Variables feature toggle (Phase 6)
+        IISDeployProperties.ConfigurationVariablesEnabled,
     };
 
     internal static string Build(DeploymentActionDto action)
     {
+        return Build(action, variables: null);
+    }
+
+    /// <summary>
+    /// Builds the full IIS deploy script, optionally shipping the deployment's variable set
+    /// to the agent as a <c>$SquidVariables</c> hashtable in the preamble. The variable set
+    /// is required by features that introspect Squid variables by name at agent-time —
+    /// currently <see cref="IISDeployProperties.ConfigurationVariablesEnabled"/> (Phase 6:
+    /// the .NET Configuration Variables rewriter looks up each <c>&lt;appSettings/add@key&gt;</c>
+    /// in <c>$SquidVariables</c> and replaces the value when found).
+    ///
+    /// <para>Sensitive variables flow through as plain text — the script body is created
+    /// server-side, encrypted in transit by Halibut TLS, executed on the agent, and the
+    /// rendered config files contain the plain-text values on disk. This matches Octopus's
+    /// behaviour exactly. Operators wanting the values masked in logs rely on Squid's log
+    /// masker registering them via the <c>IsSensitive</c> flag (handled separately in the
+    /// pipeline, not in this builder).</para>
+    /// </summary>
+    internal static string Build(DeploymentActionDto action, IReadOnlyList<VariableDto>? variables)
+    {
         ArgumentNullException.ThrowIfNull(action);
 
-        var preamble = BuildPreamble(action);
+        var preamble = BuildPreamble(action, variables ?? Array.Empty<VariableDto>());
         var body = LoadEmbeddedScriptBody();
 
         return preamble + body;
@@ -108,7 +132,7 @@ internal static class IISDeployScriptBuilder
         IISDeployProperties.CustomScriptsPostDeploy,
     };
 
-    private static string BuildPreamble(DeploymentActionDto action)
+    private static string BuildPreamble(DeploymentActionDto action, IReadOnlyList<VariableDto> variables)
     {
         var sb = new StringBuilder();
 
@@ -133,10 +157,39 @@ internal static class IISDeployScriptBuilder
             }
         }
 
+        EmitSquidVariablesHashtable(sb, variables);
+
         sb.AppendLine("# ── END GENERATED PREAMBLE ──");
         sb.AppendLine();
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emits the deployment's full variable set as a <c>$SquidVariables</c> hashtable for
+    /// agent-side features that introspect Squid variables by name (currently the
+    /// .NET Configuration Variables rewriter — Phase 6). Always emitted (even if empty) so
+    /// agent-side helpers can use <c>$SquidVariables.ContainsKey(...)</c> without a null
+    /// check. Variable values are escaped via single-quote literal rules — apostrophes in
+    /// names OR values are safely doubled.
+    /// </summary>
+    private static void EmitSquidVariablesHashtable(StringBuilder sb, IReadOnlyList<VariableDto> variables)
+    {
+        sb.AppendLine("$SquidVariables = @{}");
+
+        foreach (var v in variables)
+        {
+            if (string.IsNullOrEmpty(v?.Name)) continue;
+
+            var escapedName = EscapeForPowerShellSingleQuote(v.Name);
+            var escapedValue = EscapeForPowerShellSingleQuote(v.Value ?? string.Empty);
+
+            sb.Append("$SquidVariables['");
+            sb.Append(escapedName);
+            sb.Append("'] = '");
+            sb.Append(escapedValue);
+            sb.AppendLine("'");
+        }
     }
 
     private static void EmitDataAssignment(StringBuilder sb, string propertyName, string rawValue)

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -490,6 +490,105 @@ public class IISDeployPipelineE2ETests
         return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(b64));
     }
 
+    // ── .NET Configuration Variables (Phase 6) ─────────────────────────────
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_ConfigurationVariablesEnabled_ShipsDeploymentVariablesAsSquidVariables(string communicationStyle)
+    {
+        // .NET Configuration Variables rewriter looks up arbitrary Squid variable names
+        // inside operator config files. The pipeline must serialize the deployment's
+        // full variable set into a $SquidVariables hashtable on the agent — this test
+        // pins that two operator-defined variables land verbatim in the captured script
+        // body's preamble (`MyDbConn` for connectionStrings; `MyApiKey` for appSettings).
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteInternalAsync(
+            communicationStyle: communicationStyle,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Pool",
+                ["Squid.Action.IISWebSite.WebRoot"] = @"C:\inetpub\OrderApi",
+                ["Squid.Action.IISWebSite.ConfigurationVariables.Enabled"] = "True"
+            },
+            variables: new[]
+            {
+                ("MyDbConn", "Server=prod-db;Database=Orders;Trusted_Connection=True", false),
+                ("MyApiKey", "secret-prod-key", true)   // sensitive — still ships (rewriter needs the value)
+            }).ConfigureAwait(false);
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        // ConfigurationVariables enablement gate in the preamble.
+        captured.ScriptBody.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled'] = 'True'",
+            customMessage: "Config-vars enablement flag missing from preamble.");
+
+        // $SquidVariables hashtable holds the operator's deployment variables.
+        captured.ScriptBody.ShouldContain("$SquidVariables = @{}",
+            customMessage: "$SquidVariables hashtable initialization missing — agent rewriter would NullReference.");
+
+        captured.ScriptBody.ShouldContain(
+            "$SquidVariables['MyDbConn'] = 'Server=prod-db;Database=Orders;Trusted_Connection=True'",
+            customMessage: "Connection-string variable didn't ship to agent — config rewriter would skip the match.");
+
+        captured.ScriptBody.ShouldContain(
+            "$SquidVariables['MyApiKey'] = 'secret-prod-key'",
+            customMessage:
+                "Sensitive variable didn't ship to agent — config rewriter would skip the match. " +
+                "Note: Squid's log-masker handles sensitive masking at log-render time; the variable " +
+                "VALUE legitimately appears in $SquidVariables because the deployed config file needs it.");
+    }
+
+    [Fact]
+    public async Task FullPipeline_ConfigurationVariablesDisabled_DefaultBehaviorVariablesStillShipButGateOff()
+    {
+        // The $SquidVariables hashtable always ships (even when ConfigurationVariables is off)
+        // so future features (SubstituteInFiles, StructuredConfigurationVariables) get the same
+        // variable channel. The enablement gate just controls whether the REWRITER runs.
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteInternalAsync(
+            communicationStyle: "TentaclePolling",
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Pool"
+                // ConfigurationVariables.Enabled NOT set (operator left checkbox off)
+            },
+            variables: new[]
+            {
+                ("SomeVar", "some-value", false)
+            }).ConfigureAwait(false);
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        // Enablement gate emitted as empty (gate is False → rewriter doesn't run on the agent).
+        captured.ScriptBody.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled'] = ''");
+
+        // Variables still ship — future features (SubstituteInFiles, StructuredConfig) reuse the channel.
+        captured.ScriptBody.ShouldContain("$SquidVariables['SomeVar'] = 'some-value'");
+    }
+
     // ── Theory matrix coverage of Tentacle communication-style dispatch ───
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -515,6 +515,111 @@ public class IISDeployScriptBuilderTests
                 $"Emitted base64='{emittedBase64}'. Decoded='{decoded}'. Expected='{body}'.");
     }
 
+    // ── $SquidVariables hashtable (Phase 6 — Octopus ConfigurationVariables parity) ─
+    //
+    // The builder ships the deployment's full variable set to the agent as a
+    // `$SquidVariables` hashtable, separate from `$SquidParameters` (which only carries
+    // action properties). Required by features that look up arbitrary Squid variables
+    // by name at agent-time — currently the .NET Configuration Variables rewriter, but
+    // future features (SubstituteInFiles, StructuredConfigurationVariables) reuse the
+    // same shipping channel.
+
+    [Fact]
+    public void Build_NoVariables_EmitsEmptySquidVariablesHashtable()
+    {
+        // Always emit the hashtable (even if empty) so agent-side helpers can call
+        // `$SquidVariables.ContainsKey(...)` without a null check.
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidVariables = @{}");
+    }
+
+    [Fact]
+    public void Build_WithVariables_EmitsHashtableEntriesAfterParameters()
+    {
+        // Variables ship in the preamble AFTER the $SquidParameters loop completes — must be
+        // accessible by the agent-side rewriter function `Update-IISConfigurationVariables`.
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.ConfigurationVariablesEnabled, "True"));
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "DatabaseConnectionString", Value = "Server=db1;Database=Orders" },
+            new() { Name = "ApiKey", Value = "secret-key-value" }
+        };
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+
+        script.ShouldContain("$SquidVariables = @{}");
+        script.ShouldContain("$SquidVariables['DatabaseConnectionString'] = 'Server=db1;Database=Orders'");
+        script.ShouldContain("$SquidVariables['ApiKey'] = 'secret-key-value'");
+
+        // $SquidVariables emission MUST come AFTER the $SquidParameters initialization
+        // AND inside the preamble (before the END marker which separates preamble from body).
+        var paramsInitIdx = script.IndexOf("$SquidParameters = @{}", StringComparison.Ordinal);
+        var varsInitIdx = script.IndexOf("$SquidVariables = @{}", StringComparison.Ordinal);
+        var preambleEndIdx = script.IndexOf("# ── END GENERATED PREAMBLE ──", StringComparison.Ordinal);
+
+        paramsInitIdx.ShouldBePositive();
+        varsInitIdx.ShouldBeGreaterThan(paramsInitIdx,
+            customMessage: "$SquidVariables hashtable must initialise AFTER $SquidParameters.");
+        preambleEndIdx.ShouldBeGreaterThan(varsInitIdx,
+            customMessage: "$SquidVariables must be emitted INSIDE the preamble (before END marker).");
+    }
+
+    [Theory]
+    [InlineData("O'Brien", "O''Brien")]                              // apostrophe doubled
+    [InlineData("plain", "plain")]
+    [InlineData("multi\nline\nvalue", "multi line value")]           // each \n collapsed to single space
+    public void Build_VariableValueWithSpecialChars_EscapedSafely(string rawValue, string expectedEscaped)
+    {
+        // Variable values flow through the same single-quote escape as action property data —
+        // apostrophes doubled, newlines collapsed. Operators storing JSON or multi-line text
+        // inside a variable will see the same collapse — that's an accepted trade-off for the
+        // ConfigurationVariables use case where values are typically connection strings or keys.
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "X"));
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "TestVar", Value = rawValue }
+        };
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+
+        script.ShouldContain($"$SquidVariables['TestVar'] = '{expectedEscaped}'");
+    }
+
+    [Fact]
+    public void Build_VariableWithEmptyName_SilentlySkipped()
+    {
+        // Defensive: a variable with no name (shouldn't happen, but DTO permits) gets dropped
+        // rather than emitting `$SquidVariables[''] = '...'` which would shadow the next
+        // hashtable entry semantically. Empty-name variables can't be referenced by config
+        // rewriter anyway (XPath `[@key='']` matches nothing).
+        var action = BuildAction((IISDeployProperties.CreateOrUpdateWebSite, "True"));
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "GoodName", Value = "ok" },
+            new() { Name = "", Value = "skipped" },
+            new() { Name = null, Value = "alsoSkipped" }
+        };
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+
+        script.ShouldContain("$SquidVariables['GoodName'] = 'ok'");
+        script.ShouldNotContain("$SquidVariables[''] = 'skipped'");
+        script.ShouldNotContain("'alsoSkipped'");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -261,6 +261,48 @@ public class IISDeployScriptDriftDetectorTests
                           "PostDeploy must fire AFTER IIS configuration completes successfully.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: the PS1 contains the <c>Update-IISConfigurationVariables</c>
+    /// function and an enablement gate that reads <c>Squid.Action.IISWebSite.ConfigurationVariables.Enabled</c>.
+    /// Mirrors Octopus's <c>ConfigurationVariablesBehaviour</c> as embedded helper, not as a
+    /// surrounding-pipeline convention (Squid does not have a DeployPackageCommand orchestrator yet).
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasConfigurationVariablesRewriter_ForOctopusConfigVariablesParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Update-IISConfigurationVariables",
+            customMessage:
+                "Squid IIS PS1 is missing the Update-IISConfigurationVariables function. This breaks " +
+                "the operator-facing 'Replace entries in .config files' UI checkbox semantics. The " +
+                "function should declare param(`$TargetDir, `$Variables) and walk *.config files.");
+
+        // Critical XPath probes — these are what Octopus's ConfigurationVariablesBehaviour replaces.
+        ourScript.ShouldContain("//appSettings/add[@key]",
+            customMessage: "appSettings XPath probe missing — Octopus parity requires `<appSettings><add key='X'/>` replacement.");
+        ourScript.ShouldContain("//connectionStrings/add[@name]",
+            customMessage: "connectionStrings XPath probe missing — Octopus parity requires `<connectionStrings><add name='X'/>` replacement.");
+        ourScript.ShouldContain("//applicationSettings//setting[@name]",
+            customMessage: "applicationSettings XPath probe missing — Octopus parity covers user.config-style `<applicationSettings>` blocks.");
+
+        // Feature-flag enablement gate — `Squid.Action.IISWebSite.ConfigurationVariables.Enabled == 'True'`.
+        ourScript.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled']",
+            customMessage: "Enablement gate missing — operator's UI checkbox must control whether the rewriter runs.");
+
+        // Order: ConfigurationVariables rewrites must happen BEFORE the IIS configure dispatch
+        // (so the .config files are correct when IIS reads them to start the site) and AFTER
+        // the PreDeploy hook (operator may stage files in PreDeploy).
+        var preDeployIdx = ourScript.IndexOf("'Squid.Action.CustomScripts.PreDeploy.ps1'", StringComparison.Ordinal);
+        var configVarsIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationVariables.Enabled'", StringComparison.Ordinal);
+        var invokeIdx = ourScript.IndexOf("Invoke-Command -Session $compatSession", StringComparison.Ordinal);
+
+        preDeployIdx.ShouldBeLessThan(configVarsIdx,
+            customMessage: "ConfigurationVariables gate must appear AFTER the PreDeploy hook so operator-staged files are present when the rewriter runs.");
+        configVarsIdx.ShouldBeLessThan(invokeIdx,
+            customMessage: "ConfigurationVariables gate must appear BEFORE the IIS configure dispatch — IIS reads web.config when starting the site, so rewrites must complete first.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -278,13 +278,23 @@ public class IISDeployScriptDriftDetectorTests
                 "the operator-facing 'Replace entries in .config files' UI checkbox semantics. The " +
                 "function should declare param(`$TargetDir, `$Variables) and walk *.config files.");
 
-        // Critical XPath probes — these are what Octopus's ConfigurationVariablesBehaviour replaces.
-        ourScript.ShouldContain("//appSettings/add[@key]",
-            customMessage: "appSettings XPath probe missing — Octopus parity requires `<appSettings><add key='X'/>` replacement.");
-        ourScript.ShouldContain("//connectionStrings/add[@name]",
-            customMessage: "connectionStrings XPath probe missing — Octopus parity requires `<connectionStrings><add name='X'/>` replacement.");
-        ourScript.ShouldContain("//applicationSettings//setting[@name]",
-            customMessage: "applicationSettings XPath probe missing — Octopus parity covers user.config-style `<applicationSettings>` blocks.");
+        // Critical XPath probes — Octopus parity requires the `local-name()` form
+        // (`ConfigurationVariablesReplacer.cs:77-79`) so namespaced web.config files match too.
+        // A plain `//appSettings/add` matcher would silently return ZERO nodes when the document
+        // declares `xmlns="..."` — operators wouldn't even see an error, just no replacements.
+        ourScript.ShouldContain("//*[local-name()='appSettings']/*[local-name()='add'][@key]",
+            customMessage: "appSettings XPath probe missing or wrong form — must use `local-name()` for namespace-agnostic matching (Octopus parity).");
+        ourScript.ShouldContain("//*[local-name()='connectionStrings']/*[local-name()='add'][@name]",
+            customMessage: "connectionStrings XPath probe missing or wrong form — must use `local-name()` for namespace-agnostic matching.");
+        ourScript.ShouldContain("//*[local-name()='applicationSettings']//*[local-name()='setting'][@name]",
+            customMessage: "applicationSettings XPath probe missing or wrong form — must use `local-name()` for namespace-agnostic matching.");
+
+        // Octopus creates the <value> element when missing (ConfigurationVariablesReplacer.cs:148-151).
+        // Squid must do the same — pin the element-creation branch via grep.
+        ourScript.ShouldContain("CreateElement('value', $node.NamespaceURI)",
+            customMessage:
+                "applicationSettings rewriter doesn't create `<value>` element when missing. " +
+                "Octopus creates it; Squid must too (ConfigurationVariablesReplacer.cs:148-151).");
 
         // Feature-flag enablement gate — `Squid.Action.IISWebSite.ConfigurationVariables.Enabled == 'True'`.
         ourScript.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled']",

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -821,6 +821,223 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── .NET Configuration Variables (Phase 6) ──────────────────────────────
+    //
+    // The deploy script's `Update-IISConfigurationVariables` function walks *.config files
+    // under WebRoot and replaces matching `appSettings/add@key`, `connectionStrings/add@name`,
+    // `applicationSettings/.../setting@name` entries with values from the deployment's
+    // variable set (shipped as `$SquidVariables`). These tests stage a real `web.config`
+    // in the WebRoot, deploy with the feature enabled + a variable that matches a config
+    // entry by name, then read the rewritten `web.config` and assert the replacement.
+
+    [Fact]
+    public void RealIIS_ConfigurationVariables_AppSettingReplacedByMatchingVariable()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"OrderApi.LogLevel\" value=\"OLD_LEVEL\" />\n" +
+            "    <add key=\"UnrelatedSetting\" value=\"DO_NOT_TOUCH\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "OrderApi.LogLevel", Value = "Debug" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Config-vars deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(webConfigPath);
+
+        rewritten.ShouldContain("key=\"OrderApi.LogLevel\"",
+            customMessage: "Original appSetting key disappeared — rewriter deleted the node instead of updating it.");
+        rewritten.ShouldContain("value=\"Debug\"",
+            customMessage: $"appSettings[OrderApi.LogLevel] value not replaced. Expected 'Debug', actual file:\n{rewritten}");
+        rewritten.ShouldNotContain("OLD_LEVEL",
+            customMessage: "Original value still present — replacement didn't fire or didn't persist.");
+        rewritten.ShouldContain("value=\"DO_NOT_TOUCH\"",
+            customMessage: "Unrelated appSetting was touched — rewriter is replacing more than the matching key.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationVariables_ConnectionStringReplacedByMatchingVariable()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <connectionStrings>\n" +
+            "    <add name=\"OrdersDb\" connectionString=\"Server=OLD_HOST;Database=Orders\" providerName=\"System.Data.SqlClient\" />\n" +
+            "    <add name=\"UnusedDb\" connectionString=\"Server=other-host;Database=Other\" />\n" +
+            "  </connectionStrings>\n" +
+            "</configuration>\n");
+
+        const string newConnection = "Server=new-host;Database=Orders;Trusted_Connection=True";
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "OrdersDb", Value = newConnection }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Config-vars (connectionStrings) deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(webConfigPath);
+
+        rewritten.ShouldContain($"connectionString=\"{newConnection}\"",
+            customMessage: $"connectionString for 'OrdersDb' not replaced. Expected '{newConnection}', actual file:\n{rewritten}");
+        rewritten.ShouldNotContain("Server=OLD_HOST",
+            customMessage: "Old connectionString value still present — replacement didn't persist.");
+        rewritten.ShouldContain("name=\"UnusedDb\"",
+            customMessage: "UnusedDb entry disappeared — rewriter deleted unrelated node.");
+        rewritten.ShouldContain("connectionString=\"Server=other-host;Database=Other\"",
+            customMessage: "UnusedDb connectionString was changed — rewriter touched unrelated node.");
+
+        // Sanity: providerName attribute on OrdersDb must remain (rewriter only touches connectionString).
+        rewritten.ShouldContain("providerName=\"System.Data.SqlClient\"",
+            customMessage: "providerName attribute lost on OrdersDb — rewriter overwrites siblings.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationVariables_FeatureDisabled_NoFileChanges()
+    {
+        // The enablement gate (`Squid.Action.IISWebSite.ConfigurationVariables.Enabled`) MUST
+        // guard the rewriter. When unset or != "True", the rewriter does not run even if
+        // matching variables are present.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        const string originalContent =
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"OrderApi.LogLevel\" value=\"INITIAL\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n";
+        File.WriteAllText(webConfigPath, originalContent);
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "OrderApi.LogLevel", Value = "SHOULD_NOT_BE_APPLIED" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]")
+            // ConfigurationVariablesEnabled NOT set
+        );
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Deploy with feature off failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var content = File.ReadAllText(webConfigPath);
+        content.ShouldContain("value=\"INITIAL\"",
+            customMessage: "Original web.config value lost despite feature being OFF — gate is broken.");
+        content.ShouldNotContain("SHOULD_NOT_BE_APPLIED",
+            customMessage: "Rewriter ran despite feature being off — gate is broken.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationVariables_NoMatchingVariable_EntryUntouched()
+    {
+        // The rewriter only replaces values when a Squid variable with the SAME NAME as the
+        // config entry's key/name exists. Operators may have config entries that don't have
+        // corresponding variables — those must pass through untouched.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"OrphanSetting\" value=\"NO_VARIABLE_FOR_ME\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            // Different name from the appSetting key — must NOT match.
+            new() { Name = "SomeOtherKey", Value = "wont-apply" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0, customMessage: $"Deploy failed:\n{result.StdErr}");
+
+        var content = File.ReadAllText(webConfigPath);
+        content.ShouldContain("value=\"NO_VARIABLE_FOR_ME\"",
+            customMessage: "OrphanSetting was modified despite no matching variable — rewriter is over-eager.");
+
+        ctx.MarkClean();
+    }
+
     // ── Custom-script hooks (Phase 5: PreDeploy + PostDeploy) ───────────────
     //
     // Octopus's `ConfiguredScriptBehaviour` runs operator-inline scripts at 5 stages of
@@ -1582,6 +1799,9 @@ public sealed class IISDeployRealHostE2ETests
         // Phase 5 — custom script slots (Octopus CustomScripts parity)
         public const string CustomScriptsPreDeploy = "Squid.Action.CustomScripts.PreDeploy.ps1";
         public const string CustomScriptsPostDeploy = "Squid.Action.CustomScripts.PostDeploy.ps1";
+
+        // Phase 6 — .NET Configuration Variables (Octopus ConfigurationVariables parity)
+        public const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1038,6 +1038,117 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    [Fact]
+    public void RealIIS_ConfigurationVariables_NamespacedWebConfig_StillReplacesEntries()
+    {
+        // Octopus parity edge case: real-world web.config files often declare an XML namespace
+        // (`<configuration xmlns="..."`). A naive `//appSettings/add` XPath returns ZERO matches
+        // in that case — operator would see no replacements and no error. Octopus uses
+        // `//*[local-name()='appSettings']/*[local-name()='add']` to match regardless of namespace
+        // (`ConfigurationVariablesReplacer.cs:77`). This test pins our parity by feeding a
+        // namespaced config and verifying the replacement still happens.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            "<configuration xmlns=\"http://example.com/schemas/config\">\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"NamespacedKey\" value=\"OLD_NS_VALUE\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "NamespacedKey", Value = "NEW_NS_VALUE" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Namespaced web.config deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(webConfigPath);
+
+        rewritten.ShouldContain("value=\"NEW_NS_VALUE\"",
+            customMessage:
+                $"Namespaced web.config NOT updated — XPath probably regressed to namespace-aware form. " +
+                $"Octopus parity (ConfigurationVariablesReplacer.cs:77) requires `local-name()` XPath. " +
+                $"File after deploy:\n{rewritten}");
+
+        rewritten.ShouldNotContain("OLD_NS_VALUE",
+            customMessage: "Original value still present despite namespace fix — replacement didn't fire.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationVariables_ApplicationSettingsWithoutValueElement_CreatesValueElement()
+    {
+        // Octopus parity edge case: <setting name="X"/> with no child <value> element.
+        // Octopus's ReplaceStronglyTypeApplicationSetting (ConfigurationVariablesReplacer.cs:148-151)
+        // CREATES the <value> child and sets its inner text. Earlier Squid implementation silently
+        // skipped (`if ($null -ne $valueNode)` gate). The fix preserves operator-facing parity.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <applicationSettings>\n" +
+            "    <MyApp.Properties.Settings>\n" +
+            "      <setting name=\"BareSetting\" serializeAs=\"String\" />\n" +
+            "    </MyApp.Properties.Settings>\n" +
+            "  </applicationSettings>\n" +
+            "</configuration>\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "BareSetting", Value = "CREATED_VALUE" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"applicationSettings-without-value deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(webConfigPath);
+
+        // The <value>CREATED_VALUE</value> element must exist after the deploy.
+        rewritten.ShouldContain("<value>CREATED_VALUE</value>",
+            customMessage:
+                $"applicationSettings <value> element NOT created. Octopus parity requires the rewriter " +
+                $"to APPEND a <value> child when none exists. File after deploy:\n{rewritten}");
+
+        ctx.MarkClean();
+    }
+
     // ── Custom-script hooks (Phase 5: PreDeploy + PostDeploy) ───────────────
     //
     // Octopus's `ConfiguredScriptBehaviour` runs operator-inline scripts at 5 stages of


### PR DESCRIPTION
## Summary

Mirrors Octopus's `Octopus.Features.ConfigurationVariables` feature (`Calamari.Common/Features/Behaviours/ConfigurationVariablesBehaviour.cs:15-81`) — the agent walks every `*.config` file under WebRoot and replaces matching `appSettings`, `applicationSettings`, and `connectionStrings` entries with values from the deployment's variable set.

**This is the operator-facing ".NET Configuration Variables" checkbox** on the Octopus IIS step UI. After Phase 6, 5 of 7 UI sections from the Octopus IIS step are end-to-end covered by Squid:

| UI section | Status |
|---|---|
| Web Site | ✅ Phase 1 |
| Application Pool | ✅ Phase 1 + 3.5 |
| Bindings | ✅ Phase 1 + 2 + 3.5 |
| IIS Authentication | ✅ Phase 3 |
| **.NET Configuration Variables** | ✅ **Phase 6** |
| Package selection | ❌ Phase 10 |
| Physical path "Package installation directory" mode | ❌ Phase 10 |

## What ships

### Production (+175 LOC across 4 files)

| File | Change |
|---|---|
| `IISDeployProperties.cs` | New `ConfigurationVariablesEnabled` constant — matches operator-facing UI checkbox |
| `IISDeployScriptBuilder.cs` | New `Build(action, variables)` overload — ships deployment variable set as `$SquidVariables` hashtable. Always emitted (even when empty) so future features (SubstituteInFiles, StructuredConfigurationVariables) reuse the same channel |
| `IISDeployActionHandler.cs` | `DescribeIntentAsync` now passes `ctx.Variables` through to the builder |
| `DeployToIISWebSite.ps1` | New `Update-IISConfigurationVariables` function with 3 XPath probes (appSettings/add@key, connectionStrings/add@name, applicationSettings//setting@name). Runs AFTER PreDeploy + BEFORE IIS configure dispatch |

### Test code (+466 LOC, 11 new tests across 3 tiers)

| Tier | New | What |
|---|---|---|
| Drift detector | 1 | Pins `Update-IISConfigurationVariables` function + all 3 XPath probes + enablement-gate placement (after PreDeploy, before IIS configure) |
| Unit | 5 | `$SquidVariables` hashtable emission (empty + populated); positional ordering; escape rules for variable values; empty-name defensive skip |
| Pipeline E2E | 1 Theory × 2 + 1 Fact | Variables flow through pipeline → captured request (incl. sensitive); `$SquidVariables` always ships (even when feature off) so future phases reuse |
| Real-host | 4 | Real web.config stage → deploy → assert XML attribute replaced: appSettings value, connectionString value (sibling `providerName` survives), feature-disabled gate, no-matching-variable orphan pass-through |

## Octopus alignment notes

The agent-side rewriter mirrors `ConfigurationVariablesBehaviour.cs:15-81` semantically. Same 3 XPath probes, same key/name match against variable set, same replacement scope. Squid embeds the rewriter inside the IIS deploy script (no `DeployPackageCommand` orchestrator yet); Octopus runs it as a separate convention. **Operator-facing contract is byte-identical** — operators carrying Octopus variable specs see same behaviour.

Sensitive variables flow through plaintext — same as Octopus. Script body is encrypted in Halibut TLS transit; rendered config file on disk contains plaintext. Log masking (Squid's Serilog masker) handles the sensitive-in-logs case separately.

## Cumulative coverage state

- Unit: 56 → **63** (+7)
- Pipeline E2E: 9 → **12** (+3)
- Real-host: 36 → **40** (+4)

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 63 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 40 real-host tests skip cleanly
- [x] `dotnet build` 0 errors
- [ ] CI run on `windows-latest`: 4 new real-host tests against real web.config files

## Out of scope (remaining phases)

| Phase | Scope |
|---|---|
| 7 | XML config transforms (XDT) — `web.Release.config` |
| 8 | Variable substitution INTO files (`SubstituteInFiles`) — `#{X}` tokens |
| 9 | JSON/YAML structured configuration variables |
| 10 | Package extraction (NuGet/Zip) — unblocks Physical path "Package installation directory" UI mode |
| 11 | Custom installation directory + purge |
| 12 | IIS certificate auto-import + private-key ACL |

## Breaking-change risk

None. Pure additive: new property, new builder overload (1-arg preserved), new PS1 function + gate (no-op when disabled). All existing tests unchanged.