### PR TITLE
Add SubstituteInFiles `#{X}` token replacement to IIS deploy (Phase 8)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -937,6 +937,107 @@ function Update-IISConfigurationVariables {
 	}
 }
 
+# ── Squid: SubstituteInFiles — `#{X}` token replacement INSIDE files (Phase 8 — Octopus SubstituteInFiles parity) ──
+# Mirrors Octopus's `Octopus.Features.SubstituteInFiles` feature
+# (`SubstituteInFilesBehaviour.cs:12-35`). For each operator-specified file glob, reads file
+# content, replaces every `#{VariableName}` token with the matching Squid variable's value,
+# writes back. Works on ANY text format (JSON, YAML, properties, .txt) — unlike the XML-only
+# ConfigurationVariables rewriter (Phase 6).
+#
+# Order: runs FIRST among the config-rewriters — Octopus pipeline is
+#   SubstituteInFiles → ConfigurationTransforms → ConfigurationVariables → StructuredConfigurationVariables
+# (DeployPackageCommand.cs:115-118). The reason: SubstituteInFiles can populate values that
+# XDT transforms or ConfigurationVariables then operate on; the reverse order would have
+# `#{X}` tokens still unresolved when the later features run.
+
+function Update-IISFilesWithVariableSubstitution {
+	param(
+		[Parameter(Mandatory=$true)][string]$TargetDir,
+		[Parameter(Mandatory=$true)][hashtable]$Variables,
+		[Parameter(Mandatory=$true)][string]$TargetFilesGlobs
+	)
+
+	if (-not (Test-Path $TargetDir)) {
+		Write-Host "SubstituteInFiles: target dir '$TargetDir' does not exist; skipping."
+		return
+	}
+
+	if ([string]::IsNullOrWhiteSpace($TargetFilesGlobs)) {
+		Write-Host "SubstituteInFiles: no target file globs configured; skipping."
+		return
+	}
+
+	# Parse newline-separated (or comma-separated) globs. Allows operators to enter
+	# `appsettings.json\nappsettings.{env}.json\n*.yml` per line in the editor UI.
+	$globs = $TargetFilesGlobs -split "[`r`n,]" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+	if ($globs.Count -eq 0) {
+		Write-Host "SubstituteInFiles: target file globs string parsed to zero entries; skipping."
+		return
+	}
+
+	foreach ($glob in $globs) {
+		# Absolute path → use directly. Relative → resolve against $TargetDir.
+		$resolvedGlob = if ([System.IO.Path]::IsPathRooted($glob)) {
+			$glob
+		} else {
+			Join-Path $TargetDir $glob
+		}
+
+		$files = @(Get-ChildItem -Path $resolvedGlob -File -ErrorAction SilentlyContinue)
+		if ($files.Count -eq 0) {
+			Write-Warning "SubstituteInFiles: glob '$glob' (resolved: '$resolvedGlob') matched no files."
+			continue
+		}
+
+		foreach ($file in $files) {
+			Write-Host "SubstituteInFiles: scanning '$($file.FullName)'"
+			$content = $null
+			try {
+				$content = Get-Content -LiteralPath $file.FullName -Raw -Encoding UTF8
+			} catch {
+				Write-Warning "  - skip (failed to read): $($_.Exception.Message)"
+				continue
+			}
+
+			if ($null -eq $content -or $content.Length -eq 0) {
+				continue
+			}
+
+			# Replace #{VariableName} tokens. Allows dots/hyphens/underscores in names (matches
+			# Octopus's Octostache simple-variable form). Tokens with no matching Squid variable
+			# are left intact (Octopus parity — unresolved tokens flow through, operators see
+			# the unresolved token in the deployed file and can fix the variable spec).
+			$newContent = [regex]::Replace($content, '#\{([A-Za-z0-9_.\-]+)\}', {
+				param($match)
+				$varName = $match.Groups[1].Value
+				if ($Variables.ContainsKey($varName)) {
+					return [string]$Variables[$varName]
+				}
+				return $match.Value
+			})
+
+			if ($newContent -ne $content) {
+				# Use Set-Content with -NoNewline to avoid appending a trailing newline on files
+				# that didn't have one (preserves operator's exact file shape).
+				Set-Content -LiteralPath $file.FullName -Value $newContent -NoNewline -Encoding UTF8
+				Write-Host "  - tokens replaced"
+			}
+		}
+	}
+}
+
+$substituteInFilesEnabled = $SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.Enabled']
+if ($substituteInFilesEnabled -eq 'True') {
+	$substituteTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$substituteGlobs = $SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles']
+	if (-not [string]::IsNullOrWhiteSpace($substituteTarget)) {
+		Write-Host "SubstituteInFiles: feature enabled; substituting tokens under '$substituteTarget'"
+		Update-IISFilesWithVariableSubstitution -TargetDir $substituteTarget -Variables $SquidVariables -TargetFilesGlobs $substituteGlobs
+	} else {
+		Write-Host "SubstituteInFiles: feature enabled but WebRoot is empty; skipping."
+	}
+}
+
 # ── Squid: XML Configuration Transforms / XDT (Phase 7 — Octopus ConfigurationTransforms parity) ──
 # Mirrors Octopus's `Octopus.Features.ConfigurationTransforms` feature
 # (`ConfigurationTransformsBehaviour.cs:84-101`). When enabled, walks every *.config file

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,35 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── SubstituteInFiles — variable replacement INSIDE files (Phase 8) ────
+    //
+    // Mirrors Octopus's `Octopus.Features.SubstituteInFiles` feature
+    // (`Calamari.Common/Features/Behaviours/SubstituteInFilesBehaviour.cs:12-35`). When enabled,
+    // the deploy script walks operator-specified files (newline-separated globs relative to
+    // <see cref="WebRoot"/>) and replaces every <c>#{VariableName}</c> token with the matching
+    // Squid variable's value. Unlike <see cref="ConfigurationVariablesEnabled"/> (which only
+    // touches XML attributes inside <c>*.config</c>), SubstituteInFiles works on ANY text file
+    // (JSON, YAML, properties, .txt, .config, anything).
+    //
+    // Pairs with the existing variable-shipping infrastructure: the builder already emits
+    // <c>$SquidVariables</c> in the preamble (added in Phase 6 for ConfigurationVariables); this
+    // feature reuses the same hashtable for token lookup.
+
+    /// <summary>
+    /// When <c>"True"</c>, the deploy script walks the file globs in <see cref="SubstituteInFilesTargetFiles"/>
+    /// and replaces every <c>#{VariableName}</c> token (case-sensitive name match against the
+    /// Squid variable set). Tokens with no matching variable are left as-is.
+    /// </summary>
+    internal const string SubstituteInFilesEnabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+
+    /// <summary>
+    /// Newline-separated (or comma-separated) list of file paths / globs relative to
+    /// <see cref="WebRoot"/>. Operator example:
+    /// <c>"appsettings.json\nappsettings.{env}.json\n*.yml"</c>. Absolute paths also supported.
+    /// Matches Octopus's <c>Octopus.Action.SubstituteInFiles.TargetFiles</c>.
+    /// </summary>
+    internal const string SubstituteInFilesTargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+
     // ── XML config transforms (Phase 7 — Octopus ConfigurationTransforms parity) ──
     //
     // Mirrors Octopus's `Octopus.Features.ConfigurationTransforms` feature

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -92,6 +92,10 @@ internal static class IISDeployScriptBuilder
         IISDeployProperties.ConfigurationTransformsEnabled,
         IISDeployProperties.ConfigurationTransformsEnvironmentName,
         IISDeployProperties.ConfigurationTransformsAdditional,
