### PR TITLE
Add IIS cert auto-import + private-key ACL (P0-1)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -959,6 +959,130 @@ function Update-IISConfigurationVariables {
 	}
 }
 
+# ── Squid: Certificate auto-import (1.6.9 P0-1 — Octopus IisWebSiteBeforeDeployFeature parity) ──
+# When the operator sets `Squid.Action.IISWebSite.Certificate.PfxBase64`, decode the PFX
+# bytes, import into Cert:\LocalMachine\My, and expose the resulting thumbprint via
+# `$SquidVariables["<VariableName>.Thumbprint"]` so the Bindings JSON's
+# `"certificateVariable": "<VariableName>"` path resolves to the freshly-imported thumbprint.
+# Mirrors Octopus's `IisWebSiteBeforeDeployFeature.cs:24-89`.
+
+function Import-IISCertificateFromPfxBase64 {
+	param(
+		[Parameter(Mandatory=$true)][string]$Base64,
+		[string]$Password,
+		[string]$ThumbprintVariableName
+	)
+
+	if ([string]::IsNullOrWhiteSpace($Base64)) { return $null }
+
+	$bytes = [System.Convert]::FromBase64String($Base64)
+	$tempPfx = Join-Path ([System.IO.Path]::GetTempPath()) ("squid-iis-cert-" + [System.Guid]::NewGuid().ToString("N") + ".pfx")
+	try {
+		[System.IO.File]::WriteAllBytes($tempPfx, $bytes)
+
+		# Import: KeyStorageFlags include MachineKeySet (key in machine store, not user)
+		# + PersistKeySet (private key persists across import) + Exportable (operator can
+		# re-export if needed). Same flags Octopus uses.
+		$securePw = if ([string]::IsNullOrEmpty($Password)) {
+			New-Object System.Security.SecureString
+		} else {
+			ConvertTo-SecureString -String $Password -AsPlainText -Force
+		}
+
+		$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+			$tempPfx,
+			$securePw,
+			[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags] 'MachineKeySet, PersistKeySet, Exportable')
+
+		$store = New-Object System.Security.Cryptography.X509Certificates.X509Store(
+			[System.Security.Cryptography.X509Certificates.StoreName]::My,
+			[System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine)
+		try {
+			$store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+			$store.Add($cert)
+		} finally {
+			$store.Close()
+		}
+
+		Write-Host "Certificate: imported PFX with thumbprint $($cert.Thumbprint) into LocalMachine\My"
+
+		if (-not [string]::IsNullOrWhiteSpace($ThumbprintVariableName)) {
+			# Expose via the cert-variable convention so Bindings JSON's
+			# `"certificateVariable": "<name>"` lookup finds it.
+			$SquidVariables["$ThumbprintVariableName.Thumbprint"] = $cert.Thumbprint
+			Write-Host "Certificate: exposed thumbprint via SquidVariables['$ThumbprintVariableName.Thumbprint']"
+		}
+
+		return $cert.Thumbprint
+	} finally {
+		try { if (Test-Path -LiteralPath $tempPfx) { Remove-Item -LiteralPath $tempPfx -Force -ErrorAction SilentlyContinue } } catch {}
+	}
+}
+
+# Grant the AppPool's identity Read access on the imported cert's PRIVATE KEY file.
+# Without this ACL, the IIS worker process can't load the private key and HTTPS requests
+# return TLS-handshake failures even though netsh binding is correct. Mirrors Octopus's
+# `IisWebSiteAfterPostDeployFeature.cs:27-94`.
+function Grant-AppPoolPrivateKeyAccess {
+	param(
+		[Parameter(Mandatory=$true)][string]$Thumbprint,
+		[Parameter(Mandatory=$true)][string]$AppPoolName
+	)
+
+	$cert = Get-ChildItem -Path "Cert:\LocalMachine\My\$Thumbprint" -ErrorAction SilentlyContinue
+	if ($null -eq $cert) {
+		Write-Warning "Grant-AppPoolPrivateKeyAccess: cert with thumbprint $Thumbprint not in Cert:\LocalMachine\My; skipping ACL grant."
+		return
+	}
+
+	# Locate the private-key file on disk. The path differs by key-storage provider
+	# (CSP/CNG); we use CertificateExtensionsRSA helper introduced in .NET 4.6+ which
+	# handles both.
+	$rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
+	if ($null -eq $rsa) {
+		Write-Warning "Grant-AppPoolPrivateKeyAccess: cert $Thumbprint has no RSA private key; skipping."
+		return
+	}
+
+	$keyFilePath = $null
+	# CNG path (modern certs)
+	if ($rsa -is [System.Security.Cryptography.RSACng]) {
+		$keyName = $rsa.Key.UniqueName
+		$keyFilePath = Join-Path "$env:ProgramData\Microsoft\Crypto\Keys" $keyName
+		if (-not (Test-Path -LiteralPath $keyFilePath)) {
+			$keyFilePath = Join-Path "$env:ALLUSERSPROFILE\Microsoft\Crypto\Keys" $keyName
+		}
+	}
+	# Legacy CSP path
+	if ($null -eq $keyFilePath -and $rsa -is [System.Security.Cryptography.RSACryptoServiceProvider]) {
+		$keyName = $rsa.CspKeyContainerInfo.UniqueKeyContainerName
+		$keyFilePath = Join-Path "$env:ProgramData\Microsoft\Crypto\RSA\MachineKeys" $keyName
+	}
+
+	if ([string]::IsNullOrEmpty($keyFilePath) -or -not (Test-Path -LiteralPath $keyFilePath)) {
+		Write-Warning "Grant-AppPoolPrivateKeyAccess: could not locate private-key file for thumbprint $Thumbprint (probed CNG + CSP paths). Skipping ACL grant."
+		return
+	}
+
+	$acl = Get-Acl -LiteralPath $keyFilePath
+	$appPoolIdentity = "IIS APPPOOL\$AppPoolName"
+	$rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+		$appPoolIdentity,
+		[System.Security.AccessControl.FileSystemRights]::Read,
+		[System.Security.AccessControl.AccessControlType]::Allow)
+	$acl.AddAccessRule($rule)
+	Set-Acl -LiteralPath $keyFilePath -AclObject $acl
+	Write-Host "Certificate: granted Read access on private key '$keyFilePath' to '$appPoolIdentity'"
+}
+
+$certPfxBase64 = $SquidParameters['Squid.Action.IISWebSite.Certificate.PfxBase64']
+$importedCertThumbprint = $null
+if (-not [string]::IsNullOrWhiteSpace($certPfxBase64)) {
+	$certPfxPassword = $SquidParameters['Squid.Action.IISWebSite.Certificate.PfxPassword']
+	$certVarName = $SquidParameters['Squid.Action.IISWebSite.Certificate.ThumbprintVariableName']
+	$importedCertThumbprint = Import-IISCertificateFromPfxBase64 -Base64 $certPfxBase64 -Password $certPfxPassword -ThumbprintVariableName $certVarName
+}
+
 # ── Squid: Package extraction (Phase 10 — operator-staged .zip / .nupkg into WebRoot) ──
 # Mirrors Octopus's package-extraction step. Operator stages a `.zip` or `.nupkg` somewhere on
 # the Tentacle agent (prior step, fileserver, pre-baked path) and points `Squid.Action.IISWebSite.Package.SourcePath`
