### PR TITLE
Enrich 403 register response with structured permission hint

### DIFF
--- a/src/Squid.Api/Filters/GlobalExceptionFilter.cs
+++ b/src/Squid.Api/Filters/GlobalExceptionFilter.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Serilog;
+using Squid.Core.Services.Authorization;
 using Squid.Core.Services.Authorization.Exceptions;
 using Squid.Core.Services.Machines.Exceptions;
 using Squid.Message.Response;
@@ -29,12 +30,35 @@ public class GlobalExceptionFilter : IExceptionFilter
             ? $"{context.Exception.Message} → {context.Exception.InnerException.Message}"
             : context.Exception.Message;
 
-        context.Result = new OkObjectResult(new SquidResponse
+        var response = new SquidResponse
         {
             Code = statusCode,
             Msg = message
-        });
+        };
 
+        // PR 2 (1.7.0): when the failure is a permission denial, enrich the
+        // response with the missing permission name + the built-in roles that
+        // grant it. Tentacle CLI and install-script consumers read these
+        // structured fields and emit operator-actionable hints — without this,
+        // every 403 is a bare "permission denied" that operators have to debug
+        // by reading server source.
+        if (context.Exception is PermissionDeniedException permissionEx)
+        {
+            EnrichForPermissionDenial(response, permissionEx);
+        }
+
+        context.Result = new OkObjectResult(response);
         context.ExceptionHandled = true;
+    }
+
+    private static void EnrichForPermissionDenial(SquidResponse response, PermissionDeniedException ex)
+    {
+        var permissionName = ex.Permission.ToString();
+        var suggestedRoles = PermissionRoleResolver.GetBuiltInRolesGranting(ex.Permission);
+        var hint = PermissionRoleResolver.BuildOperatorHint(ex.Permission);
+
+        response.MissingPermission = permissionName;
+        response.SuggestedRoles = suggestedRoles;
+        response.Msg = $"{response.Msg} {hint}";
     }
 }

--- a/src/Squid.Core/Services/Authorization/PermissionRoleResolver.cs
+++ b/src/Squid.Core/Services/Authorization/PermissionRoleResolver.cs
@@ -1,0 +1,66 @@
+using Squid.Core.Services.DataSeeding;
+using Squid.Message.Enums;
+
+namespace Squid.Core.Services.Authorization;
+
+/// <summary>
+/// Maps a denied <see cref="Permission"/> to the built-in roles that grant it,
+/// so the server's 403 response body + the Tentacle CLI's error output can
+/// give operators an actionable remediation path instead of an opaque
+/// "Permission denied" message.
+///
+/// <para><b>Why a static helper, not a service</b>: built-in role
+/// definitions are compile-time constants (<see cref="BuiltInRoleSeeder"/>).
+/// They don't change at runtime, so we don't need DI lifetime management —
+/// a pure function is enough.</para>
+///
+/// <para><b>Custom roles</b>: operators can grant <c>MachineCreate</c> to
+/// any custom role they create. The "suggested roles" list intentionally
+/// surfaces only the BUILT-IN roles that ship with Squid, because those
+/// are the ones every install has by default. The error message tells the
+/// operator they can also add the permission to their existing custom
+/// role — covers the "we have a custom role and don't want to change
+/// roles" workflow.</para>
+/// </summary>
+public static class PermissionRoleResolver
+{
+    /// <summary>
+    /// Returns the names of the built-in roles that grant <paramref name="permission"/>.
+    /// Empty when no built-in role grants it (operator must use a custom role
+    /// or add the permission to an existing role).
+    /// </summary>
+    public static IReadOnlyList<string> GetBuiltInRolesGranting(Permission permission)
+    {
+        var matches = new List<string>();
+
+        foreach (var role in BuiltInRoles.All)
+        {
+            if (role.Permissions.Contains(permission))
+                matches.Add(role.Name);
+        }
+
+        return matches;
+    }
+
+    /// <summary>
+    /// Composes a single-paragraph operator-facing hint that names the missing
+    /// permission AND lists the built-in roles that grant it. Empty string when
+    /// no built-in role grants it (the structured response still carries
+    /// <c>MissingPermission</c> + an empty <c>SuggestedRoles</c>, and the
+    /// install script's exit-code handler can fall back to its own message).
+    /// </summary>
+    public static string BuildOperatorHint(Permission permission)
+    {
+        var roles = GetBuiltInRolesGranting(permission);
+
+        if (roles.Count == 0)
+        {
+            return $"Missing permission '{permission}'. No built-in role grants it — " +
+                   $"add the permission to the API key user's current role, or create a custom role with it.";
+        }
+
+        return $"Missing permission '{permission}'. Built-in roles that grant it: " +
+               $"{string.Join(", ", roles)}. Assign one of these roles to the API key user, " +
+               $"or add '{permission}' to their existing role.";
+    }
+}