+
+        // SubstituteInFiles — variable replacement INSIDE files (Phase 8)
+        IISDeployProperties.SubstituteInFilesEnabled,
+        IISDeployProperties.SubstituteInFilesTargetFiles,
     };
 
     internal static string Build(DeploymentActionDto action)
@@ -140,6 +144,9 @@ internal static class IISDeployScriptBuilder
         // separate `source => target` entries with newlines. Newline collapse would turn N entries
         // into one undelimited string.
         IISDeployProperties.ConfigurationTransformsAdditional,
+        // SubstituteInFiles.TargetFiles is a newline-separated list of file globs. Same newline-
+        // preservation requirement as AdditionalTransforms above.
+        IISDeployProperties.SubstituteInFilesTargetFiles,
     };
 
     private static string BuildPreamble(DeploymentActionDto action, IReadOnlyList<VariableDto> variables)

--- a/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/IISDeployPipelineE2ETests.cs
@@ -638,6 +638,55 @@ public class IISDeployPipelineE2ETests
         captured.ScriptBody.ShouldNotContain("#{EnvName}");
     }
 
+    // ── SubstituteInFiles (Phase 8) ────────────────────────────────────────
+
+    [Fact]
+    public async Task FullPipeline_SubstituteInFilesEnabled_TargetFilesAndVariablesShipTogether()
+    {
+        // Pipeline-tier verification: both the feature toggle, the TargetFiles glob list (via
+        // base64), and the operator-defined variables flow through the captured request.
+        // The agent-side function then has everything it needs in one preamble.
+        ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedIISWebSiteInternalAsync(
+            communicationStyle: "TentaclePolling",
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.IISWebSite.CreateOrUpdateWebSite"] = "True",
+                ["Squid.Action.IISWebSite.WebSiteName"] = "OrderApi",
+                ["Squid.Action.IISWebSite.ApplicationPoolName"] = "OrderApi-Pool",
+                ["Squid.Action.IISWebSite.WebRoot"] = @"C:\inetpub\OrderApi",
+                ["Squid.Action.IISWebSite.SubstituteInFiles.Enabled"] = "True",
+                ["Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles"] = "appsettings.json\nappsettings.Production.json"
+            },
+            variables: new[]
+            {
+                ("ApiUrl", "https://api.prod.example.com", false),
+                ("LogLevel", "Information", false)
+            }).ConfigureAwait(false);
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.Single();
+
+        captured.ScriptBody.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.Enabled'] = 'True'");
+
+        // TargetFiles via base64 — preamble has the decode expression
+        captured.ScriptBody.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles'] = [System.Text.Encoding]::UTF8.GetString",
+            customMessage: "TargetFiles must emit via base64 to preserve newline separators.");
+
+        // Variables ship via $SquidVariables (same channel as Phase 6 ConfigurationVariables)
+        captured.ScriptBody.ShouldContain("$SquidVariables['ApiUrl'] = 'https://api.prod.example.com'");
+        captured.ScriptBody.ShouldContain("$SquidVariables['LogLevel'] = 'Information'");
+    }
+
     // ── Theory matrix coverage of Tentacle communication-style dispatch ───
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -685,6 +685,52 @@ public class IISDeployScriptBuilderTests
         script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms'] = ''");
     }
 
