### PR TITLE
Add XML configuration transforms (XDT) to IIS deploy (Phase 7)

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -86,6 +86,29 @@ jobs:
           Install-WindowsFeature -Name Web-WebServer,Web-Mgmt-Console,Web-Basic-Auth,Web-Windows-Auth -IncludeManagementTools
           Get-WindowsFeature Web-WebServer, Web-Basic-Auth, Web-Windows-Auth | Format-Table -Property Name, InstallState, DisplayName
 
+      - name: Install Microsoft.Web.Xdt (XDT engine for Phase 7 ConfigurationTransforms)
+        # The Phase 7 IIS deploy script invokes Microsoft.Web.XmlTransform for XDT transforms.
+        # `windows-latest` has VS Build Tools pre-installed but the DLL is not GAC-resident
+        # by default. We populate the NuGet global cache so the PS1's probe lookup
+        # (`~/.nuget/packages/microsoft.web.xdt/*/lib/...`) resolves the DLL.
+        shell: pwsh
+        run: |
+          $tempProj = "$env:RUNNER_TEMP\xdt-installer"
+          New-Item -ItemType Directory -Force -Path $tempProj | Out-Null
+          Push-Location $tempProj
+          dotnet new classlib -n XdtInstaller --force | Out-Null
+          Set-Location XdtInstaller
+          dotnet add package Microsoft.Web.Xdt --version 3.0.0
+          dotnet restore
+          Pop-Location
+
+          $dll = Get-ChildItem -Path "$env:USERPROFILE\.nuget\packages\microsoft.web.xdt" -Recurse -Filter "Microsoft.Web.XmlTransform.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($dll) {
+            Write-Host "Microsoft.Web.XmlTransform.dll available at: $($dll.FullName)"
+          } else {
+            Write-Warning "Microsoft.Web.XmlTransform.dll NOT found in NuGet global cache — Phase 7 XDT real-host tests will skip."
+          }
+
       - name: Restore Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: dotnet restore tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj --configfile "$env:NUGET_CONFIG"

--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -937,6 +937,144 @@ function Update-IISConfigurationVariables {
 	}
 }
 
