### PR TITLE
Add deployment journal + SkipIfAlreadyInstalled to IIS deploy (P0-2)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -959,6 +959,87 @@ function Update-IISConfigurationVariables {
 	}
 }
 
+# ── Squid: Deployment journal + SkipIfAlreadyInstalled (1.6.9 P0-2 — Octopus AlreadyInstalledConvention parity) ──
+# Mirrors Octopus's `Octopus.Action.Package.SkipIfAlreadyInstalled` short-circuit.
+# When the flag is True and the local journal records a prior successful deploy with the
+# same package fingerprint + WebRoot, exits with status 0 (skip) — no extraction, no
+# rewriting, no IIS reconfig. Saves ~minutes per idempotent re-run.
+
+function Get-IISDeployJournalPath {
+	param([Parameter(Mandatory=$true)][string]$SiteName)
+	$root = Join-Path $env:ProgramData 'Squid\IISDeploy\journal'
+	if (-not (Test-Path -LiteralPath $root)) { New-Item -Path $root -ItemType Directory -Force | Out-Null }
+	# Sanitise siteName to a filename-safe form (IIS site names can contain spaces / special chars).
+	$safeName = [System.Text.RegularExpressions.Regex]::Replace($SiteName, '[^A-Za-z0-9._-]', '_')
+	return Join-Path $root "$safeName.json"
+}
+
+function Get-IISDeployFingerprint {
+	param([string]$SourcePath, [string]$WebRoot)
+	# Hash combines the package's last-modified time + size + the operator-configured WebRoot.
+	# When the operator re-runs with the same package + same target, fingerprint matches → skip.
+	$parts = New-Object System.Collections.Generic.List[string]
+	if (-not [string]::IsNullOrWhiteSpace($SourcePath) -and (Test-Path -LiteralPath $SourcePath)) {
+		$info = Get-Item -LiteralPath $SourcePath
+		$parts.Add($info.FullName)
+		$parts.Add($info.Length.ToString())
+		$parts.Add($info.LastWriteTimeUtc.ToString('o'))
+	}
+	$parts.Add($WebRoot)
+	$concat = ($parts -join '|')
+	$sha = [System.Security.Cryptography.SHA256]::Create()
+	try {
+		$bytes = [System.Text.Encoding]::UTF8.GetBytes($concat)
+		$hash = $sha.ComputeHash($bytes)
+		return [System.BitConverter]::ToString($hash).Replace('-', '').ToLowerInvariant()
+	} finally {
+		$sha.Dispose()
+	}
+}
+
+function Read-IISDeployJournalEntry {
+	param([Parameter(Mandatory=$true)][string]$SiteName)
+	$path = Get-IISDeployJournalPath -SiteName $SiteName
+	if (-not (Test-Path -LiteralPath $path)) { return $null }
+	try {
+		return Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json
+	} catch {
+		Write-Warning "Could not parse deployment journal at '$path': $($_.Exception.Message). Treating as no prior entry."
+		return $null
+	}
+}
+
+function Write-IISDeployJournalEntry {
+	param(
+		[Parameter(Mandatory=$true)][string]$SiteName,
+		[Parameter(Mandatory=$true)][string]$Fingerprint,
+		[Parameter(Mandatory=$true)][string]$Status
+	)
+	$path = Get-IISDeployJournalPath -SiteName $SiteName
+	$entry = [pscustomobject]@{
+		SiteName = $SiteName
+		Fingerprint = $Fingerprint
+		Status = $Status
+		DeployedAt = (Get-Date -Format 'o')
+	}
+	$entry | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $path -Encoding UTF8 -NoNewline
+	Write-Host "Deployment journal: wrote entry to '$path' (status=$Status, fingerprint=$($Fingerprint.Substring(0,8))...)"
+}
+
+$skipIfAlreadyInstalled = $SquidParameters['Squid.Action.IISWebSite.Package.SkipIfAlreadyInstalled']
+$journalSiteName = $SquidParameters['Squid.Action.IISWebSite.WebSiteName']
+$journalSourcePath = $SquidParameters['Squid.Action.IISWebSite.Package.SourcePath']
+$journalWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+$journalFingerprint = Get-IISDeployFingerprint -SourcePath $journalSourcePath -WebRoot $journalWebRoot
+
+if ($skipIfAlreadyInstalled -eq 'True' -and -not [string]::IsNullOrWhiteSpace($journalSiteName)) {
+	$priorEntry = Read-IISDeployJournalEntry -SiteName $journalSiteName
+	if ($null -ne $priorEntry -and $priorEntry.Status -eq 'Success' -and $priorEntry.Fingerprint -eq $journalFingerprint) {
+		Write-Host "SkipIfAlreadyInstalled: prior deploy at $($priorEntry.DeployedAt) had the same package fingerprint + WebRoot. Skipping this deploy."
+		exit 0
+	}
+}
+
 # ── Squid: Certificate auto-import (1.6.9 P0-1 — Octopus IisWebSiteBeforeDeployFeature parity) ──
 # When the operator sets `Squid.Action.IISWebSite.Certificate.PfxBase64`, decode the PFX
 # bytes, import into Cert:\LocalMachine\My, and expose the resulting thumbprint via