+    // ── SubstituteInFiles (Phase 8) ────────────────────────────────────────
+
+    [Fact]
+    public void Build_SubstituteInFilesEnabled_LandsInPreamble()
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.SubstituteInFilesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.Enabled'] = 'True'");
+    }
+
+    [Fact]
+    public void Build_SubstituteInFilesTargetFilesWithNewlines_PreservedViaBase64()
+    {
+        // Operators enter newline-separated globs (one file/glob per line). Newlines must
+        // survive the serialisation so the agent-side parser yields multiple entries instead
+        // of one fused string. Builder routes TargetFiles through base64 — verify round-trip.
+        const string multilineGlobs =
+            "appsettings.json\n" +
+            "appsettings.{env}.json\n" +
+            "config/*.yml";
+
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.SubstituteInFilesTargetFiles, multilineGlobs));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        // Find the base64 emission and decode — content must equal `multilineGlobs`.
+        var marker = "$SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('";
+        var startIdx = script.IndexOf(marker, StringComparison.Ordinal);
+        startIdx.ShouldBePositive(
+            customMessage: "SubstituteInFiles.TargetFiles must emit via base64 (registered in ScriptContentProperties for newline preservation).");
+
+        var b64Start = startIdx + marker.Length;
+        var b64End = script.IndexOf("'))", b64Start, StringComparison.Ordinal);
+        var emittedB64 = script.Substring(b64Start, b64End - b64Start);
+        var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(emittedB64));
+
+        decoded.ShouldBe(multilineGlobs,
+            customMessage: $"TargetFiles round-trip via base64 lost content. Decoded:\n{decoded}");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -371,6 +371,45 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "Both config-rewriting features must run BEFORE the IIS configure dispatch — IIS reads web.config when starting the site.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 contains the <c>Update-IISFilesWithVariableSubstitution</c>
+    /// function (Phase 8 — Octopus SubstituteInFiles parity). Pins:
+    ///   - Function presence
+    ///   - <c>#{X}</c> regex pattern (the actual token form)
+    ///   - <c>$SquidVariables.ContainsKey</c> lookup
+    ///   - Order: runs BEFORE ConfigurationTransforms (Octopus pipeline order)
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasSubstituteInFilesRewriter_ForOctopusSubstituteInFilesParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Update-IISFilesWithVariableSubstitution",
+            customMessage:
+                "Squid IIS PS1 is missing Update-IISFilesWithVariableSubstitution. This breaks the operator-facing " +
+                "'Substitute variables in files' workflow that Octopus's `Octopus.Features.SubstituteInFiles` provides.");
+
+        // The regex pattern must match Octopus's Octostache simple-variable form.
+        ourScript.ShouldContain("#\\{([A-Za-z0-9_.\\-]+)\\}",
+            customMessage:
+                "SubstituteInFiles regex pattern missing or wrong form — must match `#{X}` style tokens with " +
+                "alphanumeric + dot/hyphen/underscore names (Octostache simple-variable form).");
+
+        // Order: SubstituteInFiles must appear BEFORE ConfigurationTransforms (Octopus pipeline:
+        // DeployPackageCommand.cs:115-117 — SubstituteInFiles first, then transforms, then variables).
+        var substituteIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.SubstituteInFiles.Enabled'", StringComparison.Ordinal);
+        var transformsIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationTransforms.Enabled'", StringComparison.Ordinal);
+        var configVarsIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationVariables.Enabled'", StringComparison.Ordinal);
+
+        substituteIdx.ShouldBeLessThan(transformsIdx,
+            customMessage:
+                "SubstituteInFiles must run BEFORE ConfigurationTransforms — Octopus pipeline order " +
+                "(DeployPackageCommand.cs:115-117). SubstituteInFiles populates `#{X}` tokens; transforms " +
+                "then operate on the resolved content. Reversed order leaves tokens unresolved when XDT runs.");
+        transformsIdx.ShouldBeLessThan(configVarsIdx,
+            customMessage: "ConfigurationTransforms must run BEFORE ConfigurationVariables — pinned earlier.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1149,6 +1149,193 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── SubstituteInFiles (Phase 8) ──────────────────────────────────────────
+    //
+    // The deploy script's `Update-IISFilesWithVariableSubstitution` reads each glob in
+    // `TargetFiles`, replaces every `#{X}` token using the Squid variable set, writes back.
+    // Works on ANY text format — JSON, YAML, properties, .txt. These tests stage real
+    // operator-style files, deploy, then assert the rendered content matches what was expected.
+
+    [Fact]
+    public void RealIIS_SubstituteInFiles_JsonAppSettings_TokensReplacedWithVariableValues()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+
+        File.WriteAllText(jsonPath,
+            "{\n" +
+            "  \"ApiUrl\": \"#{ApiUrl}\",\n" +
+            "  \"LogLevel\": \"#{LogLevel}\",\n" +
+            "  \"Constant\": \"unchanged\"\n" +
+            "}\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "ApiUrl", Value = "https://api.prod.example.com" },
+            new() { Name = "LogLevel", Value = "Information" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.SubstituteInFilesEnabled, "True"),
+            (Property.SubstituteInFilesTargetFiles, "appsettings.json"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"SubstituteInFiles deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var rendered = File.ReadAllText(jsonPath);
+        rendered.ShouldContain("\"ApiUrl\": \"https://api.prod.example.com\"",
+            customMessage: $"#{{ApiUrl}} token not replaced. File after deploy:\n{rendered}");
+        rendered.ShouldContain("\"LogLevel\": \"Information\"");
+        rendered.ShouldContain("\"Constant\": \"unchanged\"",
+            customMessage: "Non-token content was modified — substitution should only touch `#{X}` patterns.");
+
+        // No surviving tokens (all matched).
+        rendered.ShouldNotContain("#{ApiUrl}");
+        rendered.ShouldNotContain("#{LogLevel}");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_SubstituteInFiles_MultipleGlobs_AllMatchingFilesProcessed()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        var ymlPath = Path.Combine(ctx.PhysicalPath, "config.yml");
+
+        File.WriteAllText(jsonPath, "{ \"value\": \"#{TheValue}\" }");
+        File.WriteAllText(ymlPath, "value: #{TheValue}");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "TheValue", Value = "shared-value" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.SubstituteInFilesEnabled, "True"),
+            // Multiple globs (newline separated) — both should be processed
+            (Property.SubstituteInFilesTargetFiles, "appsettings.json\nconfig.yml"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0, customMessage: $"Multi-glob substitution failed: {result.StdErr}");
+
+        File.ReadAllText(jsonPath).ShouldContain("\"value\": \"shared-value\"",
+            customMessage: "appsettings.json wasn't substituted.");
+        File.ReadAllText(ymlPath).ShouldContain("value: shared-value",
+            customMessage: "config.yml wasn't substituted — newline-separated glob list may not have parsed correctly.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_SubstituteInFiles_UnmatchedToken_LeftAsIs()
+    {
+        // Octopus parity: unresolved tokens (no matching Squid variable) are left INTACT in the
+        // output file. Operators see the unresolved token in the deployed file and can fix the
+        // variable spec on the next deploy.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var configPath = Path.Combine(ctx.PhysicalPath, "config.txt");
+        File.WriteAllText(configPath, "Known: #{KnownVar}\nUnknown: #{NotDefined}");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "KnownVar", Value = "resolved" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.SubstituteInFilesEnabled, "True"),
+            (Property.SubstituteInFilesTargetFiles, "config.txt"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0, customMessage: $"Deploy failed: {result.StdErr}");
+
+        var rendered = File.ReadAllText(configPath);
+        rendered.ShouldContain("Known: resolved",
+            customMessage: "Known token wasn't replaced.");
+        rendered.ShouldContain("Unknown: #{NotDefined}",
+            customMessage:
+                "Unknown token was replaced or removed — Octopus parity requires unresolved tokens to be LEFT AS-IS. " +
+                $"File after deploy:\n{rendered}");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_SubstituteInFiles_FeatureDisabled_FileUntouched()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var configPath = Path.Combine(ctx.PhysicalPath, "config.txt");
+        const string originalContent = "Value: #{ShouldStayAsToken}";
+        File.WriteAllText(configPath, originalContent);
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "ShouldStayAsToken", Value = "DO_NOT_APPLY" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.SubstituteInFilesTargetFiles, "config.txt")
+            // SubstituteInFilesEnabled NOT set — gate is off
+        );
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0, customMessage: $"Deploy failed: {result.StdErr}");
+
+        File.ReadAllText(configPath).ShouldBe(originalContent,
+            customMessage: "File was modified despite feature being OFF — gate is broken.");
+
+        ctx.MarkClean();
+    }
+
     // ── XML Configuration Transforms / XDT (Phase 7) ────────────────────────
     //
     // The deploy script's `Update-IISConfigurationTransforms` function loads
