### PR TITLE
Seed InternalUser account + Internal Service Accounts team

### DIFF
--- a/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
+++ b/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
@@ -1,0 +1,148 @@
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Account;
+using Squid.Core.Services.Authorization;
+using Squid.Core.Services.Teams;
+using Squid.Message.Constants;
+using Serilog;
+
+namespace Squid.Core.Services.DataSeeding;
+
+/// <summary>
+/// Seeds the InternalUser account (<c>CurrentUsers.InternalUser.Id</c> = 8888) plus the
+/// "Internal Service Accounts" team that grants it the <c>SystemServiceAccount</c> role.
+/// Together this lets the Tentacle install-script bootstrap API key (owned by user 8888)
+/// pass the <c>MachineCreate</c> permission check at register time.
+///
+/// <para><b>Why an Id-pinned user</b>: <c>CurrentUsers.InternalUser.Id</c> is a compile-
+/// time constant (8888) referenced by <c>SquidDbContext</c> audit columns (default value
+/// for <c>created_by</c> / <c>last_modified_by</c>), the API-key authentication handler,
+/// and the install-script generator. All of these would silently break if the user row
+/// didn't exist or had a different Id.</para>
+///
+/// <para><b>Order = 350</b>: must run AFTER <see cref="BuiltInRoleSeeder"/> (Order=100,
+/// creates the SystemServiceAccount role row), AFTER <see cref="BuiltInTeamSeeder"/>
+/// (Order=200), and AFTER <see cref="AdminUserSeeder"/> (Order=300, so the audit
+/// columns can reference 8888 without violating audit ordering).</para>
+///
+/// <para><b>Idempotent</b>: every step uses "exists check + create-if-missing" so this
+/// seeder can run on every startup without duplicating rows. Pre-existing operator
+/// modifications (e.g. additional roles assigned to the Internal Service Accounts team)
+/// are preserved.</para>
+/// </summary>
+public class InternalUserSeeder : IDataSeeder
+{
+    private const string InternalServiceAccountsTeamName = "Internal Service Accounts";
+
+    private const string InternalServiceAccountsTeamDescription =
+        "Reserved team for the InternalUser system account (Tentacle install bootstrap, automation). " +
+        "Do NOT add human users -- assigning here silently grants them SystemServiceAccount permissions.";
+
+    public int Order => 350;
+
+    public async Task SeedAsync(ILifetimeScope scope)
+    {
+        var repository = scope.Resolve<IRepository>();
+        var unitOfWork = scope.Resolve<IUnitOfWork>();
+        var dbContext = scope.Resolve<SquidDbContext>();
+        var teamProvider = scope.Resolve<ITeamDataProvider>();
+        var roleProvider = scope.Resolve<IUserRoleDataProvider>();
+        var scopedRoleProvider = scope.Resolve<IScopedUserRoleDataProvider>();
+
+        await EnsureInternalUserAccountAsync(repository, dbContext).ConfigureAwait(false);
+        var team = await EnsureInternalServiceAccountsTeamAsync(teamProvider).ConfigureAwait(false);
+        await EnsureTeamHasSystemServiceAccountRoleAsync(roleProvider, scopedRoleProvider, team).ConfigureAwait(false);
+        await EnsureInternalUserInTeamAsync(teamProvider, team).ConfigureAwait(false);
+
+        Log.Information("Internal user seeding complete");
+    }
+
+    /// <summary>
+    /// Inserts a <c>user_account</c> row with the Id-pinned sentinel
+    /// (<c>CurrentUsers.InternalUser.Id</c>) using raw SQL — EF's Identity convention
+    /// rejects explicit Id values for auto-generated columns, so going through
+    /// <c>IRepository.InsertAsync</c> would either silently re-assign a new Id or
+    /// throw. The raw INSERT lets PostgreSQL accept the explicit Id (the sequence
+    /// default is overridden by the explicit value column).
+    /// </summary>
+    private static async Task EnsureInternalUserAccountAsync(IRepository repository, SquidDbContext dbContext)
+    {
+        var existing = await repository.FirstOrDefaultAsync<UserAccount>(x => x.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
+
+        if (existing != null)
+        {
+            if (!existing.IsSystem) Log.Warning("Internal user (id={Id}) exists but IsSystem=false -- it should be true; UI will show it as a regular user", CurrentUsers.InternalUser.Id);
+            return;
+        }
+
+        const string sql = @"
+            INSERT INTO user_account
+                (id, user_name, normalized_user_name, display_name, password_hash,
+                 is_disabled, is_system, must_change_password,
+                 created_date, last_modified_date, created_by, last_modified_by)
+            VALUES
+                ({0}, {1}, {2}, {3}, '',
+                 false, true, false,
+                 {4}, {4}, {0}, {0})
+            ON CONFLICT (id) DO NOTHING";
+
+        var now = DateTimeOffset.UtcNow;
+        var rows = await dbContext.Database.ExecuteSqlRawAsync(sql,
+            CurrentUsers.InternalUser.Id, CurrentUsers.InternalUser.Name, CurrentUsers.InternalUser.Name.ToUpperInvariant(), CurrentUsers.InternalUser.DisplayName, now).ConfigureAwait(false);
+
+        Log.Information("Seeded internal user (id={Id}, rowsAffected={Rows})", CurrentUsers.InternalUser.Id, rows);
+    }
+
+    /// <summary>
+    /// Creates the "Internal Service Accounts" team in space 0 (system / cross-space)
+    /// if absent. Idempotent: returns the existing row when already present.
+    /// </summary>
+    private static async Task<Team> EnsureInternalServiceAccountsTeamAsync(ITeamDataProvider teamProvider)
+    {
+        var teams = await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false);
+        var existing = teams.FirstOrDefault(t => t.Name == InternalServiceAccountsTeamName);
+
+        if (existing != null) return existing;
+
+        var team = new Team { Name = InternalServiceAccountsTeamName, Description = InternalServiceAccountsTeamDescription, SpaceId = 0, IsBuiltIn = true };
+        await teamProvider.AddAsync(team).ConfigureAwait(false);
+        Log.Information("Seeded team {TeamName}", InternalServiceAccountsTeamName);
+
+        return team;
+    }
+
+    /// <summary>
+    /// Assigns the <c>SystemServiceAccount</c> role to the team with <c>SpaceId=null</c>
+    /// (applies in every space, matching how <c>BuiltInTeamSeeder</c> assigns the
+    /// SystemAdministrator role to Squid Administrators). Idempotent.
+    /// </summary>
+    private static async Task EnsureTeamHasSystemServiceAccountRoleAsync(IUserRoleDataProvider roleProvider, IScopedUserRoleDataProvider scopedRoleProvider, Team team)
+    {
+        var role = await roleProvider.GetByNameAsync(BuiltInRoles.SystemServiceAccount.Name).ConfigureAwait(false);
+
+        if (role == null)
+            throw new InvalidOperationException($"Built-in role '{BuiltInRoles.SystemServiceAccount.Name}' missing; ensure {nameof(BuiltInRoleSeeder)} ran first (Order=100).");
+
+        var existing = await scopedRoleProvider.GetByTeamIdsAsync(new List<int> { team.Id }).ConfigureAwait(false);
+
+        if (existing.Any(sr => sr.UserRoleId == role.Id)) return;
+
+        await scopedRoleProvider.AddAsync(new ScopedUserRole { TeamId = team.Id, UserRoleId = role.Id, SpaceId = null }).ConfigureAwait(false);
+        Log.Information("Assigned role {RoleName} to team {TeamName} (cross-space)", BuiltInRoles.SystemServiceAccount.Name, InternalServiceAccountsTeamName);
+    }
+
+    /// <summary>
+    /// Adds the InternalUser to the team. Idempotent — checks membership first to
+    /// avoid violating the team_member primary-key constraint on re-run.
+    /// </summary>
+    private static async Task EnsureInternalUserInTeamAsync(ITeamDataProvider teamProvider, Team team)
+    {
+        var members = await teamProvider.GetMembersByTeamIdAsync(team.Id).ConfigureAwait(false);
+
+        if (members.Any(m => m.UserId == CurrentUsers.InternalUser.Id)) return;
+
+        await teamProvider.AddMemberAsync(new TeamMember { TeamId = team.Id, UserId = CurrentUsers.InternalUser.Id }).ConfigureAwait(false);
+        Log.Information("Added InternalUser (id={UserId}) to team {TeamName}", CurrentUsers.InternalUser.Id, InternalServiceAccountsTeamName);
+    }
+}

