### PR TITLE
Switch install-script API keys to single-instance bootstrap-key pattern

### DIFF
--- a/src/Squid.Core/Services/Account/AccountService.cs
+++ b/src/Squid.Core/Services/Account/AccountService.cs
@@ -23,7 +23,24 @@ public interface IAccountService : IScopedDependency
     Task<CreateApiKeyResponseData> CreateApiKeyAsync(int userId, string description, CancellationToken ct = default);
     Task DeleteApiKeyAsync(int apiKeyId, int currentUserId, CancellationToken ct = default);
     Task<List<ApiKeyDto>> GetApiKeysAsync(int userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds a single active API key owned by <paramref name="userId"/> whose
+    /// <c>Description</c> matches verbatim, returning the raw key value so the caller
+    /// can reuse it (used by the install-script generator to reuse the shared
+    /// bootstrap key instead of minting a new one on every call). Returns null when
+    /// no matching active key exists.
+    /// </summary>
+    Task<ApiKeyWithSecret?> FindApiKeyByDescriptionAsync(int userId, string description, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Internal-only DTO carrying the raw API key value for trusted Core callers
+/// (install-script generator, bootstrap-key rotation). Never expose to controllers /
+/// API responses -- the production <see cref="ApiKeyDto"/> with <c>MaskedKey</c>
+/// is the operator-facing shape.
+/// </summary>
+public sealed record ApiKeyWithSecret(int Id, string ApiKey, string Description, DateTimeOffset CreatedDate);
 
 public class AccountService : IAccountService
 {
@@ -259,6 +276,16 @@ public class AccountService : IAccountService
             Description = k.Description,
             CreatedDate = k.CreatedDate
         }).ToList();
+    }
+
+    public async Task<ApiKeyWithSecret?> FindApiKeyByDescriptionAsync(int userId, string description, CancellationToken ct = default)
+    {
+        var match = await _repository.FirstOrDefaultAsync<UserAccountApiKey>(
+            x => x.UserAccountId == userId && x.Description == description && !x.IsDisabled, ct).ConfigureAwait(false);
+
+        if (match == null) return null;
+
+        return new ApiKeyWithSecret(match.Id, match.ApiKey, match.Description ?? string.Empty, match.CreatedDate);
     }
 
     private async Task InvalidateApiKeyCacheForUserAsync(int userId, CancellationToken ct)

--- a/src/Squid.Core/Services/Machines/MachineScriptService.Install.cs
+++ b/src/Squid.Core/Services/Machines/MachineScriptService.Install.cs
@@ -41,13 +41,31 @@ public partial class MachineScriptService
         }
     }
 
+    /// <summary>
+    /// Canonical description for the SHARED Kubernetes-agent bootstrap API key.
+    /// Same get-or-create pattern as the Tentacle bootstrap key (see
+    /// <see cref="MachineScriptService.TentacleBootstrapKeyDescription"/>): one
+    /// active key per server, reused across all KubernetesAgent install-script
+    /// generations.
+    ///
+    /// <para>The previous design embedded the subscriptionId in the description
+    /// (<c>KubernetesAgent:&lt;guid&gt;</c>) which minted a NEW key per agent. That
+    /// shipped per-agent secret material into a public install script -- replaying
+    /// the old script after agent deletion left an orphan key the operator couldn't
+    /// easily find. Single-instance is simpler AND tighter security.</para>
+    /// </summary>
+    internal const string KubernetesAgentBootstrapKeyDescription = "Kubernetes Agent install bootstrap (system-shared, rotate via admin endpoint)";
+
     private async Task<(bool Success, string ApiKey, HttpStatusCode Code, string Message)> TryCreateApiKeyAsync(string subscriptionId, CancellationToken ct)
     {
-        var description = $"KubernetesAgent:{subscriptionId}";
-        var result = await _accountService.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, description, ct).ConfigureAwait(false);
+        var existing = await _accountService.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, KubernetesAgentBootstrapKeyDescription, ct).ConfigureAwait(false);
+
+        if (existing != null) return (true, existing.ApiKey, HttpStatusCode.OK, null);
+
+        var result = await _accountService.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, KubernetesAgentBootstrapKeyDescription, ct).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(result?.ApiKey))
-            return (false, null, HttpStatusCode.InternalServerError, "Failed to create API key");
+            return (false, null, HttpStatusCode.InternalServerError, "Failed to create Kubernetes Agent bootstrap API key");
 
         return (true, result.ApiKey, HttpStatusCode.OK, null);
     }

