### PR TITLE
Add Windows install + API-key permission operator docs

### DIFF
--- a/docs/api-key-permissions.md
+++ b/docs/api-key-permissions.md
@@ -1,0 +1,170 @@
+# API Key Permissions Reference
+
+> **Audience**: operators issuing or troubleshooting API keys for Tentacle
+> registration, deployment automation, and external integrations.
+> **Status**: applies to Squid 1.7.0+ (structured 403 hint responses) — see
+> "Legacy behaviour" at the bottom for 1.6.x.
+
+---
+
+## 1 — The core model
+
+A Squid **API key is a credential bound to a user**. When an API call presents an API key, Squid resolves the owner user, then checks whether THAT user has the permissions the API call requires. The API key itself doesn't carry permissions — the owner user does.
+
+**Consequence**: if you hit `403 Permission denied: X`, the API key is fine. The user it belongs to is missing permission `X`. The fix is to grant the user the permission, **not** to issue a new key.
+
+---
+
+## 2 — Permission required for common operations
+
+| Operation | HTTP path | Permission required |
+|---|---|---|
+| Register a Tentacle Polling target | `POST /api/machines/register/tentacle-polling` | `MachineCreate` |
+| Register a Tentacle Listening target | `POST /api/machines/register/tentacle-listening` | `MachineCreate` |
+| Register a Kubernetes Agent target | `POST /api/machines/register/kubernetes-agent` | `MachineCreate` |
+| Register an SSH target | `POST /api/machines/register/ssh` | `MachineCreate` |
+| Register an OpenClaw target | `POST /api/machines/register/openclaw` | `MachineCreate` |
+| Generate an install script for a Tentacle | `POST /api/machines/generate-install-script` | `MachineCreate` |
+| Edit a deployment target | `PUT /api/machines/{id}` | `MachineEdit` |
+| Delete a deployment target | `DELETE /api/machines/{id}` | `MachineDelete` |
+| Create / queue a deployment | `POST /api/deployments` | `DeploymentCreate` |
+| Cancel a running task | `POST /api/tasks/{id}/cancel` | `TaskCancel` |
+
+> All `*Machine*` permissions are **space-scoped** (`PermissionScope.SpaceOnly`). They apply within a single space; an API key user with `MachineCreate` in Space A cannot register a machine in Space B.
+
+---
+
+## 3 — Built-in roles + their permissions
+
+Squid ships with six built-in roles. The relevant ones for Tentacle register operations:
+
+| Built-in role | Has `MachineCreate`? | Has `MachineView`? | Has `DeploymentCreate`? |
+|---|---|---|---|
+| **System Administrator** | ❌ | ❌ | ❌ |
+| **Space Owner** | ✅ | ✅ | ✅ |
+| **Environment Manager** | ✅ | ✅ | ❌ |
+| **Project Deployer** | ❌ | ✅ | ✅ |
+| **Project Contributor** | ❌ | ✅ | ❌ |
+| **Project Viewer** | ❌ | ✅ | ❌ |
+
+> **Why `System Administrator` lacks `MachineCreate`**: by design. `System Administrator` is the system-wide role that manages spaces, users, teams, and identity-provider configuration. It deliberately does NOT have space-scoped resource permissions like `MachineCreate` / `DeploymentCreate` / etc. — those belong to `Space Owner` (full space access) and the resource-specific roles (`Environment Manager` for machines, etc.). If a system admin needs to register a machine, they assign themselves the `Space Owner` role on that space.
+
+---
+
+## 4 — Resolving a "403 Permission denied" on register
+
+The Tentacle CLI exits with code **403** and prints:
+
+```
+Permission denied: 'MachineCreate' permission required to register the machine.
+
+Resolve via the Squid Web UI:
+  1. Assign one of these roles to the API key user: Environment Manager, Space Owner, OR
+  2. Add 'MachineCreate' permission to the user's current role, OR
+  3. Issue a new API key from a user with one of the roles above.
+
+Built-in roles that grant MachineCreate: Environment Manager, Space Owner
+```
+
+Three remediation paths, pick whichever fits your access model:
+
+### Option A — Assign a built-in role
+
+In **Configuration → Users → {the API key owner}**:
+
+1. Open the user.
+2. Under **Space Memberships**, find the relevant space row.
+3. Assign **Environment Manager** (machine-scoped) OR **Space Owner** (full access).
+4. Save.
+5. Re-run the install snippet — no need to re-issue the API key.
+
+### Option B — Add the permission to an existing custom role
+
+If you run with custom roles (e.g. "DevOps", "Platform Engineer"):
+
+1. **Configuration → User Roles → {custom role}**.
+2. Add **`MachineCreate`** to the permission list (and typically also `MachineView`, `MachineEdit`, `MachineDelete` so the role can manage its own targets).
+3. Save.
+4. Re-run the install snippet.
+
+### Option C — Issue a new API key from a different user
+
+1. Switch to a user that has `MachineCreate` (e.g. yourself as `Space Owner`).
+2. **Profile → API Keys → Generate New Key**.
+3. Replace the old `--api-key` value in your install snippet with the new key.
+4. Re-run.
+
+---
+
+## 5 — Structured 403 response shape
+
+Squid 1.7.0+ enriches 403 responses with structured fields:
+
+```json
+{
+  "code": 403,
+  "msg": "Permission denied: MachineCreate. Missing permission 'MachineCreate'. Built-in roles that grant it: Environment Manager, Space Owner. Assign one of these roles to the API key user, or add 'MachineCreate' to their existing role.",
+  "missingPermission": "MachineCreate",
+  "suggestedRoles": ["Environment Manager", "Space Owner"]
+}
+```
+
+Programmatic consumers (CI scripts, custom integrations) can parse `missingPermission` + `suggestedRoles` directly without scraping the prose `msg` field. The Tentacle CLI does exactly this and surfaces the structured hint in its stderr output.
+
+---
+
+## 6 — Audit + revocation
+
+API keys are recorded in the audit log on every authenticated request. To find which API key was used:
+
+```sql
+-- Squid stores API keys hashed; the audit log records the resolved user + the key prefix.
+SELECT * FROM audit_events
+WHERE event_type = 'machine.register'
+  AND occurred_at > NOW() - INTERVAL '1 day';
+```
+
+To revoke an API key:
+
+1. **Profile → API Keys → {the key} → Revoke**.
+2. Any subsequent call with that key returns `401 Unauthorized`.
+
+To rotate an API key in an install snippet across many hosts:
+
+1. Generate a new key.
+2. Update the central install playbook (Ansible / Chef / SCCM / Intune script) with the new key.
+3. Re-run the install snippet on each host.
+4. Revoke the old key.
+
+---
+
+## 7 — Best practices
+
+1. **One API key per integration**. Don't share keys between scripts, CI pipelines, and operator hands. Each gets its own key so revoking one doesn't break the others.
+2. **Use service-account users for automation**, not your personal user. If you leave the company / change roles, the integration shouldn't break.
+3. **Assign the LEAST-PRIVILEGED role that works**. For a host that only needs to register Tentacles, `Environment Manager` is enough — don't give the service account `Space Owner`.
+4. **Rotate keys quarterly**. The audit log + revocation flow make this cheap.
+5. **Don't commit API keys to git**. Even in private repos. Use a secrets manager (HashiCorp Vault, Azure Key Vault, AWS Secrets Manager, GitHub Actions secrets).
+
+---
+
+## 8 — Legacy behaviour (1.6.x)
+
+Before 1.7.0, the 403 response body was a plain prose `msg` field with no structured `missingPermission` / `suggestedRoles`. The Tentacle CLI exited with generic code `1`, not `403`. The install script's exit-code wrapper couldn't programmatically detect permission denials — operators had to read the error message + cross-reference the source for the role list.
+
+If you're on 1.6.x and hit a register 403:
+
+```
+Registration failed with code 403: {"code":403,"msg":"Permission denied: MachineCreate. ..."}
+```
+
+The remediation paths in section §4 still apply — just no structured-error help text from the CLI.
+
+---
+
+## 9 — Related docs
+
+- [Windows Tentacle Install](windows-tentacle-install.md) — operator runbook for Windows installs including the 403 troubleshooting walkthrough
+- `src/Squid.Message/Enums/Permission.cs` — the full Permission enum
+- `src/Squid.Core/Services/DataSeeding/BuiltInRoleSeeder.cs` — built-in role definitions (source of truth)
+- `src/Squid.Core/Services/Authorization/PermissionRoleResolver.cs` — server-side helper that drives the structured 403 response

