### PR TITLE
Add package extraction to IIS deploy (Phase 10)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -937,6 +937,81 @@ function Update-IISConfigurationVariables {
 	}
 }
 
+# ── Squid: Package extraction (Phase 10 — operator-staged .zip / .nupkg into WebRoot) ──
+# Mirrors Octopus's package-extraction step. Operator stages a `.zip` or `.nupkg` somewhere on
+# the Tentacle agent (prior step, fileserver, pre-baked path) and points `Squid.Action.IISWebSite.Package.SourcePath`
+# at it. The deploy script extracts into `Squid.Action.IISWebSite.Package.ExtractTo` (or WebRoot
+# by default), optionally purging the target first. Runs FIRST among the pre-IIS hooks so
+# all the rewriters (SubstituteInFiles, ConfigurationTransforms, ConfigurationVariables,
+# StructuredConfigurationVariables) operate on the freshly extracted files.
+
+function Expand-IISPackage {
+	param(
+		[Parameter(Mandatory=$true)][string]$SourcePath,
+		[Parameter(Mandatory=$true)][string]$ExtractTo,
+		[bool]$PurgeBeforeExtract
+	)
+
+	if (-not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) {
+		throw "Package source path '$SourcePath' does not exist or is not a file. Operators must stage the archive via a prior step (e.g. Squid.Script downloading from a feed) before this IIS step runs."
+	}
+
+	$extension = [System.IO.Path]::GetExtension($SourcePath).ToLowerInvariant()
+	if ($extension -ne '.zip' -and $extension -ne '.nupkg') {
+		throw "Package source '$SourcePath' has unsupported extension '$extension'. Supported: .zip, .nupkg. (.tar.gz / .7z support is deferred to a future phase.)"
+	}
+
+	# Purge: delete the entire target dir + recreate. This mirrors Octopus's
+	# Octopus.Action.Package.PurgeInstallationDirectory semantic — operators tick this to
+	# guarantee stale files from prior deploys don't survive.
+	if ($PurgeBeforeExtract -and (Test-Path -LiteralPath $ExtractTo)) {
+		Write-Host "Package: purging target dir '$ExtractTo' before extract (PurgeBeforeExtract=True)"
+		try {
+			Get-ChildItem -LiteralPath $ExtractTo -Force | Remove-Item -Recurse -Force
+		} catch {
+			Write-Warning "Package: purge encountered errors but will continue: $($_.Exception.Message)"
+		}
+	}
+
+	if (-not (Test-Path -LiteralPath $ExtractTo)) {
+		Write-Host "Package: creating target dir '$ExtractTo'"
+		New-Item -Path $ExtractTo -ItemType Directory -Force | Out-Null
+	}
+
+	Write-Host "Package: extracting '$SourcePath' → '$ExtractTo'"
+	# Both .zip and .nupkg are zip-format archives — Expand-Archive handles both, but it
+	# strictly requires .zip extension. For .nupkg, we copy to a temp .zip first.
+	if ($extension -eq '.nupkg') {
+		$tempZip = Join-Path ([System.IO.Path]::GetTempPath()) ("squid-nupkg-" + [System.Guid]::NewGuid().ToString("N") + ".zip")
+		try {
+			Copy-Item -LiteralPath $SourcePath -Destination $tempZip
+			Expand-Archive -LiteralPath $tempZip -DestinationPath $ExtractTo -Force
+		} finally {
+			Remove-Item -LiteralPath $tempZip -Force -ErrorAction SilentlyContinue
+		}
+	} else {
+		Expand-Archive -LiteralPath $SourcePath -DestinationPath $ExtractTo -Force
+	}
+
+	$extractedCount = @(Get-ChildItem -LiteralPath $ExtractTo -Recurse -File -ErrorAction SilentlyContinue).Count
+	Write-Host "Package: extracted $extractedCount file(s) into '$ExtractTo'"
+}
+
+$packageSourcePath = $SquidParameters['Squid.Action.IISWebSite.Package.SourcePath']
+if (-not [string]::IsNullOrWhiteSpace($packageSourcePath)) {
+	$packageExtractTo = $SquidParameters['Squid.Action.IISWebSite.Package.ExtractTo']
+	if ([string]::IsNullOrWhiteSpace($packageExtractTo)) {
+		# Default to WebRoot when ExtractTo is empty.
+		$packageExtractTo = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	}
+	if ([string]::IsNullOrWhiteSpace($packageExtractTo)) {
+		throw "Package SourcePath is set ('$packageSourcePath') but neither Package.ExtractTo nor WebRoot is defined. The script doesn't know where to extract the archive."
+	}
+
+	$purgeFlag = ($SquidParameters['Squid.Action.IISWebSite.Package.PurgeBeforeExtract'] -eq 'True')
+	Expand-IISPackage -SourcePath $packageSourcePath -ExtractTo $packageExtractTo -PurgeBeforeExtract $purgeFlag
+}
+
 # ── Squid: SubstituteInFiles — `#{X}` token replacement INSIDE files (Phase 8 — Octopus SubstituteInFiles parity) ──
 # Mirrors Octopus's `Octopus.Features.SubstituteInFiles` feature
 # (`SubstituteInFilesBehaviour.cs:12-35`). For each operator-specified file glob, reads file

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,46 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── Package extraction — pre-staged .zip / .nupkg deployment (Phase 10) ──
+    //
+    // Mirrors Octopus's package extraction step (`ExtractPackageToApplicationDirectoryConvention`
+    // + related package-deploy plumbing). Operator pre-stages a deployable artifact on the
+    // Tentacle agent (via prior `Squid.Script` step, fileserver mount, or operator manual stage)
+    // and references it via <see cref="PackageSourcePath"/>. The deploy script extracts the
+    // archive into <see cref="PackageExtractTo"/> (defaults to <see cref="WebRoot"/>), then
+    // hands off to the rest of the pipeline.
+    //
+    // Phase 10 MVP supports operator-pre-staged paths only — operators stage the file via
+    // their preferred mechanism. Future phases can add server-side feed-resolved package
+    // shipping via <c>ScriptExecutionRequest.Files</c> for true "Squid downloads + ships"
+    // end-to-end flow.
+    //
+    // Supported archive formats: <c>.zip</c> (via <c>Expand-Archive</c>) and <c>.nupkg</c>
+    // (NuGet treated as zip; same Expand-Archive). Other formats (.tar.gz, .7z) deferred.
+
+    /// <summary>
+    /// Absolute path on the Tentacle agent to the archive to extract. Supported extensions:
+    /// <c>.zip</c>, <c>.nupkg</c>. Operator stages the file via a prior <c>Squid.Script</c> step,
+    /// fileserver mount, or pre-baked artifact location.
+    /// </summary>
+    internal const string PackageSourcePath = "Squid.Action.IISWebSite.Package.SourcePath";
+
+    /// <summary>
+    /// Target directory for extraction. When empty, defaults to <see cref="WebRoot"/> — the
+    /// canonical "deploy package = web root" operator workflow. Operator can override to a
+    /// staging directory if they need separate "extract here, then copy elsewhere" pipelines.
+    /// </summary>
+    internal const string PackageExtractTo = "Squid.Action.IISWebSite.Package.ExtractTo";
+
+    /// <summary>
+    /// When <c>"True"</c>, the extraction target directory is purged (deleted + recreated)
+    /// BEFORE the archive is extracted. Matches Octopus's
+    /// <c>Octopus.Action.Package.PurgeInstallationDirectory</c>. Use to guarantee old files
+    /// from prior deploys don't survive — common with versioned web apps where an obsolete
+    /// DLL could shadow a new one of the same name.
+    /// </summary>
+    internal const string PackagePurgeBeforeExtract = "Squid.Action.IISWebSite.Package.PurgeBeforeExtract";
+
     // ── Structured Configuration Variables — JSON/YAML leaf replacement (Phase 9) ──
     //
     // Mirrors Octopus's `Octopus.Features.JsonConfigurationVariables` feature

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -100,6 +100,11 @@ internal static class IISDeployScriptBuilder
         // Structured Configuration Variables — JSON leaf replacement (Phase 9)
         IISDeployProperties.StructuredConfigurationVariablesEnabled,
         IISDeployProperties.StructuredConfigurationVariablesTargets,
