### PR TITLE
Add structured JSON configuration variable replacement to IIS deploy (Phase 9)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -1187,6 +1187,115 @@ if ($configurationVariablesEnabled -eq 'True') {
 	}
 }
 
+# ── Squid: Structured Configuration Variables — JSON leaf replacement (Phase 9 — Octopus JsonConfigurationVariables parity) ──
+# Mirrors Octopus's `Octopus.Features.JsonConfigurationVariables` feature
+# (`StructuredConfigurationVariablesBehaviour.cs:13-35`). Walks each operator-specified JSON
+# file, recurses into the object structure, replaces leaf values where the path (with `:` or `.`
+# separator) matches a Squid variable name. Phase 9 MVP supports JSON; YAML/properties are
+# future work.
+#
+# Order: runs AFTER ConfigurationVariables — Octopus pipeline puts structured-config LAST among
+# the rewriters because it operates on a different file family (JSON) than the prior XML ones,
+# and operators may want appSettings replaced first, then JSON leaves.
+
+function Update-IISStructuredJsonConfiguration {
+	param(
+		[Parameter(Mandatory=$true)][string]$TargetDir,
+		[Parameter(Mandatory=$true)][hashtable]$Variables,
+		[Parameter(Mandatory=$true)][string]$TargetFilesGlobs
+	)
+
+	if (-not (Test-Path $TargetDir)) {
+		Write-Host "StructuredConfigurationVariables: target dir '$TargetDir' does not exist; skipping."
+		return
+	}
+
+	if ([string]::IsNullOrWhiteSpace($TargetFilesGlobs)) {
+		Write-Host "StructuredConfigurationVariables: no target file globs configured; skipping."
+		return
+	}
+
+	# Walk JSON object recursively, replacing leaf values whose path matches a Squid variable.
+	# Supports BOTH `:` and `.` path separators (operator may have stored the variable as
+	# `Logging:LogLevel:Default` or `Logging.LogLevel.Default` — try both).
+	function Walk-JsonReplace($node, $pathParts, $variables, [ref]$modifiedFlag) {
+		if ($node -is [System.Management.Automation.PSCustomObject]) {
+			foreach ($prop in $node.PSObject.Properties) {
+				$newParts = $pathParts + @($prop.Name)
+				$value = $prop.Value
+
+				if ($value -is [System.Management.Automation.PSCustomObject]) {
+					Walk-JsonReplace -node $value -pathParts $newParts -variables $variables -modifiedFlag $modifiedFlag
+				} elseif ($value -is [System.Array] -or $value -is [System.Object[]]) {
+					# Phase 9 MVP: scalar leaves only — array element replacement is Phase 9.5
+					# Arrays of strings and primitives are skipped intentionally
+				} else {
+					$pathColon = $newParts -join ':'
+					$pathDot = $newParts -join '.'
+					$matchedVar = $null
+					if ($variables.ContainsKey($pathColon)) {
+						$matchedVar = $variables[$pathColon]
+					} elseif ($variables.ContainsKey($pathDot)) {
+						$matchedVar = $variables[$pathDot]
+					}
+					if ($null -ne $matchedVar) {
+						$prop.Value = [string]$matchedVar
+						$modifiedFlag.Value = $true
+						Write-Host "  - JSON leaf '$pathColon' replaced"
+					}
+				}
+			}
+		}
+	}
+
+	$globs = $TargetFilesGlobs -split "[`r`n,]" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+	foreach ($glob in $globs) {
+		$resolvedGlob = if ([System.IO.Path]::IsPathRooted($glob)) { $glob } else { Join-Path $TargetDir $glob }
+		$files = @(Get-ChildItem -Path $resolvedGlob -File -ErrorAction SilentlyContinue)
+
+		if ($files.Count -eq 0) {
+			Write-Warning "StructuredConfigurationVariables: glob '$glob' matched no files."
+			continue
+		}
+
+		foreach ($file in $files) {
+			Write-Host "StructuredConfigurationVariables: scanning '$($file.FullName)'"
+			$json = $null
+			try {
+				$rawContent = Get-Content -LiteralPath $file.FullName -Raw -Encoding UTF8
+				$json = $rawContent | ConvertFrom-Json
+			} catch {
+				Write-Warning "  - skip (not parseable as JSON): $($_.Exception.Message)"
+				continue
+			}
+
+			if ($null -eq $json) { continue }
+
+			$modified = [ref]$false
+			Walk-JsonReplace -node $json -pathParts @() -variables $Variables -modifiedFlag $modified
+
+			if ($modified.Value) {
+				# Preserve UTF-8 (Set-Content -Encoding UTF8 doesn't add BOM by default in PS 5.1+).
+				# Depth 32 covers virtually all real-world config files; default of 2 truncates badly.
+				$serialized = $json | ConvertTo-Json -Depth 32
+				Set-Content -LiteralPath $file.FullName -Value $serialized -NoNewline -Encoding UTF8
+			}
+		}
+	}
+}
+
+$structuredEnabled = $SquidParameters['Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled']
+if ($structuredEnabled -eq 'True') {
+	$structuredTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$structuredGlobs = $SquidParameters['Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets']
+	if (-not [string]::IsNullOrWhiteSpace($structuredTarget)) {
+		Write-Host "StructuredConfigurationVariables: feature enabled; rewriting JSON leaves under '$structuredTarget'"
+		Update-IISStructuredJsonConfiguration -TargetDir $structuredTarget -Variables $SquidVariables -TargetFilesGlobs $structuredGlobs
+	} else {
+		Write-Host "StructuredConfigurationVariables: feature enabled but WebRoot is empty; skipping."
+	}
+}
+
 $psVersion = $PSVersionTable.PSVersion
 
 if ($psVersion.Major -ge 7 -and $psVersion.Minor -ge 3) {

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,37 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── Structured Configuration Variables — JSON/YAML leaf replacement (Phase 9) ──
+    //
+    // Mirrors Octopus's `Octopus.Features.JsonConfigurationVariables` feature
+    // (`Calamari.Common/Features/Behaviours/StructuredConfigurationVariablesBehaviour.cs:13-35`).
+    // Format-aware leaf replacement — walks JSON object structure, for each leaf checks if a
+    // Squid variable matches the path (with both `:` and `.` separators supported, matching
+    // .NET Core configuration conventions).
+    //
+    // Distinct from Phase 8 SubstituteInFiles:
+    //   - SubstituteInFiles: TEXT-level `#{X}` token replacement in any file format
+    //   - StructuredConfigurationVariables: STRUCTURE-AWARE leaf replacement (operator
+    //     stores `ConnectionStrings:Default` as the variable name; the rewriter walks
+    //     `appsettings.json` and replaces the `connectionStrings.default` leaf value)
+    //
+    // Phase 9 MVP supports JSON. YAML/properties files can be added in future phases
+    // (Octopus's `StructuredConfigVariables.csproj` adds those format-specific parsers).
+
+    /// <summary>
+    /// When <c>"True"</c>, the deploy script walks each JSON file in <see cref="StructuredConfigurationVariablesTargets"/>
+    /// and replaces leaf values where the JSON path matches a Squid variable name. Path forms:
+    /// dot-separated (`Logging.LogLevel.Default`) and colon-separated (`Logging:LogLevel:Default`) both supported.
+    /// </summary>
+    internal const string StructuredConfigurationVariablesEnabled = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled";
+
+    /// <summary>
+    /// Newline-separated list of file paths / globs relative to <see cref="WebRoot"/>. Operator example:
+    /// <c>"appsettings.json\nappsettings.Production.json"</c>. Matches Octopus's
+    /// <c>Octopus.Action.Package.JsonConfigurationVariablesTargets</c>.
+    /// </summary>
+    internal const string StructuredConfigurationVariablesTargets = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets";
+
     // ── SubstituteInFiles — variable replacement INSIDE files (Phase 8) ────
     //
     // Mirrors Octopus's `Octopus.Features.SubstituteInFiles` feature

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -96,6 +96,10 @@ internal static class IISDeployScriptBuilder
         // SubstituteInFiles — variable replacement INSIDE files (Phase 8)
         IISDeployProperties.SubstituteInFilesEnabled,
         IISDeployProperties.SubstituteInFilesTargetFiles,
+
+        // Structured Configuration Variables — JSON leaf replacement (Phase 9)
+        IISDeployProperties.StructuredConfigurationVariablesEnabled,
+        IISDeployProperties.StructuredConfigurationVariablesTargets,
     };
 
     internal static string Build(DeploymentActionDto action)
