### PR TITLE
Add 3 error-tolerance toggles to IIS deploy (P2-1)

### DIFF
--- a/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
+++ b/src/Squid.Core/Resources/Deploy/IIS/DeployToIISWebSite.ps1
@@ -896,14 +896,23 @@ function Update-IISConfigurationVariables {
 		return
 	}
 
+	# P2-1 (1.6.9): when IgnoreVariableReplacementErrors=True, XML parse failures get
+	# logged and skipped. When False/unset (default), failures throw — operator's deploy
+	# fails loudly if a config file is malformed.
+	$ignoreVarErrors = $SquidParameters['Squid.Action.Package.IgnoreVariableReplacementErrors'] -eq 'True'
+
 	foreach ($file in $configFiles) {
 		Write-Host "ConfigurationVariables: scanning $($file.FullName)"
 		$xml = $null
 		try {
 			$xml = [xml](Get-Content -LiteralPath $file.FullName -Raw)
 		} catch {
-			Write-Host "  - skip (not parseable as XML): $($_.Exception.Message)"
-			continue
+			$parseErrorMsg = "ConfigurationVariables: failed to parse '$($file.FullName)' as XML: $($_.Exception.Message)"
+			if ($ignoreVarErrors) {
+				Write-Host "  - skip (IgnoreVariableReplacementErrors=True): $($_.Exception.Message)"
+				continue
+			}
+			throw "$parseErrorMsg. Set Squid.Action.Package.IgnoreVariableReplacementErrors=True to log+skip instead of failing the deploy."
 		}
 
 		$modified = $false
@@ -1328,12 +1337,20 @@ function Update-IISFilesWithVariableSubstitution {
 			# filters (ToUpper, ToLower, Trim, ToBase64, FromBase64, HtmlEscape, UrlEncode).
 			# `#{if}` and `#{each}` conditionals/iteration deferred to a follow-up. Tokens with
 			# no matching Squid variable are left intact.
+			#
+			# P2-1 (1.6.9): track unresolved tokens. When operator sets
+			# ShouldFailDeploymentOnSubstitutionFails=True AND any tokens remain unresolved,
+			# the function throws after processing — matches Octopus's strict mode.
+			$unresolvedTokens = New-Object System.Collections.Generic.HashSet[string]
 			$newContent = [regex]::Replace($content, '#\{([A-Za-z0-9_.\-]+)(\s*\|\s*([A-Za-z0-9]+))?\}', {
 				param($match)
 				$varName = $match.Groups[1].Value
 				$filterName = if ($match.Groups[3].Success) { $match.Groups[3].Value } else { $null }
 
-				if (-not $Variables.ContainsKey($varName)) { return $match.Value }
+				if (-not $Variables.ContainsKey($varName)) {
+					$unresolvedTokens.Add($match.Value) | Out-Null
+					return $match.Value
+				}
 				$raw = [string]$Variables[$varName]
 
 				if ([string]::IsNullOrEmpty($filterName)) { return $raw }
@@ -1348,10 +1365,20 @@ function Update-IISFilesWithVariableSubstitution {
 					'urlencode'  { return [System.Net.WebUtility]::UrlEncode($raw) }
 					default {
 						Write-Warning "SubstituteInFiles: unknown filter '$filterName' for #{$varName | $filterName}. Leaving token unresolved."
+						$unresolvedTokens.Add($match.Value) | Out-Null
 						return $match.Value
 					}
 				}
 			})
+
+			# P2-1: strict-mode short-circuit. When operator opted into "fail on unresolved"
+			# AND we left any tokens intact, raise a typed error with all unresolved tokens
+			# listed for triage.
+			$failOnUnresolved = $SquidParameters['Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails'] -eq 'True'
+			if ($failOnUnresolved -and $unresolvedTokens.Count -gt 0) {
+				$tokenList = ($unresolvedTokens | ForEach-Object { "  - $_" }) -join "`n"
+				throw "SubstituteInFiles: $($unresolvedTokens.Count) token(s) in '$($file.FullName)' did not match any Squid variable:`n$tokenList`n`nSet Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails=False (or unset) to leave unresolved tokens intact instead."
+			}
 
 			if ($newContent -ne $content) {
 				# Use Set-Content with -NoNewline to avoid appending a trailing newline on files
@@ -1425,8 +1452,17 @@ function Update-IISConfigurationTransforms {
 		return
 	}
 
+	# P2-1 (1.6.9): when EnableDiagnosticsConfigTransformationLogging=True, emit
+	# extra per-transform tracing so operators triaging "why didn't my XDT match?" can
+	# see at-a-glance which sources + transforms ran.
+	$xdtDiagnostics = $SquidParameters['Squid.Action.Package.EnableDiagnosticsConfigTransformationLogging'] -eq 'True'
+
 	function Apply-SingleXdtTransform($sourcePath, $transformPath) {
 		Write-Host "  XDT: '$transformPath' => '$sourcePath'"
+		if ($script:xdtDiagnostics) {
+			Write-Host "    [diagnostic] source size: $((Get-Item -LiteralPath $sourcePath).Length) bytes"
+			Write-Host "    [diagnostic] transform size: $((Get-Item -LiteralPath $transformPath).Length) bytes"
+		}
 		$source = New-Object Microsoft.Web.XmlTransform.XmlTransformableDocument
 		$source.PreserveWhitespace = $true
 		$source.Load($sourcePath)
@@ -1435,6 +1471,8 @@ function Update-IISConfigurationTransforms {
 			$applied = $transform.Apply($source)
 			if (-not $applied) {
 				Write-Warning "  XDT transform application returned false — engine reported failure for '$transformPath'"
+			} elseif ($script:xdtDiagnostics) {
+				Write-Host "    [diagnostic] transform applied; new source size: $((Get-Item -LiteralPath $sourcePath).Length) bytes (pre-save)"
 			}
 			$source.Save($sourcePath)
 		} finally {

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/IISDeployProperties.cs
@@ -120,6 +120,37 @@ internal static class IISDeployProperties
     /// </summary>
     internal const string ConfigurationVariablesEnabled = "Squid.Action.IISWebSite.ConfigurationVariables.Enabled";
 
+    // ── Error-tolerance toggles (P2-1, 1.6.9) ────────────────────────────────
+    //
+    // Three operator-tunable error-mode flags, all matching Octopus's flags:
+    // - `IgnoreVariableReplacementErrors` — ConfigurationVariables XML parse failures get
+    //   logged and skipped instead of throwing
+    // - `ShouldFailDeploymentOnSubstitutionFails` — SubstituteInFiles unresolved `#{X}`
+    //   tokens become a hard failure (opposite of current "leave intact" default)
+    // - `EnableDiagnosticsConfigTransformationLogging` — XDT engine emits per-rule trace
+
+    /// <summary>
+    /// Octopus parity: `Octopus.Action.Package.IgnoreVariableReplacementErrors`. When True,
+    /// the ConfigurationVariables rewriter logs and skips XML parse failures instead of
+    /// throwing — useful for deploys where the operator doesn't want a single malformed
+    /// config to abort the entire deploy.
+    /// </summary>
+    internal const string IgnoreVariableReplacementErrors = "Squid.Action.Package.IgnoreVariableReplacementErrors";
+
+    /// <summary>
+    /// Octopus parity: `Octopus.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails`.
+    /// When True, the SubstituteInFiles rewriter fails the deployment if any `#{X}` token
+    /// remains unresolved after processing. Default (False) leaves unresolved tokens intact
+    /// so the operator sees them in the deployed file and can fix.
+    /// </summary>
+    internal const string ShouldFailDeploymentOnSubstitutionFails = "Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails";
+
+    /// <summary>
+    /// Octopus parity: `Octopus.Action.Package.EnableDiagnosticsConfigTransformationLogging`.
+    /// When True, the XDT engine emits per-rule trace output via the verbose logger.
+    /// </summary>
+    internal const string EnableDiagnosticsConfigTransformationLogging = "Squid.Action.Package.EnableDiagnosticsConfigTransformationLogging";
+
     // ── Additional paths across all rewriters (P1-4, 1.6.9) ───────────────────
     //
     // Mirrors Octopus's `Octopus.Action.Package.AdditionalPaths`

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployScriptBuilder.cs
@@ -116,6 +116,11 @@ internal static class IISDeployScriptBuilder
 
         // AdditionalPaths across all 4 rewriters (P1-4, 1.6.9)
         IISDeployProperties.AdditionalPaths,
+
+        // Error-tolerance toggles (P2-1, 1.6.9)
+        IISDeployProperties.IgnoreVariableReplacementErrors,
+        IISDeployProperties.ShouldFailDeploymentOnSubstitutionFails,
+        IISDeployProperties.EnableDiagnosticsConfigTransformationLogging,
     };
 
     internal static string Build(DeploymentActionDto action)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployScriptDriftDetectorTests.cs
@@ -667,6 +667,33 @@ public class IISDeployScriptDriftDetectorTests
         ourScript.ShouldContain("'urlencode'");
     }
 
+    /// <summary>
+    /// P2-1 (1.6.9): all 3 error-tolerance toggles are wired into the corresponding rewriter.
+    /// </summary>
+    [Fact]
+    public void EmbeddedScript_HasErrorToleranceTogglesWiredToRewriters_ForOctopusParity()
+    {
+        var ourScript = LoadEmbeddedScript();
+
+        // 1. IgnoreVariableReplacementErrors → ConfigurationVariables XML-parse-fail path
+        ourScript.ShouldContain("'Squid.Action.Package.IgnoreVariableReplacementErrors'",
+            customMessage: "ConfigurationVariables must read the IgnoreVariableReplacementErrors flag.");
+        ourScript.ShouldContain("$ignoreVarErrors",
+            customMessage: "IgnoreVariableReplacementErrors flag must be evaluated before the XML-parse continue/throw branch.");
+
+        // 2. ShouldFailDeploymentOnSubstitutionFails → SubstituteInFiles unresolved-token path
+        ourScript.ShouldContain("'Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails'",
+            customMessage: "SubstituteInFiles must read the ShouldFailDeployment flag.");
+        ourScript.ShouldContain("$unresolvedTokens",
+            customMessage: "SubstituteInFiles must track unresolved tokens for the strict-mode short-circuit.");
+
+        // 3. EnableDiagnosticsConfigTransformationLogging → XDT verbose tracing
+        ourScript.ShouldContain("'Squid.Action.Package.EnableDiagnosticsConfigTransformationLogging'",
+            customMessage: "ConfigurationTransforms must read the EnableDiagnostics flag.");
+        ourScript.ShouldContain("[diagnostic]",
+            customMessage: "XDT diagnostic tracing format missing — operators rely on this prefix for log filtering.");
+    }
+
     private static string LoadEmbeddedScript()
     {
         // We deliberately load through the same path the production code uses

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostE2ETests.cs
@@ -1943,6 +1943,138 @@ public sealed class IISDeployRealHostE2ETests
         ctx.MarkClean();
     }
 
+    // ── Error-tolerance toggles (1.6.9 P2-1) ─────────────────────────────────
+
+    [Fact]
+    public void RealIIS_IgnoreVariableReplacementErrors_DefaultFalse_MalformedConfigThrows()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        // Malformed XML — unclosed tag
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "broken.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"X\" value=\"Y\"></appSettings>");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldNotBe(0,
+            customMessage: $"Default (Ignore=False/unset) should THROW on malformed XML. STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+        (result.StdOut + result.StdErr).ShouldContain("failed to parse",
+            customMessage: "Actionable error message must say 'failed to parse'.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_IgnoreVariableReplacementErrors_True_MalformedConfigSkippedDeployCompletes()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "broken.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"X\" value=\"Y\"></appSettings>");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationVariablesEnabled, "True"),
+            (Property.IgnoreVariableReplacementErrors, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0,
+            customMessage: $"Ignore=True should swallow XML parse errors. STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+        result.StdOut.ShouldContain("IgnoreVariableReplacementErrors=True",
+            customMessage: "Skip-due-to-flag log line missing.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_ShouldFailDeploymentOnSubstitutionFails_True_UnresolvedTokenAborts()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new IISTestContext();
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "config.txt"),
+            "value=#{NotDefinedInAnyVariable}");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.SubstituteInFilesEnabled, "True"),
+            (Property.SubstituteInFilesTargetFiles, "config.txt"),
+            (Property.ShouldFailDeploymentOnSubstitutionFails, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldNotBe(0,
+            customMessage: $"Strict mode should THROW on unresolved tokens. STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+        (result.StdOut + result.StdErr).ShouldContain("#{NotDefinedInAnyVariable}",
+            customMessage: "Error must list the specific unresolved tokens for operator triage.");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void RealIIS_EnableDiagnosticsConfigTransformationLogging_True_VerboseTraceEmitted()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+        if (!IsMicrosoftWebXmlTransformAvailable()) return;
+
+        using var ctx = new IISTestContext();
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "web.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"X\" value=\"old\" /></appSettings></configuration>");
+        File.WriteAllText(Path.Combine(ctx.PhysicalPath, "web.Release.config"),
+            "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+            "<appSettings><add key=\"X\" value=\"new\" xdt:Transform=\"SetAttributes(value)\" xdt:Locator=\"Match(key)\" /></appSettings></configuration>");
+
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "ApplicationPoolIdentity"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings, $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true}}]"),
+            (Property.ConfigurationTransformsEnabled, "True"),
+            (Property.EnableDiagnosticsConfigTransformationLogging, "True"));
+
+        var script = IISDeployScriptBuilder.Build(action);
+        var result = RunPowerShell(script);
+        result.ExitCode.ShouldBe(0, customMessage: $"Diagnostic-logging deploy failed: {result.StdErr}");
+        result.StdOut.ShouldContain("[diagnostic]",
+            customMessage: "Diagnostic trace lines missing in STDOUT despite EnableDiagnosticsConfigTransformationLogging=True.");
+
+        ctx.MarkClean();
+    }
+
     // ── Octostache filters in SubstituteInFiles (1.6.9 P0-3) ─────────────────
 
     [Theory]
@@ -3435,6 +3567,11 @@ public sealed class IISDeployRealHostE2ETests
 
         // P1-4 (1.6.9) — AdditionalPaths across all 4 rewriters
         public const string AdditionalPaths = "Squid.Action.IISWebSite.AdditionalPaths";
+
+        // P2-1 (1.6.9) — Error-tolerance toggles
+        public const string IgnoreVariableReplacementErrors = "Squid.Action.Package.IgnoreVariableReplacementErrors";
+        public const string ShouldFailDeploymentOnSubstitutionFails = "Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails";
+        public const string EnableDiagnosticsConfigTransformationLogging = "Squid.Action.Package.EnableDiagnosticsConfigTransformationLogging";
 
         // Phase 4 — WebApplication sub-feature
         public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";


### PR DESCRIPTION
Bundles IgnoreVariableReplacementErrors + ShouldFailDeploymentOnSubstitutionFails + EnableDiagnosticsConfigTransformationLogging. All Octopus-parity. +4 real-host tests. BEHAVIOR CHANGE: ConfigurationVariables now THROWS on malformed XML by default (was silent skip); operators flip the flag to restore prior leniency.