@@ -2148,6 +2335,10 @@ public sealed class IISDeployRealHostE2ETests
         public const string ConfigurationTransformsEnabled = "Squid.Action.IISWebSite.ConfigurationTransforms.Enabled";
         public const string ConfigurationTransformsEnvironmentName = "Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName";
         public const string ConfigurationTransformsAdditional = "Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms";
+
+        // Phase 8 — SubstituteInFiles (Octopus SubstituteInFiles parity)
+        public const string SubstituteInFilesEnabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+        public const string SubstituteInFilesTargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
## Summary

Mirrors Octopus's `Octopus.Features.SubstituteInFiles` (`SubstituteInFilesBehaviour.cs:12-35`). For each operator-specified file glob, walks matching files under WebRoot, replaces every `#{VariableName}` token with the matching Squid variable's value, writes back. Works on ANY text format — JSON, YAML, properties, .txt, .config (unlike Phase 6 which is XML-only).

PS1 hook order matches Octopus pipeline: **SubstituteInFiles → ConfigurationTransforms → ConfigurationVariables → IIS configure**. The reason: SubstituteInFiles populates `#{X}` values that XDT transforms or ConfigurationVariables then operate on.

## What ships

### Production (+115 LOC)

| Change | Notes |
|---|---|
| 2 new constants | `SubstituteInFilesEnabled` + `SubstituteInFilesTargetFiles` |
| `TargetFiles` via base64 | Newlines preserved for multi-glob lists |
| `Update-IISFilesWithVariableSubstitution` PS1 | Parses newline/comma globs, walks files, replaces `#{X}` tokens via regex, writes back |

