### PR TITLE
Drain AsyncStreamReader in GetStatus to fix flaky pwsh log-capture

### DIFF
--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -367,6 +367,26 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
 
     private static ScriptStatusResponse BuildStatus(ScriptTicket ticket, RunningScript running, long afterSequence = -1)
     {
+        // Drain AsyncStreamReader callbacks on the FIRST poll that observes
+        // HasExited=true. Without this, GetStatus can return state=Complete
+        // with stdout lines still in flight on the threadpool — the line is
+        // already in the kernel pipe and the AsyncStreamReader has read it,
+        // but the OutputDataReceived event hasn't been dispatched yet, so it
+        // isn't in the on-disk log file when ReadLogsAndCursor reads below.
+        // The test then sees "ExitCode=0 + last 1-2 log lines missing".
+        //
+        // CompleteScript already does this drain on its own teardown path
+        // (line ~594), but GetStatus is the OTHER way state=Complete becomes
+        // observable — when the test polls before calling CompleteScript.
+        // PR #317's RunToCompletion accumulator papered over this by polling
+        // additional times after seeing Complete; this fix removes the race
+        // at its source so single-poll callers also get the full output.
+        //
+        // Idempotent: WaitForExit() on an already-drained process is a no-op,
+        // but we gate via Interlocked.Exchange to avoid taking the lock-equivalent
+        // path on every subsequent poll.
+        DrainAsyncReadersOnce(running);
+
         // Cursor MUST be derived from the same disk read as `logs` — see
         // ReadLogsAndCursor's XML for the race that the previous two-source
         // code (ReadLogs + LogWriter.NextSequence) opened.
@@ -375,6 +395,38 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         var exitCode = running.Process.HasExited ? running.Process.ExitCode : 0;
 
         return new ScriptStatusResponse(ticket, state, exitCode, logs, nextSequence);
+    }
+
+    /// <summary>
+    /// Drains <see cref="Process.OutputDataReceived"/> / <see cref="Process.ErrorDataReceived"/>
+    /// callbacks via the parameterless <see cref="Process.WaitForExit()"/> overload,
+    /// AT MOST ONCE per <paramref name="running"/> instance. No-op when the process
+    /// hasn't exited yet (the readers are still actively delivering lines).
+    ///
+    /// <para>The .NET docs say: "Following a call to <see cref="Process.BeginOutputReadLine"/>,
+    /// only calling <see cref="Process.WaitForExit()"/> (no args) ensures async output is
+    /// flushed before returning." The timeout overload, and the implicit `HasExited` poll,
+    /// do NOT wait for the AsyncStreamReader to drain.</para>
+    ///
+    /// <para>Race we're closing: process writes "last line" → process exits → threadpool
+    /// hasn't yet scheduled the <c>OutputDataReceived</c> callback for "last line" → test
+    /// polls <see cref="GetStatus"/> → sees <c>HasExited=true</c> → reads log file from disk
+    /// → "last line" not there yet → returns Complete with truncated logs.</para>
+    /// </summary>
+    private static void DrainAsyncReadersOnce(RunningScript running)
+    {
+        if (!running.Process.HasExited) return;
+        if (Interlocked.Exchange(ref running.DrainedAsyncReaders, 1) != 0) return;
+
+        try
+        {
+            running.Process.WaitForExit();
+        }
+        catch
+        {
+            // Drain is best-effort — if Process was disposed mid-drain (e.g.
+            // CompleteScript ran concurrently), the readers are gone anyway.
+        }
     }
 
     public ScriptStatusResponse GetStatus(ScriptStatusRequest request)
@@ -1357,6 +1409,13 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         public StartScriptCommand? Command { get; }
         public DateTimeOffset StartedAt { get; }
         public string? TraceId { get; }
+
+        /// <summary>
+        /// 0 = `WaitForExit()` (no-arg drain) not yet called; 1 = called. Toggled
+        /// via <see cref="Interlocked.Exchange"/> so concurrent GetStatus polls don't
+        /// double-call. See <c>DrainAsyncReadersOnce</c> for the race this closes.
+        /// </summary>
+        public int DrainedAsyncReaders;
 
         public long LogSequence => LogWriter?.NextSequence ?? 0;
 

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/LocalScriptServiceTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/LocalScriptServiceTests.cs
@@ -1047,6 +1047,84 @@ public class LocalScriptServiceTests : IDisposable
     // ========================================================================
 
     [Fact]