--- a/src/Squid.Message/Response/SquidResponse.cs
+++ b/src/Squid.Message/Response/SquidResponse.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json.Serialization;
 
 namespace Squid.Message.Response;
 
@@ -7,6 +8,25 @@ public class SquidResponse : IResponse
     public string Msg { get; set; }
 
     public HttpStatusCode Code { get; set; }
+
+    /// <summary>
+    /// When <see cref="Code"/> is <see cref="HttpStatusCode.Forbidden"/>, names the
+    /// permission the user lacks (e.g. <c>"MachineCreate"</c>). Lets Tentacle CLI and
+    /// install-script consumers programmatically detect "this is a permission issue,
+    /// here's exactly which permission" without parsing <see cref="Msg"/>.
+    /// Null on success / non-403 responses.
+    /// </summary>
+    [JsonPropertyName("missingPermission")]
+    public string MissingPermission { get; set; }
+
+    /// <summary>
+    /// When <see cref="MissingPermission"/> is set, lists the built-in roles
+    /// that grant it (e.g. <c>["Environment Manager", "Space Owner", "System Administrator"]</c>).
+    /// Empty array when no built-in role grants the permission (operator must
+    /// add it to a custom role). Null on success / non-403 responses.
+    /// </summary>
+    [JsonPropertyName("suggestedRoles")]
+    public IReadOnlyList<string> SuggestedRoles { get; set; }
 }
 
 public class SquidResponse<T> : SquidResponse

--- a/src/Squid.Tentacle/Core/TentacleEntry.cs
+++ b/src/Squid.Tentacle/Core/TentacleEntry.cs
@@ -108,6 +108,16 @@ public static class TentacleEntry
             Log.Information("Squid Tentacle shutdown requested");
             return 0;
         }
+        catch (Squid.Tentacle.Registration.PermissionDeniedRegistrationException ex)
+        {
+            // PR 2 (1.7.0): permission denials get a distinct exit code (403) and
+            // a multi-line operator hint instead of a generic exit 1. The hint
+            // lists the built-in roles that grant the missing permission, so the
+            // operator can resolve without reading server source.
+            EmitPermissionDeniedHint(ex);
+            TryWriteScmDiagnostic($"TentacleEntry.RunAsync caught PermissionDeniedRegistrationException: {ex.MissingPermission}");
+            return 403;
+        }
         catch (Exception ex)
         {
             Log.Fatal(ex, "Squid Tentacle terminated unexpectedly");
@@ -121,6 +131,34 @@ public static class TentacleEntry
             TryWriteScmDiagnostic($"TentacleEntry.RunAsync caught {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Emits a multi-line permission-denied hint to stderr. The structured fields
+    /// come from the server's enriched 403 response body (<c>missingPermission</c>
+    /// + <c>suggestedRoles</c>); we display them as plain text the operator can
+    /// read directly from the install script's console output.
+    ///
+    /// <para>Format is deliberately stable — install-script E2E tests grep for
+    /// the literal "Permission denied:" prefix + "Built-in roles that grant"
+    /// substring to assert the hint reached the operator.</para>
+    /// </summary>
+    private static void EmitPermissionDeniedHint(Squid.Tentacle.Registration.PermissionDeniedRegistrationException ex)
+    {
+        var roles = ex.SuggestedRoles.Count > 0
+            ? string.Join(", ", ex.SuggestedRoles)
+            : "(no built-in role grants this permission — add it to a custom role)";
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"Permission denied: '{ex.MissingPermission}' permission required to register the machine.");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Resolve via the Squid Web UI:");
+        Console.Error.WriteLine($"  1. Assign one of these roles to the API key user: {roles}, OR");
+        Console.Error.WriteLine($"  2. Add '{ex.MissingPermission}' permission to the user's current role, OR");
+        Console.Error.WriteLine($"  3. Issue a new API key from a user with one of the roles above.");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"Built-in roles that grant {ex.MissingPermission}: {roles}");
+        Console.Error.WriteLine();
     }
 
     /// <summary>