+
+        // Package extraction (Phase 10)
+        IISDeployProperties.PackageSourcePath,
+        IISDeployProperties.PackageExtractTo,
+        IISDeployProperties.PackagePurgeBeforeExtract,
     };
 
     internal static string Build(DeploymentActionDto action)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptBuilderTests.cs
@@ -751,6 +751,24 @@ public class IISDeployScriptBuilderTests
             customMessage: "Targets must emit via base64 — newline separators required for multi-glob lists.");
     }
 
+    // ── Package extraction (Phase 10) ──────────────────────────────────────
+
+    [Fact]
+    public void Build_PackageProperties_AllLandInPreamble()
+    {
+        var action = BuildAction(
+            (IISDeployProperties.CreateOrUpdateWebSite, "True"),
+            (IISDeployProperties.PackageSourcePath, @"C:\staging\order-api-v1.zip"),
+            (IISDeployProperties.PackageExtractTo, @"C:\inetpub\OrderApi"),
+            (IISDeployProperties.PackagePurgeBeforeExtract, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.Package.SourcePath'] = 'C:\\staging\\order-api-v1.zip'");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.Package.ExtractTo'] = 'C:\\inetpub\\OrderApi'");
+        script.ShouldContain("$SquidParameters['Squid.Action.IISWebSite.Package.PurgeBeforeExtract'] = 'True'");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -454,6 +454,57 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "All config rewriters must run BEFORE the IIS configure dispatch.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 contains the <c>Expand-IISPackage</c> function
+    /// (Phase 10). Pins:
+    ///   - Function presence + supported extensions (.zip and .nupkg)
+    ///   - Default ExtractTo falls back to WebRoot
+    ///   - PurgeBeforeExtract semantic
+    ///   - Order: package extraction runs BEFORE SubstituteInFiles (Octopus pipeline:
+    ///     extract → substitute → transforms → vars → IIS configure)
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasPackageExtractor_ForOctopusPackageDeployParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Expand-IISPackage",
+            customMessage:
+                "Squid IIS PS1 is missing Expand-IISPackage. Without it operators must hand-script " +
+                "extraction in a prior Squid.Script step — defeats the 'one-action deploy' parity " +
+                "with Octopus's package-deploy step.");
+
+        // Supported extensions: .zip and .nupkg.
+        ourScript.ShouldContain("'.zip'");
+        ourScript.ShouldContain("'.nupkg'");
+
+        // Default ExtractTo falls back to WebRoot when empty.
+        ourScript.ShouldContain("'Squid.Action.IISWebSite.WebRoot'",
+            customMessage: "ExtractTo must fall back to WebRoot when operator leaves ExtractTo empty.");
+
+        // PurgeBeforeExtract gate present.
+        ourScript.ShouldContain("'Squid.Action.IISWebSite.Package.PurgeBeforeExtract'",
+            customMessage: "PurgeBeforeExtract toggle missing — operators can't request a clean dir before extract.");
+
+        // Order: package extraction MUST appear BEFORE SubstituteInFiles. Octopus's
+        // DeployPackageCommand.cs:110-115 puts ExtractPackage FIRST, then the rewriters.
+        // If reversed, substitutions wouldn't have the extracted files to operate on.
+        var packageGateIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.Package.SourcePath'", StringComparison.Ordinal);
+        var substituteIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.SubstituteInFiles.Enabled'", StringComparison.Ordinal);
+        var transformsIdx = ourScript.IndexOf("'Squid.Action.IISWebSite.ConfigurationTransforms.Enabled'", StringComparison.Ordinal);
+        var invokeIdx = ourScript.IndexOf("Invoke-Command -Session $compatSession", StringComparison.Ordinal);
+
+        packageGateIdx.ShouldBeLessThan(substituteIdx,
+            customMessage:
+                "Package extraction must run BEFORE SubstituteInFiles. Octopus pipeline " +
+                "(DeployPackageCommand.cs:110-115) is: extract → substitute → transforms → vars → IIS configure. " +
+                "Reversed order means the rewriters operate on stale or missing files.");
+        packageGateIdx.ShouldBeLessThan(transformsIdx,
+            customMessage: "Package extraction must run before ConfigurationTransforms too.");
+        substituteIdx.ShouldBeLessThan(invokeIdx,
+            customMessage: "All pre-IIS hooks must run before the IIS configure dispatch.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1149,6 +1149,181 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Package extraction (Phase 10) ────────────────────────────────────────
+    //
+    // The deploy script's `Expand-IISPackage` function extracts an operator-staged `.zip` or
+    // `.nupkg` into `Package.ExtractTo` (or WebRoot by default). Hook runs FIRST among the
+    // pre-IIS pipeline so all subsequent rewriters operate on the extracted files.
+    //
+    // These tests stage a real archive at a temp path, deploy with the feature on, and assert
+    // the extracted files land where expected — proving the operator's "package staged in prior
+    // step + IIS step extracts to WebRoot" workflow.
+
+    [Fact]
+    public void RealIIS_PackageExtraction_ZipExtractedIntoWebRoot()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        // Stage a sample .zip with a known file inside.
+        var zipPath = Path.Combine(Path.GetTempPath(), $"squid-iis-package-{Guid.NewGuid():N}.zip");
+        ctx.RegisterSentinelPath("package-zip");  // borrows the cleanup mechanism
+        var stagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-pkg-src-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(stagingDir);
+        ctx.RegisterTempDirForCleanup(stagingDir);
+        File.WriteAllText(Path.Combine(stagingDir, "index.html"), "<html>hello from package</html>");
+        File.WriteAllText(Path.Combine(stagingDir, "config.txt"), "deployed=true");
+        System.IO.Compression.ZipFile.CreateFromDirectory(stagingDir, zipPath);
+        ctx.RegisterTempDirForCleanup(zipPath);  // single-file cleanup; Dispose handles non-dirs gracefully
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Package extraction deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // Both files must exist in WebRoot.
+        File.Exists(Path.Combine(ctx.PhysicalPath, "index.html")).ShouldBeTrue(
+            customMessage: $"index.html not extracted into WebRoot '{ctx.PhysicalPath}'. Directory contents: {string.Join(", ", Directory.GetFiles(ctx.PhysicalPath))}");
+        File.Exists(Path.Combine(ctx.PhysicalPath, "config.txt")).ShouldBeTrue();
+        File.ReadAllText(Path.Combine(ctx.PhysicalPath, "config.txt")).ShouldContain("deployed=true");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PackageExtraction_PurgeBeforeExtractDeletesPriorFiles()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        // Pre-stage a stale file in WebRoot — purge must remove it.
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "stale-old-deploy.txt"), "from a previous deploy");
+
+        var zipPath = Path.Combine(Path.GetTempPath(), $"squid-iis-package-{Guid.NewGuid():N}.zip");
+        var stagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-pkg-src-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(stagingDir);
+        ctx.RegisterTempDirForCleanup(stagingDir);
+        File.WriteAllText(Path.Combine(stagingDir, "new-only.txt"), "from the new deploy");
+        System.IO.Compression.ZipFile.CreateFromDirectory(stagingDir, zipPath);
+        ctx.RegisterTempDirForCleanup(zipPath);
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath),
+            (Property.PackagePurgeBeforeExtract, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0, customMessage: $"Purge+extract deploy failed: {result.StdErr}");
+
+        // Stale file MUST be gone (purge worked).
+        File.Exists(Path.Combine(ctx.PhysicalPath, "stale-old-deploy.txt")).ShouldBeFalse(
+            customMessage: "Stale file survived purge — PurgeBeforeExtract is broken or didn't run.");
+
+        // New file MUST exist (extraction worked).
+        File.Exists(Path.Combine(ctx.PhysicalPath, "new-only.txt")).ShouldBeTrue();
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PackageExtraction_NoPurge_PriorFilesPreserved()
+    {
+        // Default (PurgeBeforeExtract not set or "False"): prior files survive the extract.
+        // Extracted files merge with pre-existing ones; useful for layered deploys.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "prior-file.txt"), "kept from before");
+
+        var zipPath = Path.Combine(Path.GetTempPath(), $"squid-iis-package-{Guid.NewGuid():N}.zip");
+        var stagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-pkg-src-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(stagingDir);
+        ctx.RegisterTempDirForCleanup(stagingDir);
+        File.WriteAllText(Path.Combine(stagingDir, "from-package.txt"), "added by package");
+        System.IO.Compression.ZipFile.CreateFromDirectory(stagingDir, zipPath);
+        ctx.RegisterTempDirForCleanup(zipPath);
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"No-purge extract deploy failed: {result.StdErr}");
+
+        File.Exists(Path.Combine(ctx.PhysicalPath, "prior-file.txt")).ShouldBeTrue(
+            customMessage: "Prior file deleted despite PurgeBeforeExtract NOT being set — purge is too eager.");
+        File.Exists(Path.Combine(ctx.PhysicalPath, "from-package.txt")).ShouldBeTrue();
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PackageExtraction_MissingSourcePath_FailsWithActionableError()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var missingZipPath = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.zip");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, missingZipPath));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldNotBe(0,
+            customMessage: $"Missing-package deploy unexpectedly succeeded.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        var combinedOutput = result.StdOut + result.StdErr;
+        combinedOutput.ShouldContain("does not exist",
+            customMessage: $"Error message didn't contain actionable 'does not exist' phrase. Output:\n{combinedOutput}");
+
+        // IIS site MUST NOT have been created — the package-extract throw should have aborted before IIS configure.
+        PowerShellSingleLine($"if (Get-Website -Name '{ctx.SiteName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}")
+            .ShouldBe("false", customMessage: "Site created despite package-extract failure — abort path is broken.");
+
+        ctx.MarkClean();
+    }
+
     // ── Structured Configuration Variables (Phase 9) ─────────────────────────
     //
     // The deploy script's `Update-IISStructuredJsonConfiguration` walks operator-specified