@@ -1408,6 +1532,18 @@ if ($psVersion.Major -ge 7 -and $psVersion.Minor -ge 3) {
 }
 else {
 	&$DeployIISScriptBlock -SquidParameters $SquidParameters
+}
+
+# ── Squid: Grant AppPool private-key ACL (1.6.9 P0-1) ──
+# After bindings have been applied (during IIS configure dispatch above), grant the
+# AppPool's identity Read access on the imported cert's private key file. Without this
+# the worker process can't load the private key → TLS handshake fails. Runs only if
+# we auto-imported a cert AND the AppPool name is set.
+if (-not [string]::IsNullOrWhiteSpace($importedCertThumbprint)) {
+	$appPoolForAcl = $SquidParameters['Squid.Action.IISWebSite.ApplicationPoolName']
+	if (-not [string]::IsNullOrWhiteSpace($appPoolForAcl)) {
+		Grant-AppPoolPrivateKeyAccess -Thumbprint $importedCertThumbprint -AppPoolName $appPoolForAcl
+	}
 }
 
 # ── Squid: Custom-script PostDeploy hook (Phase 5) ──

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,43 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── Certificate auto-import + private-key ACL (P0-1, 1.6.9) ───────────────
+    //
+    // Operator-friendly HTTPS deploys without manual cert staging. Operator stores the PFX
+    // contents as a base64 string in a Squid variable, references that variable here.
+    // The deploy script imports the cert into `Cert:\LocalMachine\My`, writes the resulting
+    // thumbprint into `$SquidVariables["<SiteThumbprintVariableName>.Thumbprint"]`, then the
+    // Bindings JSON references it via `"certificateVariable": "<SiteThumbprintVariableName>"`
+    // (Phase 2's existing cert-variable lookup path).
+    //
+    // After the bindings apply via `netsh http add sslcert`, the script grants the AppPool's
+    // identity Read access on the cert's private key file. Mirrors Octopus's
+    // `IisWebSiteBeforeDeployFeature.cs:24-89` (import) + `IisWebSiteAfterPostDeployFeature.cs:27-94`
+    // (ACL).
+
+    /// <summary>
+    /// Base64-encoded PFX (PKCS#12) bytes. Operator-friendly path: store the PFX as a
+    /// sensitive Squid variable, then reference via <c>#{MyPfxVariable}</c> here. When set,
+    /// the deploy script imports the cert into <c>Cert:\LocalMachine\My</c> on the agent
+    /// before binding resolution.
+    /// </summary>
+    internal const string CertificatePfxBase64 = "Squid.Action.IISWebSite.Certificate.PfxBase64";
+
+    /// <summary>
+    /// Import password for the PFX. Sensitive — operators set this as a Squid sensitive
+    /// variable and reference here. Empty / unset when the PFX has no password.
+    /// </summary>
+    internal const string CertificatePfxPassword = "Squid.Action.IISWebSite.Certificate.PfxPassword";
+
+    /// <summary>
+    /// Logical variable name under which the imported cert's thumbprint is exposed at runtime.
+    /// For example, if set to <c>"OrderApiCert"</c>, the imported thumbprint lands in
+    /// <c>$SquidVariables["OrderApiCert.Thumbprint"]</c>. The operator's Bindings JSON can
+    /// then reference it via <c>"certificateVariable": "OrderApiCert"</c> — Phase 2's existing
+    /// cert-variable lookup path finds it automatically.
+    /// </summary>
+    internal const string CertificateThumbprintVariableName = "Squid.Action.IISWebSite.Certificate.ThumbprintVariableName";
+
     // ── Package extraction — pre-staged .zip / .nupkg deployment (Phase 10) ──
     //
     // Mirrors Octopus's package extraction step (`ExtractPackageToApplicationDirectoryConvention`

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -105,6 +105,11 @@ internal static class IISDeployScriptBuilder
         IISDeployProperties.PackageSourcePath,
         IISDeployProperties.PackageExtractTo,
         IISDeployProperties.PackagePurgeBeforeExtract,