--- a/src/Squid.Tentacle/Registration/PermissionDeniedRegistrationException.cs
+++ b/src/Squid.Tentacle/Registration/PermissionDeniedRegistrationException.cs
@@ -1,0 +1,33 @@
+using System.Net;
+
+namespace Squid.Tentacle.Registration;
+
+/// <summary>
+/// Thrown when the Squid Server rejects a register call with HTTP 403 +
+/// a structured permission-denial body (containing <c>missingPermission</c>
+/// + <c>suggestedRoles</c>).
+///
+/// <para>The Tentacle CLI's exception handler catches this type explicitly
+/// and emits a multi-line operator-facing hint (missing permission name +
+/// list of built-in roles that grant it), then exits with code <c>403</c>.
+/// The install script's exit-code check then sees the 403 and propagates
+/// the same hint to the operator who copy-pasted the snippet.</para>
+///
+/// <para>This is a separate type from <see cref="HttpRequestException"/>
+/// so the entry-point catch can branch on type rather than parsing
+/// inner message strings — the latter would silently break the moment
+/// anyone reformats the message.</para>
+/// </summary>
+public sealed class PermissionDeniedRegistrationException : HttpRequestException
+{
+    public PermissionDeniedRegistrationException(string missingPermission, IReadOnlyList<string> suggestedRoles, string message)
+        : base(message, null, HttpStatusCode.Forbidden)
+    {
+        MissingPermission = missingPermission ?? string.Empty;
+        SuggestedRoles = suggestedRoles ?? Array.Empty<string>();
+    }
+
+    public string MissingPermission { get; }
+
+    public IReadOnlyList<string> SuggestedRoles { get; }
+}

--- a/src/Squid.Tentacle/Registration/TentacleRegistrationClient.cs
+++ b/src/Squid.Tentacle/Registration/TentacleRegistrationClient.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Squid.Tentacle.Certificate;
 using Squid.Tentacle.Configuration;
 using Serilog;
@@ -188,7 +189,51 @@ public class TentacleRegistrationClient
             : $"Registration failed with code {code}: {bodyOrMessage}";
 
         Log.Error(message);
+
+        // Permission-denied path (PR 2, 1.7.0): if the server emitted the
+        // structured 403 envelope with missingPermission + suggestedRoles,
+        // throw the typed exception so the entry-point catch can render the
+        // operator hint AND exit with code 403 — the install script's
+        // exit-code handler then propagates the same hint to the operator
+        // who copy-pasted the snippet.
+        if (code == (int)HttpStatusCode.Forbidden)
+        {
+            var permissionInfo = TryParsePermissionInfo(bodyOrMessage);
+            if (permissionInfo.HasValue)
+            {
+                throw new PermissionDeniedRegistrationException(
+                    permissionInfo.Value.MissingPermission,
+                    permissionInfo.Value.SuggestedRoles,
+                    message);
+            }
+        }
+
         throw new HttpRequestException(message, null, httpStatus);