+# ── Squid: XML Configuration Transforms / XDT (Phase 7 — Octopus ConfigurationTransforms parity) ──
+# Mirrors Octopus's `Octopus.Features.ConfigurationTransforms` feature
+# (`ConfigurationTransformsBehaviour.cs:84-101`). When enabled, walks every *.config file
+# under WebRoot and applies XDT transforms:
+#   - Auto: <baseName>.Release.config (always)
+#   - Auto: <baseName>.{EnvironmentName}.config (when EnvironmentName is set)
+#   - Explicit: any CSV of `transform.config => target.config` entries in AdditionalTransforms
+#
+# RUNS BEFORE ConfigurationVariables — XDT can ADD <appSettings> entries that ConfigurationVariables
+# then rewrites by value (Octopus pipeline order: ConfigurationTransforms → ConfigurationVariables).
+
+function Update-IISConfigurationTransforms {
+	param(
+		[Parameter(Mandatory=$true)][string]$TargetDir,
+		[string]$EnvironmentName,
+		[string]$AdditionalTransforms
+	)
+
+	if (-not (Test-Path $TargetDir)) {
+		Write-Host "ConfigurationTransforms: target dir '$TargetDir' does not exist; skipping."
+		return
+	}
+
+	# Locate Microsoft.Web.XmlTransform — try GAC first, then probe common install paths.
+	$xdtLoaded = $false
+	try {
+		Add-Type -AssemblyName "Microsoft.Web.XmlTransform" -ErrorAction Stop
+		$xdtLoaded = $true
+	} catch {
+		$probePaths = @(
+			"${env:ProgramFiles}\Microsoft Visual Studio\*\*\MSBuild\Microsoft\VisualStudio\v*\Web\Microsoft.Web.XmlTransform.dll",
+			"${env:ProgramFiles(x86)}\Microsoft Visual Studio\*\*\MSBuild\Microsoft\VisualStudio\v*\Web\Microsoft.Web.XmlTransform.dll",
+			"${env:USERPROFILE}\.nuget\packages\microsoft.web.xdt\*\lib\net40\Microsoft.Web.XmlTransform.dll",
+			"${env:USERPROFILE}\.nuget\packages\microsoft.web.xdt\*\lib\netstandard2.0\Microsoft.Web.XmlTransform.dll"
+		)
+		foreach ($pattern in $probePaths) {
+			$found = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue | Select-Object -First 1
+			if ($found) {
+				try { Add-Type -Path $found.FullName; $xdtLoaded = $true; break } catch {}
+			}
+		}
+	}
+
+	if (-not $xdtLoaded) {
+		Write-Warning ("ConfigurationTransforms: Microsoft.Web.XmlTransform not available on this agent. " +
+			"Install via 'dotnet add package Microsoft.Web.Xdt' or via VS Build Tools 'Web development workload'. " +
+			"Transforms will NOT be applied to *.config files.")
+		return
+	}
+
+	function Apply-SingleXdtTransform($sourcePath, $transformPath) {
+		Write-Host "  XDT: '$transformPath' => '$sourcePath'"
+		$source = New-Object Microsoft.Web.XmlTransform.XmlTransformableDocument
+		$source.PreserveWhitespace = $true
+		$source.Load($sourcePath)
+		$transform = New-Object Microsoft.Web.XmlTransform.XmlTransformation($transformPath)
+		try {
+			$applied = $transform.Apply($source)
+			if (-not $applied) {
+				Write-Warning "  XDT transform application returned false — engine reported failure for '$transformPath'"
+			}
+			$source.Save($sourcePath)
+		} finally {
+			$source.Dispose()
+			$transform.Dispose()
+		}
+	}
+
+	# Build the auto-transform name list.
+	$autoTransformNames = New-Object System.Collections.Generic.List[string]
+	$autoTransformNames.Add("Release") | Out-Null
+	if (-not [string]::IsNullOrWhiteSpace($EnvironmentName) -and $EnvironmentName -ne "Release") {
+		$autoTransformNames.Add($EnvironmentName) | Out-Null
+	}
+
+	# Discover all *.config files; auto-apply siblings.
+	$allConfigs = @(Get-ChildItem -Path $TargetDir -Recurse -Filter "*.config" -File -ErrorAction SilentlyContinue)
+	foreach ($baseFile in $allConfigs) {
+		$baseName = [System.IO.Path]::GetFileNameWithoutExtension($baseFile.Name)
+
+		# Skip files that ARE transforms themselves (e.g. "web.Release" → would chain-apply onto itself).
+		$isItselfATransform = $false
+		foreach ($transformName in $autoTransformNames) {
+			if ($baseName.EndsWith(".$transformName", [System.StringComparison]::OrdinalIgnoreCase)) {
+				$isItselfATransform = $true; break
+			}
+		}
+		if ($isItselfATransform) { continue }
+
+		foreach ($transformName in $autoTransformNames) {
+			$transformPath = Join-Path $baseFile.DirectoryName "$baseName.$transformName.config"
+			if (Test-Path $transformPath) {
+				Write-Host "ConfigurationTransforms: applying '$transformName' transform to '$($baseFile.FullName)'"
+				Apply-SingleXdtTransform -sourcePath $baseFile.FullName -transformPath $transformPath
+			}
+		}
+	}
+
+	# Explicit additional transforms (CSV `source => target`, comma or newline separated).
+	if (-not [string]::IsNullOrWhiteSpace($AdditionalTransforms)) {
+		$entries = $AdditionalTransforms -split "[`r`n,]" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+		foreach ($entry in $entries) {
+			$parts = $entry -split '\s*=>\s*'
+			if ($parts.Count -ne 2) {
+				Write-Warning "ConfigurationTransforms: skipping malformed entry '$entry' (expected 'transform.config => target.config')"
+				continue
+			}
+			$transformFile = $parts[0].Trim()
+			$targetFile = $parts[1].Trim()
+			$resolvedTransform = if ([System.IO.Path]::IsPathRooted($transformFile)) { $transformFile } else { Join-Path $TargetDir $transformFile }
+			$resolvedTarget = if ([System.IO.Path]::IsPathRooted($targetFile)) { $targetFile } else { Join-Path $TargetDir $targetFile }
+			if (-not (Test-Path $resolvedTransform)) {
+				Write-Warning "ConfigurationTransforms: transform file '$resolvedTransform' not found; skipping"
+				continue
+			}
+			if (-not (Test-Path $resolvedTarget)) {
+				Write-Warning "ConfigurationTransforms: target file '$resolvedTarget' not found; skipping"
+				continue
+			}
+			Write-Host "ConfigurationTransforms: applying explicit '$transformFile' => '$targetFile'"
+			Apply-SingleXdtTransform -sourcePath $resolvedTarget -transformPath $resolvedTransform
+		}
+	}
+}
+
+$configurationTransformsEnabled = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.Enabled']
+$configurationTransformsAdditional = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms']
+if ($configurationTransformsEnabled -eq 'True' -or -not [string]::IsNullOrWhiteSpace($configurationTransformsAdditional)) {
+	$transformsTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	if (-not [string]::IsNullOrWhiteSpace($transformsTarget)) {
+		$transformsEnv = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName']
+		Write-Host "ConfigurationTransforms: feature enabled; processing *.config under '$transformsTarget'"
+		Update-IISConfigurationTransforms -TargetDir $transformsTarget -EnvironmentName $transformsEnv -AdditionalTransforms $configurationTransformsAdditional
+	} else {
+		Write-Host "ConfigurationTransforms: feature enabled but WebRoot is empty; skipping (nothing to scan)."
+	}
+}
+
 $configurationVariablesEnabled = $SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled']
 if ($configurationVariablesEnabled -eq 'True') {
 	$configRewriteTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,48 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── XML config transforms (Phase 7 — Octopus ConfigurationTransforms parity) ──
+    //
+    // Mirrors Octopus's `Octopus.Features.ConfigurationTransforms` feature
+    // (`Calamari.Common/Features/Behaviours/ConfigurationTransformsBehaviour.cs:84-101`).
+    // When enabled, the deploy script applies XDT (XML Document Transform) overlays to
+    // every `*.config` file under <see cref="WebRoot"/>:
+    //
+    //   - <c>web.config</c> + <c>web.Release.config</c> → applies the Release transform
+    //   - <c>web.config</c> + <c>web.{EnvironmentName}.config</c> → applies the env transform
+    //
+    // Operators can also specify explicit transforms via <see cref="ConfigurationTransformsAdditional"/>
+    // (CSV of <c>transform.config =&gt; target.config</c> entries; matches Octopus's
+    // <c>Octopus.Action.Package.AdditionalXmlConfigurationTransforms</c> format).
+    //
+    // The transform engine on the agent is <c>Microsoft.Web.XmlTransform.dll</c> (from the
+    // <c>Microsoft.Web.Xdt</c> NuGet package). The script probes the GAC + common VS install
+    // paths; if not found, the feature emits a clear remediation message and the script
+    // continues (transform skipped — operator's `web.config` is left as-is).
+
+    /// <summary>
+    /// When <c>"True"</c>, the deploy script applies <c>*.Release.config</c> and
+    /// <c>*.{EnvironmentName}.config</c> XDT transforms over their base files under
+    /// <see cref="WebRoot"/>. Matches Octopus's
+    /// <c>Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles</c>.
+    /// </summary>
+    internal const string ConfigurationTransformsEnabled = "Squid.Action.IISWebSite.ConfigurationTransforms.Enabled";
+
+    /// <summary>
+    /// Environment name used for auto-transforms (<c>*.{EnvironmentName}.config</c>). Operators
+    /// typically set this to <c>#{Squid.Environment.Name}</c> so the deploy picks the right env
+    /// overlay automatically. Optional — when empty, only the Release transform is applied.
+    /// </summary>
+    internal const string ConfigurationTransformsEnvironmentName = "Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName";
+
+    /// <summary>
+    /// Operator-specified explicit transforms as CSV of <c>source =&gt; target</c> entries
+    /// (newline OR comma separated). Each transform applies independently of the auto-discovery
+    /// flow. Example: <c>"connectionStrings.config =&gt; web.config, settings.{env}.config =&gt; settings.config"</c>.
+    /// Matches Octopus's <c>Octopus.Action.Package.AdditionalXmlConfigurationTransforms</c>.
+    /// </summary>
+    internal const string ConfigurationTransformsAdditional = "Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms";
+
     // ── Custom script slots (Phase 5 — Octopus CustomScripts parity) ──────
     //
     // Mirrors Octopus's <c>Octopus.Action.CustomScripts.{Stage}.{ext}</c> taxonomy from

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -87,6 +87,11 @@ internal static class IISDeployScriptBuilder
 
         // .NET Configuration Variables feature toggle (Phase 6)
         IISDeployProperties.ConfigurationVariablesEnabled,
+
+        // XML Configuration Transforms (Phase 7 — XDT)
+        IISDeployProperties.ConfigurationTransformsEnabled,
+        IISDeployProperties.ConfigurationTransformsEnvironmentName,
+        IISDeployProperties.ConfigurationTransformsAdditional,
     };
 
     internal static string Build(DeploymentActionDto action)