--- a/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
+++ b/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
@@ -50,7 +50,7 @@ public class InternalUserSeeder : IDataSeeder
         var roleProvider = scope.Resolve<IUserRoleDataProvider>();
         var scopedRoleProvider = scope.Resolve<IScopedUserRoleDataProvider>();
 
-        await EnsureInternalUserAccountAsync(repository, dbContext).ConfigureAwait(false);
+        await EnsureInternalUserAccountAsync(repository, unitOfWork, dbContext).ConfigureAwait(false);
         var team = await EnsureInternalServiceAccountsTeamAsync(teamProvider).ConfigureAwait(false);
         await EnsureTeamHasSystemServiceAccountRoleAsync(roleProvider, scopedRoleProvider, team).ConfigureAwait(false);
         await EnsureInternalUserInTeamAsync(teamProvider, team).ConfigureAwait(false);
@@ -66,13 +66,13 @@ public class InternalUserSeeder : IDataSeeder
     /// throw. The raw INSERT lets PostgreSQL accept the explicit Id (the sequence
     /// default is overridden by the explicit value column).
     /// </summary>
-    private static async Task EnsureInternalUserAccountAsync(IRepository repository, SquidDbContext dbContext)
+    private static async Task EnsureInternalUserAccountAsync(IRepository repository, IUnitOfWork unitOfWork, SquidDbContext dbContext)
     {
         var existing = await repository.FirstOrDefaultAsync<UserAccount>(x => x.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
 
         if (existing != null)
         {
-            if (!existing.IsSystem) Log.Warning("Internal user (id={Id}) exists but IsSystem=false -- it should be true; UI will show it as a regular user", CurrentUsers.InternalUser.Id);
+            await NormaliseLegacyInternalUserAsync(repository, unitOfWork, existing).ConfigureAwait(false);
             return;
         }
 
@@ -92,6 +92,38 @@ public class InternalUserSeeder : IDataSeeder
             CurrentUsers.InternalUser.Id, CurrentUsers.InternalUser.Name, CurrentUsers.InternalUser.Name.ToUpperInvariant(), CurrentUsers.InternalUser.DisplayName, now).ConfigureAwait(false);
 
         Log.Information("Seeded internal user (id={Id}, rowsAffected={Rows})", CurrentUsers.InternalUser.Id, rows);
+    }
+
+    /// <summary>
+    /// Upgrades an existing InternalUser row to the canonical values when fields drift
+    /// from the constants in <see cref="CurrentUsers.InternalUser"/>. Specifically, the
+    /// <c>001_initial_schema.sql</c> migration seeds <c>display_name='internal_user'</c>
+    /// (legacy -- same as user_name), but the canonical value is <c>'System'</c>. Same
+    /// for <c>IsSystem</c>: must be true so the UI can hide it from human user lists.
+    /// </summary>
+    private static async Task NormaliseLegacyInternalUserAsync(IRepository repository, IUnitOfWork unitOfWork, UserAccount existing)
+    {
+        var dirty = false;
+
+        if (existing.DisplayName != CurrentUsers.InternalUser.DisplayName)
+        {
+            Log.Information("Upgrading internal user display_name from '{Old}' to '{New}'", existing.DisplayName, CurrentUsers.InternalUser.DisplayName);
+            existing.DisplayName = CurrentUsers.InternalUser.DisplayName;
+            dirty = true;
+        }
+
+        if (!existing.IsSystem)
+        {
+            Log.Information("Upgrading internal user IsSystem from false to true");
+            existing.IsSystem = true;
+            dirty = true;
+        }
+
+        if (!dirty) return;
+
+        existing.LastModifiedDate = DateTimeOffset.UtcNow;
+        await repository.UpdateAsync(existing).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/Squid.IntegrationTests/Services/Authorization/BuiltInRoleSeederIntegrationTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Authorization/BuiltInRoleSeederIntegrationTests.cs
@@ -28,12 +28,13 @@ public class BuiltInRoleSeederIntegrationTests : TestBase
     {
         var seeders = CurrentScope.Resolve<IEnumerable<IDataSeeder>>().OrderBy(s => s.Order).ToList();
 
-        seeders.Count.ShouldBeGreaterThanOrEqualTo(5);
-        seeders[0].Order.ShouldBe(100);
-        seeders[1].Order.ShouldBe(200);
-        seeders[2].Order.ShouldBe(300);
-        seeders[3].Order.ShouldBe(400);
-        seeders[4].Order.ShouldBe(500);
+        seeders.Count.ShouldBeGreaterThanOrEqualTo(6);
+        seeders[0].Order.ShouldBe(100);    // BuiltInRoleSeeder
+        seeders[1].Order.ShouldBe(200);    // BuiltInTeamSeeder
+        seeders[2].Order.ShouldBe(300);    // AdminUserSeeder
+        seeders[3].Order.ShouldBe(350);    // InternalUserSeeder
+        seeders[4].Order.ShouldBe(400);    // DefaultSpaceSeeder
+        seeders[5].Order.ShouldBe(500);    // DefaultMachinePolicySeeder
     }
 
     [Fact]

--- a/tests/Squid.IntegrationTests/Services/Authorization/InternalUserSeederIntegrationTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Authorization/InternalUserSeederIntegrationTests.cs
@@ -1,0 +1,187 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Account;
+using Squid.Core.Services.Authorization;
+using Squid.Core.Services.DataSeeding;
+using Squid.Core.Services.Teams;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+
+namespace Squid.IntegrationTests.Services.Authorization;
+
+/// <summary>
+/// Pins the InternalUser bootstrap surface in DB form: user_account row 8888 exists,
+/// the "Internal Service Accounts" team owns the SystemServiceAccount role cross-space,
+/// and user 8888 is a member of that team. Together this is what makes a Tentacle
+/// register call (carrying an InternalUser-owned API key) actually pass the
+/// MachineCreate permission check.
+/// </summary>
+public class InternalUserSeederIntegrationTests : TestBase
+{
+    public InternalUserSeederIntegrationTests()
+        : base("InternalUserSeeder", "squid_it_internal_user_seeder")
+    {
+    }
+
+    [Fact]
+    public async Task SeedRuns_CreatesInternalUserAccountWithCanonicalId()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IRepository>(async repository =>
+        {
+            var user = await repository.FirstOrDefaultAsync<UserAccount>(x => x.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
+
+            user.ShouldNotBeNull(customMessage: "InternalUser (id=8888) must exist after seeding.");
+            user.UserName.ShouldBe(CurrentUsers.InternalUser.Name);
+            user.DisplayName.ShouldBe(CurrentUsers.InternalUser.DisplayName);
+            user.IsSystem.ShouldBeTrue(customMessage: "InternalUser must have IsSystem=true so the UI can hide it from human-user lists.");
+            user.IsDisabled.ShouldBeFalse();
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_CreatesInternalServiceAccountsTeam_InSpaceZero()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<ITeamDataProvider>(async teamProvider =>
+        {
+            var teams = await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false);
+            var team = teams.FirstOrDefault(t => t.Name == "Internal Service Accounts");
+
+            team.ShouldNotBeNull(customMessage: "Internal Service Accounts team must exist in space 0 (system).");
+            team.IsBuiltIn.ShouldBeTrue();
+            team.Description.ShouldContain("Do NOT add human users",
+                customMessage: "Team description must warn against human assignment.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_AssignsSystemServiceAccountRoleToTeam_CrossSpace()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<ITeamDataProvider, IUserRoleDataProvider, IScopedUserRoleDataProvider>(async (teamProvider, roleProvider, scopedProvider) =>
+        {
+            var team = (await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false)).First(t => t.Name == "Internal Service Accounts");
+            var role = await roleProvider.GetByNameAsync(BuiltInRoles.SystemServiceAccount.Name).ConfigureAwait(false);
+
+            role.ShouldNotBeNull();
+
+            var scopedRoles = await scopedProvider.GetByTeamIdsAsync(new List<int> { team.Id }).ConfigureAwait(false);
+            var assignment = scopedRoles.FirstOrDefault(sr => sr.UserRoleId == role.Id);
+
+            assignment.ShouldNotBeNull(customMessage: "SystemServiceAccount role must be assigned to the Internal Service Accounts team.");
+            assignment.SpaceId.ShouldBeNull(customMessage:
+                "SpaceId must be null (cross-space) so the InternalUser can register Tentacles in any space. " +
+                "A non-null SpaceId would limit the bootstrap to that single space.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_AddsInternalUserToTeam()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<ITeamDataProvider>(async teamProvider =>
+        {
+            var team = (await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false)).First(t => t.Name == "Internal Service Accounts");
+            var members = await teamProvider.GetMembersByTeamIdAsync(team.Id).ConfigureAwait(false);
+
+            members.ShouldContain(m => m.UserId == CurrentUsers.InternalUser.Id,
+                customMessage: "InternalUser must be a member of the Internal Service Accounts team to inherit the role.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_InternalUserHasMachineCreatePermission_ViaAuthorizationService()
+    {
+        // End-to-end pin: walk the full permission resolution path the way the
+        // register endpoint does. If this passes, a Tentacle register call carrying
+        // an InternalUser-owned API key WILL pass the MachineCreate authorization check.
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IAuthorizationService>(async authzService =>
+        {
+            var result = await authzService.CheckPermissionAsync(new PermissionCheckRequest
+            {
+                UserId = CurrentUsers.InternalUser.Id,
+                Permission = Permission.MachineCreate,
+                SpaceId = 1
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            result.IsAuthorized.ShouldBeTrue(customMessage:
+                "InternalUser MUST have MachineCreate permission in default space (SpaceId=1) -- this is the " +
+                "whole point of the bootstrap-key redesign. If this fails, the install script's register call " +
+                "will hit 403 every time. Trace: SystemServiceAccount role → ScopedUserRole (SpaceId=null) → " +
+                "team membership → user 8888.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_InternalUserDoesNotHaveMachineDelete()
+    {
+        // Least-privilege pin: the bootstrap surface must NOT include Delete.
+        // If a leaked bootstrap key could also delete machines, blast radius is huge.
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IAuthorizationService>(async authzService =>
+        {
+            var result = await authzService.CheckPermissionAsync(new PermissionCheckRequest
+            {
+                UserId = CurrentUsers.InternalUser.Id,
+                Permission = Permission.MachineDelete,
+                SpaceId = 1
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            result.IsAuthorized.ShouldBeFalse(customMessage:
+                "InternalUser MUST NOT have MachineDelete -- bootstrap key blast radius must stay narrow. " +
+                "If this assertion now fails, SystemServiceAccount role was widened OR a new role assignment leaked in.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_Idempotent_NoDuplicateUserOrTeamOrAssignment()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+        await RunDataSeeders().ConfigureAwait(false);
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IRepository, ITeamDataProvider, IScopedUserRoleDataProvider, IUserRoleDataProvider>(async (repository, teamProvider, scopedProvider, roleProvider) =>
+        {
+            var users = await repository.ToListAsync<UserAccount>(u => u.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
+            users.Count.ShouldBe(1, customMessage: "Running seeder N times must NOT duplicate the InternalUser row.");
+
+            var teams = (await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false)).Where(t => t.Name == "Internal Service Accounts").ToList();
+            teams.Count.ShouldBe(1, customMessage: "Internal Service Accounts team must not be duplicated.");
+
+            var members = await teamProvider.GetMembersByTeamIdAsync(teams[0].Id).ConfigureAwait(false);
+            members.Count(m => m.UserId == CurrentUsers.InternalUser.Id).ShouldBe(1, customMessage: "team_member row must not duplicate.");
+
+            var role = await roleProvider.GetByNameAsync(BuiltInRoles.SystemServiceAccount.Name).ConfigureAwait(false);
+            var scopedRoles = await scopedProvider.GetByTeamIdsAsync(new List<int> { teams[0].Id }).ConfigureAwait(false);
+            scopedRoles.Count(sr => sr.UserRoleId == role.Id).ShouldBe(1, customMessage: "scoped_user_role assignment must not duplicate.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_RegisteredAtOrder350()
+    {
+        // Ordering pin: InternalUserSeeder must run AFTER BuiltInRoleSeeder (100) so the
+        // SystemServiceAccount role row exists when we look it up, AFTER BuiltInTeamSeeder
+        // (200), AFTER AdminUserSeeder (300) so audit columns reference a real user.
+        var seeder = new InternalUserSeeder();
+        seeder.Order.ShouldBe(350);
+    }
+
+    private async Task RunDataSeeders()
+    {
+        await Run<ILifetimeScope>(async scope =>
+        {
+            var runner = new DataSeederRunner(scope);
+            runner.Start();
+
+            await Task.CompletedTask;
+        }).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Tentacle install-script bootstrap-key redesign. **Depends on PR #334 (Phase 1).** Base branch set to \`feat/system-service-account-role\` so merging happens in order.

\`InternalUserSeeder\` (Order=350) ensures:
- \`user_account\` row id=8888 exists (raw SQL INSERT — EF rejects explicit Id for sequence-default columns)
- "Internal Service Accounts" team exists in space 0 with warning description
- \`SystemServiceAccount\` role assigned to team with \`SpaceId=null\` (cross-space)
- InternalUser is a team member

End-to-end integration test \`SeedRuns_InternalUserHasMachineCreatePermission_ViaAuthorizationService\` walks the full \`IAuthorizationService.CheckPermissionAsync\` path — if this passes, register calls carrying InternalUser-owned API keys will pass MachineCreate.

Least-privilege test \`SeedRuns_InternalUserDoesNotHaveMachineDelete\` guards against role widening.

## Test plan

- [x] Unit: 5230/5230 pass
- [x] Integration: 8 new tests pin DB-level invariants (user row, team, role assignment, membership, permission resolution end-to-end, idempotence, seeder ordering)
- [x] Build: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)