### PR TITLE
Add packaged-scripts discovery to IIS deploy (P1-3)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -849,6 +849,28 @@ if (-not [string]::IsNullOrWhiteSpace($preDeployScript)) {
 	}
 }
 
+# ── Squid: Packaged PreDeploy script (Phase 1.6.9 P1-3 — Octopus PackagedScriptBehaviour parity) ──
+# After Octopus's `ConfiguredScriptBehaviour` runs the operator-inline PreDeploy script,
+# `PackagedScriptBehaviour` (`PackagedScriptBehaviour.cs:14-35`) ALSO looks inside the
+# EXTRACTED PACKAGE for a `PreDeploy.ps1` file and runs it. This lets developers ship
+# deploy-stage scripts WITH their application code instead of authoring them inline in
+# the deploy step UI. Squid mirrors the same operator-facing contract: when the package
+# extraction step (Phase 10) wrote a `PreDeploy.ps1` into WebRoot, we invoke it here.
+#
+# Order vs. inline PreDeploy: matches Octopus — configured (inline) first, packaged second.
+$preDeployWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+if (-not [string]::IsNullOrWhiteSpace($preDeployWebRoot)) {
+	$packagedPreDeploy = Join-Path $preDeployWebRoot 'PreDeploy.ps1'
+	if (Test-Path -LiteralPath $packagedPreDeploy -PathType Leaf) {
+		Write-Host "Packaged PreDeploy: running '$packagedPreDeploy'"
+		Import-Module WebAdministration -ErrorAction SilentlyContinue
+		& $packagedPreDeploy
+		if ($LastExitCode -ne 0 -and $null -ne $LastExitCode) {
+			throw "Packaged PreDeploy script '$packagedPreDeploy' exited with code $LastExitCode. Aborting IIS deploy."
+		}
+	}
+}
+
 # ── Squid: .NET Configuration Variables rewriter (Phase 6 — Octopus ConfigurationVariables parity) ──
 # Mirrors Octopus's `Octopus.Features.ConfigurationVariables` feature. When the toggle is True
 # and a `Squid.Action.IISWebSite.WebRoot` is set, walks every *.config file under that dir and