@@ -120,16 +125,21 @@ internal static class IISDeployScriptBuilder
     }
 
     /// <summary>
-    /// Properties whose value is an operator-authored SCRIPT BODY (not data). Multi-line scripts
-    /// must preserve newlines (PowerShell statement separator) and arbitrary apostrophes / dollar
-    /// signs without breakage — single-quote single-line escape cannot guarantee that. We instead
-    /// emit these via base64 round-trip, which is byte-safe at the cost of slight verbosity in
-    /// the rendered preamble.
+    /// Properties whose value must preserve newlines byte-for-byte. Single-quote single-line
+    /// escape collapses newlines to spaces — fine for JSON (whitespace-insensitive) but breaks:
+    ///   - PowerShell scripts (newlines are statement separators)
+    ///   - CSV / newline-separated config (newlines are entry separators)
+    /// These properties round-trip via base64 in the preamble, which is byte-safe at the cost
+    /// of slight verbosity in the rendered script.
     /// </summary>
     private static readonly HashSet<string> ScriptContentProperties = new(StringComparer.OrdinalIgnoreCase)
     {
         IISDeployProperties.CustomScriptsPreDeploy,
         IISDeployProperties.CustomScriptsPostDeploy,
+        // ConfigurationTransforms.AdditionalTransforms is multi-line CSV where operators commonly
+        // separate `source => target` entries with newlines. Newline collapse would turn N entries
+        // into one undelimited string.
+        IISDeployProperties.ConfigurationTransformsAdditional,
     };
 
     private static string BuildPreamble(DeploymentActionDto action, IReadOnlyList<VariableDto> variables)

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -589,6 +589,55 @@ public class IISDeployPipelineE2ETests
         captured.ScriptBody.ShouldContain("$SquidVariables['SomeVar'] = 'some-value'");
     }
 