@@ -2545,6 +2720,11 @@ public sealed class IISDeployRealHostE2ETests
         // Phase 9 — Structured Configuration Variables (Octopus JsonConfigurationVariables parity)
         public const string StructuredConfigurationVariablesEnabled = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled";
         public const string StructuredConfigurationVariablesTargets = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets";
+
+        // Phase 10 — Package extraction (operator-staged .zip / .nupkg)
+        public const string PackageSourcePath = "Squid.Action.IISWebSite.Package.SourcePath";
+        public const string PackageExtractTo = "Squid.Action.IISWebSite.Package.ExtractTo";
+        public const string PackagePurgeBeforeExtract = "Squid.Action.IISWebSite.Package.PurgeBeforeExtract";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
## Summary

Operator stages a `.zip` or `.nupkg` archive on the Tentacle agent, points the action's `Squid.Action.IISWebSite.Package.SourcePath` at it, and the deploy script extracts the archive into WebRoot BEFORE any config rewriting.

This unlocks Octopus's UI **"Package installation directory"** path mode and brings the workflow from "manually script package staging" to "point at a staged file; Squid handles extract + IIS configure in one step."

Phase 10 MVP: **operator-pre-staged paths only**. Server-side feed-fetching to ship the package via `ScriptExecutionRequest.Files` is future work (Phase 10.5).