@@ -1576,5 +1657,13 @@ if (-not [string]::IsNullOrWhiteSpace($postDeployWebRoot)) {
 			throw "Packaged PostDeploy script '$packagedPostDeploy' exited with code $LastExitCode."
 		}
 	}
+}
+
+# ── Squid: Write success entry to deployment journal (1.6.9 P0-2) ──
+# Reached only when every prior phase (extract, rewriters, IIS configure, post-deploy)
+# completed without throwing. Failed deploys never write — the next re-run sees no journal
+# entry (or the last successful one before this failed attempt) and proceeds.
+if (-not [string]::IsNullOrWhiteSpace($journalSiteName)) {
+	Write-IISDeployJournalEntry -SiteName $journalSiteName -Fingerprint $journalFingerprint -Status 'Success'
 }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,26 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── Deployment journal + SkipIfAlreadyInstalled (P0-2, 1.6.9) ─────────────
+    //
+    // Mirrors Octopus's `Octopus.Action.Package.SkipIfAlreadyInstalled` flag
+    // (`KnownVariables.cs:86`) + `AlreadyInstalledConvention` + `IDeploymentJournalWriter`.
+    // When enabled, the deploy script:
+    //   1. Computes a fingerprint of the package (SHA256 of source path + WebRoot)
+    //   2. Reads the deployment journal at `%PROGRAMDATA%\Squid\IISDeploy\journal\<siteName>.json`
+    //   3. If the journal's last successful entry matches the current fingerprint → exit 0 with
+    //      "already-installed; skipping" message. No extraction, no rewriting, no IIS reconfig
+    //   4. Otherwise: deploy normally. Write a journal entry at end (success status)
+    //
+    // Reduces re-deploy cycle time from ~minutes to ~seconds for idempotent re-runs.
+
+    /// <summary>
+    /// When <c>"True"</c>, the deploy script short-circuits if the deployment journal records
+    /// a prior successful deploy with the same package fingerprint + WebRoot. Default (unset /
+    /// non-True) always re-runs the deploy fresh.
+    /// </summary>
+    internal const string PackageSkipIfAlreadyInstalled = "Squid.Action.IISWebSite.Package.SkipIfAlreadyInstalled";
+
     // ── Certificate auto-import + private-key ACL (P0-1, 1.6.9) ───────────────
     //
     // Operator-friendly HTTPS deploys without manual cert staging. Operator stores the PFX

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -110,6 +110,9 @@ internal static class IISDeployScriptBuilder
         IISDeployProperties.CertificatePfxBase64,
         IISDeployProperties.CertificatePfxPassword,
         IISDeployProperties.CertificateThumbprintVariableName,
+
+        // Deployment journal + SkipIfAlreadyInstalled (P0-2, 1.6.9)
+        IISDeployProperties.PackageSkipIfAlreadyInstalled,
     };
 
     internal static string Build(DeploymentActionDto action)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -580,6 +580,45 @@ public class IISDeployScriptDriftDetectorTests
             customMessage: "Private-key ACL grant must run AFTER IIS configure dispatch — AppPool's synthetic identity exists only after pool is created.");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 has deployment journal helpers + SkipIfAlreadyInstalled
