### PR TITLE
Extend all 4 rewriters to scan AdditionalPaths (P1-4)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -1239,6 +1239,24 @@ if (-not [string]::IsNullOrWhiteSpace($packageSourcePath)) {
 	Expand-IISPackage -SourcePath $packageSourcePath -ExtractTo $packageExtractTo -PurgeBeforeExtract $purgeFlag
 }
 
+# ── Squid: AdditionalPaths resolver (1.6.9 P1-4 — Octopus Package.AdditionalPaths parity) ──
+# Returns the unified list of directories the 4 config rewriters should scan: WebRoot
+# (always) + each entry in `Squid.Action.IISWebSite.AdditionalPaths` (newline OR comma
+# separated). Used by SubstituteInFiles / ConfigurationTransforms / ConfigurationVariables /
+# StructuredConfigurationVariables.
+function Get-IISDeployScanPaths {
+	param([string]$WebRoot, [string]$AdditionalPathsRaw)
+	$paths = New-Object System.Collections.Generic.List[string]
+	if (-not [string]::IsNullOrWhiteSpace($WebRoot)) { $paths.Add($WebRoot) }
+	if (-not [string]::IsNullOrWhiteSpace($AdditionalPathsRaw)) {
+		$entries = $AdditionalPathsRaw -split "[`r`n,]" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+		foreach ($e in $entries) {
+			if (-not $paths.Contains($e)) { $paths.Add($e) }
+		}
+	}
+	return $paths
+}
+
 # ── Squid: SubstituteInFiles — `#{X}` token replacement INSIDE files (Phase 8 — Octopus SubstituteInFiles parity) ──
 # Mirrors Octopus's `Octopus.Features.SubstituteInFiles` feature
 # (`SubstituteInFilesBehaviour.cs:12-35`). For each operator-specified file glob, reads file
