### PR TITLE
JSON arrays + type preservation in StructuredConfigurationVariables (P0-4)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -1538,6 +1538,29 @@ function Update-IISStructuredJsonConfiguration {
 	# Walk JSON object recursively, replacing leaf values whose path matches a Squid variable.
 	# Supports BOTH `:` and `.` path separators (operator may have stored the variable as
 	# `Logging:LogLevel:Default` or `Logging.LogLevel.Default` — try both).
+	# P0-4 (1.6.9): type-preserving leaf coercion. If the variable's string value parses as
+	# bool/int/double AND the original JSON leaf was the same kind, coerce the replacement to
+	# that type so `ConvertTo-Json` re-serialises with the right JSON tokens (no quotes around
+	# numbers/bools). Mirrors Octopus's `JsonUpdateMap.MapNumber`/`MapBool`.
+	function Coerce-JsonReplacementValue($variableStringValue, $originalLeaf) {
+		if ($null -eq $variableStringValue) { return $null }
+		# Type-preserving paths
+		if ($originalLeaf -is [bool]) {
+			if ($variableStringValue -ieq 'true') { return $true }
+			if ($variableStringValue -ieq 'false') { return $false }
+		}
+		if ($originalLeaf -is [int] -or $originalLeaf -is [long]) {
+			$parsedInt = 0L
+			if ([long]::TryParse($variableStringValue, [ref]$parsedInt)) { return $parsedInt }
+		}
+		if ($originalLeaf -is [double] -or $originalLeaf -is [decimal] -or $originalLeaf -is [single]) {
+			$parsedFloat = 0.0
+			if ([double]::TryParse($variableStringValue, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsedFloat)) { return $parsedFloat }
+		}
+		# Default: string (preserves whatever the operator typed)
+		return [string]$variableStringValue
+	}
+
 	function Walk-JsonReplace($node, $pathParts, $variables, [ref]$modifiedFlag) {
 		if ($node -is [System.Management.Automation.PSCustomObject]) {
 			foreach ($prop in $node.PSObject.Properties) {
@@ -1547,8 +1570,26 @@ function Update-IISStructuredJsonConfiguration {
 				if ($value -is [System.Management.Automation.PSCustomObject]) {
 					Walk-JsonReplace -node $value -pathParts $newParts -variables $variables -modifiedFlag $modifiedFlag
 				} elseif ($value -is [System.Array] -or $value -is [System.Object[]]) {
-					# Phase 9 MVP: scalar leaves only — array element replacement is Phase 9.5
-					# Arrays of strings and primitives are skipped intentionally
+					# P0-4 (1.6.9): walk arrays with numeric index paths so operators can replace
+					# `Logging:LogLevel:Microsoft:0` style entries. Mirrors Octopus's JsonUpdateMap
+					# array handling.
+					for ($i = 0; $i -lt $value.Count; $i++) {
+						$elementParts = $newParts + @([string]$i)
+						if ($value[$i] -is [System.Management.Automation.PSCustomObject]) {
+							Walk-JsonReplace -node $value[$i] -pathParts $elementParts -variables $variables -modifiedFlag $modifiedFlag
+						} else {
+							$pathColon = $elementParts -join ':'
+							$pathDot = $elementParts -join '.'
+							$matchedVar = $null
+							if ($variables.ContainsKey($pathColon)) { $matchedVar = $variables[$pathColon] }
+							elseif ($variables.ContainsKey($pathDot)) { $matchedVar = $variables[$pathDot] }
+							if ($null -ne $matchedVar) {
+								$value[$i] = Coerce-JsonReplacementValue -variableStringValue $matchedVar -originalLeaf $value[$i]
+								$modifiedFlag.Value = $true
+								Write-Host "  - JSON array element '$pathColon' replaced"
+							}
+						}
+					}
 				} else {
 					$pathColon = $newParts -join ':'
 					$pathDot = $newParts -join '.'
@@ -1559,7 +1600,10 @@ function Update-IISStructuredJsonConfiguration {
 						$matchedVar = $variables[$pathDot]
 					}
 					if ($null -ne $matchedVar) {
-						$prop.Value = [string]$matchedVar
+						# P0-4: coerce the variable's string value back to the original JSON
+						# type (bool / int / double) so ConvertTo-Json doesn't string-ify numbers
+						# and booleans (which downstream JSON consumers may reject).
+						$prop.Value = Coerce-JsonReplacementValue -variableStringValue $matchedVar -originalLeaf $value
 						$modifiedFlag.Value = $true
 						Write-Host "  - JSON leaf '$pathColon' replaced"
 					}

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1943,6 +1943,109 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── JSON arrays + type preservation (1.6.9 P0-4) ─────────────────────────
+
+    [Fact]
+    public void RealIIS_StructuredJson_ArrayElement_ReplacedByIndexPath()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        File.WriteAllText(jsonPath,
+            "{\n" +
+            "  \"AllowedHosts\": [\n" +
+            "    \"localhost\",\n" +
+            "    \"OLD_HOST_2\"\n" +
+            "  ]\n" +
+            "}\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "AllowedHosts:1", Value = "api.prod.example.com" }
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StructuredConfigurationVariablesEnabled, "True"),
+            (Property.StructuredConfigurationVariablesTargets, "appsettings.json"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Array-index replacement deploy failed: {result.StdErr}");
+
+        var rewritten = File.ReadAllText(jsonPath);
+        rewritten.ShouldContain("api.prod.example.com",
+            customMessage: $"Array element at index 1 not replaced via 'AllowedHosts:1' path. File:\n{rewritten}");
+        rewritten.ShouldNotContain("OLD_HOST_2");
+        rewritten.ShouldContain("localhost",
+            customMessage: "Sibling array element at index 0 was modified — array walker is over-eager.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_StructuredJson_TypePreservation_NumberAndBoolNotStringified()
+    {
+        // Variable string values get coerced back to bool/int/double when the source leaf
+        // was that type. Without this, ConvertTo-Json renders booleans as `"True"` (string)
+        // and numbers as quoted strings — which downstream JSON consumers may reject.
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        var jsonPath = Path.Combine(ctx.PhysicalPath, "appsettings.json");
+        File.WriteAllText(jsonPath,
+            "{\n" +
+            "  \"MaxConnections\": 10,\n" +
+            "  \"EnableTelemetry\": false,\n" +
+            "  \"Timeout\": 30.5\n" +
+            "}\n");
+
+        var variables = new List<Squid.Message.Models.Deployments.Variable.VariableDto>
+        {
+            new() { Name = "MaxConnections", Value = "100" },     // int → int
+            new() { Name = "EnableTelemetry", Value = "true" },   // bool → bool
+            new() { Name = "Timeout", Value = "60.25" }           // double → double
+        };
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.StructuredConfigurationVariablesEnabled, "True"),
+            (Property.StructuredConfigurationVariablesTargets, "appsettings.json"));
+
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Type-preservation deploy failed: {result.StdErr}");
+
+        var rewritten = File.ReadAllText(jsonPath);
+
+        // Number stays as JSON number (no quotes around the value)
+        rewritten.ShouldMatch(@"""MaxConnections""\s*:\s*100\b",
+            customMessage: $"MaxConnections coerced to string instead of int. File:\n{rewritten}");
+        // Bool stays as JSON bool literal
+        rewritten.ShouldMatch(@"""EnableTelemetry""\s*:\s*true\b",
+            customMessage: $"EnableTelemetry coerced to string \"true\" instead of bool true. File:\n{rewritten}");
+        // Double stays as JSON number
+        rewritten.ShouldMatch(@"""Timeout""\s*:\s*60\.25\b",
+            customMessage: $"Timeout coerced to string instead of double. File:\n{rewritten}");
+
+        ctx.MarkClean();
+    }
+
     // ── AdditionalPaths (1.6.9 P1-4) ─────────────────────────────────────────
     //
     // All 4 config rewriters extend their scan from WebRoot-only to WebRoot + AdditionalPaths.


### PR DESCRIPTION
Walk-JsonReplace now handles array elements via numeric-index path (Foo:Bar:0) + coerces variable string values back to bool/int/double when source leaf was that type. Mirrors Octopus JsonUpdateMap. +2 real-host tests. Zero breaking risk.