@@ -147,6 +151,8 @@ internal static class IISDeployScriptBuilder
         // SubstituteInFiles.TargetFiles is a newline-separated list of file globs. Same newline-
         // preservation requirement as AdditionalTransforms above.
         IISDeployProperties.SubstituteInFilesTargetFiles,
+        // StructuredConfigurationVariables.Targets is also a newline-separated glob list.
+        IISDeployProperties.StructuredConfigurationVariablesTargets,
     };
 
     private static string BuildPreamble(DeploymentActionDto action, IReadOnlyList<VariableDto> variables)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -731,6 +731,26 @@ public class IISDeployScriptBuilderTests
             customMessage: $"TargetFiles round-trip via base64 lost content. Decoded:\n{decoded}");
     }
 
+    // ── Structured Configuration Variables (Phase 9) ──────────────────────
+
+    [Fact]
+    public void Build_StructuredConfigurationVariablesEnabled_LandsInPreamble()
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.StructuredConfigurationVariablesEnabled, "True"),
+            (IISDeployProperties.StructuredConfigurationVariablesTargets, "appsettings.json\nappsettings.Production.json"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled'] = 'True'");
+
+        // Targets via base64 so newline-separated globs survive
+        script.ShouldContain(
+            "$SquidParameters['Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets'] = [System.Text.Encoding]::UTF8.GetString",
+            customMessage: "Targets must emit via base64 — newline separators required for multi-glob lists.");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -410,6 +410,50 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "ConfigurationTransforms must run BEFORE ConfigurationVariables — pinned earlier.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 contains <c>Update-IISStructuredJsonConfiguration</c>
+    /// (Phase 9 — Octopus JsonConfigurationVariables parity). Pins:
+    ///   - Function presence
+    ///   - Walk-JsonReplace nested helper
+    ///   - Both `:` and `.` path separator support
+    ///   - Order: runs AFTER ConfigurationVariables (Octopus pipeline order)
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasStructuredJsonRewriter_ForOctopusJsonConfigurationVariablesParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Update-IISStructuredJsonConfiguration",
+            customMessage:
+                "Squid IIS PS1 is missing Update-IISStructuredJsonConfiguration. This breaks the operator-facing " +
+                "JSON `appsettings.json` leaf replacement that Octopus's `Octopus.Features.JsonConfigurationVariables` provides.");
+
+        ourScript.ShouldContain("function Walk-JsonReplace",
+            customMessage: "JSON recursion helper Walk-JsonReplace missing.");
+
+        // Both path separators MUST be supported — operators may have stored vars as
+        // `Logging:LogLevel:Default` (.NET Core style) OR `Logging.LogLevel.Default` (dot style).
+        ourScript.ShouldContain("$newParts -join ':'",
+            customMessage: "Colon-separated path lookup missing — .NET Core operators won't match.");
+        ourScript.ShouldContain("$newParts -join '.'",
+            customMessage: "Dot-separated path lookup missing — .NET Framework operators won't match.");
+
+        // Order: StructuredConfigurationVariables runs AFTER ConfigurationVariables — Octopus
+        // pipeline places it last among rewriters.
+        var configVarsIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationVariables.Enabled'", StringComparison.Ordinal);
+        var structuredIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled'", StringComparison.Ordinal);
+        var invokeIdx = ourScript.IndexOf("Invoke-Command -Session $compatSession", StringComparison.Ordinal);
+
+        configVarsIdx.ShouldBeLessThan(structuredIdx,
+            customMessage:
+                "StructuredConfigurationVariables must run AFTER ConfigurationVariables (Octopus pipeline order). " +
+                "ConfigurationVariables works on *.config XML; StructuredConfigurationVariables works on JSON — running " +
+                "the JSON rewriter first means later XML rewrites have nothing to overlap, but Octopus's canonical " +
+                "order is appSettings/connectionStrings first, then JSON leaves.");
+        structuredIdx.ShouldBeLessThan(invokeIdx,
+            customMessage: "All config rewriters must run BEFORE the IIS configure dispatch.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1149,6 +1149,208 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Structured Configuration Variables (Phase 9) ─────────────────────────
+    //
+    // The deploy script's `Update-IISStructuredJsonConfiguration` walks operator-specified
+    // JSON files, recurses into the object structure, and replaces leaf values whose path
+    // matches a Squid variable (with `:` or `.` separator). Phase 9 MVP supports JSON;
+    // YAML/properties are future work (Octopus's `StructuredConfigurationVariablesBehaviour`
+    // covers more formats via separate parsers).
+    //
+    // These tests stage real `appsettings.json` files, deploy, then assert the rewritten
+    // JSON's leaf values match the operator's variable values.
+
+    [Fact]
+    public void RealIIS_StructuredConfigurationVariables_TopLevelLeaf_ReplacedByMatchingVariable()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        File.WriteAllText(jsonPath,
+            "{\n" +
+            "  \"AppName\": \"OLD_NAME\",\n" +
+            "  \"Unchanged\": \"keep-me\"\n" +
+            "}\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "AppName", Value = "OrderApi" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StructuredConfigurationVariablesEnabled, "True"),
+            (Property.StructuredConfigurationVariablesTargets, "appsettings.json"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Top-level leaf replacement deploy failed: {result.StdErr}");
+
+        var rewrittenJson = File.ReadAllText(jsonPath);
+        rewrittenJson.ShouldContain("\"OrderApi\"",
+            customMessage: $"Top-level leaf value 'AppName' wasn't replaced. File:\n{rewrittenJson}");
+        rewrittenJson.ShouldNotContain("OLD_NAME");
+        rewrittenJson.ShouldContain("\"keep-me\"",
+            customMessage: "Non-matching leaf was modified — walker is over-eager.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_StructuredConfigurationVariables_NestedLeaf_ColonSeparator_ReplacedByMatchingVariable()
+    {
+        // .NET Core `appsettings.json` operators typically use colon-separated paths
+        // (matches IConfiguration's section separator).
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        File.WriteAllText(jsonPath,
+            "{\n" +
+            "  \"Logging\": {\n" +
+            "    \"LogLevel\": {\n" +
+            "      \"Default\": \"Information\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"ConnectionStrings\": {\n" +
+            "    \"Default\": \"Server=localhost\"\n" +
+            "  }\n" +
+            "}\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "Logging:LogLevel:Default", Value = "Debug" },
+            new() { Name = "ConnectionStrings:Default", Value = "Server=prod-cluster" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StructuredConfigurationVariablesEnabled, "True"),
+            (Property.StructuredConfigurationVariablesTargets, "appsettings.json"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Nested-leaf colon-separator deploy failed: {result.StdErr}");
+
+        var rewritten = File.ReadAllText(jsonPath);
+        // PowerShell ConvertTo-Json may vary indentation between versions — assert on the
+        // VALUE only to keep the test independent of formatting.
+        rewritten.ShouldContain("\"Debug\"",
+            customMessage: $"Logging:LogLevel:Default not replaced to 'Debug'. File:\n{rewritten}");
+        rewritten.ShouldNotContain("Information",
+            customMessage: "Original LogLevel value still present — replacement didn't persist.");
+        rewritten.ShouldContain("Server=prod-cluster",
+            customMessage: $"ConnectionStrings:Default not replaced. File:\n{rewritten}");
+        rewritten.ShouldNotContain("Server=localhost");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_StructuredConfigurationVariables_NestedLeaf_DotSeparator_AlsoMatches()
+    {
+        // .NET Framework operators may use dot-separated variable names (more familiar from
+        // `app.config` style). The rewriter must accept BOTH separator forms (Octopus parity).
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        File.WriteAllText(jsonPath,
+            "{\n" +
+            "  \"Logging\": {\n" +
+            "    \"LogLevel\": {\n" +
+            "      \"Default\": \"Information\"\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n");
+
+        // Dot separator instead of colon
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "Logging.LogLevel.Default", Value = "Trace" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StructuredConfigurationVariablesEnabled, "True"),
+            (Property.StructuredConfigurationVariablesTargets, "appsettings.json"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Dot-separator path deploy failed: {result.StdErr}");
+
+        var rewritten = File.ReadAllText(jsonPath);
+        rewritten.ShouldContain("Trace",
+            customMessage:
+                $"Logging.LogLevel.Default (dot separator) not replaced — dot path matching is broken. " +
+                $"File:\n{rewritten}");
+        rewritten.ShouldNotContain("Information");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_StructuredConfigurationVariables_FeatureDisabled_JsonFileUntouched()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        const string originalContent = "{\n  \"X\": \"keep-me\"\n}\n";
+        File.WriteAllText(jsonPath, originalContent);
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "X", Value = "SHOULD_NOT_BE_APPLIED" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StructuredConfigurationVariablesTargets, "appsettings.json")
+            // StructuredConfigurationVariablesEnabled NOT set — gate stays off
+        );
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Deploy failed: {result.StdErr}");
+
+        File.ReadAllText(jsonPath).ShouldContain("keep-me",
+            customMessage: "JSON file was modified despite feature OFF — gate is broken.");
+        File.ReadAllText(jsonPath).ShouldNotContain("SHOULD_NOT_BE_APPLIED",
+            customMessage: "Rewriter ran despite feature OFF — gate is broken.");
+
+        ctx.MarkClean();
+    }
+
     // ── SubstituteInFiles (Phase 8) ──────────────────────────────────────────
     //
     // The deploy script's `Update-IISFilesWithVariableSubstitution` reads each glob in
@@ -2339,6 +2541,10 @@ public sealed class IISDeployRealHostE2ETests
         // Phase 8 — SubstituteInFiles (Octopus SubstituteInFiles parity)
         public const string SubstituteInFilesEnabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
         public const string SubstituteInFilesTargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+
+        // Phase 9 — Structured Configuration Variables (Octopus JsonConfigurationVariables parity)
+        public const string StructuredConfigurationVariablesEnabled = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled";
+        public const string StructuredConfigurationVariablesTargets = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
## Summary

Mirrors Octopus's `Octopus.Features.JsonConfigurationVariables` (`StructuredConfigurationVariablesBehaviour.cs:13-35`). Walks operator-specified JSON files, recurses the object structure, replaces leaf values whose path matches a Squid variable name. Supports both `:` (colon, .NET Core IConfiguration style) and `.` (dot, .NET Framework style) path separators.

**Distinct from Phase 8 SubstituteInFiles**:
- SubstituteInFiles = TEXT-level `#{X}` token replacement (any format)
- StructuredConfigurationVariables = STRUCTURE-AWARE leaf replacement (operator stores `ConnectionStrings:Default` as variable name; walker matches JSON path `connectionStrings.default` and replaces ONLY that leaf)

PS1 hook order matches Octopus pipeline: **SubstituteInFiles → ConfigurationTransforms → ConfigurationVariables → StructuredConfigurationVariables → IIS configure**.

## What ships

### Production (+105 LOC)

| Change | Notes |
|---|---|
| 2 new constants | `StructuredConfigurationVariablesEnabled` + `Targets` |
| `Targets` via base64 | Newlines preserved for multi-glob list |
| `Update-IISStructuredJsonConfiguration` PS1 | Recursive Walk-JsonReplace helper; both `:` and `.` path separators; arrays of primitives skipped (Phase 9 MVP) |
| `ConvertTo-Json -Depth 32` | Default depth of 2 truncates configs |

### Test code (+260 LOC, 6 new tests)

| Tier | New | What |
|---|---|---|
| Drift detector | 1 | Function presence; both path separators; ordering AFTER ConfigurationVariables |
| Unit | 1 | Toggle + Targets in preamble (Targets via base64) |
| Real-host | 4 | Top-level leaf; nested via `:` (.NET Core); nested via `.` (.NET Framework); feature-disabled gate |

## Octopus alignment

- **JSON-only Phase 9 MVP**: Octopus also handles YAML/properties via separate parsers; deferred to 9.5
- **Both path separators**: matches Octopus's case-insensitive lookup against both forms
- **Hook order**: matches `DeployPackageCommand.cs:118` (LAST among rewriters)

## Cumulative state after Phase 9

- Unit: 70 → **72** (+2)
- Real-host: 50 → **54** (+4)
- **Octopus feature surface: 7/8 complete** — only Package Extraction (Phase 10) remains

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 72 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 54 real-host tests skip cleanly
- [x] `dotnet build` 0 errors
- [ ] CI run on `windows-latest`

## Out of scope

- Phase 9.5: YAML/properties structured config; array element replacement
- Phase 10: Package extraction (NuGet/Zip) — unblocks UI "Package installation directory" mode
- Phase 11: Custom installation directory + purge
- Phase 12: IIS cert auto-import + private-key ACL

## Breaking-change risk

None.