--- a/docs/windows-tentacle-install.md
+++ b/docs/windows-tentacle-install.md
@@ -1,0 +1,254 @@
+# Windows Tentacle Install — Operator Guide
+
+> **Audience**: operators installing the Squid Tentacle on a Windows host.
+> **Status**: applies to Squid 1.7.0+ (the install-info.json discovery file
+> + UAC auto-elevation surfaces). For 1.6.x and earlier, see the section
+> "Legacy 1.6.x install" at the bottom.
+
+---
+
+## 1 — Quick start (the canonical workflow)
+
+In the Squid Web UI:
+
+1. Go to **Infrastructure → Deployment Targets → Add Deployment Target → Windows Tentacle**.
+2. Pick **Listening** (server dials into your host) or **Polling** (your host dials out to Squid).
+3. Copy the generated PowerShell snippet.
+4. On your Windows host, open **PowerShell** (does NOT need to be elevated — the script auto-elevates).
+5. Paste + press Enter.
+
+The script does four things:
+
+```
+Step 1 — Download + extract Tentacle (auto-elevates via UAC if needed)
+Step 2 — Locate the binary via %ProgramData%\Squid\Tentacle\install-info.json
+Step 3 — Register with the Squid server
+Step 4 — Install + start the Windows service
+```
+
+If everything works, your Tentacle is registered and visible in the Squid Web UI within ~30 seconds.
+
+---
+
+## 2 — UAC + elevation behaviour
+
+The install script must write to `C:\Program Files\Squid Tentacle` (default install dir) which requires Administrator privileges. The script handles this automatically:
+
+| Scenario | What happens |
+|---|---|
+| You're already running PowerShell as Administrator | Script proceeds in-process — no UAC prompt. |
+| You're running a normal PowerShell with default install dir | Script triggers a UAC prompt ("Do you want to allow this app to make changes…?"). Click Yes. A new elevated PowerShell window opens, runs the install, exits when done. Your original window stays open. |
+| You're running a normal PowerShell with a user-owned install dir (e.g. `-InstallDir "$env:USERPROFILE\squid"`) | No UAC prompt — user-owned paths don't need admin. |
+| You're running via `irm <url> \| iex` (in-memory pipe) as non-admin | Script writes itself to `%TEMP%\squid-install-{guid}.ps1` first, then UAC-re-launches that file. |
+| UAC is fully disabled (`EnableLUA=0`) | Script runs as admin token directly — no prompt. |
+
+### Opting out of auto-elevation
+
+Some scenarios can't / shouldn't trigger UAC:
+- **CI environments** (no interactive desktop)
+- **WinRM remote sessions** (UAC requires interactive desktop)
+- **Scheduled tasks running as SYSTEM** (already system-level)
+
+Pass `-NoAutoElevate` to the script. If admin is genuinely required, the script will print a clear error pointing you at one of:
+
+```powershell
+# Option 1 — run from an already-elevated PowerShell
+powershell -NoProfile -ExecutionPolicy Bypass -File install-tentacle.ps1 -NoAutoElevate
+
+# Option 2 — install to a user-owned path (no admin needed)
+.\install-tentacle.ps1 -InstallDir "$env:USERPROFILE\squid-tentacle"
+```
+
+---
+
+## 3 — Install paths + custom locations
+
+Default install dir is `C:\Program Files\Squid Tentacle`. Override via:
+
+```powershell
+# Command-line parameter
+.\install-tentacle.ps1 -InstallDir "D:\squid-tentacle"
+
+# Environment variable (useful for MDM / Intune deployments)
+$env:INSTALL_DIR = "D:\squid-tentacle"
+.\install-tentacle.ps1
+```
+
+After installation, the **discovery file** at `%ProgramData%\Squid\Tentacle\install-info.json` records exactly where the binary went:
+
+```json
+{
+  "Schema": 1,
+  "BinaryPath": "D:\\squid-tentacle\\Squid.Tentacle.exe",
+  "InstallDir": "D:\\squid-tentacle",
+  "Version": "1.7.0",
+  "Architecture": "win-x64",
+  "InstalledAt": "2026-05-19T05:14:00Z",
+  "InstalledBy": "DOMAIN\\admin",
+  "ServiceName": "squid-tentacle"
+}
+```
+
+Server-generated register / service-install snippets **read this file** to locate the binary — so a custom install dir doesn't break the copy-paste experience.
+
+### Paths with spaces
+
+Fully supported. Operators commonly use paths like `D:\My Apps\Squid Tentacle`. The script + discovery file roundtrip the spaced path correctly; downstream snippets quote it.
+
+### Non-default drives
+
+`D:\squid`, `E:\path\to\install`, etc. all work. The only constraint: the drive must be writable by the install identity (admin for `C:\Program Files\…`, current user for user-owned paths).
+
+---
+
+## 4 — Troubleshooting
+
+### "Permission denied — 'MachineCreate' permission required" on Step 3
+
+The API key user lacks the `MachineCreate` permission. **The fix is operator-side, not script-side.** In the Squid Web UI:
+
+1. **Either** assign the API key user one of these built-in roles:
+   - **Environment Manager** (manages machines + accounts + environments)
+   - **Space Owner** (full space access)
+2. **Or** add the `MachineCreate` permission to their existing custom role.
+3. **Or** issue a new API key from a user with one of the roles above.
+
+> **Note**: `System Administrator` does NOT grant `MachineCreate` — it's a system-level role for managing spaces / users / teams, not space-scoped resources like machines. The install-script hint deliberately omits it.
+
+### "install-info.json not found at …" on Step 2
+
+Step 1 (the install-tentacle.ps1 download + extract) didn't complete. Check the output above Step 2 for the actual failure:
+
+- Network failure downloading from GitHub (firewall / proxy)
+- Disk full
+- Antivirus blocked the binary mid-extract (Defender SmartScreen / 3rd-party AV)
+
+### "Binary '…' (recorded in install-info.json) does not exist" on Step 2
+
+Something deleted the binary after Step 1 finished. Common causes:
+
+- Antivirus quarantined `Squid.Tentacle.exe` after extract
+- Manual cleanup of the install dir
+- Failed prior upgrade left partial state
+
+Just re-run Step 1 — the script is idempotent.
+
+### "Service install failed (exit X)" on Step 4
+
+Service installation hit the Windows Service Control Manager. Check:
+
+- `sc query squid-tentacle` — does the service exist already?
+- If exists: `sc stop squid-tentacle` + `sc delete squid-tentacle`, then re-run Step 4
+- Check the SCM diagnostic log at `%ProgramData%\Squid\Tentacle\scm-diagnostic.log`
+
+### Auto-elevation hangs / UAC prompt doesn't appear
+
+You're likely in a non-interactive context (WinRM remote, scheduled task, SSH). UAC requires an interactive desktop. Fixes:
+
+1. Pass `-NoAutoElevate` — the script will error out cleanly with remediation steps.
+2. Use `psexec -s` to run as SYSTEM (already elevated, no prompt).
+3. Use CredSSP if running over WinRM (`Enable-WSManCredSSP`).
+4. Connect via RDP and run interactively.
+
+### "Unexpected token" / parser error in the script
+
+You're running an older script with non-ASCII characters that PowerShell 5.1 can't decode under your locale's OEM codepage. Update to the latest `install-tentacle.ps1` (1.7.0+) — em-dashes were replaced with ASCII `--` in 1.7.0 specifically to fix this.
+
+---
+
+## 5 — Air-gapped installs
+
+For hosts with no internet access:
+
+1. Download `squid-tentacle-{version}-win-x64.zip` (or `win-arm64.zip`) from GitHub Releases on a machine WITH internet.
+2. Stand up a private HTTP server hosting the file at e.g. `https://internal-mirror.corp.example.com/squid/releases/...`.
+3. Pass `-DownloadBase https://internal-mirror.corp.example.com/squid/releases` (or set `$env:DOWNLOAD_BASE`).
+
+The script's URL resolution mirrors the GitHub Release layout:
+
+```
+{DownloadBase}/latest/download/squid-tentacle-{rid}.zip
+{DownloadBase}/download/{version}/squid-tentacle-{version}-{rid}.zip
+{DownloadBase}/download/v{version}/squid-tentacle-{version}-{rid}.zip  ← fallback
+```
+
+---
+
+## 6 — Architecture support
+
+- **x64 (AMD64)** — fully supported.
+- **ARM64** — fully supported. The script auto-detects via `$env:PROCESSOR_ARCHITECTURE` and picks the right zip (`win-arm64`).
+- **x86 (32-bit)** — NOT supported. The script refuses with a clear error.
+
+---
+
+## 7 — Reinstalling / upgrading
+
+The install script is idempotent. Re-running it on a host with an existing install:
+
+- Stops the running service (if `-NoServiceInstall` was NOT passed).
+- Downloads + extracts the new version (overwriting existing files via `Expand-Archive -Force`).
+- Updates `install-info.json` with the new version + timestamp.
+- Re-installs the service (idempotent — updates existing service config).
+- Restarts the service.
+
+For controlled upgrades (where you want to manage the upgrade flow yourself), use the Squid Web UI's **Upgrade Tentacle** action — it goes through the staged upgrade pipeline with rollback support.
+
+---
+
+## 8 — Removing the Tentacle
+
+```powershell
+# Stop + delete the service
+& "C:\Program Files\Squid Tentacle\Squid.Tentacle.exe" service uninstall
+
+# OR via sc.exe directly
+sc.exe stop squid-tentacle
+sc.exe delete squid-tentacle
+
+# Remove the install dir
+Remove-Item -Path "C:\Program Files\Squid Tentacle" -Recurse -Force
+
+# Remove the discovery file + config
+Remove-Item -Path "C:\ProgramData\Squid\Tentacle" -Recurse -Force
+
+# Remove the firewall rule (Listening Tentacle only)
+Remove-NetFirewallRule -DisplayName "Squid Tentacle (Listening)"
+```
+
+In the Squid Web UI, also delete the corresponding deployment target.
+
+---
+
+## 9 — Reference
+
+| Item | Value |
+|---|---|
+| Default install dir | `C:\Program Files\Squid Tentacle` |
+| Binary name | `Squid.Tentacle.exe` (NOT `squid-tentacle.exe` — that's the Linux shell wrapper) |
+| Default service name | `squid-tentacle` |
+| Discovery file | `%ProgramData%\Squid\Tentacle\install-info.json` |
+| Listening port (default) | 10933 |
+| Polling target (Squid server's polling listener) | typically 10943 |
+| Install log | `%ProgramData%\Squid\Tentacle\scm-diagnostic.log` |
+| Env-var overrides | `TENTACLE_VERSION`, `INSTALL_DIR`, `DOWNLOAD_BASE` |
+| Script parameters | `-Version`, `-InstallDir`, `-DownloadBase`, `-ServiceName`, `-NoServiceInstall`, `-NoAutoElevate` |
+
+---
+
+## 10 — Related docs
+
+- [API Key Permissions](api-key-permissions.md) — which permissions an API key needs for various operations, including the `MachineCreate` permission required for register
+- [E2E Scenario Matrix](e2e-scenario-matrix.md) — the test-coverage ledger Phase 12.M tracks Windows install scenarios
+- `deploy/scripts/install-tentacle.ps1` — the install script itself
+- `src/Squid.Core/Services/Machines/Scripts/Tentacle/WindowsPowerShellScriptBuilder.cs` — server-side script generator
+
+---
+
+## Legacy 1.6.x install
+
+Before 1.7.0, the Squid-generated snippet hardcoded `'C:\Program Files\Squid Tentacle\squid-tentacle.exe'` (wrong binary name; default path only). If you're on 1.6.x and see "file not found" at Step 2 / 3:
+
+1. Manually rename the executable: the actual published binary is `Squid.Tentacle.exe`, not `squid-tentacle.exe`. The legacy snippet's literal won't find it.
+2. Manually replace `'C:\Program Files\Squid Tentacle\…'` references in the copy-pasted snippet with your actual install dir.
+3. Upgrade to Squid 1.7.0+ — the discovery-file mechanism removes both of these hand-edit steps.


### PR DESCRIPTION
## Summary

Two operator-facing reference docs covering the 1.7.0 install-resilience + permission-hint surface (PR #329 + #330):

- **\`docs/windows-tentacle-install.md\`** — quick-start, UAC + elevation behaviour, custom install paths, 5 common failures + remediation, air-gapped install, reinstall / upgrade flow, full uninstall sequence, reference table.
- **\`docs/api-key-permissions.md\`** — core model (API key binds to user, not permission), 10-row operation→permission matrix, built-in role table (System Administrator deliberately lacks MachineCreate, documented inline), three remediation paths for 403, structured 403 response shape, audit + revocation, best practices.

Both docs cross-link each other and cite source-of-truth files (\`BuiltInRoleSeeder.cs\`, \`PermissionRoleResolver.cs\`, \`WindowsPowerShellScriptBuilder.cs\`).

## Test plan

- [x] Doc-only PR — no code changes
- [ ] Operator review — confirm troubleshooting scenarios match real-world flows

Depends on PR #329 (install-info.json + UAC auto-elevation) + PR #330 (structured 403 response) for the behaviour the docs describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)