### PR TITLE
Make Windows Tentacle install path-agnostic and auto-elevate

### DIFF
--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -35,7 +35,7 @@
 
 .PARAMETER NoServiceInstall
     Skip the `service install` step. Use when bootstrapping a base VM image
-    that will be cloned — the SCM-registered service identity must be unique
+    that will be cloned -- the SCM-registered service identity must be unique
     per machine.
 
 .PARAMETER NoAutoElevate
@@ -45,7 +45,7 @@
     is undesired or impossible.
 
 .EXAMPLE
-    # One-liner (latest) — auto-elevates if needed
+    # One-liner (latest) -- auto-elevates if needed
     irm https://raw.githubusercontent.com/SolarifyDev/Squid/main/deploy/scripts/install-tentacle.ps1 | iex
 
 .EXAMPLE
@@ -75,7 +75,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# ── Defaults (Rule 8 — pinned literals) ─────────────────────────────────────
+# ── Defaults (Rule 8 -- pinned literals) ─────────────────────────────────────
 # Renaming any of these breaks operator runbooks, MDM playbooks, and the
 # in-UI script-generator's expectations.
 $DefaultVersion       = 'latest'
@@ -84,7 +84,7 @@ $DefaultDownloadBase  = 'https://github.com/SolarifyDev/Squid/releases'
 $BinaryName           = 'Squid.Tentacle.exe'
 $ListeningPort        = 10933
 
-# Discovery file path — Server-generated `register` / `service install`
+# Discovery file path -- Server-generated `register` / `service install`
 # snippet reads this to locate the binary regardless of install dir.
 $InstallInfoDir       = Join-Path $env:ProgramData 'Squid\Tentacle'
 $InstallInfoPath      = Join-Path $InstallInfoDir 'install-info.json'
@@ -102,7 +102,7 @@ function Resolve-Rid {
         'AMD64' { return 'win-x64' }
         'ARM64' { return 'win-arm64' }
         default {
-            throw "Unsupported architecture: $Arch. Squid Tentacle ships for win-x64 and win-arm64 only — 32-bit Windows is not supported."
+            throw "Unsupported architecture: $Arch. Squid Tentacle ships for win-x64 and win-arm64 only -- 32-bit Windows is not supported."
         }
     }
 }
@@ -120,19 +120,19 @@ $rid = Resolve-Rid -Arch $arch
 # we re-launch this script under UAC.
 #
 # Two invocation modes need handling:
-#   1. File-invocation  (`.\install-tentacle.ps1 …`) — $PSCommandPath is set;
+#   1. File-invocation  (`.\install-tentacle.ps1 …`) -- $PSCommandPath is set;
 #                       we relaunch the same file.
-#   2. Pipe-invocation  (`irm <url> | iex`) — $PSCommandPath is empty; the
+#   2. Pipe-invocation  (`irm <url> | iex`) -- $PSCommandPath is empty; the
 #                       script body lives in $MyInvocation.MyCommand.ScriptContents.
 #                       We materialise it to %TEMP%\squid-install-{guid}.ps1
 #                       and relaunch that.
 #
 # In both cases the original (non-admin) process exits with code 0 after
-# the elevated child finishes — operator sees the UAC prompt, then progress.
+# the elevated child finishes -- operator sees the UAC prompt, then progress.
 #
 # Skip elevation when:
 #   - Already admin (Test-IsAdministrator)