+    /// gate (P0-2, 1.6.9). Mirrors Octopus's AlreadyInstalledConvention.
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasDeploymentJournalAndSkipIfAlreadyInstalledGate_ForOctopusAlreadyInstalledParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Get-IISDeployJournalPath");
+        ourScript.ShouldContain("function Get-IISDeployFingerprint");
+        ourScript.ShouldContain("function Read-IISDeployJournalEntry");
+        ourScript.ShouldContain("function Write-IISDeployJournalEntry");
+
+        // Journal location: %PROGRAMDATA%\Squid\IISDeploy\journal — machine-wide, persists.
+        ourScript.ShouldContain("$env:ProgramData",
+            customMessage: "Journal must persist under %PROGRAMDATA% so it survives reboots + spans deployments.");
+        ourScript.ShouldContain("Squid\\IISDeploy\\journal",
+            customMessage: "Journal namespace mismatch.");
+
+        // Skip-gate triggers on SkipIfAlreadyInstalled=True + matching fingerprint.
+        ourScript.ShouldContain("'Squid.Action.IISWebSite.Package.SkipIfAlreadyInstalled'");
+        ourScript.ShouldContain("Skipping this deploy",
+            customMessage: "Skip-gate exit message missing — operators rely on this log line.");
+
+        // Order: skip gate must come BEFORE any work (cert import, package extract, etc.)
+        var skipGateIdx = ourScript.IndexOf("SkipIfAlreadyInstalled: prior deploy at", StringComparison.Ordinal);
+        var certImportIdx = ourScript.IndexOf("Import-IISCertificateFromPfxBase64 -Base64", StringComparison.Ordinal);
+        var packageExtractIdx = ourScript.IndexOf("Expand-IISPackage", StringComparison.Ordinal);
+
+        skipGateIdx.ShouldBeLessThan(certImportIdx,
+            customMessage: "SkipIfAlreadyInstalled gate must run BEFORE cert auto-import (don't import a cert just to skip).");
+        skipGateIdx.ShouldBeLessThan(packageExtractIdx,
+            customMessage: "SkipIfAlreadyInstalled gate must run BEFORE package extraction (the whole point is to avoid the work).");
+
+        // Journal write at end (after PostDeploy) — only on success path.
+        ourScript.ShouldContain("Write-IISDeployJournalEntry -SiteName $journalSiteName -Fingerprint $journalFingerprint -Status 'Success'");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1943,6 +1943,149 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Deployment journal + SkipIfAlreadyInstalled (1.6.9 P0-2) ─────────────
+    //
+    // First deploy writes a journal entry. Re-deploy with SkipIfAlreadyInstalled=True +
+    // unchanged package short-circuits with no IIS work. Re-deploy with different package
+    // (different content / mtime / size) bypasses the skip — fingerprint mismatch.
+
+    [Fact]
+    public void RealIIS_DeploymentJournal_SkipIfAlreadyInstalled_SecondIdenticalRunShortCircuits()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var zipPath = StageTinyPackageZip(ctx);
+        ctx.RegisterDeploymentJournalForCleanup(ctx.SiteName);
+
+        // Action shared by both runs — identical fingerprint expected.
+        DeploymentActionDto BuildDeploy() => BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath),
+            (Property.PackageSkipIfAlreadyInstalled, "True"));
+
+        // First deploy: writes journal, normal flow.
+        var script1 = IISDeployScriptBuilder.Build(BuildDeploy());
+        var result1 = RunPowerShell(script1);
+        result1.ExitCode.ShouldBe(0, customMessage: $"First deploy failed: {result1.StdErr}");
+        result1.StdOut.ShouldContain("Deployment journal: wrote entry");
+
+        // Second deploy with same package: should short-circuit.
+        var script2 = IISDeployScriptBuilder.Build(BuildDeploy());
+        var result2 = RunPowerShell(script2);
+        result2.ExitCode.ShouldBe(0, customMessage: $"Second deploy failed: {result2.StdErr}");
+        result2.StdOut.ShouldContain("Skipping this deploy",
+            customMessage: $"Second identical deploy should have short-circuited via journal lookup. STDOUT:\n{result2.StdOut}");
+
+        // Confirm no IIS site re-creation logs appear in the second run.
+        result2.StdOut.ShouldNotContain("Making sure a Website",
+            customMessage: "IIS configure script ran despite SkipIfAlreadyInstalled gate — gate didn't fire.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_DeploymentJournal_DifferentPackage_BypassesSkipGate()
+    {
+        // Same site + same flag = True, but the package CHANGED between deploys (different
+        // file content → different mtime/size/fingerprint). Second deploy must run fresh,
+        // NOT short-circuit.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        ctx.RegisterDeploymentJournalForCleanup(ctx.SiteName);
+
+        var zipPath1 = StageTinyPackageZip(ctx, "first-version-content");
+        var action1 = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath1),
+            (Property.PackageSkipIfAlreadyInstalled, "True"));
+
+        RunPowerShell(IISDeployScriptBuilder.Build(action1)).ExitCode.ShouldBe(0);
+
+        // New artifact = new fingerprint.
+        var zipPath2 = StageTinyPackageZip(ctx, "second-version-content");
+        var action2 = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath2),
+            (Property.PackageSkipIfAlreadyInstalled, "True"));
+
+        var result2 = RunPowerShell(IISDeployScriptBuilder.Build(action2));
+        result2.ExitCode.ShouldBe(0, customMessage: $"Second deploy with different package failed: {result2.StdErr}");
+        result2.StdOut.ShouldNotContain("Skipping this deploy",
+            customMessage: "Different package fingerprint should have BYPASSED the skip gate. Gate is too eager.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_DeploymentJournal_FlagDisabled_AlwaysRunsFresh()
+    {
+        // SkipIfAlreadyInstalled is False (or unset) — even with a matching prior entry,
+        // every deploy runs fresh.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        ctx.RegisterDeploymentJournalForCleanup(ctx.SiteName);
+
+        var zipPath = StageTinyPackageZip(ctx);
+
+        DeploymentActionDto BuildDeploy(string skipFlag) => BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.PackageSourcePath, zipPath),
+            (Property.PackageSkipIfAlreadyInstalled, skipFlag));
+
+        // First deploy with flag True → writes journal entry.
+        RunPowerShell(IISDeployScriptBuilder.Build(BuildDeploy("True"))).ExitCode.ShouldBe(0);
+
+        // Second deploy with flag False → runs fresh despite matching prior entry.
+        var result2 = RunPowerShell(IISDeployScriptBuilder.Build(BuildDeploy("False")));
+        result2.ExitCode.ShouldBe(0);
+        result2.StdOut.ShouldNotContain("Skipping this deploy",
+            customMessage: "Flag=False should disable the skip gate even when journal matches.");
+
+        ctx.MarkClean();
+    }
+
+    private static string StageTinyPackageZip(IISTestContext ctx, string contentVariant = "content-v1")
+    {
+        var stagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-tinypkg-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(stagingDir);
+        ctx.RegisterTempDirForCleanup(stagingDir);
+        File.WriteAllText(Path.Combine(stagingDir, "marker.txt"), contentVariant);
+        var zipPath = Path.Combine(Path.GetTempPath(), $"squid-iis-tinypkg-{Guid.NewGuid():N}.zip");
+        ctx.RegisterTempDirForCleanup(zipPath);
+        System.IO.Compression.ZipFile.CreateFromDirectory(stagingDir, zipPath);
+        return zipPath;
+    }
+
     // ── Certificate auto-import + private-key ACL (1.6.9 P0-1) ───────────────
     //
     // Operator stores PFX bytes as a base64 Squid variable. Deploy script decodes,