+    // ── XML Configuration Transforms (Phase 7 — XDT) ──────────────────────
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_ConfigurationTransforms_EnabledAndEnvironmentResolved(string communicationStyle)
+    {
+        // Pipeline-tier verification that XDT properties flow through the pipeline + variable
+        // substitution resolves `#{Squid.Environment.Name}` (or any operator-defined var) for
+        // the EnvironmentName property — operators set this so per-env `web.{env}.config`
+        // transforms apply automatically.
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteWithVariableAsync(
+            communicationStyle: communicationStyle,
+            variableName: "EnvName",
+            variableValue: "Production",
+            isSensitive: false,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Pool",
+                ["Squid.Action.IISWebSite.WebRoot"] = @"C:\inetpub\OrderApi",
+                ["Squid.Action.IISWebSite.ConfigurationTransforms.Enabled"] = "True",
+                ["Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName"] = "#{EnvName}"
+            }).ConfigureAwait(false);
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        captured.ScriptBody.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.Enabled'] = 'True'");
+
+        // Variable reference resolves BEFORE the builder serialises — agent sees the literal env name.
+        captured.ScriptBody.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName'] = 'Production'",
+            customMessage:
+                "EnvironmentName template wasn't resolved by pipeline variable substitution. " +
+                "Agent would receive literal '#{EnvName}' and look for `web.#{EnvName}.config` which doesn't exist.");
+        captured.ScriptBody.ShouldNotContain("#{EnvName}");
+    }
+
     // ── Theory matrix coverage of Tentacle communication-style dispatch ───
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -620,6 +620,71 @@ public class IISDeployScriptBuilderTests
         script.ShouldNotContain("'alsoSkipped'");
     }
 