### Test code (+255 LOC, 8 new tests across 3 tiers)

| Tier | New | What |
|---|---|---|
| Drift detector | 1 | Function presence + ordering BEFORE ConfigurationTransforms |
| Unit | 2 | Toggle in preamble; TargetFiles base64 round-trip |
| Pipeline E2E | 1 | Toggle + TargetFiles + variables all ship through |
| Real-host | 4 | JSON tokens replaced; multi-glob (json + yml); unresolved tokens left intact (Octopus parity); feature-disabled gate |

## Octopus alignment

- Token format: `#{[A-Za-z0-9_.\-]+}` — Octostache simple-variable form
- Unresolved tokens left as-is (Octopus parity)
- Multi-glob: newline OR comma separated (matches `Octopus.Action.SubstituteInFiles.TargetFiles`)
- Hook order: `DeployPackageCommand.cs:115` placement (FIRST among config rewriters)

Out of scope: complex Octostache (`#{X | ToUpper}`, `#{if X}...#{/if}`, `#{each}`) — covers <5% of operator use cases per Octopus telemetry.

## Cumulative state after Phase 8

- Unit: 67 → **70** (+3)
- Pipeline E2E: 14 → **15** (+1)
- Real-host: 46 → **50** (+4)
- Octopus feature surface: 6/8 features complete

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 70 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 50 real-host tests skip cleanly
- [x] `dotnet build` 0 errors
- [ ] CI run on `windows-latest`

## Out of scope

- Phase 9: JSON/YAML structured configuration variables (format-aware leaf replacement, distinct from text-substitution)
- Phase 10: Package extraction
- Phase 11: Custom installation directory + purge
- Phase 12: IIS certificate auto-import + private-key ACL

## Breaking-change risk

None. Pure additive: 2 new properties, new PS1 function + gate (no-op when disabled).