-#   - Installing to a user-owned path (InstallDir != default) — admin not required
+#   - Installing to a user-owned path (InstallDir != default) -- admin not required
 #   - -NoAutoElevate switch was passed (CI, SYSTEM-context invocations)
 function Test-IsAdministrator {
     $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
@@ -169,7 +169,7 @@ function Invoke-SelfElevation {
         if ([string]::IsNullOrWhiteSpace($body)) {
             throw "Auto-elevation impossible: invoked via pipe but `$MyInvocation.MyCommand.ScriptContents` is empty. Run from an elevated PowerShell directly, or download the script to disk first."
         }
-        # Write WITHOUT BOM — PowerShell.exe (5.1) accepts UTF-8 with or without
+        # Write WITHOUT BOM -- PowerShell.exe (5.1) accepts UTF-8 with or without
         # BOM but staying BOM-less keeps `Get-Content` of the file identical to
         # the original irm response.
         [System.IO.File]::WriteAllText($scriptPath, $body, [System.Text.UTF8Encoding]::new($false))
@@ -304,7 +304,7 @@ Possible causes:
 # ── Discovery file ──────────────────────────────────────────────────────────
 # Downstream scripts read %ProgramData%\Squid\Tentacle\install-info.json to
 # locate the binary. Without this, the server-generated register/service-install
-# snippet would have to hardcode the install path — breaking custom InstallDir.
+# snippet would have to hardcode the install path -- breaking custom InstallDir.
 function Write-InstallInfo {
     param(
         [string] $BinaryPath,
@@ -356,7 +356,7 @@ function Add-ListeningFirewallRule {
     $existing = Get-NetFirewallRule -DisplayName $RuleName -ErrorAction SilentlyContinue
 
     if ($existing) {
-        Write-Host "Firewall rule '$RuleName' already exists — skipping."
+        Write-Host "Firewall rule '$RuleName' already exists -- skipping."
         return
     }
 
@@ -380,7 +380,7 @@ try {
 # ── Service install ─────────────────────────────────────────────────────────
 if ($NoServiceInstall) {
     Write-Host ''
-    Write-Host '-NoServiceInstall set — skipping service install.'
+    Write-Host '-NoServiceInstall set -- skipping service install.'
     Write-Host "To install the service later, run:"
     Write-Host "  & '$binaryPath' service install --instance Default --service-name $ServiceName"
     Write-Host ''
@@ -404,7 +404,7 @@ Write-Host '=== Next steps ==='
 Write-Host ''
 Write-Host 'Register the agent with your Squid server (the install-info.json above'
 Write-Host 'lets the Squid Web UI generate a copy-pasteable register snippet that'
-Write-Host 'discovers the binary automatically — no hardcoded paths):'
+Write-Host 'discovers the binary automatically -- no hardcoded paths):'
 Write-Host ''
 Write-Host '  Listening agent (Squid server connects IN to this Windows host):'
 Write-Host "      & '$binaryPath' register \"

--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -4,60 +4,64 @@
 
 .DESCRIPTION
     Downloads a self-contained Squid Tentacle .zip from GitHub Releases,
-    extracts it to the install dir, and registers it as a Windows service
-    via `squid-tentacle service install` (Phase-12.C / sc.exe under the hood).
+    extracts it to the install dir, registers a Windows Firewall inbound
+    rule, and (unless `-NoServiceInstall`) installs the Tentacle as a
+    Windows Service via `Squid.Tentacle.exe service install`.
 
-    Companion to deploy/scripts/install-tentacle.sh - same one-liner UX,
-    same arg shape (--version maps to -Version), same env-var override
-    points (TENTACLE_VERSION → -Version, INSTALL_DIR → -InstallDir,
-    DOWNLOAD_BASE → -DownloadBase). Per Phase-12.E analysis, Octopus's
-    .NET-Framework MSI flow does not 1:1 to a .NET 9 self-contained app:
-    Squid ships zip + this script, the zip is extracted by Expand-Archive
-    instead of msiexec, and service install runs through the same CLI
-    surface the in-UI upgrade flow will eventually reuse.
+    Compatibility goals (every Windows scenario must work):
+      * Auto-elevates via UAC when not run as Administrator
+      * Works in both file-invocation (`.\install-tentacle.ps1`) AND
+        pipe-invocation (`irm <url> | iex`) modes
+      * Writes a discovery file at
+        `%ProgramData%\Squid\Tentacle\install-info.json` so downstream
+        scripts (register, service install, upgrade) find the binary
+        regardless of where the operator installed it
+      * Honours custom `INSTALL_DIR` (env var) or `-InstallDir` overrides
 
 .PARAMETER Version
-    Tentacle version to install (e.g. 1.6.0). Defaults to "latest" - uses
-    GitHub's /releases/latest/download redirect. Override via env var
-    TENTACLE_VERSION.
+    Tentacle version to install (e.g. 1.6.0). Defaults to "latest". Override via
+    env var TENTACLE_VERSION.
 
 .PARAMETER InstallDir
     Where to extract the binaries. Defaults to
     "C:\Program Files\Squid Tentacle". Override via env var INSTALL_DIR.
 
 .PARAMETER DownloadBase
-    Base URL for the GitHub Releases. Defaults to
-    "https://github.com/SolarifyDev/Squid/releases". Override via env var
-    DOWNLOAD_BASE - useful for air-gapped operators pointing at a private
-    mirror that copies the GitHub release tree.
+    Base URL for the GitHub Releases. Override via env var DOWNLOAD_BASE for
+    air-gapped operators pointing at a private mirror.
 
 .PARAMETER ServiceName
-    Windows service name. Defaults to "squid-tentacle" (mirrors the Linux
-    systemd unit name). Pinned per Rule 8 - operator runbooks reference
-    this literal.
+    Windows service name. Defaults to "squid-tentacle".
 
 .PARAMETER NoServiceInstall
-    Skip the `squid-tentacle service install` step. Use when bootstrapping
-    a base VM image that will be cloned - the service install MUST happen
-    AFTER the image is cloned, otherwise every clone shares the same
-    SCM-registered service identity. Same caveat as Octopus's "do not
-    complete the configuration wizard before snapshotting".
+    Skip the `service install` step. Use when bootstrapping a base VM image
+    that will be cloned — the SCM-registered service identity must be unique
+    per machine.
+
+.PARAMETER NoAutoElevate
+    Skip the UAC auto-elevation. Use when the caller knows the current shell
+    is already elevated (avoids a redundant re-launch) OR when running
+    non-interactively (CI, scheduled task as SYSTEM) where the UAC prompt
+    is undesired or impossible.
 
 .EXAMPLE
-    # One-liner (latest)
+    # One-liner (latest) — auto-elevates if needed
     irm https://raw.githubusercontent.com/SolarifyDev/Squid/main/deploy/scripts/install-tentacle.ps1 | iex
 
 .EXAMPLE
-    # Specific version
-    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/SolarifyDev/Squid/main/deploy/scripts/install-tentacle.ps1))) -Version 1.6.0
+    # Specific version with custom install dir
+    .\install-tentacle.ps1 -Version 1.6.9 -InstallDir "D:\squid-tentacle"
 
 .EXAMPLE
-    # Bootstrap-time install (no service yet, registers later)
+    # Bootstrap-time install (no service yet)
     .\install-tentacle.ps1 -NoServiceInstall
 
 .NOTES
-    Author: Squid project
-    Phase:  P1-Phase12.E.0
+    Discovery file schema (Schema = 1):
+        BinaryPath, InstallDir, Version, Architecture, InstalledAt,
+        InstalledBy, ServiceName
+    Downstream scripts (Squid-generated register/service-install snippet)
+    read this file to locate the binary.
 #>
 [CmdletBinding()]
 param(
@@ -65,28 +69,32 @@ param(
     [string] $InstallDir = $env:INSTALL_DIR,
     [string] $DownloadBase = $env:DOWNLOAD_BASE,
     [string] $ServiceName = 'squid-tentacle',
-    [switch] $NoServiceInstall
+    [switch] $NoServiceInstall,
+    [switch] $NoAutoElevate
 )
 
 $ErrorActionPreference = 'Stop'
 
-# -- Defaults (Rule 8 - pinned literals) --------------------------------------
+# ── Defaults (Rule 8 — pinned literals) ─────────────────────────────────────
 # Renaming any of these breaks operator runbooks, MDM playbooks, and the
-# in-UI upgrade flow's expectations.
+# in-UI script-generator's expectations.
 $DefaultVersion       = 'latest'
 $DefaultInstallDir    = 'C:\Program Files\Squid Tentacle'
 $DefaultDownloadBase  = 'https://github.com/SolarifyDev/Squid/releases'
 $BinaryName           = 'Squid.Tentacle.exe'
 $ListeningPort        = 10933
 
+# Discovery file path — Server-generated `register` / `service install`
+# snippet reads this to locate the binary regardless of install dir.
+$InstallInfoDir       = Join-Path $env:ProgramData 'Squid\Tentacle'
+$InstallInfoPath      = Join-Path $InstallInfoDir 'install-info.json'
+$InstallInfoSchema    = 1
+
 if ([string]::IsNullOrWhiteSpace($Version))      { $Version = $DefaultVersion }
 if ([string]::IsNullOrWhiteSpace($InstallDir))   { $InstallDir = $DefaultInstallDir }
 if ([string]::IsNullOrWhiteSpace($DownloadBase)) { $DownloadBase = $DefaultDownloadBase }
 
-# -- Arch detection ----------------------------------------------------------
-# $env:PROCESSOR_ARCHITECTURE on a 64-bit OS is "AMD64" (x64) or "ARM64".
-# 32-bit Windows is intentionally NOT supported - Phase-12.E analysis
-# (per Octopus docs review) concluded x86 has no real audience in 2026.
+# ── Arch detection ──────────────────────────────────────────────────────────
 function Resolve-Rid {
     param([string] $Arch)
 
@@ -94,40 +102,124 @@ function Resolve-Rid {
         'AMD64' { return 'win-x64' }
         'ARM64' { return 'win-arm64' }
         default {
-            throw "Unsupported architecture: $Arch. Squid Tentacle ships for win-x64 and win-arm64 only - 32-bit Windows is not supported."
+            throw "Unsupported architecture: $Arch. Squid Tentacle ships for win-x64 and win-arm64 only — 32-bit Windows is not supported."
         }
     }
 }
 
 $arch = $env:PROCESSOR_ARCHITECTURE
 if ([string]::IsNullOrWhiteSpace($arch)) {
-    # PowerShell on non-Windows doesn't set this. Help local developers
-    # who curiously curl the script on macOS/Linux see a clean error
-    # rather than a "Unsupported: " message.
     throw "PROCESSOR_ARCHITECTURE env var is not set. This script must run on Windows."
 }
 
 $rid = Resolve-Rid -Arch $arch
 
-# -- Elevation guard ---------------------------------------------------------
-# Default install dir is under %ProgramFiles% which requires Admin to write
-# to. Skip the check when the operator overrode -InstallDir to a user-owned
-# path (e.g. "C:\Users\me\squid-tentacle" for dev/test).
+# ── UAC auto-elevation ──────────────────────────────────────────────────────
+# Default install dir (%ProgramFiles%) + writing %ProgramData%\Squid both
+# require Administrator. Rather than refuse to run for non-admin operators,
+# we re-launch this script under UAC.
+#
+# Two invocation modes need handling:
+#   1. File-invocation  (`.\install-tentacle.ps1 …`) — $PSCommandPath is set;
+#                       we relaunch the same file.
+#   2. Pipe-invocation  (`irm <url> | iex`) — $PSCommandPath is empty; the
+#                       script body lives in $MyInvocation.MyCommand.ScriptContents.
+#                       We materialise it to %TEMP%\squid-install-{guid}.ps1
+#                       and relaunch that.
+#
+# In both cases the original (non-admin) process exits with code 0 after
+# the elevated child finishes — operator sees the UAC prompt, then progress.
+#
+# Skip elevation when:
+#   - Already admin (Test-IsAdministrator)
+#   - Installing to a user-owned path (InstallDir != default) — admin not required
+#   - -NoAutoElevate switch was passed (CI, SYSTEM-context invocations)
 function Test-IsAdministrator {
     $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = New-Object System.Security.Principal.WindowsPrincipal($identity)
     return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-if ($InstallDir -eq $DefaultInstallDir -and -not (Test-IsAdministrator)) {
+function Get-OriginalArgs {
+    # Reconstruct the user's original args so the elevated re-launch sees
+    # exactly the same parameters. Only emit explicitly-bound parameters
+    # (defaults are re-applied by the relaunched process).
+    $list = New-Object System.Collections.Generic.List[string]
+    foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+        $name = $entry.Key
+        $value = $entry.Value
+        if ($value -is [System.Management.Automation.SwitchParameter]) {
+            if ($value.IsPresent) { $list.Add("-$name") }
+        } else {
+            $list.Add("-$name")
+            $list.Add("`"$value`"")
+        }
+    }
+    return ,$list.ToArray()
+}
+
+function Invoke-SelfElevation {
+    # Stage 1: locate (or materialise) the script body
+    $scriptPath = $PSCommandPath
+    $isPipeInvocation = [string]::IsNullOrWhiteSpace($scriptPath)
+
+    if ($isPipeInvocation) {
+        $scriptPath = Join-Path $env:TEMP ("squid-install-" + [guid]::NewGuid().ToString('N') + ".ps1")
+        $body = $MyInvocation.MyCommand.ScriptContents
+        if ([string]::IsNullOrWhiteSpace($body)) {
+            throw "Auto-elevation impossible: invoked via pipe but `$MyInvocation.MyCommand.ScriptContents` is empty. Run from an elevated PowerShell directly, or download the script to disk first."
+        }
+        # Write WITHOUT BOM — PowerShell.exe (5.1) accepts UTF-8 with or without
+        # BOM but staying BOM-less keeps `Get-Content` of the file identical to
+        # the original irm response.
+        [System.IO.File]::WriteAllText($scriptPath, $body, [System.Text.UTF8Encoding]::new($false))
+    }
+
+    # Stage 2: assemble argv for the elevated PowerShell
+    $forwarded = Get-OriginalArgs
+    $childArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $scriptPath) + $forwarded
+
+    Write-Host ""
+    Write-Host "Administrator privileges required. Triggering UAC re-launch..."
+    Write-Host ""
+
+    try {
+        $proc = Start-Process powershell.exe -Verb RunAs -ArgumentList $childArgs -Wait -PassThru
+        $childExit = $proc.ExitCode
+    } catch {
+        Write-Error @"
+UAC elevation failed: $($_.Exception.Message)
+
+Workarounds:
+  1. Right-click PowerShell → 'Run as Administrator', then re-run this script
+  2. From an admin terminal: powershell -NoProfile -ExecutionPolicy Bypass -File '$scriptPath' $(($forwarded -join ' '))
+  3. Install to a user-owned path (no admin needed):
+       .\install-tentacle.ps1 -InstallDir "$env:USERPROFILE\squid-tentacle"
+"@
+        exit 1
+    } finally {
+        if ($isPipeInvocation -and (Test-Path -LiteralPath $scriptPath)) {
+            Remove-Item -LiteralPath $scriptPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    exit $childExit
+}
+
+$needsElevation = ($InstallDir -eq $DefaultInstallDir) -and -not (Test-IsAdministrator)
+if ($needsElevation -and -not $NoAutoElevate) {
+    Invoke-SelfElevation
+}
+
+if ($needsElevation -and $NoAutoElevate) {
     Write-Error @"
-Administrator privileges required for the default install dir ($DefaultInstallDir).
+Administrator privileges required for the default install dir ($DefaultInstallDir), but -NoAutoElevate was set.
 
-Either re-run from an elevated PowerShell:
-    Start-Process pwsh -Verb RunAs -ArgumentList '-File', '$PSCommandPath'
-
-Or install to a user-owned path:
-    .\install-tentacle.ps1 -InstallDir "C:\Users\$env:USERNAME\squid-tentacle"
+Either:
+  1. Drop -NoAutoElevate to allow UAC re-launch
+  2. Re-run from an already-elevated PowerShell
+  3. Install to a user-owned path:
+       .\install-tentacle.ps1 -InstallDir "$env:USERPROFILE\squid-tentacle"
 "@
     exit 1
 }
@@ -138,12 +230,7 @@ Write-Host "Arch:     $rid"
 Write-Host "Install:  $InstallDir"
 Write-Host ''
 
-# -- Download URL resolution -------------------------------------------------
-# Mirrors install-tentacle.sh's two-path logic:
-#   latest        → /releases/latest/download/squid-tentacle-{rid}.zip
-#                   (GitHub redirects this to the highest non-prerelease tag)
-#   <version>     → /releases/download/{version}/squid-tentacle-{version}-{rid}.zip
-#                   with v-prefix fallback if the un-prefixed tag 404s
+# ── Download URL resolution ─────────────────────────────────────────────────
 function Resolve-DownloadUrls {
     param(
         [string] $Version,
@@ -174,9 +261,6 @@ try {
         Write-Host "Downloading from $url..."
 
         try {
-            # -UseBasicParsing avoids needing IE first-run config on
-            # stripped Server Core images. -TimeoutSec 300 = 5 min budget
-            # mirrors install-tentacle.sh's `--max-time 300`.
             Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing -TimeoutSec 300
             $downloaded = $true
             break
@@ -198,17 +282,12 @@ Possible causes:
         exit 1
     }
 
-    # -- Extract --------------------------------------------------------------
+    # ── Extract ─────────────────────────────────────────────────────────────
     if (-not (Test-Path $InstallDir)) {
         New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
     }
 
     Write-Host "Extracting to $InstallDir..."
-    # -Force overwrites an existing install - same idempotent re-run UX as
-    # install-tentacle.sh (tar xzf overwrites). The Tentacle service should
-    # be stopped first if upgrading; the in-UI upgrade flow handles that
-    # via the upgrade PowerShell script. For a manual re-install, the
-    # operator should `sc stop squid-tentacle` first.
     Expand-Archive -Path $archivePath -DestinationPath $InstallDir -Force
 
     $binaryPath = Join-Path $InstallDir $BinaryName
@@ -222,13 +301,52 @@ Possible causes:
     Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-# -- Firewall rule for Listening Tentacle ------------------------------------
-# Idempotent: New-NetFirewallRule throws if the rule already exists, so
-# Get-NetFirewallRule first. Same defensive pattern Octopus's automation
-# docs use (`netsh advfirewall firewall add rule`). Phase-12.E.0 ships
-# the rule unconditionally because the operator can't easily know yet
-# whether they'll register as Listening or Polling - adding it always is
-# cheap (one inbound TCP allow) and saves a separate operator step.
+# ── Discovery file ──────────────────────────────────────────────────────────
+# Downstream scripts read %ProgramData%\Squid\Tentacle\install-info.json to
+# locate the binary. Without this, the server-generated register/service-install
+# snippet would have to hardcode the install path — breaking custom InstallDir.
+function Write-InstallInfo {
+    param(
+        [string] $BinaryPath,
+        [string] $InstallDir,
+        [string] $Version,
+        [string] $Rid,
+        [string] $ServiceName,
+        [string] $InfoDir,
+        [string] $InfoPath,
+        [int]    $Schema
+    )
+
+    if (-not (Test-Path $InfoDir)) {
+        New-Item -ItemType Directory -Path $InfoDir -Force | Out-Null
+    }
+
+    $info = [ordered]@{
+        Schema        = $Schema
+        BinaryPath    = $BinaryPath
+        InstallDir    = $InstallDir
+        Version       = $Version
+        Architecture  = $Rid
+        InstalledAt   = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        InstalledBy   = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+        ServiceName   = $ServiceName
+    }
+
+    $info | ConvertTo-Json -Depth 3 | Set-Content -Path $InfoPath -Encoding UTF8
+    Write-Host "Install info: $InfoPath"
+}
+
+Write-InstallInfo `
+    -BinaryPath $binaryPath `
+    -InstallDir $InstallDir `
+    -Version $Version `
+    -Rid $rid `
+    -ServiceName $ServiceName `
+    -InfoDir $InstallInfoDir `
+    -InfoPath $InstallInfoPath `
+    -Schema $InstallInfoSchema
+
+# ── Firewall rule for Listening Tentacle ────────────────────────────────────
 function Add-ListeningFirewallRule {
     param(
         [string] $RuleName,
@@ -238,7 +356,7 @@ function Add-ListeningFirewallRule {
     $existing = Get-NetFirewallRule -DisplayName $RuleName -ErrorAction SilentlyContinue
 
     if ($existing) {
-        Write-Host "Firewall rule '$RuleName' already exists - skipping."
+        Write-Host "Firewall rule '$RuleName' already exists — skipping."
         return
     }
 
@@ -259,15 +377,10 @@ try {
     Write-Warning "Failed to add firewall rule: $($_.Exception.Message). For Listening Tentacle, manually run: New-NetFirewallRule -DisplayName 'Squid Tentacle' -Direction Inbound -Protocol TCP -LocalPort $ListeningPort -Action Allow"
 }
 
-# -- Service install (Phase 12.C path) ---------------------------------------
-# `squid-tentacle service install` routes through WindowsServiceHost (Phase
-# 12.C) → BuildScCreateArgs → sc create + sc failure (Phase 12.D) + sc start.
-# The service installs as LocalSystem by default (Phase 12.C contract). LSA
-# SeServiceLogonRight grant for non-LocalSystem identities is Phase 12.C-
-# followup scope.
+# ── Service install ─────────────────────────────────────────────────────────
 if ($NoServiceInstall) {
     Write-Host ''
-    Write-Host '-NoServiceInstall set - skipping service install.'
+    Write-Host '-NoServiceInstall set — skipping service install.'
     Write-Host "To install the service later, run:"
     Write-Host "  & '$binaryPath' service install --instance Default --service-name $ServiceName"
     Write-Host ''
@@ -275,12 +388,6 @@ if ($NoServiceInstall) {
     Write-Host ''
     Write-Host "Installing Windows service '$ServiceName'..."
 
-    # ServiceCommand.Install internally derives the SCM Description as
-    # "Squid Tentacle Agent ({instance})" - no --display-name flag exposed.
-    # The instance name argument is positional after `--instance`, defaulting
-    # to "Default" when omitted (which yields service name "squid-tentacle"
-    # via ServiceCommand's default-instance branch). Pass it explicitly so the
-    # operator-facing service name matches -ServiceName.
     & $binaryPath service install --instance Default --service-name $ServiceName
 
     if ($LASTEXITCODE -ne 0) {
@@ -292,19 +399,12 @@ if ($NoServiceInstall) {
     Write-Host ''
 }
 
-# -- Next-step hints ---------------------------------------------------------
-# Squid CLI shape:
-#   register        - registers the agent with the Squid server, persists config
-#   --server URL    - Squid server URL
-#   --api-key KEY   - issued by the Squid server admin under User → API Keys
-#   --role ROLE     - target tag (single value; pass --role multiple times for several tags)
-#   --environment   - environment name (same multi-value pattern as --role)
-#   --comms-url URL - set for Polling agents (where the agent dials Squid back)
-# The Listening vs Polling distinction is implicit in whether --comms-url
-# is set. There's no Octopus-style `--comms-style TentaclePassive/Active`.
+# ── Next-step hints ─────────────────────────────────────────────────────────
 Write-Host '=== Next steps ==='
 Write-Host ''
-Write-Host 'Register the agent with your Squid server:'
+Write-Host 'Register the agent with your Squid server (the install-info.json above'
+Write-Host 'lets the Squid Web UI generate a copy-pasteable register snippet that'
+Write-Host 'discovers the binary automatically — no hardcoded paths):'
 Write-Host ''
 Write-Host '  Listening agent (Squid server connects IN to this Windows host):'
 Write-Host "      & '$binaryPath' register \"

--- a/src/Squid.Core/Services/Machines/Scripts/Tentacle/WindowsPowerShellScriptBuilder.cs
+++ b/src/Squid.Core/Services/Machines/Scripts/Tentacle/WindowsPowerShellScriptBuilder.cs
@@ -80,7 +80,7 @@ public sealed class WindowsPowerShellScriptBuilder : TentacleInstallScriptBuilde
             "# the subsequent register/service-install commands.",
             $"$infoPath = Join-Path $env:ProgramData '{DiscoveryFileRelativePath}'",
             "if (-not (Test-Path $infoPath)) {",
-            "    throw \"install-info.json not found at $infoPath. Step 1 did not complete — review its output above.\"",
+            "    throw \"install-info.json not found at $infoPath. Step 1 did not complete -- review its output above.\"",
             "}",
             "$installInfo = Get-Content -Raw $infoPath | ConvertFrom-Json",
             "$tentacle = $installInfo.BinaryPath",
@@ -147,26 +147,28 @@ public sealed class WindowsPowerShellScriptBuilder : TentacleInstallScriptBuilde
     /// structured error message. Operators hitting <c>MachineCreate</c> permission
     /// denials get a clear remediation path instead of opaque "HTTP 403".
     ///
-    /// <para>Built-in roles with <c>MachineCreate</c> (per
-    /// <c>BuiltInRoleSeeder.cs</c>): Environment Manager, Space Owner,
-    /// System Administrator.</para>
+    /// <para>Built-in roles with <c>MachineCreate</c> (per <c>BuiltInRoles</c>
+    /// in <c>BuiltInRoleSeeder.cs</c>): Environment Manager, Space Owner.
+    /// System Administrator does NOT grant MachineCreate — it's a system-level
+    /// role for managing spaces/users/teams, not a space-resource role.
+    /// Pinned by <c>PermissionRoleResolverTests.GetBuiltInRolesGranting_MachineCreate_...</c>.</para>
     /// </summary>
     private static string BuildRegisterExitCodeHandler()
     {
         return @"if ($LASTEXITCODE -ne 0) {
     if ($LASTEXITCODE -eq 403) {
         throw @""
-Register failed with HTTP 403 — the API key user lacks the 'MachineCreate' permission.
+Register failed with HTTP 403 -- the API key user lacks the 'MachineCreate' permission.
 
 Resolve via the Squid Web UI:
-  1. Assign the 'Environment Manager' role (or higher) to the API key's owner user, OR
-  2. Add 'MachineCreate' permission to the owner's current role, OR
-  3. Issue a new API key from a user with 'Space Owner' or 'System Administrator' role.
+  1. Assign 'Environment Manager' role to the API key's owner user, OR
+  2. Assign 'Space Owner' role for full space access, OR
+  3. Add 'MachineCreate' permission to the owner's current role, OR
+  4. Issue a new API key from a user with one of those roles.
 
 Built-in roles that grant MachineCreate:
   - Environment Manager
   - Space Owner
-  - System Administrator
 ""@
     }
     throw ""Register failed (exit $LASTEXITCODE). Review the output above.""

--- a/src/Squid.Core/Services/Machines/Scripts/Tentacle/WindowsPowerShellScriptBuilder.cs
+++ b/src/Squid.Core/Services/Machines/Scripts/Tentacle/WindowsPowerShellScriptBuilder.cs
@@ -5,26 +5,41 @@ namespace Squid.Core.Services.Machines.Scripts.Tentacle;
 /// Mirrors <see cref="LinuxBinaryScriptBuilder"/>'s shape and step ordering so an
 /// operator copying-and-pasting on Windows gets the same UX as on Linux.
 ///
-/// <para><b>Step ordering</b> (matches Linux): install → register → service install.
-/// Installing the Windows Service BEFORE register would have the SCM start the
-/// process with no persisted config → service crashes within seconds → operator
-/// sees a confusing "service stopped immediately" instead of a clean register
-/// failure. So <c>install-tentacle.ps1</c> is invoked with <c>-NoServiceInstall</c>
-/// to defer Step 3 until after Step 2 has written the config.</para>
+/// <para><b>Step ordering</b> (matches Linux): install → discover → register →
+/// service install. <c>install-tentacle.ps1</c> is invoked with <c>-NoServiceInstall</c>
+/// so register can write config BEFORE the SCM starts the worker process.
+/// Otherwise the service would start with no persisted config → crash within
+/// seconds → operator sees a confusing "service stopped immediately" instead
+/// of a clean register failure.</para>
+///
+/// <para><b>Path discovery via install-info.json</b>: <c>install-tentacle.ps1</c>
+/// writes <c>%ProgramData%\Squid\Tentacle\install-info.json</c> after extraction.
+/// Step 2 of this generated script reads that file to locate the binary, so
+/// operators who override <c>$env:INSTALL_DIR</c> (or pass <c>-InstallDir</c>)
+/// don't break Steps 3-4. No hardcoded paths — the discovery file is the
+/// source of truth.</para>
+///
+/// <para><b>UAC auto-elevation</b>: <c>install-tentacle.ps1</c> auto-elevates
+/// via UAC when not run as Administrator (both file and <c>irm | iex</c>
+/// modes). The generated script does not need to know about elevation — it
+/// just invokes the installer, which handles the re-launch.</para>
+///
+/// <para><b>403 detection</b>: the register call wraps <c>$LASTEXITCODE</c>
+/// detection so operators hitting <c>MachineCreate</c> permission denials
+/// get a structured error message naming the missing permission AND the
+/// built-in roles that grant it (Environment Manager, Space Owner, System
+/// Administrator). Without this hint, the raw 403 is opaque.</para>
 ///
 /// <para><b>Why backtick continuation</b>: PowerShell uses backtick (<c>`</c>)
-/// for line continuation. A backslash at end-of-line (the bash convention used
-/// by <see cref="TentacleInstallScriptBuilderBase.JoinLines"/>) would be parsed
-/// as a path-separator typo and the register call would fail with cryptic
-/// argv-parse errors. The local <see cref="JoinLinesPowerShell"/> helper
-/// emits the correct continuation token; pinned by a unit test.</para>
+/// for line continuation. A backslash at end-of-line would be parsed as a
+/// path-separator typo and the register call would fail with cryptic
+/// argv-parse errors.</para>
 ///
-/// <para><b>Flavor selection</b>: emits <c>--flavor LinuxTentacle</c> matching
-/// what <c>install-tentacle.sh</c> uses today. The shipped <c>squid-tentacle.exe</c>
-/// binary supports the LinuxTentacle flavor's registration mechanics on Windows;
-/// a dedicated WindowsTentacleFlavor is a future concern (would distinguish
-/// Windows-specific runtime behaviour, not the registration RPC which is
-/// already OS-agnostic on the server side).</para>
+/// <para><b>Flavor selection</b>: emits <c>--flavor LinuxTentacle</c>
+/// matching what <c>install-tentacle.sh</c> uses today. The shipped
+/// <c>Squid.Tentacle.exe</c> binary supports the LinuxTentacle flavor's
+/// registration mechanics on Windows; a dedicated WindowsTentacleFlavor is
+/// a future concern.</para>
 /// </summary>
 public sealed class WindowsPowerShellScriptBuilder : TentacleInstallScriptBuilderBase
 {
@@ -35,7 +50,19 @@ public sealed class WindowsPowerShellScriptBuilder : TentacleInstallScriptBuilde
     public override string ScriptType => "powershell";
     public override bool IsRecommended => true;
 
-    private const string CanonicalBinaryPath = @"C:\Program Files\Squid Tentacle\squid-tentacle.exe";
+    /// <summary>
+    /// Discovery-file path written by <c>install-tentacle.ps1</c>. The generated
+    /// script reads this to locate the binary regardless of install dir.
+    /// Pinned by a unit test — renaming requires lockstep update in install-tentacle.ps1.
+    /// </summary>
+    internal const string DiscoveryFileRelativePath = @"Squid\Tentacle\install-info.json";
+
+    /// <summary>
+    /// Canonical binary filename. The .NET publish output is <c>Squid.Tentacle.exe</c>
+    /// (per <c>Squid.Tentacle.csproj</c> RootNamespace + workflow publish step).
+    /// NOT <c>squid-tentacle.exe</c> (that's the Linux shell wrapper).
+    /// </summary>
+    internal const string BinaryFileName = "Squid.Tentacle.exe";
 
     protected override string BuildContent(TentacleInstallContext context)
     {
@@ -43,60 +70,107 @@ public sealed class WindowsPowerShellScriptBuilder : TentacleInstallScriptBuilde
 
         var lines = new List<string>
         {
-            "# Step 1: Download + extract Tentacle binary",
+            "# Step 1: Download + extract Tentacle binary (auto-elevates via UAC if needed)",
             "Invoke-WebRequest -UseBasicParsing -Uri https://raw.githubusercontent.com/SolarifyDev/Squid/main/deploy/scripts/install-tentacle.ps1 -OutFile $env:TEMP\\install-tentacle.ps1",
             "& $env:TEMP\\install-tentacle.ps1 -NoServiceInstall",
             "",
-            "# Step 2: Register agent with server"
+            "# Step 2: Locate the freshly-installed binary via the discovery file",
+            "# (install-tentacle.ps1 writes %ProgramData%\\Squid\\Tentacle\\install-info.json).",
+            "# Reading from disk lets the operator override -InstallDir without breaking",
+            "# the subsequent register/service-install commands.",
+            $"$infoPath = Join-Path $env:ProgramData '{DiscoveryFileRelativePath}'",
+            "if (-not (Test-Path $infoPath)) {",
+            "    throw \"install-info.json not found at $infoPath. Step 1 did not complete — review its output above.\"",
+            "}",
+            "$installInfo = Get-Content -Raw $infoPath | ConvertFrom-Json",
+            "$tentacle = $installInfo.BinaryPath",
+            "if (-not (Test-Path $tentacle)) {",
+            "    throw \"Binary '$tentacle' (recorded in install-info.json) does not exist. Re-run Step 1.\"",
+            "}",
+            "",
+            "# Step 3: Register agent with server"
         };
 
-        // The register CLI runs as the current (elevated) user. Windows has no
-        // sudo equivalent — operator runs the whole script in an Administrator
-        // PowerShell session. Config writes land under %ProgramData%\Squid\Tentacle\
-        // where the LocalSystem service account can read it (same per-user-vs-
-        // service-account concern the Linux builder solves with sudo, just
-        // resolved by a different OS mechanism).
-        var registerArgs = new List<string>
+        var registerArgs = BuildRegisterArgs(context, command);
+        lines.Add(JoinLinesPowerShell(registerArgs.ToArray()));
+
+        lines.Add("");
+        lines.Add(BuildRegisterExitCodeHandler());
+
+        lines.Add("");
+        lines.Add("# Step 4: Install as Windows Service");
+        lines.Add("& $tentacle service install --instance Default --service-name squid-tentacle");
+        lines.Add("if ($LASTEXITCODE -ne 0) {");
+        lines.Add("    throw \"Service install failed (exit $LASTEXITCODE). Review the output above for SCM errors.\"");
+        lines.Add("}");
+
+        return string.Join("\n", lines);
+    }
+
+    private static List<string> BuildRegisterArgs(TentacleInstallContext context, Squid.Message.Commands.Machine.GenerateTentacleInstallScriptCommand command)
+    {
+        var args = new List<string>
         {
-            $"& '{CanonicalBinaryPath}' register",
+            "& $tentacle register",
             $"--server \"{command.ServerUrl}\"",
             $"--api-key \"{context.ApiKey}\"",
             "--flavor LinuxTentacle"
         };
 
         if (!string.IsNullOrWhiteSpace(context.RolesCsv))
-            registerArgs.Add($"--role \"{context.RolesCsv}\"");
+            args.Add($"--role \"{context.RolesCsv}\"");
 
         if (!string.IsNullOrWhiteSpace(context.EnvironmentsCsv))
-            registerArgs.Add($"--environment \"{context.EnvironmentsCsv}\"");
+            args.Add($"--environment \"{context.EnvironmentsCsv}\"");
 
         if (!string.IsNullOrWhiteSpace(command.MachineName))
-            registerArgs.Add($"--name \"{command.MachineName}\"");
+            args.Add($"--name \"{command.MachineName}\"");
 
         if (context.IsListening)
         {
-            registerArgs.Add($"--listening-host \"{command.ListeningHostName}\"");
-            registerArgs.Add($"--listening-port \"{command.ListeningPort}\"");
+            args.Add($"--listening-host \"{command.ListeningHostName}\"");
+            args.Add($"--listening-port \"{command.ListeningPort}\"");
         }
         else
         {
-            registerArgs.Add($"--comms-url \"{command.ServerCommsUrl}\"");
+            args.Add($"--comms-url \"{command.ServerCommsUrl}\"");
         }
 
-        // Same TLS-thumbprint pinning rationale as Linux builders: the Tentacle's
-        // initial register-with HTTP call (Listening) and every Halibut poll
-        // handshake (Polling) verify this against the Server's actual cert.
-        // Without it, ServerCertificateValidator falls back to
-        // "accept with warning" — works but unsafe.
         if (!string.IsNullOrWhiteSpace(context.ServerThumbprint))
-            registerArgs.Add($"--server-cert \"{context.ServerThumbprint}\"");
+            args.Add($"--server-cert \"{context.ServerThumbprint}\"");
 
-        lines.Add(JoinLinesPowerShell(registerArgs.ToArray()));
-        lines.Add("");
-        lines.Add("# Step 3: Install as Windows Service");
-        lines.Add($"& '{CanonicalBinaryPath}' service install");
+        return args;
+    }
 
-        return string.Join("\n", lines);
+    /// <summary>
+    /// Emits an exit-code handler that turns a register-call <c>403</c> into a
+    /// structured error message. Operators hitting <c>MachineCreate</c> permission
+    /// denials get a clear remediation path instead of opaque "HTTP 403".
+    ///
+    /// <para>Built-in roles with <c>MachineCreate</c> (per
+    /// <c>BuiltInRoleSeeder.cs</c>): Environment Manager, Space Owner,
+    /// System Administrator.</para>
+    /// </summary>
+    private static string BuildRegisterExitCodeHandler()
+    {
+        return @"if ($LASTEXITCODE -ne 0) {
+    if ($LASTEXITCODE -eq 403) {
+        throw @""
+Register failed with HTTP 403 — the API key user lacks the 'MachineCreate' permission.
+
+Resolve via the Squid Web UI:
+  1. Assign the 'Environment Manager' role (or higher) to the API key's owner user, OR
+  2. Add 'MachineCreate' permission to the owner's current role, OR
+  3. Issue a new API key from a user with 'Space Owner' or 'System Administrator' role.
+
+Built-in roles that grant MachineCreate:
+  - Environment Manager
+  - Space Owner
+  - System Administrator
+""@
+    }
+    throw ""Register failed (exit $LASTEXITCODE). Review the output above.""
+}";
     }
 
     private static string JoinLinesPowerShell(params string[] lines) => string.Join(" `\n", lines);

--- a/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/GenerateTentacleInstallScriptServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/GenerateTentacleInstallScriptServiceTests.cs
@@ -176,8 +176,9 @@ public class GenerateTentacleInstallScriptServiceTests
         response.Data.Scripts[0].ScriptType.ShouldBe("powershell");
         response.Data.Scripts[0].Content.ShouldContain("Invoke-WebRequest", customMessage:
             "Real Windows builder must emit PowerShell-flavoured download command.");
-        response.Data.Scripts[0].Content.ShouldContain("squid-tentacle.exe' register", customMessage:
-            "Real Windows builder must invoke the Windows binary path for register.");
+        response.Data.Scripts[0].Content.ShouldContain("$tentacle register", customMessage:
+            "Real Windows builder must invoke the discovery-resolved $tentacle variable for register " +
+            "(path comes from install-info.json — no hardcoded C:\\Program Files\\...).");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/TentacleInstallScriptBuildersTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/TentacleInstallScriptBuildersTests.cs
@@ -372,11 +372,16 @@ public class TentacleInstallScriptBuildersTests
         script.Content.ShouldContain("MachineCreate", customMessage:
             "403 error message must name the missing permission so operators know what to grant.");
 
-        // The three roles must be named explicitly — pinned by drift detector so
-        // a future role-rename triggers CI failure and the script gets updated.
+        // The roles that actually grant MachineCreate must be named explicitly.
+        // System Administrator is INTENTIONALLY omitted — it's a system-level
+        // role and does not grant space-scoped MachineCreate (verified by
+        // PermissionRoleResolverTests). Listing it would mislead operators.
         script.Content.ShouldContain("Environment Manager");
         script.Content.ShouldContain("Space Owner");
-        script.Content.ShouldContain("System Administrator");
+        script.Content.ShouldNotContain("System Administrator", customMessage:
+            "System Administrator does NOT grant MachineCreate — suggesting it would mislead operators. " +
+            "If BuiltInRoles.SystemAdministrator changes to include MachineCreate, update " +
+            "WindowsPowerShellScriptBuilder.BuildRegisterExitCodeHandler AND this test.");
     }
 
     [Fact]
@@ -416,8 +421,30 @@ public class TentacleInstallScriptBuildersTests
             "Step 2 must validate the discovery file exists before reading.");
         script.Content.ShouldContain("install-info.json not found", customMessage:
             "Discovery-file-missing error must name the file explicitly so operators know what failed.");
-        script.Content.ShouldContain("Step 1 did not complete", customMessage:
-            "Error must direct operator back to Step 1 instead of leaving them guessing.");
+        script.Content.ShouldContain("Step 1 did not complete --", customMessage:
+            "Error must direct operator back to Step 1 instead of leaving them guessing. " +
+            "Must use ASCII -- (not em-dash —) for PowerShell 5.1 OEM-codepage compatibility.");
+    }
+
+    [Fact]
+    public void WindowsPowerShell_GeneratedContent_HasNoEmDashesInExecutableStrings()
+    {
+        // PowerShell 5.1 reads files using the host's OEM codepage when no BOM is
+        // present. An em-dash (—, U+2014) in a string literal is decoded as
+        // `â?"` under cp437/cp1252, which the PS parser then chokes on with
+        // "Unexpected token" — entire script bails before reaching the first
+        // executable line. CI failure 2026-05-19 (run 26077385538) hit exactly
+        // this; the fix is to use ASCII `--` in strings.
+        //
+        // Comments are safe (parser skips them) so this check looks only at
+        // string-literal context — any em-dash inside the generated script body
+        // breaks operators on cp437/cp1252/cp936/cp932 hosts.
+        var script = new WindowsPowerShellScriptBuilder().Build(ListeningContext());
+
+        script.Content.ShouldNotContain("—", customMessage:
+            "Generated PowerShell content contains an em-dash (—). PowerShell 5.1 on cp437/cp1252/cp936 " +
+            "hosts mis-decodes this as 'â?\"' and fails to parse the surrounding statement. Use ASCII `--` instead. " +
+            "Test pinned after CI failure on workflow run 26077385538.");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/TentacleInstallScriptBuildersTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/TentacleInstallScriptBuildersTests.cs
@@ -234,14 +234,15 @@ public class TentacleInstallScriptBuildersTests
             "Step 1 must defer service install so register can write config first " +
             "(matches LinuxBinaryScriptBuilder's install-then-register-then-service order).");
 
-        // register
-        script.Content.ShouldContain("squid-tentacle.exe' register");
+        // register — uses the $tentacle variable discovered from install-info.json
+        // (no hardcoded path; survives operator's -InstallDir override)
+        script.Content.ShouldContain("$tentacle register");
         script.Content.ShouldContain("--listening-host \"host.local\"");
         script.Content.ShouldContain("--listening-port \"10933\"");
         script.Content.ShouldContain("--server-cert \"FAF04764\"");
 
         // service install must come AFTER register
-        var registerIdx = script.Content.IndexOf("register", StringComparison.Ordinal);
+        var registerIdx = script.Content.IndexOf("$tentacle register", StringComparison.Ordinal);
         var serviceInstallIdx = script.Content.IndexOf("service install", StringComparison.Ordinal);
         registerIdx.ShouldBeGreaterThan(0);
         serviceInstallIdx.ShouldBeGreaterThan(registerIdx,
@@ -320,37 +321,129 @@ public class TentacleInstallScriptBuildersTests
     }
 
     [Fact]
-    public void WindowsPowerShell_BinaryPath_PinsCanonicalProgramFilesLocation()
+    public void WindowsPowerShell_DoesNotHardcodeBinaryPath_ReadsInstallInfoJson()
     {
-        // install-tentacle.ps1 default install dir is C:\Program Files\Squid Tentacle.
-        // Pinning the literal here ensures the script and the installer agree —
-        // a future installer that defaults elsewhere would silently break this
-        // generated script (binary not found at the path the script invokes).
+        // Path-agnostic invariant: the generated script MUST NOT hardcode
+        // C:\Program Files\Squid Tentacle\... because operators routinely
+        // override -InstallDir for D: drive installs, dev-machine layouts,
+        // or air-gapped per-tenant paths.
+        //
+        // Instead, the script reads %ProgramData%\Squid\Tentacle\install-info.json
+        // (written by install-tentacle.ps1 post-extraction) and uses the
+        // BinaryPath field. This survives any -InstallDir override.
         var script = new WindowsPowerShellScriptBuilder().Build(ListeningContext());
 
-        script.Content.ShouldContain(@"C:\Program Files\Squid Tentacle\squid-tentacle.exe", customMessage:
-            "Generated script must reference the canonical install path written by install-tentacle.ps1. " +
-            "If install-tentacle.ps1's default ever changes, update both sides — caught by this pin.");
+        script.Content.ShouldNotContain(@"C:\Program Files\Squid Tentacle\Squid.Tentacle.exe", customMessage:
+            "Generated script hardcodes the default install path. Operators with custom -InstallDir " +
+            "would silently break — read from install-info.json instead.");
+        script.Content.ShouldNotContain(@"C:\Program Files\Squid Tentacle\squid-tentacle.exe", customMessage:
+            "Generated script contains the deprecated lowercase 'squid-tentacle.exe' name. The actual " +
+            "published binary is 'Squid.Tentacle.exe' (per Squid.Tentacle.csproj RootNamespace).");
+
+        // Discovery-file path is pinned exactly — install-tentacle.ps1 writes here.
+        script.Content.ShouldContain(@"Squid\Tentacle\install-info.json", customMessage:
+            "Step 2 must read the discovery file at %ProgramData%\\Squid\\Tentacle\\install-info.json. " +
+            "Renaming requires lockstep update in install-tentacle.ps1's Write-InstallInfo function.");
+
+        // The `$tentacle` PowerShell variable is the resolved binary path used
+        // throughout Steps 3-4. Pin both the assignment and the consumption.
+        script.Content.ShouldContain("$tentacle = $installInfo.BinaryPath");
+        script.Content.ShouldContain("$tentacle register");
+        script.Content.ShouldContain("$tentacle service install");
     }
 
     [Fact]
-    public void WindowsPowerShell_ContainsAllThreeOrderedSteps()
+    public void WindowsPowerShell_GeneratedScript_ChecksRegisterExitCodeForHttp403WithPermissionHint()
+    {
+        // 403 from /api/machines/register/* almost always means the API key user
+        // lacks the MachineCreate permission. Without a structured error message,
+        // the operator just sees an exit code and has no idea what to do.
+        //
+        // The generated script wraps $LASTEXITCODE = 403 and emits the three
+        // built-in roles that grant MachineCreate (Environment Manager / Space
+        // Owner / System Administrator) so the operator can self-service the
+        // fix.
+        var script = new WindowsPowerShellScriptBuilder().Build(ListeningContext());
+
+        script.Content.ShouldContain("$LASTEXITCODE -eq 403", customMessage:
+            "Register exit-code handler must explicitly detect 403 — that's the canonical " +
+            "permission-denied signal from /api/machines/register/*.");
+
+        script.Content.ShouldContain("MachineCreate", customMessage:
+            "403 error message must name the missing permission so operators know what to grant.");
+
+        // The three roles must be named explicitly — pinned by drift detector so
+        // a future role-rename triggers CI failure and the script gets updated.
+        script.Content.ShouldContain("Environment Manager");
+        script.Content.ShouldContain("Space Owner");
+        script.Content.ShouldContain("System Administrator");
+    }
+
+    [Fact]
+    public void WindowsPowerShell_ContainsAllFourOrderedSteps()
     {
         // Defensive ordering pin: the script must contain Step 1 (install),
-        // Step 2 (register), Step 3 (service install) in that order. A refactor
-        // that accidentally reorders them would break the registration flow
-        // because service install before register starts the SCM-managed
-        // process with no config → it crashes within seconds → operator sees
-        // a confusing "service stopped immediately" rather than a clean error.
+        // Step 2 (discover), Step 3 (register), Step 4 (service install) in
+        // that order. A refactor that accidentally reorders them breaks the
+        // registration flow.
+        //
+        // Step 2 (discover) is new in the install-info.json design — it reads
+        // the discovery file written by install-tentacle.ps1 and resolves the
+        // $tentacle variable that Steps 3-4 use.
         var script = new WindowsPowerShellScriptBuilder().Build(ListeningContext());
 
         var step1Idx = script.Content.IndexOf("Step 1", StringComparison.Ordinal);
         var step2Idx = script.Content.IndexOf("Step 2", StringComparison.Ordinal);
         var step3Idx = script.Content.IndexOf("Step 3", StringComparison.Ordinal);
+        var step4Idx = script.Content.IndexOf("Step 4", StringComparison.Ordinal);
 
         step1Idx.ShouldBeGreaterThan(-1);
         step2Idx.ShouldBeGreaterThan(step1Idx);
         step3Idx.ShouldBeGreaterThan(step2Idx);
+        step4Idx.ShouldBeGreaterThan(step3Idx);
+    }
+
+    [Fact]
+    public void WindowsPowerShell_DiscoveryFileMissing_ScriptThrowsActionableError()
+    {
+        // If Step 1 (install-tentacle.ps1) failed silently or got skipped, Step 2
+        // must throw with an actionable error pointing at the missing discovery
+        // file — not a cryptic "$tentacle is null" or NullReferenceException at
+        // Step 3.
+        var script = new WindowsPowerShellScriptBuilder().Build(ListeningContext());
+
+        script.Content.ShouldContain("Test-Path $infoPath", customMessage:
+            "Step 2 must validate the discovery file exists before reading.");
+        script.Content.ShouldContain("install-info.json not found", customMessage:
+            "Discovery-file-missing error must name the file explicitly so operators know what failed.");
+        script.Content.ShouldContain("Step 1 did not complete", customMessage:
+            "Error must direct operator back to Step 1 instead of leaving them guessing.");
+    }
+
+    [Fact]
+    public void WindowsPowerShell_PinsBinaryFileNameConstant_SquidTentacleExe()
+    {
+        // Drift detector for the canonical binary filename. The .NET publish
+        // output is "Squid.Tentacle.exe" (Squid.Tentacle.csproj has
+        // <RootNamespace>Squid.Tentacle</RootNamespace>, AssemblyName defaults
+        // to project name). A rename in the csproj OR a future "lowercase
+        // everything" refactor would silently break the generated script.
+        WindowsPowerShellScriptBuilder.BinaryFileName.ShouldBe("Squid.Tentacle.exe", customMessage:
+            "Renaming the published binary breaks every install-tentacle.ps1 invocation. " +
+            "If you genuinely want to rename, update install-tentacle.ps1's $BinaryName " +
+            "(line ~80) AND this pin in lockstep.");
+    }
+
+    [Fact]
+    public void WindowsPowerShell_PinsDiscoveryFileRelativePath()
+    {
+        // Drift detector for the discovery-file location. install-tentacle.ps1
+        // writes to %ProgramData%\Squid\Tentacle\install-info.json; the
+        // generated script reads from the same path. Renaming one without the
+        // other breaks every fresh install.
+        WindowsPowerShellScriptBuilder.DiscoveryFileRelativePath.ShouldBe(@"Squid\Tentacle\install-info.json", customMessage:
+            "Discovery-file path changed. install-tentacle.ps1's Write-InstallInfo writes here; " +
+            "the generated script reads from the same constant. Update both sides in lockstep.");
     }
 
     // ========================================================================

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptResilienceE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptResilienceE2ETests.cs
@@ -1,0 +1,517 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json;
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Phase 12.M -- E2E coverage for the install-resilience surface added by
+/// PR #329 (path-agnostic install + UAC auto-elevation + install-info.json
+/// discovery file).
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real <c>powershell.exe</c>, real
+/// <c>install-tentacle.ps1</c> from disk, real <see cref="LocalReleaseMirror"/>
+/// serving fake zip downloads, real file-system writes. Skip-on-non-Windows
+/// guard keeps cross-OS dev hosts running a clean "0 / 0" instead of
+/// spurious failures.</para>
+///
+/// <para><b>Test groups</b> (each section below covers one resilience axis):
+/// <list type="number">
+///   <item>install-info.json discovery file -- schema, fields, path</item>
+///   <item>Auto-elevation skip semantics -- already admin / user-path /
+///         -NoAutoElevate / default-path-without-admin</item>
+///   <item>Idempotence stress -- re-install over existing dir, 5 iterations</item>
+///   <item>Corrupt-state recovery -- info.json present but binary missing,
+///         info.json malformed, info.json missing entirely</item>
+///   <item>Custom install paths -- with spaces, non-ASCII (where supported),
+///         different drives, deep nested</item>
+/// </list></para>
+///
+/// <para>Tests NOT covered here because they're impossible / impractical in CI:
+/// real UAC prompt (would block the runner forever), Windows Defender
+/// SmartScreen blocking unsigned binaries (Defender is disabled on
+/// windows-latest runners), corporate GPO ExecutionPolicy locks (no GPO
+/// infrastructure on runners). Those are documented in
+/// <c>docs/windows-tentacle-install.md</c> as known operator workflows.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.TentacleInstallScript)]
+public sealed class TentacleInstallScriptResilienceE2ETests
+{
+    // ========================================================================
+    // Group 1 -- install-info.json discovery file
+    // ========================================================================
+
+    [Fact]
+    public async Task InstallScript_WritesInstallInfoJson_AtCanonicalPath_AfterExtract()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        using var ctx = new InstallScriptTestContext();
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# fake test binary\n"));
+
+        var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+            "-Version", "1.6.0-test",
+            "-InstallDir", ctx.InstallDir,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall",
+            "-NoAutoElevate"
+        );
+
+        exitCode.ShouldBe(0,
+            customMessage: $"install MUST succeed. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var infoPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Squid", "Tentacle", "install-info.json");
+
+        File.Exists(infoPath).ShouldBeTrue(
+            customMessage:
+                $"install-info.json MUST be written to {infoPath}. " +
+                $"Downstream scripts (register/service-install) read this file to locate the binary. " +
+                $"Without it, operators with custom -InstallDir get a broken copy-paste experience.");
+
+        ctx.RegisterCleanupPath(infoPath);
+    }
+
+    [Fact]
+    public async Task InstallScript_InstallInfoJson_HasAllRequiredFields()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        using var ctx = new InstallScriptTestContext();
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
+
+        var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+            "-Version", "2.0.1-test",
+            "-InstallDir", ctx.InstallDir,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall",
+            "-NoAutoElevate"
+        );
+
+        exitCode.ShouldBe(0, customMessage: $"install MUST succeed. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var infoPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Squid", "Tentacle", "install-info.json");
+        ctx.RegisterCleanupPath(infoPath);
+
+        var raw = await File.ReadAllTextAsync(infoPath);
+        var info = JsonDocument.Parse(raw).RootElement;
+
+        // Schema = 1 -- a future schema bump must update both writer and
+        // downstream readers in lockstep. Pinned to make the bump explicit.
+        info.GetProperty("Schema").GetInt32().ShouldBe(1);
+
+        // BinaryPath -- the actual on-disk path to Squid.Tentacle.exe. The
+        // server-generated register/service-install snippet reads this verbatim.
+        var binaryPath = info.GetProperty("BinaryPath").GetString();
+        binaryPath.ShouldEndWith("Squid.Tentacle.exe");
+        binaryPath.ShouldStartWith(ctx.InstallDir);
+        File.Exists(binaryPath).ShouldBeTrue(
+            customMessage: $"BinaryPath '{binaryPath}' must point at an existing file.");
+
+        // InstallDir matches what operator passed
+        info.GetProperty("InstallDir").GetString().ShouldBe(ctx.InstallDir);
+
+        // Version + Architecture present
+        info.GetProperty("Version").GetString().ShouldBe("2.0.1-test");
+        info.GetProperty("Architecture").GetString().ShouldBeOneOf("win-x64", "win-arm64");
+
+        // InstalledAt is a parseable ISO-8601 timestamp
+        var installedAt = info.GetProperty("InstalledAt").GetString();
+        DateTimeOffset.TryParse(installedAt, out var parsed).ShouldBeTrue(
+            customMessage: $"InstalledAt '{installedAt}' must be parseable as ISO-8601. Operators read this when investigating which deploy installed when.");
+        (DateTimeOffset.UtcNow - parsed).TotalMinutes.ShouldBeLessThan(5,
+            customMessage: "InstalledAt should be recent (within the last 5 minutes).");
+
+        // InstalledBy = the current user identity
+        info.GetProperty("InstalledBy").GetString().ShouldNotBeNullOrWhiteSpace();
+
+        // ServiceName -- defaults to squid-tentacle
+        info.GetProperty("ServiceName").GetString().ShouldBe("squid-tentacle");
+    }
+
+    [Fact]
+    public async Task InstallScript_InstallInfoJson_BinaryPathReflectsCustomInstallDir()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        // Use a path with deep nesting to prove path-resolution works for
+        // non-trivial structures operators might pick.
+        var nestedPath = Path.Combine(Path.GetTempPath(), $"squid-deep-{Guid.NewGuid():N}", "level2", "level3");
+        using var ctx = new InstallScriptTestContext(nestedPath);
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
+
+        var (exitCode, _, stderr) = await RunInstallScriptAsync(
+            "-Version", "1.6.0-test",
+            "-InstallDir", ctx.InstallDir,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall",
+            "-NoAutoElevate"
+        );
+
+        exitCode.ShouldBe(0, customMessage: $"deep-nested install dir must work. stderr:\n{stderr}");
+
+        var infoPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Squid", "Tentacle", "install-info.json");
+        ctx.RegisterCleanupPath(infoPath);
+
+        var info = JsonDocument.Parse(await File.ReadAllTextAsync(infoPath)).RootElement;
+        info.GetProperty("BinaryPath").GetString().ShouldBe(Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe"));
+    }
+
+    // ========================================================================
+    // Group 2 -- Auto-elevation skip semantics
+    //
+    // We can't actually drive a UAC prompt in CI (would block the runner)
+    // but we CAN verify the elevation-skip conditions all work:
+    //   - already admin → no relaunch
+    //   - user-owned install dir → no relaunch (admin not needed)
+    //   - -NoAutoElevate flag → refuse to relaunch (clean error if would need to)
+    // ========================================================================
+
+    [Fact]
+    public async Task InstallScript_AlreadyAdmin_NoReElevation_CompletesInProcess()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // CI runner runs as administrator by default. Default install dir
+        // requires admin -- the script should detect "already admin" and proceed.
+        // We invoke with default install dir but use -NoAutoElevate to make any
+        // accidental elevation attempt fail loudly (rather than block on UAC).
+        // If the script correctly detects already-admin, -NoAutoElevate is a no-op.
+        using var mirror = LocalReleaseMirror.Start();
+        var defaultInstallDir = @"C:\Program Files\Squid Tentacle";
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
+
+        try
+        {
+            var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+                "-Version", "1.6.0-test",
+                "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+                "-NoServiceInstall",
+                "-NoAutoElevate"
+            );
+
+            exitCode.ShouldBe(0,
+                customMessage:
+                    $"CI runner is already admin; default install dir should succeed without UAC re-launch. " +
+                    $"stdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        finally
+        {
+            // Clean up Program Files install + the global info.json
+            try { Directory.Delete(defaultInstallDir, recursive: true); } catch { }
+            try
+            {
+                var infoPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                    "Squid", "Tentacle", "install-info.json");
+                File.Delete(infoPath);
+            }
+            catch { }
+        }
+    }
+
+    [Fact]
+    public async Task InstallScript_UserOwnedInstallDir_SkipsElevationEvenWithoutNoAutoElevateFlag()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        using var ctx = new InstallScriptTestContext();
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
+
+        // User-owned path (under %TEMP%) -- admin not required, so elevation
+        // logic should detect "no admin needed" and proceed in-process even
+        // without the -NoAutoElevate flag. If the script wrongly insisted on
+        // UAC for non-admin-required paths, this test would hang or fail.
+        var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+            "-Version", "1.6.0-test",
+            "-InstallDir", ctx.InstallDir,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall"
+            // Deliberately NO -NoAutoElevate -- we want to prove the script's
+            // own logic skips elevation for user-owned paths.
+        );
+
+        exitCode.ShouldBe(0,
+            customMessage:
+                $"User-owned install dir ({ctx.InstallDir}) must NOT trigger UAC re-launch even without " +
+                $"-NoAutoElevate. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe")).ShouldBeTrue();
+    }
+
+    // ========================================================================
+    // Group 3 -- Idempotence stress (5 iterations)
+    //
+    // A single install pass succeeding isn't enough -- production operators
+    // re-run install scripts in 1) bake-image automation, 2) drift remediation,
+    // 3) version upgrades. Each loop here proves no state corruption / lock
+    // leaks across iterations.
+    // ========================================================================
+
+    [Fact]
+    public async Task InstallScript_FreshInstall_FiveIterations_AllSucceed()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        const int iterations = 5;
+        var failures = new List<string>();
+
+        for (var i = 0; i < iterations; i++)
+        {
+            using var mirror = LocalReleaseMirror.Start();
+            using var ctx = new InstallScriptTestContext();
+            mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes($"# iter {i}\n"));
+
+            var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+                "-Version", "1.6.0-test",
+                "-InstallDir", ctx.InstallDir,
+                "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+                "-NoServiceInstall",
+                "-NoAutoElevate"
+            );
+
+            if (exitCode != 0)
+            {
+                failures.Add($"iter {i}: exit={exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+                continue;
+            }
+
+            if (!File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe")))
+                failures.Add($"iter {i}: binary missing after exit 0");
+        }
+
+        failures.ShouldBeEmpty(
+            customMessage:
+                $"5/{iterations} fresh installs must succeed. Pre-fix flake or post-fix regression " +
+                $"surfaces here. Failures:\n{string.Join("\n----\n", failures)}");
+    }
+
+    [Fact]
+    public async Task InstallScript_ReInstallOverSameDir_FiveIterations_NoStateCorruption()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        using var ctx = new InstallScriptTestContext();
+        const int iterations = 5;
+        var failures = new List<string>();
+
+        for (var i = 0; i < iterations; i++)
+        {
+            // Each iteration stages a different binary content so we can verify
+            // the latest install actually overwrote the previous one. If
+            // Expand-Archive -Force broke and silently no-op'd, we'd see stale
+            // content here.
+            var marker = $"iter-{i}-{Guid.NewGuid():N}";
+            mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes(marker));
+
+            var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+                "-Version", "1.6.0-test",
+                "-InstallDir", ctx.InstallDir,
+                "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+                "-NoServiceInstall",
+                "-NoAutoElevate"
+            );
+
+            if (exitCode != 0)
+            {
+                failures.Add($"iter {i}: exit={exitCode}. stdout:\n{stdout}\nstderr:\n{stderr}");
+                continue;
+            }
+
+            var content = await File.ReadAllTextAsync(Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe"));
+            if (!content.Contains(marker))
+                failures.Add($"iter {i}: binary content '{content}' missing marker '{marker}' -- Expand-Archive -Force did not overwrite.");
+        }
+
+        failures.ShouldBeEmpty(
+            customMessage:
+                $"5/{iterations} re-installs over same dir must succeed with content actually replaced. " +
+                $"Failures:\n{string.Join("\n----\n", failures)}");
+    }
+
+    // ========================================================================
+    // Group 4 -- Corrupt-state recovery
+    //
+    // Production hosts can have partial-install state from a prior crash,
+    // operator manual edits, AV quarantine, etc. The script must not crash
+    // on these, and the discovery-file consumer (server-generated snippet)
+    // must give actionable errors when reading mangled state.
+    // ========================================================================
+
+    [Fact]
+    public async Task InstallScript_OverwritesStaleInstallInfoJson_OnReInstall()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        using var ctx = new InstallScriptTestContext();
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
+
+        var infoDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Squid", "Tentacle");
+        var infoPath = Path.Combine(infoDir, "install-info.json");
+        ctx.RegisterCleanupPath(infoPath);
+
+        // Pre-stage stale install-info pointing at a fictitious path
+        Directory.CreateDirectory(infoDir);
+        await File.WriteAllTextAsync(infoPath,
+            """{"Schema":1,"BinaryPath":"C:\\stale\\path\\Squid.Tentacle.exe","InstallDir":"C:\\stale\\path","Version":"0.0.0-stale"}""");
+
+        var (exitCode, _, stderr) = await RunInstallScriptAsync(
+            "-Version", "1.6.0-test",
+            "-InstallDir", ctx.InstallDir,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall",
+            "-NoAutoElevate"
+        );
+
+        exitCode.ShouldBe(0, customMessage: $"re-install over stale info MUST succeed. stderr:\n{stderr}");
+
+        // Stale info was replaced with fresh content reflecting the new install dir.
+        var info = JsonDocument.Parse(await File.ReadAllTextAsync(infoPath)).RootElement;
+        info.GetProperty("BinaryPath").GetString().ShouldStartWith(ctx.InstallDir,
+            customMessage: "install-info.json BinaryPath must reflect the NEW install, not the stale entry.");
+        info.GetProperty("Version").GetString().ShouldBe("1.6.0-test",
+            customMessage: "Version must update to reflect the new install.");
+    }
+
+    // ========================================================================
+    // Group 5 -- Custom install paths
+    // ========================================================================
+
+    [Fact]
+    public async Task InstallScript_InstallDirWithSpaces_ExtractsAndDiscoversCorrectly()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        // Path with spaces -- common operator workflow (e.g. "D:\My Apps\Squid Tentacle").
+        // Quoting + path-resolution must handle this cleanly.
+        var pathWithSpaces = Path.Combine(Path.GetTempPath(), $"squid install {Guid.NewGuid():N}");
+        using var ctx = new InstallScriptTestContext(pathWithSpaces);
+        mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
+
+        var (exitCode, _, stderr) = await RunInstallScriptAsync(
+            "-Version", "1.6.0-test",
+            "-InstallDir", pathWithSpaces,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall",
+            "-NoAutoElevate"
+        );
+
+        exitCode.ShouldBe(0,
+            customMessage: $"install dir with spaces must work. stderr:\n{stderr}");
+
+        File.Exists(Path.Combine(pathWithSpaces, "Squid.Tentacle.exe")).ShouldBeTrue();
+
+        // install-info.json must roundtrip the spaced path correctly.
+        var infoPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Squid", "Tentacle", "install-info.json");
+        ctx.RegisterCleanupPath(infoPath);
+
+        var info = JsonDocument.Parse(await File.ReadAllTextAsync(infoPath)).RootElement;
+        info.GetProperty("InstallDir").GetString().ShouldBe(pathWithSpaces);
+        info.GetProperty("BinaryPath").GetString().ShouldBe(Path.Combine(pathWithSpaces, "Squid.Tentacle.exe"));
+    }
+
+    // ========================================================================
+    // Helpers (shared with TentacleInstallScriptWindowsE2ETests via parallel
+    // copies -- intentional: keep the per-test-class scope explicit, and avoid
+    // a cross-cutting fixture that two classes share state through).
+    // ========================================================================
+
+    private static async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
+    {
+        var scriptPath = LocateInstallScript();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-NonInteractive");
+        psi.ArgumentList.Add("-ExecutionPolicy");
+        psi.ArgumentList.Add("Bypass");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(scriptPath);
+        foreach (var arg in scriptArgs) psi.ArgumentList.Add(arg);
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch powershell.exe");
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+
+        if (!p.WaitForExit(60_000))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("install-tentacle.ps1 did not exit within 60s");
+        }
+
+        return (p.ExitCode, await stdoutTask, await stderrTask);
+    }
+
+    private static string LocateInstallScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "deploy", "scripts", "install-tentacle.ps1");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException("Could not locate deploy/scripts/install-tentacle.ps1 from the test assembly's directory tree");
+    }
+
+    private sealed class InstallScriptTestContext : IDisposable
+    {
+        private readonly List<string> _cleanupPaths = new();
+
+        public string InstallDir { get; }
+
+        public InstallScriptTestContext()
+            : this(Path.Combine(Path.GetTempPath(), $"squid-install-e2e-{Guid.NewGuid():N}")) { }
+
+        public InstallScriptTestContext(string installDir)
+        {
+            InstallDir = installDir;
+            _cleanupPaths.Add(InstallDir);
+        }
+
+        public void RegisterCleanupPath(string path) => _cleanupPaths.Add(path);
+
+        public void Dispose()
+        {
+            foreach (var path in _cleanupPaths)
+            {
+                try
+                {
+                    if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+                    else if (File.Exists(path)) File.Delete(path);
+                }
+                catch { /* best-effort */ }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes three operator-visible failures in the Squid-generated Windows install snippet, plus a CI repro fix:

- **Wrong binary name**: server emitted `squid-tentacle.exe`, but the .NET publish output is `Squid.Tentacle.exe` (per `Squid.Tentacle.csproj` `RootNamespace`). Every install hit "file not found" at register.
- **Hardcoded install path**: server emitted `'C:\Program Files\Squid Tentacle\…'`, breaking operators who override `\$env:INSTALL_DIR` or `-InstallDir`.
- **No UAC auto-elevation**: `install-tentacle.ps1` errored out for non-admin shells instead of triggering UAC.
- **Em-dash parse error**: PowerShell 5.1 mis-decoded em-dashes under OEM codepage on `windows-latest` runners. Fixed + drift detector pinned.

Three-layer fix:

1. **`install-tentacle.ps1`** writes `%ProgramData%\Squid\Tentacle\install-info.json` (Schema=1) after extraction.
2. **`install-tentacle.ps1`** auto-elevates via `Start-Process -Verb RunAs`. Handles both file invocation and `irm | iex` pipe invocation. Skippable via `-NoAutoElevate` for CI / SYSTEM-context.
3. **`WindowsPowerShellScriptBuilder`** reads the discovery file in Step 2; uses `\$tentacle` throughout Steps 3-4. Wraps register-call `\$LASTEXITCODE = 403` with a structured error naming `MachineCreate` permission + the granting built-in roles (Environment Manager / Space Owner).

Tests:
- **Unit (8 new)**: drift detectors for binary name, discovery-file path, em-dash absence in generated content, 4-step ordering, missing-discovery-file error, 403 hint contents, role-list accuracy.
- **E2E (9 new in resilience matrix)**: install-info.json schema, BinaryPath reflects `-InstallDir`, idempotence stress (5×), corrupt-state recovery, paths-with-spaces.

## Test plan

- [x] Unit: 5217/5217 pass locally
- [x] Build: zero errors across all projects
- [ ] Windows CI: install-tentacle.ps1 + WindowsPowerShellScriptBuilder + 9 new resilience E2E tests pass on \`windows-latest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)