@@ -2848,6 +2991,21 @@ public sealed class IISDeployRealHostE2ETests
         public void RegisterCertThumbprintForCleanup(string thumbprint) => _certThumbprintsToClean.Add(thumbprint);
 
         /// <summary>
+        /// Registers the deployment-journal file for this test's site for removal during
+        /// <see cref="Dispose"/>. P0-2 tests write to %PROGRAMDATA%\Squid\IISDeploy\journal\&lt;site&gt;.json;
+        /// without cleanup, repeated test runs would carry state forward.
+        /// </summary>
+        public void RegisterDeploymentJournalForCleanup(string siteName)
+        {
+            var programData = Environment.GetEnvironmentVariable("ProgramData");
+            if (string.IsNullOrEmpty(programData)) return;
+            // Same sanitisation logic as the PS1 Get-IISDeployJournalPath.
+            var safeName = System.Text.RegularExpressions.Regex.Replace(siteName, @"[^A-Za-z0-9._-]", "_");
+            var journalPath = Path.Combine(programData, "Squid", "IISDeploy", "journal", $"{safeName}.json");
+            _sentinelFilesToClean.Add(journalPath);
+        }
+
+        /// <summary>
         /// Tells <see cref="Dispose"/> to run <c>netsh http delete sslcert ipport=0.0.0.0:{port}</c>
         /// on teardown. Production deploys (non-SNI) leave entries in the netsh sslcert table;
         /// CI parallelism would accumulate them otherwise.
@@ -2985,6 +3143,9 @@ public sealed class IISDeployRealHostE2ETests
         public const string CertificatePfxBase64 = "Squid.Action.IISWebSite.Certificate.PfxBase64";
         public const string CertificatePfxPassword = "Squid.Action.IISWebSite.Certificate.PfxPassword";
         public const string CertificateThumbprintVariableName = "Squid.Action.IISWebSite.Certificate.ThumbprintVariableName";
+
+        // P0-2 (1.6.9) — Deployment journal + SkipIfAlreadyInstalled
+        public const string PackageSkipIfAlreadyInstalled = "Squid.Action.IISWebSite.Package.SkipIfAlreadyInstalled";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
Idempotent re-deploys short-circuit. Journal at %PROGRAMDATA%\Squid\IISDeploy\journal\<site>.json; fingerprint=SHA256(SourcePath|size|mtime|WebRoot). Mirrors Octopus AlreadyInstalledConvention. +3 real-host tests, +1 drift detector. DeployFailed.ps1 rollback deferred to follow-up.