@@ -1400,6 +1422,23 @@ if (-not [string]::IsNullOrWhiteSpace($postDeployScript)) {
 	& $postDeployBlock
 	if ($LastExitCode -ne 0 -and $null -ne $LastExitCode) {
 		throw "PostDeploy custom script exited with code $LastExitCode."
+	}
+}
+
+# ── Squid: Packaged PostDeploy script (Phase 1.6.9 P1-3) ──
+# Same as packaged PreDeploy above but for the PostDeploy stage. Operator can ship a
+# `PostDeploy.ps1` inside the package — usually for smoke-tests, cache warming, or
+# instrumentation. Runs AFTER both IIS configure AND the inline PostDeploy hook.
+$postDeployWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+if (-not [string]::IsNullOrWhiteSpace($postDeployWebRoot)) {
+	$packagedPostDeploy = Join-Path $postDeployWebRoot 'PostDeploy.ps1'
+	if (Test-Path -LiteralPath $packagedPostDeploy -PathType Leaf) {
+		Write-Host "Packaged PostDeploy: running '$packagedPostDeploy'"
+		Import-Module WebAdministration -ErrorAction SilentlyContinue
+		& $packagedPostDeploy
+		if ($LastExitCode -ne 0 -and $null -ne $LastExitCode) {
+			throw "Packaged PostDeploy script '$packagedPostDeploy' exited with code $LastExitCode."
+		}
 	}
 }
 

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -505,6 +505,37 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "All pre-IIS hooks must run before the IIS configure dispatch.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 picks up <c>PreDeploy.ps1</c> / <c>PostDeploy.ps1</c>
+    /// files inside the extracted package (Phase 1.6.9 P1-3 — Octopus PackagedScriptBehaviour parity).
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasPackagedPreAndPostDeployDiscovery_ForOctopusPackagedScriptParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("Packaged PreDeploy",
+            customMessage: "Packaged PreDeploy block missing — operators can't ship PreDeploy.ps1 inside their package.");
+        ourScript.ShouldContain("Packaged PostDeploy",
+            customMessage: "Packaged PostDeploy block missing.");
+
+        ourScript.ShouldContain("Join-Path $preDeployWebRoot 'PreDeploy.ps1'",
+            customMessage: "Packaged PreDeploy must resolve PreDeploy.ps1 relative to WebRoot.");
+        ourScript.ShouldContain("Join-Path $postDeployWebRoot 'PostDeploy.ps1'",
+            customMessage: "Packaged PostDeploy must resolve PostDeploy.ps1 relative to WebRoot.");
+
+        // Ordering: configured (inline) PreDeploy must run BEFORE packaged PreDeploy.
+        var inlinePre = ourScript.IndexOf("'Squid.Action.CustomScripts.PreDeploy.ps1'", StringComparison.Ordinal);
+        var packagedPre = ourScript.IndexOf("Packaged PreDeploy", StringComparison.Ordinal);
+        var packagedPost = ourScript.IndexOf("Packaged PostDeploy", StringComparison.Ordinal);
+        var inlinePost = ourScript.IndexOf("'Squid.Action.CustomScripts.PostDeploy.ps1'", StringComparison.Ordinal);
+
+        inlinePre.ShouldBeLessThan(packagedPre,
+            customMessage: "Configured (inline) PreDeploy must run BEFORE packaged PreDeploy.ps1 (Octopus order).");
+        inlinePost.ShouldBeLessThan(packagedPost,
+            customMessage: "Configured PostDeploy must run BEFORE packaged PostDeploy.ps1 (Octopus order).");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1943,6 +1943,112 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Packaged scripts inside the artifact (Phase 1.6.9 P1-3) ─────────────
+    //
+    // After Phase 10 package extraction, the deploy script auto-discovers `PreDeploy.ps1`
+    // and `PostDeploy.ps1` in the extracted package and runs them. Mirrors Octopus's
+    // `PackagedScriptBehaviour` so devs can ship deploy-stage scripts WITH their app code.
+
+    [Fact]
+    public void RealIIS_PackagedPreDeployScript_DiscoveredAndExecuted()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var sentinelPath = ctx.RegisterSentinelPath("packaged-predeploy");
+
+        // Pre-stage the WebRoot with a `PreDeploy.ps1` file — simulates a deploy package
+        // that has the script in its root after extraction.
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "PreDeploy.ps1"),
+            $"Set-Content -Path '{sentinelPath}' -Value 'packaged-predeploy-fired'");
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Packaged PreDeploy deploy failed: {result.StdErr}");
+
+        File.Exists(sentinelPath).ShouldBeTrue(
+            customMessage: $"Packaged PreDeploy.ps1 didn't run — sentinel '{sentinelPath}' missing. " +
+                          "Check the `Test-Path PreDeploy.ps1` discovery block in PS1.");
+        File.ReadAllText(sentinelPath).Trim().ShouldBe("packaged-predeploy-fired");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PackagedPostDeployScript_DiscoveredAndExecutedAfterIISConfigure()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var sentinelPath = ctx.RegisterSentinelPath("packaged-postdeploy");
+
+        // PostDeploy queries the IIS site state — proves it ran AFTER IIS configure.
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "PostDeploy.ps1"),
+            $"$site = Get-Website -Name '{ctx.SiteName}'; " +
+            $"Set-Content -Path '{sentinelPath}' -Value $site.State");
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StartApplicationPool, "True"),
+            (Property.StartWebSite, "True")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Packaged PostDeploy deploy failed: {result.StdErr}");
+
+        File.Exists(sentinelPath).ShouldBeTrue(
+            customMessage: $"Packaged PostDeploy.ps1 didn't run.");
+        File.ReadAllText(sentinelPath).Trim().ShouldBe("Started",
+            customMessage: "Packaged PostDeploy observed wrong site state — confirms ordering: must run AFTER IIS configure.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_PackagedScriptsAbsent_DeployProceedsNormally()
+    {
+        // Operator's package has neither PreDeploy.ps1 nor PostDeploy.ps1 — deploy should
+        // complete normally without errors (Test-Path negative + skip).
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Deploy without packaged scripts failed: {result.StdErr}");
+
+        PowerShellSingleLine($"if (Get-Website -Name '{ctx.SiteName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}")
+            .ShouldBe("true", customMessage: "Site missing — deploy didn't complete despite scripts being absent.");
+
+        ctx.MarkClean();
+    }
+
     // ── Custom-script hooks (Phase 5: PreDeploy + PostDeploy) ───────────────
     //
     // Octopus's `ConfiguredScriptBehaviour` runs operator-inline scripts at 5 stages of


### PR DESCRIPTION
Operator ships PreDeploy.ps1 / PostDeploy.ps1 IN the package; deploy script auto-discovers + runs them. Mirrors Octopus's PackagedScriptBehaviour. +3 real-host tests, +1 drift-detector invariant. Zero production breaking risk.