+
+        // Certificate auto-import (P0-1, 1.6.9)
+        IISDeployProperties.CertificatePfxBase64,
+        IISDeployProperties.CertificatePfxPassword,
+        IISDeployProperties.CertificateThumbprintVariableName,
     };
 
     internal static string Build(DeploymentActionDto action)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -536,6 +536,50 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "Configured PostDeploy must run BEFORE packaged PostDeploy.ps1 (Octopus order).");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 contains <c>Import-IISCertificateFromPfxBase64</c> +
+    /// <c>Grant-AppPoolPrivateKeyAccess</c> (Phase 1.6.9 P0-1).
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasCertificateAutoImportAndAclGrant_ForOctopusIisWebSiteCertParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Import-IISCertificateFromPfxBase64",
+            customMessage: "Cert import function missing — operators can't auto-import PFX certs.");
+        ourScript.ShouldContain("function Grant-AppPoolPrivateKeyAccess",
+            customMessage: "Private-key ACL function missing — HTTPS deploys would TLS-handshake-fail despite correct netsh binding.");
+
+        // Imports into LocalMachine\My (not CurrentUser — IIS reads from machine store).
+        ourScript.ShouldContain("StoreName]::My",
+            customMessage: "Cert must be imported to LocalMachine\\My (operator-friendly default).");
+        ourScript.ShouldContain("StoreLocation]::LocalMachine");
+
+        // Exposes thumbprint via the cert-variable convention so Phase 2's binding lookup works.
+        ourScript.ShouldContain("$ThumbprintVariableName.Thumbprint",
+            customMessage: "Imported thumbprint must be exposed via SquidVariables[VarName.Thumbprint] for Bindings JSON cert-variable lookup.");
+
+        // ACL grant uses `IIS APPPOOL\<PoolName>` — IIS-specific synthetic identity.
+        ourScript.ShouldContain("IIS APPPOOL",
+            customMessage: "ACL grant must target the AppPool's synthetic identity 'IIS APPPOOL\\<PoolName>'.");
+
+        // Order: cert IMPORT happens BEFORE the IIS configure dispatch (bindings need the
+        // thumbprint exposed before they resolve). ACL grant happens AFTER (AppPool must exist).
+        var importIdx = ourScript.IndexOf("Import-IISCertificateFromPfxBase64", StringComparison.Ordinal);
+        var invokeIdx = ourScript.IndexOf("Invoke-Command -Session $compatSession", StringComparison.Ordinal);
+        var aclIdx = ourScript.IndexOf("Grant-AppPoolPrivateKeyAccess", StringComparison.Ordinal);
+
+        // The function DEFINITION should appear before the invocation. We're checking the
+        // INVOCATION position of `Grant-AppPoolPrivateKeyAccess` which calls the function —
+        // the LAST occurrence is the invocation site, not the definition. Use LastIndexOf.
+        var aclInvokeIdx = ourScript.LastIndexOf("Grant-AppPoolPrivateKeyAccess", StringComparison.Ordinal);
+
+        importIdx.ShouldBeLessThan(invokeIdx,
+            customMessage: "Cert import must run BEFORE IIS configure dispatch — bindings need the thumbprint exposed first.");
+        invokeIdx.ShouldBeLessThan(aclInvokeIdx,
+            customMessage: "Private-key ACL grant must run AFTER IIS configure dispatch — AppPool's synthetic identity exists only after pool is created.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1943,6 +1943,148 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Certificate auto-import + private-key ACL (1.6.9 P0-1) ───────────────
+    //
+    // Operator stores PFX bytes as a base64 Squid variable. Deploy script decodes,
+    // imports to `Cert:\LocalMachine\My`, exposes the thumbprint via $SquidVariables,
+    // and the binding cert-variable lookup uses it. After IIS configure, grants the
+    // AppPool's identity Read access on the cert's private key file.
+
+    [Fact]
+    public void RealIIS_CertificateAutoImport_PfxLandsInLocalMachineMy_AndExposedViaSquidVariables()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        // Stage a self-signed PFX in memory; capture base64 for the action property.
+        var pfxBytes = GenerateSelfSignedPfxBytes($"squid-iis-autoimport-{Guid.NewGuid():N}", "P@ssw0rd!Test");
+        var pfxBase64 = Convert.ToBase64String(pfxBytes);
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.CertificatePfxBase64, pfxBase64),
+            (Property.CertificatePfxPassword, "P@ssw0rd!Test"),
+            (Property.CertificateThumbprintVariableName, "MyImportedCert")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Cert auto-import deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // Confirm the cert is now in LocalMachine\My. Grep STDOUT for the thumbprint line
+        // emitted by the import function.
+        result.StdOut.ShouldContain("imported PFX with thumbprint",
+            customMessage: $"Import didn't log success. STDOUT:\n{result.StdOut}");
+
+        // Look up the imported thumbprint from STDOUT for cleanup verification.
+        var match = System.Text.RegularExpressions.Regex.Match(
+            result.StdOut, @"thumbprint ([A-F0-9]{40})", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        match.Success.ShouldBeTrue("Couldn't extract imported thumbprint from STDOUT — log format may have changed.");
+
+        var importedThumbprint = match.Groups[1].Value;
+        ctx.RegisterCertThumbprintForCleanup(importedThumbprint);
+
+        // The cert MUST be in the store now.
+        var inStore = PowerShellSingleLine(
+            $"if (Get-ChildItem -Path 'Cert:\\LocalMachine\\My\\{importedThumbprint}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}");
+        inStore.ShouldBe("true",
+            customMessage: $"Imported cert with thumbprint {importedThumbprint} not found in Cert:\\LocalMachine\\My after deploy.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_CertificateAutoImport_HttpsBindingViaCertificateVariable_ResolvesToAutoImportedThumbprint()
+    {
+        // End-to-end: auto-import PFX + Bindings JSON references the cert via
+        // `certificateVariable` (the variable name set by the operator). After deploy,
+        // `netsh http show sslcert` must show the auto-imported thumbprint bound.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        ctx.RegisterNetshIpPortForCleanup(ctx.HttpsPort);
+
+        var pfxBytes = GenerateSelfSignedPfxBytes($"squid-iis-https-auto-{Guid.NewGuid():N}", "");
+        var pfxBase64 = Convert.ToBase64String(pfxBytes);
+
+        var script = IISDeployScriptBuilder.Build(BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.CertificatePfxBase64, pfxBase64),
+            (Property.CertificatePfxPassword, ""),
+            (Property.CertificateThumbprintVariableName, "AutoImportedSiteCert"),
+            // Bindings JSON uses `certificateVariable` to reference the auto-imported cert
+            // by its operator-chosen logical name. The PS1's cert-variable lookup resolves
+            // to `$SquidVariables["AutoImportedSiteCert.Thumbprint"]` which the import
+            // function populated.
+            (Property.Bindings,
+                "[{\"protocol\":\"https\",\"port\":\"" + ctx.HttpsPort + "\",\"host\":\"\"," +
+                "\"ipAddress\":\"*\",\"certificateVariable\":\"AutoImportedSiteCert\"," +
+                "\"requireSni\":false,\"enabled\":true}]")));
+
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Auto-import + HTTPS-binding deploy failed.\nSTDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // Extract thumbprint + register for cleanup
+        var match = System.Text.RegularExpressions.Regex.Match(
+            result.StdOut, @"imported PFX with thumbprint ([A-F0-9]{40})", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        match.Success.ShouldBeTrue();
+        var importedThumbprint = match.Groups[1].Value;
+        ctx.RegisterCertThumbprintForCleanup(importedThumbprint);
+
+        // netsh MUST show the auto-imported thumbprint bound on the HTTPS port.
+        var netshOutput = RunPowerShell($"& netsh http show sslcert ipport=0.0.0.0:{ctx.HttpsPort}").StdOut;
+        netshOutput.ToUpperInvariant().ShouldContain(importedThumbprint.ToUpperInvariant(),
+            customMessage:
+                $"netsh sslcert binding doesn't show auto-imported thumbprint {importedThumbprint}. " +
+                "Confirms cert-variable resolution failed to find the import. netsh output:\n" + netshOutput);
+
+        ctx.MarkClean();
+    }
+
+    /// <summary>
+    /// Generates a self-signed PFX in memory for testing. Returns the raw PFX bytes
+    /// (operator-equivalent of <c>Get-Content -AsByteStream</c> on a real cert file).
+    /// </summary>
+    private static byte[] GenerateSelfSignedPfxBytes(string dnsName, string password)
+    {
+        var pwArg = string.IsNullOrEmpty(password) ? "$null" : $"(ConvertTo-SecureString -String '{password}' -AsPlainText -Force)";
+        var tempPfx = Path.Combine(Path.GetTempPath(), $"squid-gen-cert-{Guid.NewGuid():N}.pfx");
+        try
+        {
+            // PowerShell is the easiest way to generate a self-signed cert + export to PFX
+            // on Windows. The result bytes are what an operator would have on disk.
+            var script =
+                $"$cert = New-SelfSignedCertificate -DnsName '{dnsName}' " +
+                $"-CertStoreLocation Cert:\\CurrentUser\\My -KeyExportPolicy Exportable; " +
+                $"Export-PfxCertificate -Cert $cert -FilePath '{tempPfx}' -Password {pwArg} | Out-Null; " +
+                // Clean up the CurrentUser copy — we only need the PFX bytes for the test.
+                $"Remove-Item Cert:\\CurrentUser\\My\\$($cert.Thumbprint) -Force -ErrorAction SilentlyContinue";
+
+            var r = RunPowerShell(script);
+            if (r.ExitCode != 0)
+                throw new InvalidOperationException($"Self-signed PFX generation failed: {r.StdErr}");
+            return File.ReadAllBytes(tempPfx);
+        }
+        finally
+        {
+            try { if (File.Exists(tempPfx)) File.Delete(tempPfx); } catch { }
+        }
+    }
+
     // ── Packaged scripts inside the artifact (Phase 1.6.9 P1-3) ─────────────
     //
     // After Phase 10 package extraction, the deploy script auto-discovers `PreDeploy.ps1`
@@ -2699,6 +2841,13 @@ public sealed class IISDeployRealHostE2ETests
         }
 
         /// <summary>