+    }
+
+    /// <summary>
+    /// Best-effort extraction of <c>missingPermission</c> + <c>suggestedRoles</c>
+    /// from a server-emitted 403 body. Returns null when the body isn't JSON or
+    /// doesn't carry the structured fields — caller falls back to the generic
+    /// <see cref="HttpRequestException"/> path.
+    /// </summary>
+    private static (string MissingPermission, IReadOnlyList<string> SuggestedRoles)? TryParsePermissionInfo(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+
+        try
+        {
+            var envelope = JsonSerializer.Deserialize<BusinessEnvelope>(body, JsonOptions);
+            if (envelope == null || string.IsNullOrWhiteSpace(envelope.MissingPermission)) return null;
+
+            IReadOnlyList<string> roles = envelope.SuggestedRoles ?? new List<string>();
+            return (envelope.MissingPermission, roles);
+        }
+        catch
+        {
+            // Server may have returned a non-JSON 403 (e.g. nginx default page); fall back.
+            return null;
+        }
     }
 
     private static HttpStatusCode MapCodeToHttpStatus(int code)
@@ -219,6 +264,21 @@ public class TentacleRegistrationClient
         public int Code { get; set; }
 
         public string Msg { get; set; }
+
+        /// <summary>
+        /// Populated by the server on permission-denial responses (PR 2, 1.7.0).
+        /// Null when the response isn't a permission denial.
+        /// </summary>
+        [JsonPropertyName("missingPermission")]
+        public string MissingPermission { get; set; }
+
+        /// <summary>
+        /// Built-in roles that grant <see cref="MissingPermission"/>. Empty
+        /// list when no built-in role grants it (operator must use a custom
+        /// role or add the permission to an existing role).
+        /// </summary>
+        [JsonPropertyName("suggestedRoles")]
+        public List<string> SuggestedRoles { get; set; }
     }
 
     private class RegistrationResponse

--- a/tests/Squid.Tentacle.Tests/Registration/TentacleRegistrationClientTests.cs
+++ b/tests/Squid.Tentacle.Tests/Registration/TentacleRegistrationClientTests.cs
@@ -190,6 +190,73 @@ public class TentacleRegistrationClientTests
         callCount.ShouldBe(1); // Retry loop gave up on the 4xx
     }
 