+    // ── XML Configuration Transforms (Phase 7 — XDT) ──────────────────────
+
+    [Fact]
+    public void Build_ConfigurationTransformsProperties_AllLandInPreamble()
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.WebSiteName, "OrderApi"),
+            (IISDeployProperties.ConfigurationTransformsEnabled, "True"),
+            (IISDeployProperties.ConfigurationTransformsEnvironmentName, "Production"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.Enabled'] = 'True'");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName'] = 'Production'");
+    }
+
+    [Fact]
+    public void Build_ConfigurationTransformsAdditionalTransformsWithNewlines_PreservedViaBase64()
+    {
+        // Operators typically separate explicit transforms with newlines (one entry per line).
+        // Single-quote single-line escape collapses newlines to spaces — that breaks the CSV
+        // parser on the agent (`-split "[\r\n,]"` would yield one fused entry with embedded `=>`).
+        // The builder routes AdditionalTransforms through base64 (registered in
+        // ScriptContentProperties) so newlines survive.
+        const string multilineCsv =
+            "connectionStrings.config => web.config\n" +
+            "settings.Production.config => settings.config\n" +
+            "appsettings.transform.config => appsettings.config";
+
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.ConfigurationTransformsAdditional, multilineCsv));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // Find the base64 emission for AdditionalTransforms and verify round-trip preserves content.
+        var marker = "$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('";
+        var startIdx = script.IndexOf(marker, StringComparison.Ordinal);
+        startIdx.ShouldBePositive(
+            customMessage: "AdditionalTransforms must emit via base64 (registered in ScriptContentProperties).");
+
+        var b64Start = startIdx + marker.Length;
+        var b64End = script.IndexOf("'))", b64Start, StringComparison.Ordinal);
+        var emittedB64 = script.Substring(b64Start, b64End - b64Start);
+        var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(emittedB64));
+
+        decoded.ShouldBe(multilineCsv,
+            customMessage: $"AdditionalTransforms round-trip via base64 lost content. Decoded:\n{decoded}");
+    }
+
+    [Fact]
+    public void Build_ConfigurationTransformsUnset_BothToggleAndAdditionalEmitAsEmpty()
+    {
+        // Phase 7 defaults: operator hasn't enabled XDT. Both properties emit as empty strings
+        // (parameter not base64 + toggle not "True") — agent script's gate short-circuits, no work.
+        var action = BuildAction((IISDeployProperties.CreateOrUpdateWebSite, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.Enabled'] = ''");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName'] = ''");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms'] = ''");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -313,6 +313,64 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "ConfigurationVariables gate must appear BEFORE the IIS configure dispatch — IIS reads web.config when starting the site, so rewrites must complete first.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: the PS1 contains the <c>Update-IISConfigurationTransforms</c>
+    /// function with XDT (XML Document Transform) semantics. Mirrors Octopus's
+    /// <c>ConfigurationTransformsBehaviour</c> as an embedded helper. Pins:
+    ///   - Function presence
+    ///   - Microsoft.Web.XmlTransform loading attempt (GAC + NuGet probe path)
+    ///   - Auto-transform for "Release" (always)
+    ///   - Auto-transform for `$EnvironmentName` (conditional)
+    ///   - Order: XDT runs AFTER PreDeploy, BEFORE ConfigurationVariables, BEFORE IIS configure dispatch
+    ///     (matches Octopus pipeline: ConfigurationTransforms → ConfigurationVariables)
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasConfigurationTransformsRewriter_ForOctopusXdtParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Update-IISConfigurationTransforms",
+            customMessage:
+                "Squid IIS PS1 is missing Update-IISConfigurationTransforms. This breaks the operator-facing " +
+                "'Auto-run config transformations' workflow that Octopus's `Octopus.Features.ConfigurationTransforms` " +
+                "provides — `web.Release.config` and `web.{Env}.config` overlays won't apply.");
+
+        ourScript.ShouldContain("Microsoft.Web.XmlTransform.XmlTransformableDocument",
+            customMessage: "XDT engine type reference missing — function must instantiate XmlTransformableDocument.");
+
+        ourScript.ShouldContain("Microsoft.Web.XmlTransform.XmlTransformation",
+            customMessage: "XDT engine type reference missing — function must instantiate XmlTransformation.");
+
+        // Auto-transform names — Release is unconditional, EnvironmentName is conditional.
+        ourScript.ShouldContain("$autoTransformNames.Add(\"Release\")",
+            customMessage: "Auto-transform must always include Release (Octopus parity — ConfigurationTransformsBehaviour.cs:86).");
+        ourScript.ShouldContain("$autoTransformNames.Add($EnvironmentName)",
+            customMessage: "Auto-transform must conditionally include EnvironmentName (Octopus parity — ConfigurationTransformsBehaviour.cs:92).");
+
+        // Enablement gate uses ConfigurationTransforms.Enabled OR has AdditionalTransforms set.
+        ourScript.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.Enabled']",
+            customMessage: "Enablement gate missing — operator's UI checkbox controls auto-discovery.");
+        ourScript.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms']",
+            customMessage: "AdditionalTransforms property read missing.");
+
+        // Order: ConfigurationTransforms gate must appear AFTER PreDeploy hook AND BEFORE ConfigurationVariables gate
+        // AND BEFORE the IIS configure dispatch.
+        var preDeployIdx = ourScript.IndexOf("'Squid.Action.CustomScripts.PreDeploy.ps1'", StringComparison.Ordinal);
+        var transformsGateIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationTransforms.Enabled'", StringComparison.Ordinal);
+        var configVarsIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationVariables.Enabled'", StringComparison.Ordinal);
+        var invokeIdx = ourScript.IndexOf("Invoke-Command -Session $compatSession", StringComparison.Ordinal);
+
+        preDeployIdx.ShouldBeLessThan(transformsGateIdx,
+            customMessage: "ConfigurationTransforms gate must run AFTER PreDeploy hook (operator may stage *.Release.config files in PreDeploy).");
+        transformsGateIdx.ShouldBeLessThan(configVarsIdx,
+            customMessage:
+                "ConfigurationTransforms must run BEFORE ConfigurationVariables — Octopus pipeline order " +
+                "(DeployPackageCommand.cs:116-117). Transforms may ADD <appSettings> entries that " +
+                "ConfigurationVariables then rewrites by value; reversed order skips the new entries.");
+        configVarsIdx.ShouldBeLessThan(invokeIdx,
+            customMessage: "Both config-rewriting features must run BEFORE the IIS configure dispatch — IIS reads web.config when starting the site.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1149,6 +1149,236 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── XML Configuration Transforms / XDT (Phase 7) ────────────────────────
+    //
+    // The deploy script's `Update-IISConfigurationTransforms` function loads
+    // Microsoft.Web.XmlTransform.dll and applies XDT transforms:
+    //   - Auto: `<base>.Release.config` over `<base>.config`
+    //   - Auto: `<base>.{EnvironmentName}.config` over `<base>.config`
+    //   - Explicit: CSV `transform.config => target.config` entries
+    //
+    // These tests stage real config + transform files in the WebRoot, deploy with the
+    // feature enabled, and assert XDT semantics were applied (e.g. `xdt:Transform="SetAttributes"`
+    // replaced the target attribute value).
+
+    [Fact]
+    public void RealIIS_ConfigurationTransforms_AutoReleaseTransform_AppliedOverBase()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+        if (!IsMicrosoftWebXmlTransformAvailable()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        var releaseTransformPath = Path.Combine(ctx.PhysicalPath, "web.Release.config");
+
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"ApiUrl\" value=\"https://localhost-dev.example.com\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        File.WriteAllText(releaseTransformPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"ApiUrl\" value=\"https://api.prod.example.com\"\n" +
+            "         xdt:Transform=\"SetAttributes(value)\" xdt:Locator=\"Match(key)\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationTransformsEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"XDT Release transform deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(webConfigPath);
+        rewritten.ShouldContain("value=\"https://api.prod.example.com\"",
+            customMessage:
+                $"XDT Release transform NOT applied — `xdt:Transform=\"SetAttributes(value)\"` should have replaced the ApiUrl value. " +
+                $"File after deploy:\n{rewritten}");
+        rewritten.ShouldNotContain("localhost-dev.example.com",
+            customMessage: "Original (pre-transform) ApiUrl value still present — XDT didn't take effect.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationTransforms_EnvironmentSpecificTransform_AppliedOverBase()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+        if (!IsMicrosoftWebXmlTransformAvailable()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        var stagingTransformPath = Path.Combine(ctx.PhysicalPath, "web.Staging.config");
+
+        File.WriteAllText(webConfigPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"LogLevel\" value=\"Info\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        File.WriteAllText(stagingTransformPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"LogLevel\" value=\"Debug\"\n" +
+            "         xdt:Transform=\"SetAttributes(value)\" xdt:Locator=\"Match(key)\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationTransformsEnabled, "True"),
+            (Property.ConfigurationTransformsEnvironmentName, "Staging"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"XDT Staging transform deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(webConfigPath);
+        rewritten.ShouldContain("value=\"Debug\"",
+            customMessage:
+                $"web.Staging.config transform NOT applied — EnvironmentName='Staging' should have triggered the env-specific overlay. " +
+                $"File after deploy:\n{rewritten}");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationTransforms_ExplicitAdditionalTransform_AppliedOverNonStandardTarget()
+    {
+        // Explicit transforms via the AdditionalTransforms CSV — operators use this for
+        // transforms whose source filename doesn't follow the `<base>.{name}.config` convention.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+        if (!IsMicrosoftWebXmlTransformAvailable()) return;
+
+        using var ctx = new IISTestContext();
+        var configPath = Path.Combine(ctx.PhysicalPath, "ConnectionStrings.config");
+        var transformPath = Path.Combine(ctx.PhysicalPath, "ConnectionStrings.transform.config");
+
+        File.WriteAllText(configPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<connectionStrings>\n" +
+            "  <add name=\"Default\" connectionString=\"Server=localhost\" />\n" +
+            "</connectionStrings>\n");
+
+        File.WriteAllText(transformPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<connectionStrings xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">\n" +
+            "  <add name=\"Default\" connectionString=\"Server=prod-cluster\"\n" +
+            "       xdt:Transform=\"SetAttributes(connectionString)\" xdt:Locator=\"Match(name)\" />\n" +
+            "</connectionStrings>\n");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            // Toggle off, but additional transforms present — agent still runs the rewriter
+            // because of the gate condition (`enabled == "True" -or additionalTransforms is non-empty`)
+            (Property.ConfigurationTransformsAdditional, "ConnectionStrings.transform.config => ConnectionStrings.config"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"XDT explicit-transform deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rewritten = File.ReadAllText(configPath);
+        rewritten.ShouldContain("connectionString=\"Server=prod-cluster\"",
+            customMessage:
+                $"Explicit `transform => target` did not apply. CSV parsing or non-base-file XDT path is broken. " +
+                $"File after deploy:\n{rewritten}");
+        rewritten.ShouldNotContain("Server=localhost",
+            customMessage: "Original connectionString still present after explicit transform.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ConfigurationTransforms_FeatureDisabled_FileUntouched()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var webConfigPath = Path.Combine(ctx.PhysicalPath, "web.config");
+        var releaseTransformPath = Path.Combine(ctx.PhysicalPath, "web.Release.config");
+
+        const string originalContent =
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"ApiUrl\" value=\"localhost-dev\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n";
+        File.WriteAllText(webConfigPath, originalContent);
+
+        File.WriteAllText(releaseTransformPath,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"ApiUrl\" value=\"SHOULD_NOT_BE_APPLIED\"\n" +
+            "         xdt:Transform=\"SetAttributes(value)\" xdt:Locator=\"Match(key)\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]")
+            // ConfigurationTransformsEnabled NOT set + no AdditionalTransforms = gate stays off
+        );
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Deploy with XDT off failed:\n{result.StdErr}");
+
+        var content = File.ReadAllText(webConfigPath);
+        content.ShouldContain("value=\"localhost-dev\"",
+            customMessage: "Base web.config value lost despite XDT feature OFF — gate is broken.");
+        content.ShouldNotContain("SHOULD_NOT_BE_APPLIED",
+            customMessage: "Transform applied despite feature being off — gate is broken.");
+
+        ctx.MarkClean();
+    }
+
     // ── Custom-script hooks (Phase 5: PreDeploy + PostDeploy) ───────────────
     //
     // Octopus's `ConfiguredScriptBehaviour` runs operator-inline scripts at 5 stages of
@@ -1914,6 +2144,11 @@ public sealed class IISDeployRealHostE2ETests
         // Phase 6 — .NET Configuration Variables (Octopus ConfigurationVariables parity)
         public const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+        // Phase 7 — XML Configuration Transforms (Octopus ConfigurationTransforms parity / XDT)
+        public const string ConfigurationTransformsEnabled = "Squid.Action.IISWebSite.ConfigurationTransforms.Enabled";
+        public const string ConfigurationTransformsEnvironmentName = "Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName";
+        public const string ConfigurationTransformsAdditional = "Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms";
+
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";
         public const string WebApplicationWebSiteName = "Squid.Action.IISWebSite.WebApplication.WebSiteName";
@@ -1950,6 +2185,34 @@ public sealed class IISDeployRealHostE2ETests
         try
         {
             var result = RunPowerShell("(Get-WindowsFeature Web-WebServer -ErrorAction SilentlyContinue).Installed");
+            return result.ExitCode == 0 && result.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Probes whether <c>Microsoft.Web.XmlTransform.dll</c> is loadable on the host. Phase 7 XDT
+    /// tests use this to skip cleanly when the DLL isn't installed (typical dev hosts without
+    /// VS Build Tools). CI installs via the workflow's <c>dotnet add package Microsoft.Web.Xdt</c>
+    /// step so this returns true there.
+    /// </summary>
+    private static bool IsMicrosoftWebXmlTransformAvailable()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+
+        try
+        {
+            var result = RunPowerShell(
+                "$ok = $false; " +
+                "try { Add-Type -AssemblyName 'Microsoft.Web.XmlTransform' -ErrorAction Stop; $ok = $true } catch {}; " +
+                "if (-not $ok) { " +
+                "  $probe = Get-ChildItem -Path \"$env:USERPROFILE\\.nuget\\packages\\microsoft.web.xdt\" -Recurse -Filter Microsoft.Web.XmlTransform.dll -ErrorAction SilentlyContinue | Select-Object -First 1; " +
+                "  if ($probe) { try { Add-Type -Path $probe.FullName; $ok = $true } catch {} } " +
+                "}; " +
+                "Write-Host -NoNewline ($ok.ToString())");
             return result.ExitCode == 0 && result.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
         }
         catch


### PR DESCRIPTION
## Summary

Mirrors Octopus's `Octopus.Features.ConfigurationTransforms` feature (`ConfigurationTransformsBehaviour.cs:84-101`). When enabled, the deploy script applies XDT (XML Document Transform) overlays to every `*.config` file under WebRoot:

- **Auto-discovery**: `<base>.Release.config` over `<base>.config`
- **Auto-discovery**: `<base>.{EnvironmentName}.config` over `<base>.config`
- **Explicit**: CSV of `transform.config => target.config` entries

Pairs with Phase 6 (.NET Configuration Variables). PS1 hook order matches Octopus pipeline: **ConfigurationTransforms → ConfigurationVariables → IIS configure**.

## What ships

### Production (+200 LOC across 3 files + 1 workflow update)

| Change | Notes |
|---|---|
| 3 new constants in `IISDeployProperties` | `ConfigurationTransformsEnabled` + `EnvironmentName` + `AdditionalTransforms` |
| Builder routes `AdditionalTransforms` through base64 | Multi-line CSV needs newline preservation; reused the existing base64 emission path |
| `Update-IISConfigurationTransforms` PS1 function | Probes for `Microsoft.Web.XmlTransform.dll` (GAC + NuGet global cache); auto-discovers Release + env overlays; processes explicit CSV transforms; skip-itself logic for `<base>.Release` |
| Workflow installs `Microsoft.Web.Xdt 3.0.0` | NuGet global cache → PS1 probe resolves it |

### Test code (+435 LOC, 10 new tests across 3 tiers)

| Tier | New | What |
|---|---|---|
| 🟢 Drift detector | 1 | XDT function presence + type references + auto-transform name list + ordering BEFORE ConfigurationVariables (Octopus pipeline) |
| 🟢 Unit | 3 | 3 new properties in preamble; AdditionalTransforms via base64 (CSV with newlines preserved); empty defaults |
| 🟡 Pipeline E2E | 1 Theory × 2 | Variable substitution: `#{EnvName}` resolves to literal env name before serialisation |
| 🟢 Real-host | 4 | Auto Release transform; env-specific transform (Staging); explicit AdditionalTransforms with non-standard naming; feature-disabled gate |

### Test infrastructure

`IsMicrosoftWebXmlTransformAvailable()` probe — tests skip cleanly when the DLL isn't installed (dev hosts without VS Build Tools); CI installs the package so tests run there.

## Octopus alignment notes

The agent-side function mirrors `ConfigurationTransformsBehaviour.cs:80-117` semantically: auto-discovery iterates Release + environment-name overlays; explicit transforms via CSV `=>` separator; **uses the IDENTICAL Microsoft.Web.XmlTransform.dll** Octopus uses, so transform semantics (`SetAttributes`, `Insert`, `Replace`, `Locator=Match/Condition/XPath`) are byte-for-byte the same.

Squid Phase 7 covers `Release` + `EnvironmentName`. Octopus also auto-discovers `<base>.{TenantName}.config` — deferred because Squid doesn't have a tenant concept yet.

## Cumulative state

- Unit: 63 → **67** (+4)
- Pipeline E2E: 12 → **14** (+2)
- Real-host: 42 → **46** (+4)

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 67 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 46 real-host tests skip cleanly
- [x] `dotnet build` 0 errors
- [ ] CI run on `windows-latest`: workflow installs Microsoft.Web.Xdt → 4 new XDT tests against real config files

## Out of scope

| Phase | Scope |
|---|---|
| 8 | `SubstituteInFiles` — `#{X}` token replacement INSIDE files |
| 9 | JSON/YAML structured configuration variables |
| 10 | Package extraction |
| 11 | Custom installation directory + purge |
| 12 | IIS certificate auto-import + private-key ACL |

## Breaking-change risk

None. Pure additive: 3 new properties, new builder routing (existing tests pass unchanged), new PS1 function + gate (no-op when disabled), new workflow step (idempotent NuGet install).