+    public void GetStatus_FlushesAsyncStreamReaders_FastExitScript_FirstCompletePollSeesAllLines()
+    {
+        // Pins the `DrainAsyncReadersOnce` call in `BuildStatus`. Pre-fix race:
+        //   1. Script writes a single line + exits within 50ms
+        //   2. Test polls GetStatus → BuildStatus reads HasExited=true → returns Complete
+        //   3. But .NET's AsyncStreamReader hasn't yet dispatched the OutputDataReceived
+        //      callback for the last line → log file on disk is still empty
+        //   4. ReadLogsAndCursor returns empty list → test sees state=Complete + 0 lines
+        //
+        // CompleteScript already had the WaitForExit() (no-arg) drain (pinned by the
+        // sibling test below). GetStatus is the OTHER way state=Complete becomes
+        // observable — when the test polls before invoking CompleteScript.
+        // PR #317's RunToCompletion accumulator papered over this by polling many
+        // times after seeing Complete; this fix closes the race at the source.
+        //
+        // 5 iterations to amplify the intermittent race. Pre-fix typically 1-2
+        // iterations show empty logs; post-fix all 5 capture the marker.
+        const int iterations = 5;
+        var failures = new List<string>();
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var marker = $"fast-exit-getstatus-{i}-{Guid.NewGuid():N}";
+            var script = OperatingSystem.IsWindows()
+                ? $"Write-Output '{marker}'"
+                : $"echo '{marker}'";
+
+            var command = new StartScriptCommand(
+                new ScriptTicket(Guid.NewGuid().ToString("N")),
+                script,
+                ScriptIsolationLevel.NoIsolation,
+                TimeSpan.FromMinutes(1),
+                null,
+                Array.Empty<string>(),
+                null,
+                TimeSpan.Zero)
+            {
+                ScriptSyntax = OperatingSystem.IsWindows() ? ScriptType.PowerShell : ScriptType.Bash
+            };
+
+            _service.StartScript(command);
+            var ticket = command.ScriptTicket;
+            _createdTickets.Add(ticket.TaskId);
+
+            // Poll GetStatus until state=Complete. Critical: we use ONLY the first
+            // poll's logs that returns Complete — not an accumulator. Pre-fix this
+            // is where the line was lost.
+            var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+            ScriptStatusResponse? completeStatus = null;
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                var status = _service.GetStatus(new ScriptStatusRequest(ticket, 0));
+                if (status.State == ProcessState.Complete)
+                {
+                    completeStatus = status;
+                    break;
+                }
+                Thread.Sleep(10);
+            }
+
+            completeStatus.ShouldNotBeNull(
+                customMessage: $"iter {i}: GetStatus never reported Complete within 30s.");
+
+            var allText = string.Join("\n", completeStatus.Logs.Select(l => l.Text));
+            if (!allText.Contains(marker))
+                failures.Add($"iter {i}: expected '{marker}' missing from FIRST Complete poll. Got: '{allText}'");
+        }
+
+        failures.ShouldBeEmpty(
+            customMessage:
+                $"GetStatus MUST drain async stream readers on the first poll that observes HasExited=true. " +
+                $"Got {failures.Count}/{iterations} flake(s) — pre-fix this race dropped output silently when " +
+                $"a fast-exit script's last line was still in flight on the threadpool. Without the drain, the " +
+                $"in-memory RunningScript reports state=Complete but the on-disk log file is missing the " +
+                $"unflushed final line(s).\n\nFailures:\n{string.Join("\n", failures)}");
+    }
+
+    [Fact]
     public void CompleteScript_FlushesAsyncStreamReaders_FastExitScript_OutputCaptured()
     {
         // 5 iterations to surface intermittent race. Each iteration uses a


### PR DESCRIPTION
## Summary

Closes the deeper root cause behind the flaky `WindowsPowerShellE2ETests` that PR #317's `RunToCompletion` accumulator papered over. The race:

1. Script writes a single line + exits within 50ms
2. Test polls `GetStatus` → `BuildStatus` reads `HasExited=true` → returns Complete
3. .NET's `AsyncStreamReader` hasn't yet dispatched the `OutputDataReceived` callback for the last line → log file on disk is still empty
4. `ReadLogsAndCursor` returns empty list → test sees state=Complete + 0 lines

`CompleteScript` already drains via `WaitForExit()` (no-arg) at `LocalScriptService.cs:594`. `GetStatus` is the OTHER way `state=Complete` becomes observable — when the test polls before invoking `CompleteScript`. This PR adds the same drain to `BuildStatus`.

- **`DrainAsyncReadersOnce(RunningScript)`** — gates on `Interlocked.Exchange` of a new `DrainedAsyncReaders` flag so concurrent polls don't double-call
- **Regression test** — 5-iteration fast-exit script, first-Complete-poll asserts marker present
- Affects every Windows-only PR; multiple flakes traced to this race across #317, #320

## Test plan

- [x] Unit: 5212/5212 pass locally
- [x] Build: zero errors
- [ ] Windows CI: WindowsPowerShellE2ETests + LocalScriptServiceTests stable across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)