+    // ────────────────────────────────────────────────────────────────────────
+    // PR 2 (1.7.0): structured 403 permission-denial response parsing.
+    // When the server emits `missingPermission` + `suggestedRoles` in the
+    // 403 body, the client must throw PermissionDeniedRegistrationException
+    // (not generic HttpRequestException) so the entry-point catch can map to
+    // exit code 403 + emit the operator hint.
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RegisterAsync_403WithStructuredPermissionBody_ThrowsTypedException()
+    {
+        var body = """
+            {
+                "code": 403,
+                "msg": "Permission denied: MachineCreate.",
+                "missingPermission": "MachineCreate",
+                "suggestedRoles": ["Environment Manager", "Space Owner", "System Administrator"]
+            }
+            """;
+
+        var client = BuildClientWithStubbedResponse(HttpStatusCode.Forbidden, body);
+
+        var ex = await Should.ThrowAsync<Squid.Tentacle.Registration.PermissionDeniedRegistrationException>(
+            () => client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        ex.MissingPermission.ShouldBe("MachineCreate");
+        ex.SuggestedRoles.ShouldContain("Environment Manager");
+        ex.SuggestedRoles.ShouldContain("Space Owner");
+        ex.SuggestedRoles.ShouldContain("System Administrator");
+        ex.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_403WithoutStructuredFields_ThrowsGenericHttpException()
+    {
+        // Backwards compatibility: a server running an older version that
+        // doesn't emit the structured fields still produces a meaningful
+        // failure — we fall back to the generic HttpRequestException so old
+        // server + new tentacle still work.
+        var body = """{"code":403,"msg":"Permission denied"}""";
+
+        var client = BuildClientWithStubbedResponse(HttpStatusCode.Forbidden, body);
+
+        var ex = await Should.ThrowAsync<HttpRequestException>(
+            () => client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        // Specifically NOT the typed exception — old server can't trigger it.
+        ex.ShouldNotBeOfType<Squid.Tentacle.Registration.PermissionDeniedRegistrationException>(
+            customMessage: "Without `missingPermission` in the body, the client must fall back to the generic " +
+                          "HttpRequestException — promoting to the typed exception would mask other 403 causes " +
+                          "(e.g. firewall-injected 403 page with no JSON).");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_403WithMalformedJson_ThrowsGenericHttpException()
+    {
+        // Some corporate proxies / WAFs inject a non-JSON HTML 403 page.
+        // The client must not crash on parse failure — fall back to the
+        // generic exception so the operator at least sees the HTTP status.
+        var client = BuildClientWithStubbedResponse(HttpStatusCode.Forbidden, "<html>blocked by Acme WAF</html>");
+
+        var ex = await Should.ThrowAsync<HttpRequestException>(
+            () => client.RegisterAsync("sub-1", "AABB", CancellationToken.None));
+
+        ex.ShouldNotBeOfType<Squid.Tentacle.Registration.PermissionDeniedRegistrationException>();
+    }
+
     private static TentacleRegistrationClient BuildClientWithStubbedResponse(HttpStatusCode status, string body)
     {
         var handler = new StubMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(status)

--- a/tests/Squid.UnitTests/Services/Authorization/PermissionRoleResolverTests.cs
+++ b/tests/Squid.UnitTests/Services/Authorization/PermissionRoleResolverTests.cs
@@ -1,0 +1,95 @@
+using Shouldly;
+using Squid.Core.Services.Authorization;
+using Squid.Message.Enums;
+
+namespace Squid.UnitTests.Services.Authorization;
+
+/// <summary>
+/// Pins the permission → built-in role mapping that the server's 403 response
+/// + Tentacle CLI 403 hint both depend on. A regression in the built-in role
+/// definitions (e.g. someone accidentally drops <c>MachineCreate</c> from
+/// Environment Manager) would silently leave operators with an empty
+/// <c>SuggestedRoles</c> list and a useless permission-denied hint.
+/// </summary>
+public class PermissionRoleResolverTests
+{
+    [Fact]
+    public void GetBuiltInRolesGranting_MachineCreate_ReturnsSpaceOwnerAndEnvironmentManager()
+    {
+        // Operator-facing contract pinned: the built-in roles that ship with
+        // MachineCreate permission. Tentacle's PR 2 install-script hint
+        // explicitly names these — drift breaks the operator UX.
+        //
+        // System Administrator deliberately does NOT have MachineCreate — it's
+        // a system-level role (manage spaces, users, teams), not a space-
+        // resource role. Machines live inside a space, so MachineCreate ships
+        // on space-scoped roles only.
+        var roles = PermissionRoleResolver.GetBuiltInRolesGranting(Permission.MachineCreate);
+
+        roles.ShouldContain("Environment Manager");
+        roles.ShouldContain("Space Owner");
+        roles.ShouldNotContain("System Administrator", customMessage:
+            "System Administrator is a system-level role and does not grant space-scoped MachineCreate. " +
+            "If this changed in BuiltInRoles.SystemAdministrator, update the install-script hint AND this test.");
+        roles.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetBuiltInRolesGranting_ProjectView_ReturnsViewerRolesAndUp()
+    {
+        // Read permissions are broader — anything from Viewer upwards has them.
+        var roles = PermissionRoleResolver.GetBuiltInRolesGranting(Permission.ProjectView);
+
+        roles.ShouldContain("Project Viewer");
+        roles.ShouldContain("Project Contributor");
+        roles.ShouldContain("Project Deployer");
+        // System Administrator + Space Owner also have it.
+        roles.Count.ShouldBeGreaterThanOrEqualTo(4);
+    }
+
+    [Fact]
+    public void BuildOperatorHint_MachineCreate_ListsCorrectRoles()
+    {
+        var hint = PermissionRoleResolver.BuildOperatorHint(Permission.MachineCreate);
+
+        hint.ShouldContain("MachineCreate");
+        hint.ShouldContain("Environment Manager");
+        hint.ShouldContain("Space Owner");
+        hint.ShouldNotContain("System Administrator", customMessage:
+            "System Administrator does not grant space-scoped MachineCreate. Suggesting it would mislead operators.");
+        // The hint must direct operators to one of two remediation paths.
+        hint.ShouldContain("Assign one of these roles");
+        hint.ShouldContain("add 'MachineCreate'");
+    }
+
+    [Fact]
+    public void BuildOperatorHint_PermissionWithoutBuiltInRole_FallsBackToCustomRoleGuidance()
+    {
+        // If a permission is somehow not granted by any built-in role (future
+        // additions before role updates), the hint must still be actionable.
+        // We construct an enum value that exists but assert the fallback path
+        // behaves sensibly by stubbing via a permission that genuinely has no
+        // built-in granter today (none currently, but the resolver code path
+        // must handle it).
+        //
+        // Defensive test: assert the hint never returns an empty/whitespace
+        // string for any defined Permission value.
+        foreach (Permission permission in Enum.GetValues(typeof(Permission)))
+        {
+            var hint = PermissionRoleResolver.BuildOperatorHint(permission);
+            hint.ShouldNotBeNullOrWhiteSpace(
+                customMessage: $"BuildOperatorHint returned empty/whitespace for permission '{permission}' — every value must produce an actionable message.");
+        }
+    }
+
+    [Fact]
+    public void GetBuiltInRolesGranting_EveryDefinedPermission_DoesNotThrow()
+    {
+        // Defensive: looking up any defined Permission must not throw, even
+        // if no role grants it. Returning an empty list is fine.
+        foreach (Permission permission in Enum.GetValues(typeof(Permission)))
+        {
+            Should.NotThrow(() => PermissionRoleResolver.GetBuiltInRolesGranting(permission));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Operator-visible failure today: a Tentacle register call against an API key that lacks \`MachineCreate\` returns a bare HTTP 403 with a prose message. The operator has no way to know which role to assign without reading server source.

Three coordinated changes:

**Server**: \`PermissionRoleResolver\` maps a permission to its granting built-in roles. \`SquidResponse\` gains optional \`MissingPermission\` + \`SuggestedRoles\` fields (additive; null on non-403). \`GlobalExceptionFilter\` populates them on \`PermissionDeniedException\`.

**Tentacle**: New \`PermissionDeniedRegistrationException\` (extends \`HttpRequestException\`). \`TentacleRegistrationClient\` parses the structured 403 body; \`TentacleEntry\` catches the typed exception, emits a multi-line operator hint to stderr, exits with code 403 (instead of generic 1).

**Install script (PR 1)**: already wraps \`\$LASTEXITCODE -eq 403\` → operator copy-pasted snippet now surfaces the hint automatically.

Pinned: \`MachineCreate\` → \`Environment Manager + Space Owner\` (System Administrator is system-level only, deliberately omitted).

## Test plan

- [x] Unit: 5 new PermissionRoleResolver tests + 3 new TentacleRegistrationClient tests
- [x] Backwards-compat: old server without structured fields → client falls back to generic exception (test pinned)
- [x] WAF robustness: malformed-JSON 403 body → generic exception, no crash (test pinned)
- [x] Build: zero errors across Squid.Core / Squid.Tentacle / Squid.Api

Depends on PR #329 (install-info.json + auto-elevation) to be in place for the install-script-side exit-code propagation to work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)