--- a/src/Squid.Core/Services/Machines/MachineScriptService.Tentacle.cs
+++ b/src/Squid.Core/Services/Machines/MachineScriptService.Tentacle.cs
@@ -105,13 +105,28 @@ public partial class MachineScriptService
             new MachineRuntimeCapabilities { Os = os },
             ct);
 
+    /// <summary>
+    /// Canonical description for the SHARED Tentacle bootstrap API key. Pinned in
+    /// <see cref="TentacleBootstrapKeyDescription"/> so the rotation endpoint
+    /// (system admin) and the script generator agree on which row to look up.
+    ///
+    /// <para>Single instance per server: <see cref="TryCreateTentacleApiKeyAsync"/>
+    /// always queries by this description first and reuses the existing key when
+    /// present. New keys are minted only on first install + after rotation. The
+    /// DB accumulates AT MOST ONE active Tentacle bootstrap key per server.</para>
+    /// </summary>
+    internal const string TentacleBootstrapKeyDescription = "Tentacle install bootstrap (system-shared, rotate via admin endpoint)";
+
     private async Task<(bool Success, string ApiKey, HttpStatusCode Code, string Message)> TryCreateTentacleApiKeyAsync(CancellationToken ct)
     {
-        var description = $"Tentacle:{Guid.NewGuid():N}";
-        var result = await _accountService.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, description, ct).ConfigureAwait(false);
+        var existing = await _accountService.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, TentacleBootstrapKeyDescription, ct).ConfigureAwait(false);
+
+        if (existing != null) return (true, existing.ApiKey, HttpStatusCode.OK, null);
+
+        var result = await _accountService.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, TentacleBootstrapKeyDescription, ct).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(result?.ApiKey))
-            return (false, null, HttpStatusCode.InternalServerError, "Failed to create API key");
+            return (false, null, HttpStatusCode.InternalServerError, "Failed to create Tentacle bootstrap API key");
 
         return (true, result.ApiKey, HttpStatusCode.OK, null);
     }

--- a/tests/Squid.UnitTests/Services/Account/AccountServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Account/AccountServiceTests.cs
@@ -241,6 +241,38 @@ public class AccountServiceTests
     }
 
     [Fact]