+        /// Registers an externally-imported cert thumbprint for removal during <see cref="Dispose"/>.
+        /// Used by Phase 1.6.9 P0-1 tests that drive the deploy script's <c>Import-IISCertificateFromPfxBase64</c>
+        /// and need to clean up the cert the script imported (not staged by this test directly).
+        /// </summary>
+        public void RegisterCertThumbprintForCleanup(string thumbprint) => _certThumbprintsToClean.Add(thumbprint);
+
+        /// <summary>
         /// Tells <see cref="Dispose"/> to run <c>netsh http delete sslcert ipport=0.0.0.0:{port}</c>
         /// on teardown. Production deploys (non-SNI) leave entries in the netsh sslcert table;
         /// CI parallelism would accumulate them otherwise.
@@ -2831,6 +2980,11 @@ public sealed class IISDeployRealHostE2ETests
         public const string PackageSourcePath = "Squid.Action.IISWebSite.Package.SourcePath";
         public const string PackageExtractTo = "Squid.Action.IISWebSite.Package.ExtractTo";
         public const string PackagePurgeBeforeExtract = "Squid.Action.IISWebSite.Package.PurgeBeforeExtract";
+
+        // P0-1 (1.6.9) — Certificate auto-import + private-key ACL
+        public const string CertificatePfxBase64 = "Squid.Action.IISWebSite.Certificate.PfxBase64";
+        public const string CertificatePfxPassword = "Squid.Action.IISWebSite.Certificate.PfxPassword";
+        public const string CertificateThumbprintVariableName = "Squid.Action.IISWebSite.Certificate.ThumbprintVariableName";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
Operator-friendly HTTPS deploys: PFX bytes via Squid variable → script imports to LocalMachine\My, exposes thumbprint to Bindings JSON, grants AppPool identity private-key ACL after IIS configure. Mirrors Octopus's IisWebSite{Before,After}DeployFeature. +2 real-host tests, +1 drift detector. Zero breaking risk.