@@ -1330,13 +1348,13 @@ function Update-IISFilesWithVariableSubstitution {
 
 $substituteInFilesEnabled = $SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.Enabled']
 if ($substituteInFilesEnabled -eq 'True') {
-	$substituteTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$substituteWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$substituteAdditional = $SquidParameters['Squid.Action.IISWebSite.AdditionalPaths']
 	$substituteGlobs = $SquidParameters['Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles']
-	if (-not [string]::IsNullOrWhiteSpace($substituteTarget)) {
-		Write-Host "SubstituteInFiles: feature enabled; substituting tokens under '$substituteTarget'"
-		Update-IISFilesWithVariableSubstitution -TargetDir $substituteTarget -Variables $SquidVariables -TargetFilesGlobs $substituteGlobs
-	} else {
-		Write-Host "SubstituteInFiles: feature enabled but WebRoot is empty; skipping."
+	$substitutePaths = Get-IISDeployScanPaths -WebRoot $substituteWebRoot -AdditionalPathsRaw $substituteAdditional
+	foreach ($p in $substitutePaths) {
+		Write-Host "SubstituteInFiles: scanning '$p'"
+		Update-IISFilesWithVariableSubstitution -TargetDir $p -Variables $SquidVariables -TargetFilesGlobs $substituteGlobs
 	}
 }
 
@@ -1468,24 +1486,24 @@ function Update-IISConfigurationTransforms {
 $configurationTransformsEnabled = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.Enabled']
 $configurationTransformsAdditional = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms']
 if ($configurationTransformsEnabled -eq 'True' -or -not [string]::IsNullOrWhiteSpace($configurationTransformsAdditional)) {
-	$transformsTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
-	if (-not [string]::IsNullOrWhiteSpace($transformsTarget)) {
-		$transformsEnv = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName']
-		Write-Host "ConfigurationTransforms: feature enabled; processing *.config under '$transformsTarget'"
-		Update-IISConfigurationTransforms -TargetDir $transformsTarget -EnvironmentName $transformsEnv -AdditionalTransforms $configurationTransformsAdditional
-	} else {
-		Write-Host "ConfigurationTransforms: feature enabled but WebRoot is empty; skipping (nothing to scan)."
+	$transformsWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$transformsAdditionalPaths = $SquidParameters['Squid.Action.IISWebSite.AdditionalPaths']
+	$transformsEnv = $SquidParameters['Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName']
+	$transformsPaths = Get-IISDeployScanPaths -WebRoot $transformsWebRoot -AdditionalPathsRaw $transformsAdditionalPaths
+	foreach ($p in $transformsPaths) {
+		Write-Host "ConfigurationTransforms: processing *.config under '$p'"
+		Update-IISConfigurationTransforms -TargetDir $p -EnvironmentName $transformsEnv -AdditionalTransforms $configurationTransformsAdditional
 	}
 }
 
 $configurationVariablesEnabled = $SquidParameters['Squid.Action.IISWebSite.ConfigurationVariables.Enabled']
 if ($configurationVariablesEnabled -eq 'True') {
-	$configRewriteTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
-	if (-not [string]::IsNullOrWhiteSpace($configRewriteTarget)) {
-		Write-Host "ConfigurationVariables: feature enabled; rewriting *.config under '$configRewriteTarget'"
-		Update-IISConfigurationVariables -TargetDir $configRewriteTarget -Variables $SquidVariables
-	} else {
-		Write-Host "ConfigurationVariables: feature enabled but WebRoot is empty; skipping (nothing to scan)."
+	$configVarsWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$configVarsAdditional = $SquidParameters['Squid.Action.IISWebSite.AdditionalPaths']
+	$configVarsPaths = Get-IISDeployScanPaths -WebRoot $configVarsWebRoot -AdditionalPathsRaw $configVarsAdditional
+	foreach ($p in $configVarsPaths) {
+		Write-Host "ConfigurationVariables: rewriting *.config under '$p'"
+		Update-IISConfigurationVariables -TargetDir $p -Variables $SquidVariables
 	}
 }
 
@@ -1588,13 +1606,13 @@ function Update-IISStructuredJsonConfiguration {
 
 $structuredEnabled = $SquidParameters['Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled']
 if ($structuredEnabled -eq 'True') {
-	$structuredTarget = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$structuredWebRoot = $SquidParameters['Squid.Action.IISWebSite.WebRoot']
+	$structuredAdditional = $SquidParameters['Squid.Action.IISWebSite.AdditionalPaths']
 	$structuredGlobs = $SquidParameters['Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets']
-	if (-not [string]::IsNullOrWhiteSpace($structuredTarget)) {
-		Write-Host "StructuredConfigurationVariables: feature enabled; rewriting JSON leaves under '$structuredTarget'"
-		Update-IISStructuredJsonConfiguration -TargetDir $structuredTarget -Variables $SquidVariables -TargetFilesGlobs $structuredGlobs
-	} else {
-		Write-Host "StructuredConfigurationVariables: feature enabled but WebRoot is empty; skipping."
+	$structuredPaths = Get-IISDeployScanPaths -WebRoot $structuredWebRoot -AdditionalPathsRaw $structuredAdditional
+	foreach ($p in $structuredPaths) {
+		Write-Host "StructuredConfigurationVariables: rewriting JSON leaves under '$p'"
+		Update-IISStructuredJsonConfiguration -TargetDir $p -Variables $SquidVariables -TargetFilesGlobs $structuredGlobs
 	}
 }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,24 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── Additional paths across all rewriters (P1-4, 1.6.9) ───────────────────
+    //
+    // Mirrors Octopus's `Octopus.Action.Package.AdditionalPaths`
+    // (`ConfigurationVariablesBehaviour.cs:74-76`). Some apps store config files OUTSIDE
+    // WebRoot — e.g. `<install>/config/*.config` sibling of `<install>/wwwroot/`. By
+    // default the 4 rewriters (SubstituteInFiles, ConfigurationTransforms,
+    // ConfigurationVariables, StructuredConfigurationVariables) scan WebRoot only;
+    // setting AdditionalPaths extends the scan to those dirs too.
+    //
+    // Format: newline-separated absolute paths. Each path is scanned IN ADDITION to WebRoot.
+
+    /// <summary>
+    /// Newline-separated absolute directory paths. When set, all 4 config rewriters
+    /// (SubstituteInFiles / ConfigurationTransforms / ConfigurationVariables /
+    /// StructuredConfigurationVariables) scan WebRoot + each AdditionalPath.
+    /// </summary>
+    internal const string AdditionalPaths = "Squid.Action.IISWebSite.AdditionalPaths";
+
     // ── Deployment journal + SkipIfAlreadyInstalled (P0-2, 1.6.9) ─────────────
     //
     // Mirrors Octopus's `Octopus.Action.Package.SkipIfAlreadyInstalled` flag

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -113,6 +113,9 @@ internal static class IISDeployScriptBuilder
 
         // Deployment journal + SkipIfAlreadyInstalled (P0-2, 1.6.9)
         IISDeployProperties.PackageSkipIfAlreadyInstalled,
+
+        // AdditionalPaths across all 4 rewriters (P1-4, 1.6.9)
+        IISDeployProperties.AdditionalPaths,
     };
 
     internal static string Build(DeploymentActionDto action)
@@ -166,6 +169,8 @@ internal static class IISDeployScriptBuilder
         IISDeployProperties.SubstituteInFilesTargetFiles,
         // StructuredConfigurationVariables.Targets is also a newline-separated glob list.
         IISDeployProperties.StructuredConfigurationVariablesTargets,
+        // AdditionalPaths is a newline-separated list of dirs.
+        IISDeployProperties.AdditionalPaths,
     };
 
     private static string BuildPreamble(DeploymentActionDto action, IReadOnlyList<VariableDto> variables)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -619,6 +619,29 @@ public class IISDeployScriptDriftDetectorTests
         ourScript.ShouldContain("Write-IISDeployJournalEntry -SiteName $journalSiteName -Fingerprint $journalFingerprint -Status 'Success'");
     }
 
+    /// <summary>
+    /// Squid-specific invariant: PS1 has AdditionalPaths scan-list helper + all 4 rewriters
+    /// invoke it (P1-4, 1.6.9). Mirrors Octopus's `Octopus.Action.Package.AdditionalPaths`.
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasAdditionalPathsHelperAndAllRewritersUseIt_ForOctopusAdditionalPathsParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        ourScript.ShouldContain("function Get-IISDeployScanPaths");
+
+        // All 4 rewriter call sites must invoke the helper (proves they extend to AdditionalPaths).
+        var helperInvocations = System.Text.RegularExpressions.Regex.Matches(
+            ourScript, @"Get-IISDeployScanPaths -WebRoot");
+        helperInvocations.Count.ShouldBeGreaterThanOrEqualTo(4,
+            customMessage:
+                $"AdditionalPaths helper must be invoked by all 4 rewriters (SubstituteInFiles, " +
+                $"ConfigurationTransforms, ConfigurationVariables, StructuredConfigurationVariables). " +
+                $"Found {helperInvocations.Count} invocations — missing one or more call sites.");
+
+        ourScript.ShouldContain("'Squid.Action.IISWebSite.AdditionalPaths'");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1943,6 +1943,107 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── AdditionalPaths (1.6.9 P1-4) ─────────────────────────────────────────
+    //
+    // All 4 config rewriters extend their scan from WebRoot-only to WebRoot + AdditionalPaths.
+    // Verifies the loop wires through to all rewriters by staging files in a sibling dir
+    // and confirming each rewriter touches them.
+
+    [Fact]
+    public void RealIIS_AdditionalPaths_ConfigurationVariables_AppliesToSiblingDir()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        // Sibling dir alongside WebRoot — operator's "config files outside wwwroot" layout.
+        var siblingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-sibling-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(siblingDir);
+        ctx.RegisterTempDirForCleanup(siblingDir);
+
+        var siblingWebConfig = Path.Combine(siblingDir, "external.config");
+        File.WriteAllText(siblingWebConfig,
+            "<?xml version=\"1.0\"?>\n" +
+            "<configuration>\n" +
+            "  <appSettings>\n" +
+            "    <add key=\"ExternalKey\" value=\"OLD_VALUE\" />\n" +
+            "  </appSettings>\n" +
+            "</configuration>\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "ExternalKey", Value = "NEW_FROM_SIBLING_DIR" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"),
+            (Property.AdditionalPaths, siblingDir));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"AdditionalPaths deploy failed: {result.StdErr}");
+
+        // The SIBLING dir's external.config must have been rewritten.
+        var rewritten = File.ReadAllText(siblingWebConfig);
+        rewritten.ShouldContain("value=\"NEW_FROM_SIBLING_DIR\"",
+            customMessage:
+                $"ConfigurationVariables didn't scan the AdditionalPaths sibling dir. " +
+                $"File after deploy:\n{rewritten}");
+        rewritten.ShouldNotContain("OLD_VALUE");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_AdditionalPaths_SubstituteInFiles_AppliesToSiblingDir()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+
+        var siblingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-sibling-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(siblingDir);
+        ctx.RegisterTempDirForCleanup(siblingDir);
+
+        var siblingFile = Path.Combine(siblingDir, "external-config.txt");
+        File.WriteAllText(siblingFile, "Setting: #{ExternalSetting}");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "ExternalSetting", Value = "resolved-from-sibling" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.SubstituteInFilesEnabled, "True"),
+            (Property.SubstituteInFilesTargetFiles, "external-config.txt"),
+            (Property.AdditionalPaths, siblingDir));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"AdditionalPaths SubstituteInFiles failed: {result.StdErr}");
+
+        File.ReadAllText(siblingFile).ShouldContain("Setting: resolved-from-sibling",
+            customMessage: "SubstituteInFiles didn't scan the AdditionalPaths sibling dir.");
+
+        ctx.MarkClean();
+    }
+
     // ── Deployment journal + SkipIfAlreadyInstalled (1.6.9 P0-2) ─────────────
     //
     // First deploy writes a journal entry. Re-deploy with SkipIfAlreadyInstalled=True +
@@ -3146,6 +3247,9 @@ public sealed class IISDeployRealHostE2ETests
 
         // P0-2 (1.6.9) — Deployment journal + SkipIfAlreadyInstalled
         public const string PackageSkipIfAlreadyInstalled = "Squid.Action.IISWebSite.Package.SkipIfAlreadyInstalled";
+
+        // P1-4 (1.6.9) — AdditionalPaths across all 4 rewriters
+        public const string AdditionalPaths = "Squid.Action.IISWebSite.AdditionalPaths";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
All 4 config rewriters (SubstituteInFiles, ConfigurationTransforms, ConfigurationVariables, StructuredConfigurationVariables) now scan WebRoot + AdditionalPaths. Mirrors Octopus's Package.AdditionalPaths. +2 real-host tests verifying sibling-dir scan. Zero breaking risk (helper returns [WebRoot] when unset).