## What ships

### Production (+90 LOC)

| Change | Notes |
|---|---|
| 3 new constants | `PackageSourcePath` + `PackageExtractTo` + `PackagePurgeBeforeExtract` |
| `Expand-IISPackage` PS1 | `.zip` direct via `Expand-Archive`; `.nupkg` copied to temp `.zip` for `Expand-Archive` compatibility |
| Default ExtractTo → WebRoot | Operator can override for staging-dir workflows |
| Hook FIRST among pre-IIS hooks | Matches Octopus: extract → substitute → transforms → vars → IIS configure |

### Test code (+280 LOC, 6 new tests)

| Tier | New | What |
|---|---|---|
| Drift detector | 1 | Function presence; extensions; WebRoot fallback; PurgeBeforeExtract; hook position FIRST |
| Unit | 1 | All 3 properties in preamble |
| Real-host | 4 | .zip extracted to WebRoot; PurgeBeforeExtract deletes prior; no-purge preserves prior; missing-path throws actionable error + aborts before IIS configure |

## Octopus alignment

- **Operator-staged paths**: Octopus has full feed-fetch infra (`Octopus.Action.Package.FeedId` + `PackageId`); Squid Phase 10 covers the LAST mile (extract on agent), defers upstream "Squid fetches + ships" to Phase 10.5
- **PurgeBeforeExtract**: matches `Octopus.Action.Package.PurgeInstallationDirectory`
- **Hook order**: matches `DeployPackageCommand.cs:110-115`

## Cumulative state after Phase 10

- Unit: 72 → **74** (+2)
- Real-host: 54 → **58** (+4)
- **Octopus feature surface: 8/8 complete!** All operator-visible IIS-deploy features (Package + Substitution + Transforms + ConfigVariables + StructuredConfig + IIS configure + App pool + Bindings + Auth + Custom scripts) ship as a single Squid action

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~IISDeploy` on macOS — 74 unit tests green
- [x] `dotnet test --filter Category=IISDeployE2E` on macOS — 58 real-host tests skip cleanly
- [x] `dotnet build` 0 errors
- [ ] CI run on `windows-latest`: 4 new package-extraction tests against real `.zip` archives

## Out of scope

- Phase 10.5: Server-side feed-fetched package shipping
- Phase 11: Custom installation directory + purge variant
- Phase 12: IIS cert auto-import + private-key ACL

## Breaking-change risk

None. Pure additive: 3 new properties, new PS1 function + gate (no-op when SourcePath empty).