+    public async Task FindApiKeyByDescription_ExistingActiveKey_ReturnsApiKeyWithSecret()
+    {
+        var existing = new UserAccountApiKey
+        {
+            Id = 42, UserAccountId = 1, ApiKey = "raw-secret-value", Description = "test-key", IsDisabled = false, CreatedDate = DateTimeOffset.UtcNow
+        };
+        _repository.Setup(r => r.FirstOrDefaultAsync<UserAccountApiKey>(It.IsAny<Expression<Func<UserAccountApiKey, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var result = await _sut.FindApiKeyByDescriptionAsync(userId: 1, description: "test-key");
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(42);
+        result.ApiKey.ShouldBe("raw-secret-value",
+            customMessage: "FindApiKeyByDescriptionAsync MUST return the raw key value -- callers like the " +
+                          "install-script generator embed it in the generated PowerShell snippet. " +
+                          "Returning a masked value here would silently produce useless install scripts.");
+        result.Description.ShouldBe("test-key");
+    }
+
+    [Fact]
+    public async Task FindApiKeyByDescription_NotFound_ReturnsNull()
+    {
+        _repository.Setup(r => r.FirstOrDefaultAsync<UserAccountApiKey>(It.IsAny<Expression<Func<UserAccountApiKey, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserAccountApiKey?)null);
+
+        var result = await _sut.FindApiKeyByDescriptionAsync(userId: 1, description: "missing");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task DeleteApiKey_DisablesAndClearsCache()
     {
         var apiKey = new UserAccountApiKey { Id = 5, UserAccountId = 1, ApiKey = "raw-key-value", IsDisabled = false };

--- a/tests/Squid.UnitTests/Services/Machines/MachineInstallScriptServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineInstallScriptServiceTests.cs
@@ -325,6 +325,12 @@ public class MachineInstallScriptServiceTests
     [Fact]
     public async Task GenerateScript_ApiKeyCreationFails_ReturnsInternalServerError()
     {
+        // Force FindApiKeyByDescriptionAsync to return null (no shared key yet) so we
+        // exercise the mint path; then have CreateApiKeyAsync return an empty key to
+        // simulate failure.
+        _accountService
+            .Setup(x => x.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiKeyWithSecret?)null);
         _accountService
             .Setup(x => x.CreateApiKeyAsync(CurrentUsers.InternalUser.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CreateApiKeyResponseData { ApiKey = "" });
@@ -332,8 +338,45 @@ public class MachineInstallScriptServiceTests
         var response = await _service.GenerateKubernetesAgentInstallScriptAsync(CreateCommand(), CancellationToken.None);
 
         response.Code.ShouldBe(HttpStatusCode.InternalServerError);
-        response.Msg.ShouldContain("Failed to create API key");
+        response.Msg.ShouldContain("Failed to create Kubernetes Agent bootstrap API key",
+            customMessage: "Error message must name the specific surface (bootstrap key) so operators know where to look.");
         response.Data.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GenerateScript_SharedKeyAlreadyExists_ReusesItWithoutMinting()
+    {
+        // Single-instance pin: when FindApiKeyByDescriptionAsync returns an existing
+        // key, the service MUST NOT call CreateApiKeyAsync. DB must not accumulate
+        // one row per install-script call.
+        const string sharedKey = "SHARED-K8S-KEY-VALUE";
+        _accountService
+            .Setup(x => x.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, MachineScriptService.KubernetesAgentBootstrapKeyDescription, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiKeyWithSecret(99, sharedKey, MachineScriptService.KubernetesAgentBootstrapKeyDescription, DateTimeOffset.UtcNow));
+
+        var response = await _service.GenerateKubernetesAgentInstallScriptAsync(CreateCommand(), CancellationToken.None);
+
+        response.Code.ShouldBe(HttpStatusCode.OK);
+        _accountService.Verify(x => x.CreateApiKeyAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never, failMessage: "MUST NOT mint a new key when a shared bootstrap key already exists. " +
+                                     "Mint per call was the 1.6.x bug -- DB accumulated one row per install-script call.");
+    }
+
+    [Fact]
+    public async Task GenerateScript_NoSharedKey_MintsExactlyOneNewKey()
+    {
+        // Mint-once pin: when no shared key exists, CreateApiKeyAsync is called
+        // exactly once with the canonical description.
+        _accountService
+            .Setup(x => x.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, MachineScriptService.KubernetesAgentBootstrapKeyDescription, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiKeyWithSecret?)null);
+
+        await _service.GenerateKubernetesAgentInstallScriptAsync(CreateCommand(), CancellationToken.None);
+
+        _accountService.Verify(x => x.CreateApiKeyAsync(
+            CurrentUsers.InternalUser.Id,
+            MachineScriptService.KubernetesAgentBootstrapKeyDescription,
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ========================================================================

--- a/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/GenerateTentacleInstallScriptServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Scripts/Tentacle/GenerateTentacleInstallScriptServiceTests.cs
@@ -185,6 +185,9 @@ public class GenerateTentacleInstallScriptServiceTests
     public async Task GenerateTentacleInstallScript_ApiKeyCreationFails_ReturnsInternalError()
     {
         _accountService
+            .Setup(x => x.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiKeyWithSecret?)null);
+        _accountService
             .Setup(x => x.CreateApiKeyAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CreateApiKeyResponseData { ApiKey = null });
 
@@ -195,6 +198,49 @@ public class GenerateTentacleInstallScriptServiceTests
             CancellationToken.None);
 
         response.Code.ShouldBe(HttpStatusCode.InternalServerError);
+        response.Msg.ShouldContain("Failed to create Tentacle bootstrap API key",
+            customMessage: "Error message must name the specific surface (bootstrap key).");
+    }
+
+    [Fact]
+    public async Task GenerateTentacleInstallScript_SharedKeyExists_ReusesItWithoutMinting()
+    {
+        // Single-instance pin for the Tentacle bootstrap key. Mirror of the K8s pin
+        // in MachineInstallScriptServiceTests -- both install surfaces share the
+        // get-or-create pattern.
+        _accountService
+            .Setup(x => x.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, MachineScriptService.TentacleBootstrapKeyDescription, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiKeyWithSecret(99, "SHARED-TENTACLE-KEY", MachineScriptService.TentacleBootstrapKeyDescription, DateTimeOffset.UtcNow));
+
+        var service = BuildService(new FakeBuilder("linux-binary", "Linux"));
+
+        var response = await service.GenerateTentacleInstallScriptAsync(
+            new GenerateTentacleInstallScriptCommand { CommunicationMode = "Polling" },
+            CancellationToken.None);
+
+        response.Code.ShouldBe(HttpStatusCode.OK);
+        _accountService.Verify(x => x.CreateApiKeyAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never, failMessage:
+                "MUST reuse the existing Tentacle bootstrap key when present. Mint-per-call was the 1.6.x bug.");
+    }
+
+    [Fact]
+    public async Task GenerateTentacleInstallScript_NoSharedKey_MintsExactlyOneWithCanonicalDescription()
+    {
+        _accountService
+            .Setup(x => x.FindApiKeyByDescriptionAsync(CurrentUsers.InternalUser.Id, MachineScriptService.TentacleBootstrapKeyDescription, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiKeyWithSecret?)null);
+
+        var service = BuildService(new FakeBuilder("linux-binary", "Linux"));
+
+        await service.GenerateTentacleInstallScriptAsync(
+            new GenerateTentacleInstallScriptCommand { CommunicationMode = "Polling" },
+            CancellationToken.None);
+
+        _accountService.Verify(x => x.CreateApiKeyAsync(
+            CurrentUsers.InternalUser.Id,
+            MachineScriptService.TentacleBootstrapKeyDescription,
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     private MachineScriptService BuildService(params ITentacleInstallScriptBuilder[] builders)


### PR DESCRIPTION
## Summary

Phase 3 of the bootstrap-key redesign. **Depends on PR #335 (Phase 2).**

Closes the "DB accumulates one row per install-script call" issue. The 1.6.x mint-per-call pattern created a fresh \`user_account_api_key\` row on every Add-Tentacle click. New pattern: canonical stable description + \`FindApiKeyByDescriptionAsync\` first, mint only on first install or after rotation.

\`TentacleBootstrapKeyDescription\` + \`KubernetesAgentBootstrapKeyDescription\` are \`internal const string\` pins consumed by Phase 4's rotation endpoint.

Adds \`IAccountService.FindApiKeyByDescriptionAsync\` returning the new internal \`ApiKeyWithSecret\` record (raw key value -- trusted-Core-only, never exposed via controllers).

## Test plan

- [x] Unit: 5236/5236 pass
- [x] 6 new tests: Find/SharedKey/NoSharedKey pins on both Tentacle + K8s paths
- [ ] Phase 4 rotation endpoint will test "after rotation, next GenerateScript call gets new key" end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)