### PR TITLE
Seed InternalUser account + Internal Service Accounts team

### DIFF
--- a/src/Squid.Core/Services/Authorization/PermissionRoleResolver.cs
+++ b/src/Squid.Core/Services/Authorization/PermissionRoleResolver.cs
@@ -25,18 +25,33 @@ namespace Squid.Core.Services.Authorization;
 public static class PermissionRoleResolver
 {
     /// <summary>
-    /// Returns the names of the built-in roles that grant <paramref name="permission"/>.
-    /// Empty when no built-in role grants it (operator must use a custom role
-    /// or add the permission to an existing role).
+    /// Returns the names of the built-in roles that grant <paramref name="permission"/>
+    /// AND are safe to suggest to a human operator (i.e. <c>IsReservedForSystem == false</c>).
+    /// Empty when no operator-assignable role grants it.
+    ///
+    /// <para>System-reserved roles (e.g. <c>SystemServiceAccount</c>, used by the Tentacle
+    /// bootstrap key's owner account) are deliberately filtered out -- suggesting them
+    /// would lead an operator to assign a system-reserved role to a human user, defeating
+    /// the least-privilege isolation those roles are designed for.</para>
     /// </summary>
     public static IReadOnlyList<string> GetBuiltInRolesGranting(Permission permission)
+        => GetBuiltInRolesGranting(permission, includeSystemReserved: false);
+
+    /// <summary>
+    /// Lower-level variant that lets the caller choose whether to include system-reserved
+    /// roles. Internal callers (seeders, diagnostics) may need the full list; operator-facing
+    /// surfaces (403 hint, install-script error message) MUST stick with the filtered default.
+    /// </summary>
+    public static IReadOnlyList<string> GetBuiltInRolesGranting(Permission permission, bool includeSystemReserved)
     {
         var matches = new List<string>();
 
         foreach (var role in BuiltInRoles.All)
         {
-            if (role.Permissions.Contains(permission))
-                matches.Add(role.Name);
+            if (!role.Permissions.Contains(permission)) continue;
+            if (role.IsReservedForSystem && !includeSystemReserved) continue;
+
+            matches.Add(role.Name);
         }
 
         return matches;

--- a/src/Squid.Core/Services/DataSeeding/BuiltInRoleSeeder.cs
+++ b/src/Squid.Core/Services/DataSeeding/BuiltInRoleSeeder.cs
@@ -58,6 +58,14 @@ public class BuiltInRoleDefinition
     public string Name { get; init; }
     public string Description { get; init; }
     public List<Permission> Permissions { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, this role is reserved for system / internal accounts (e.g. the
+    /// Tentacle bootstrap key's owner) and must NOT be suggested as a remediation to
+    /// human operators hitting a permission denial. Operator-facing 403 hints filter
+    /// these out via <c>PermissionRoleResolver.GetBuiltInRolesGranting</c>.
+    /// </summary>
+    public bool IsReservedForSystem { get; init; }
 }
 
 public static class BuiltInRoles
@@ -144,6 +152,30 @@ public static class BuiltInRoles
         }
     };
 
+    /// <summary>
+    /// Reserved for system-generated bootstrap operations (Tentacle install-script API keys,
+    /// automation pipelines). Deliberately narrower than <see cref="EnvironmentManager"/>:
+    /// has <c>MachineView</c> + <c>MachineCreate</c> + <c>MachineEdit</c> only -- enough for a
+    /// Tentacle to onboard itself, but explicitly NOT <c>MachineDelete</c> (bootstrap must not
+    /// be able to remove machines) and no account / environment / task permissions.
+    ///
+    /// <para><b>Operator-facing warning</b>: do NOT assign this role to a human user.
+    /// Reserved for the internal account (<c>CurrentUsers.InternalUser.Id</c>) that owns the
+    /// shared Tentacle bootstrap API key. Assigning to humans silently grants MachineCreate
+    /// without going through the documented Environment Manager / Space Owner paths.</para>
+    /// </summary>
+    public static readonly BuiltInRoleDefinition SystemServiceAccount = new()
+    {
+        Name = "System Service Account",
+        Description = "Reserved for system-generated bootstrap (Tentacle install scripts). " +
+                      "Do NOT assign to human users -- use Environment Manager or Space Owner instead.",
+        Permissions = new List<Permission>
+        {
+            Permission.MachineView, Permission.MachineCreate, Permission.MachineEdit,
+        },
+        IsReservedForSystem = true
+    };
+
     public static readonly List<BuiltInRoleDefinition> All = new()
     {
         SystemAdministrator,
@@ -152,5 +184,6 @@ public static class BuiltInRoles
         ProjectContributor,
         ProjectViewer,
         EnvironmentManager,
+        SystemServiceAccount,
     };
 }

--- a/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
+++ b/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
@@ -1,0 +1,148 @@
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Account;
+using Squid.Core.Services.Authorization;
+using Squid.Core.Services.Teams;
+using Squid.Message.Constants;
+using Serilog;
+
+namespace Squid.Core.Services.DataSeeding;
+
+/// <summary>
+/// Seeds the InternalUser account (<c>CurrentUsers.InternalUser.Id</c> = 8888) plus the
+/// "Internal Service Accounts" team that grants it the <c>SystemServiceAccount</c> role.
+/// Together this lets the Tentacle install-script bootstrap API key (owned by user 8888)
+/// pass the <c>MachineCreate</c> permission check at register time.
+///
+/// <para><b>Why an Id-pinned user</b>: <c>CurrentUsers.InternalUser.Id</c> is a compile-
+/// time constant (8888) referenced by <c>SquidDbContext</c> audit columns (default value
+/// for <c>created_by</c> / <c>last_modified_by</c>), the API-key authentication handler,
+/// and the install-script generator. All of these would silently break if the user row
+/// didn't exist or had a different Id.</para>
+///
+/// <para><b>Order = 350</b>: must run AFTER <see cref="BuiltInRoleSeeder"/> (Order=100,
+/// creates the SystemServiceAccount role row), AFTER <see cref="BuiltInTeamSeeder"/>
+/// (Order=200), and AFTER <see cref="AdminUserSeeder"/> (Order=300, so the audit
+/// columns can reference 8888 without violating audit ordering).</para>
+///
+/// <para><b>Idempotent</b>: every step uses "exists check + create-if-missing" so this
+/// seeder can run on every startup without duplicating rows. Pre-existing operator
+/// modifications (e.g. additional roles assigned to the Internal Service Accounts team)
+/// are preserved.</para>
+/// </summary>
+public class InternalUserSeeder : IDataSeeder
+{
+    private const string InternalServiceAccountsTeamName = "Internal Service Accounts";
+
+    private const string InternalServiceAccountsTeamDescription =
+        "Reserved team for the InternalUser system account (Tentacle install bootstrap, automation). " +
+        "Do NOT add human users -- assigning here silently grants them SystemServiceAccount permissions.";
+
+    public int Order => 350;
+
+    public async Task SeedAsync(ILifetimeScope scope)
+    {
+        var repository = scope.Resolve<IRepository>();
+        var unitOfWork = scope.Resolve<IUnitOfWork>();
+        var dbContext = scope.Resolve<SquidDbContext>();
+        var teamProvider = scope.Resolve<ITeamDataProvider>();
+        var roleProvider = scope.Resolve<IUserRoleDataProvider>();
+        var scopedRoleProvider = scope.Resolve<IScopedUserRoleDataProvider>();
+
+        await EnsureInternalUserAccountAsync(repository, dbContext).ConfigureAwait(false);
+        var team = await EnsureInternalServiceAccountsTeamAsync(teamProvider).ConfigureAwait(false);
+        await EnsureTeamHasSystemServiceAccountRoleAsync(roleProvider, scopedRoleProvider, team).ConfigureAwait(false);
+        await EnsureInternalUserInTeamAsync(teamProvider, team).ConfigureAwait(false);
+
+        Log.Information("Internal user seeding complete");
+    }
+
+    /// <summary>
+    /// Inserts a <c>user_account</c> row with the Id-pinned sentinel
+    /// (<c>CurrentUsers.InternalUser.Id</c>) using raw SQL — EF's Identity convention
+    /// rejects explicit Id values for auto-generated columns, so going through
+    /// <c>IRepository.InsertAsync</c> would either silently re-assign a new Id or
+    /// throw. The raw INSERT lets PostgreSQL accept the explicit Id (the sequence
+    /// default is overridden by the explicit value column).
+    /// </summary>
+    private static async Task EnsureInternalUserAccountAsync(IRepository repository, SquidDbContext dbContext)
+    {
+        var existing = await repository.FirstOrDefaultAsync<UserAccount>(x => x.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
+
+        if (existing != null)
+        {
+            if (!existing.IsSystem) Log.Warning("Internal user (id={Id}) exists but IsSystem=false -- it should be true; UI will show it as a regular user", CurrentUsers.InternalUser.Id);
+            return;
+        }
+
+        const string sql = @"
+            INSERT INTO user_account
+                (id, user_name, normalized_user_name, display_name, password_hash,
+                 is_disabled, is_system, must_change_password,
+                 created_date, last_modified_date, created_by, last_modified_by)
+            VALUES
+                ({0}, {1}, {2}, {3}, '',
+                 false, true, false,
+                 {4}, {4}, {0}, {0})
+            ON CONFLICT (id) DO NOTHING";
+
+        var now = DateTimeOffset.UtcNow;
+        var rows = await dbContext.Database.ExecuteSqlRawAsync(sql,
+            CurrentUsers.InternalUser.Id, CurrentUsers.InternalUser.Name, CurrentUsers.InternalUser.Name.ToUpperInvariant(), CurrentUsers.InternalUser.DisplayName, now).ConfigureAwait(false);
+
+        Log.Information("Seeded internal user (id={Id}, rowsAffected={Rows})", CurrentUsers.InternalUser.Id, rows);
+    }
+
+    /// <summary>
+    /// Creates the "Internal Service Accounts" team in space 0 (system / cross-space)
+    /// if absent. Idempotent: returns the existing row when already present.
+    /// </summary>
+    private static async Task<Team> EnsureInternalServiceAccountsTeamAsync(ITeamDataProvider teamProvider)
+    {
+        var teams = await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false);
+        var existing = teams.FirstOrDefault(t => t.Name == InternalServiceAccountsTeamName);
+
+        if (existing != null) return existing;
+
+        var team = new Team { Name = InternalServiceAccountsTeamName, Description = InternalServiceAccountsTeamDescription, SpaceId = 0, IsBuiltIn = true };
+        await teamProvider.AddAsync(team).ConfigureAwait(false);
+        Log.Information("Seeded team {TeamName}", InternalServiceAccountsTeamName);
+
+        return team;
+    }
+
+    /// <summary>
+    /// Assigns the <c>SystemServiceAccount</c> role to the team with <c>SpaceId=null</c>
+    /// (applies in every space, matching how <c>BuiltInTeamSeeder</c> assigns the
+    /// SystemAdministrator role to Squid Administrators). Idempotent.
+    /// </summary>
+    private static async Task EnsureTeamHasSystemServiceAccountRoleAsync(IUserRoleDataProvider roleProvider, IScopedUserRoleDataProvider scopedRoleProvider, Team team)
+    {
+        var role = await roleProvider.GetByNameAsync(BuiltInRoles.SystemServiceAccount.Name).ConfigureAwait(false);
+
+        if (role == null)
+            throw new InvalidOperationException($"Built-in role '{BuiltInRoles.SystemServiceAccount.Name}' missing; ensure {nameof(BuiltInRoleSeeder)} ran first (Order=100).");
+
+        var existing = await scopedRoleProvider.GetByTeamIdsAsync(new List<int> { team.Id }).ConfigureAwait(false);
+
+        if (existing.Any(sr => sr.UserRoleId == role.Id)) return;
+
+        await scopedRoleProvider.AddAsync(new ScopedUserRole { TeamId = team.Id, UserRoleId = role.Id, SpaceId = null }).ConfigureAwait(false);
+        Log.Information("Assigned role {RoleName} to team {TeamName} (cross-space)", BuiltInRoles.SystemServiceAccount.Name, InternalServiceAccountsTeamName);
+    }
+
+    /// <summary>
+    /// Adds the InternalUser to the team. Idempotent — checks membership first to
+    /// avoid violating the team_member primary-key constraint on re-run.
+    /// </summary>
+    private static async Task EnsureInternalUserInTeamAsync(ITeamDataProvider teamProvider, Team team)
+    {
+        var members = await teamProvider.GetMembersByTeamIdAsync(team.Id).ConfigureAwait(false);
+
+        if (members.Any(m => m.UserId == CurrentUsers.InternalUser.Id)) return;
+
+        await teamProvider.AddMemberAsync(new TeamMember { TeamId = team.Id, UserId = CurrentUsers.InternalUser.Id }).ConfigureAwait(false);
+        Log.Information("Added InternalUser (id={UserId}) to team {TeamName}", CurrentUsers.InternalUser.Id, InternalServiceAccountsTeamName);
+    }
+}

--- a/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
+++ b/src/Squid.Core/Services/DataSeeding/InternalUserSeeder.cs
@@ -50,7 +50,7 @@ public class InternalUserSeeder : IDataSeeder
         var roleProvider = scope.Resolve<IUserRoleDataProvider>();
         var scopedRoleProvider = scope.Resolve<IScopedUserRoleDataProvider>();
 
-        await EnsureInternalUserAccountAsync(repository, dbContext).ConfigureAwait(false);
+        await EnsureInternalUserAccountAsync(repository, unitOfWork, dbContext).ConfigureAwait(false);
         var team = await EnsureInternalServiceAccountsTeamAsync(teamProvider).ConfigureAwait(false);
         await EnsureTeamHasSystemServiceAccountRoleAsync(roleProvider, scopedRoleProvider, team).ConfigureAwait(false);
         await EnsureInternalUserInTeamAsync(teamProvider, team).ConfigureAwait(false);
@@ -66,13 +66,13 @@ public class InternalUserSeeder : IDataSeeder
     /// throw. The raw INSERT lets PostgreSQL accept the explicit Id (the sequence
     /// default is overridden by the explicit value column).
     /// </summary>
-    private static async Task EnsureInternalUserAccountAsync(IRepository repository, SquidDbContext dbContext)
+    private static async Task EnsureInternalUserAccountAsync(IRepository repository, IUnitOfWork unitOfWork, SquidDbContext dbContext)
     {
         var existing = await repository.FirstOrDefaultAsync<UserAccount>(x => x.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
 
         if (existing != null)
         {
-            if (!existing.IsSystem) Log.Warning("Internal user (id={Id}) exists but IsSystem=false -- it should be true; UI will show it as a regular user", CurrentUsers.InternalUser.Id);
+            await NormaliseLegacyInternalUserAsync(repository, unitOfWork, existing).ConfigureAwait(false);
             return;
         }
 
@@ -92,6 +92,38 @@ public class InternalUserSeeder : IDataSeeder
             CurrentUsers.InternalUser.Id, CurrentUsers.InternalUser.Name, CurrentUsers.InternalUser.Name.ToUpperInvariant(), CurrentUsers.InternalUser.DisplayName, now).ConfigureAwait(false);
 
         Log.Information("Seeded internal user (id={Id}, rowsAffected={Rows})", CurrentUsers.InternalUser.Id, rows);
+    }
+
+    /// <summary>
+    /// Upgrades an existing InternalUser row to the canonical values when fields drift
+    /// from the constants in <see cref="CurrentUsers.InternalUser"/>. Specifically, the
+    /// <c>001_initial_schema.sql</c> migration seeds <c>display_name='internal_user'</c>
+    /// (legacy -- same as user_name), but the canonical value is <c>'System'</c>. Same
+    /// for <c>IsSystem</c>: must be true so the UI can hide it from human user lists.
+    /// </summary>
+    private static async Task NormaliseLegacyInternalUserAsync(IRepository repository, IUnitOfWork unitOfWork, UserAccount existing)
+    {
+        var dirty = false;
+
+        if (existing.DisplayName != CurrentUsers.InternalUser.DisplayName)
+        {
+            Log.Information("Upgrading internal user display_name from '{Old}' to '{New}'", existing.DisplayName, CurrentUsers.InternalUser.DisplayName);
+            existing.DisplayName = CurrentUsers.InternalUser.DisplayName;
+            dirty = true;
+        }
+
+        if (!existing.IsSystem)
+        {
+            Log.Information("Upgrading internal user IsSystem from false to true");
+            existing.IsSystem = true;
+            dirty = true;
+        }
+
+        if (!dirty) return;
+
+        existing.LastModifiedDate = DateTimeOffset.UtcNow;
+        await repository.UpdateAsync(existing).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/Squid.IntegrationTests/Services/Authorization/BuiltInRoleSeederIntegrationTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Authorization/BuiltInRoleSeederIntegrationTests.cs
@@ -28,12 +28,13 @@ public class BuiltInRoleSeederIntegrationTests : TestBase
     {
         var seeders = CurrentScope.Resolve<IEnumerable<IDataSeeder>>().OrderBy(s => s.Order).ToList();
 
-        seeders.Count.ShouldBeGreaterThanOrEqualTo(5);
-        seeders[0].Order.ShouldBe(100);
-        seeders[1].Order.ShouldBe(200);
-        seeders[2].Order.ShouldBe(300);
-        seeders[3].Order.ShouldBe(400);
-        seeders[4].Order.ShouldBe(500);
+        seeders.Count.ShouldBeGreaterThanOrEqualTo(6);
+        seeders[0].Order.ShouldBe(100);    // BuiltInRoleSeeder
+        seeders[1].Order.ShouldBe(200);    // BuiltInTeamSeeder
+        seeders[2].Order.ShouldBe(300);    // AdminUserSeeder
+        seeders[3].Order.ShouldBe(350);    // InternalUserSeeder
+        seeders[4].Order.ShouldBe(400);    // DefaultSpaceSeeder
+        seeders[5].Order.ShouldBe(500);    // DefaultMachinePolicySeeder
     }
 
     [Fact]

--- a/tests/Squid.IntegrationTests/Services/Authorization/InternalUserSeederIntegrationTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Authorization/InternalUserSeederIntegrationTests.cs
@@ -1,0 +1,187 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Account;
+using Squid.Core.Services.Authorization;
+using Squid.Core.Services.DataSeeding;
+using Squid.Core.Services.Teams;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+
+namespace Squid.IntegrationTests.Services.Authorization;
+
+/// <summary>
+/// Pins the InternalUser bootstrap surface in DB form: user_account row 8888 exists,
+/// the "Internal Service Accounts" team owns the SystemServiceAccount role cross-space,
+/// and user 8888 is a member of that team. Together this is what makes a Tentacle
+/// register call (carrying an InternalUser-owned API key) actually pass the
+/// MachineCreate permission check.
+/// </summary>
+public class InternalUserSeederIntegrationTests : TestBase
+{
+    public InternalUserSeederIntegrationTests()
+        : base("InternalUserSeeder", "squid_it_internal_user_seeder")
+    {
+    }
+
+    [Fact]
+    public async Task SeedRuns_CreatesInternalUserAccountWithCanonicalId()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IRepository>(async repository =>
+        {
+            var user = await repository.FirstOrDefaultAsync<UserAccount>(x => x.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
+
+            user.ShouldNotBeNull(customMessage: "InternalUser (id=8888) must exist after seeding.");
+            user.UserName.ShouldBe(CurrentUsers.InternalUser.Name);
+            user.DisplayName.ShouldBe(CurrentUsers.InternalUser.DisplayName);
+            user.IsSystem.ShouldBeTrue(customMessage: "InternalUser must have IsSystem=true so the UI can hide it from human-user lists.");
+            user.IsDisabled.ShouldBeFalse();
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_CreatesInternalServiceAccountsTeam_InSpaceZero()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<ITeamDataProvider>(async teamProvider =>
+        {
+            var teams = await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false);
+            var team = teams.FirstOrDefault(t => t.Name == "Internal Service Accounts");
+
+            team.ShouldNotBeNull(customMessage: "Internal Service Accounts team must exist in space 0 (system).");
+            team.IsBuiltIn.ShouldBeTrue();
+            team.Description.ShouldContain("Do NOT add human users",
+                customMessage: "Team description must warn against human assignment.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_AssignsSystemServiceAccountRoleToTeam_CrossSpace()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<ITeamDataProvider, IUserRoleDataProvider, IScopedUserRoleDataProvider>(async (teamProvider, roleProvider, scopedProvider) =>
+        {
+            var team = (await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false)).First(t => t.Name == "Internal Service Accounts");
+            var role = await roleProvider.GetByNameAsync(BuiltInRoles.SystemServiceAccount.Name).ConfigureAwait(false);
+
+            role.ShouldNotBeNull();
+
+            var scopedRoles = await scopedProvider.GetByTeamIdsAsync(new List<int> { team.Id }).ConfigureAwait(false);
+            var assignment = scopedRoles.FirstOrDefault(sr => sr.UserRoleId == role.Id);
+
+            assignment.ShouldNotBeNull(customMessage: "SystemServiceAccount role must be assigned to the Internal Service Accounts team.");
+            assignment.SpaceId.ShouldBeNull(customMessage:
+                "SpaceId must be null (cross-space) so the InternalUser can register Tentacles in any space. " +
+                "A non-null SpaceId would limit the bootstrap to that single space.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_AddsInternalUserToTeam()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<ITeamDataProvider>(async teamProvider =>
+        {
+            var team = (await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false)).First(t => t.Name == "Internal Service Accounts");
+            var members = await teamProvider.GetMembersByTeamIdAsync(team.Id).ConfigureAwait(false);
+
+            members.ShouldContain(m => m.UserId == CurrentUsers.InternalUser.Id,
+                customMessage: "InternalUser must be a member of the Internal Service Accounts team to inherit the role.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_InternalUserHasMachineCreatePermission_ViaAuthorizationService()
+    {
+        // End-to-end pin: walk the full permission resolution path the way the
+        // register endpoint does. If this passes, a Tentacle register call carrying
+        // an InternalUser-owned API key WILL pass the MachineCreate authorization check.
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IAuthorizationService>(async authzService =>
+        {
+            var result = await authzService.CheckPermissionAsync(new PermissionCheckRequest
+            {
+                UserId = CurrentUsers.InternalUser.Id,
+                Permission = Permission.MachineCreate,
+                SpaceId = 1
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            result.IsAuthorized.ShouldBeTrue(customMessage:
+                "InternalUser MUST have MachineCreate permission in default space (SpaceId=1) -- this is the " +
+                "whole point of the bootstrap-key redesign. If this fails, the install script's register call " +
+                "will hit 403 every time. Trace: SystemServiceAccount role → ScopedUserRole (SpaceId=null) → " +
+                "team membership → user 8888.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_InternalUserDoesNotHaveMachineDelete()
+    {
+        // Least-privilege pin: the bootstrap surface must NOT include Delete.
+        // If a leaked bootstrap key could also delete machines, blast radius is huge.
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IAuthorizationService>(async authzService =>
+        {
+            var result = await authzService.CheckPermissionAsync(new PermissionCheckRequest
+            {
+                UserId = CurrentUsers.InternalUser.Id,
+                Permission = Permission.MachineDelete,
+                SpaceId = 1
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            result.IsAuthorized.ShouldBeFalse(customMessage:
+                "InternalUser MUST NOT have MachineDelete -- bootstrap key blast radius must stay narrow. " +
+                "If this assertion now fails, SystemServiceAccount role was widened OR a new role assignment leaked in.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_Idempotent_NoDuplicateUserOrTeamOrAssignment()
+    {
+        await RunDataSeeders().ConfigureAwait(false);
+        await RunDataSeeders().ConfigureAwait(false);
+        await RunDataSeeders().ConfigureAwait(false);
+
+        await Run<IRepository, ITeamDataProvider, IScopedUserRoleDataProvider, IUserRoleDataProvider>(async (repository, teamProvider, scopedProvider, roleProvider) =>
+        {
+            var users = await repository.ToListAsync<UserAccount>(u => u.Id == CurrentUsers.InternalUser.Id).ConfigureAwait(false);
+            users.Count.ShouldBe(1, customMessage: "Running seeder N times must NOT duplicate the InternalUser row.");
+
+            var teams = (await teamProvider.GetAllBySpaceAsync(0).ConfigureAwait(false)).Where(t => t.Name == "Internal Service Accounts").ToList();
+            teams.Count.ShouldBe(1, customMessage: "Internal Service Accounts team must not be duplicated.");
+
+            var members = await teamProvider.GetMembersByTeamIdAsync(teams[0].Id).ConfigureAwait(false);
+            members.Count(m => m.UserId == CurrentUsers.InternalUser.Id).ShouldBe(1, customMessage: "team_member row must not duplicate.");
+
+            var role = await roleProvider.GetByNameAsync(BuiltInRoles.SystemServiceAccount.Name).ConfigureAwait(false);
+            var scopedRoles = await scopedProvider.GetByTeamIdsAsync(new List<int> { teams[0].Id }).ConfigureAwait(false);
+            scopedRoles.Count(sr => sr.UserRoleId == role.Id).ShouldBe(1, customMessage: "scoped_user_role assignment must not duplicate.");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SeedRuns_RegisteredAtOrder350()
+    {
+        // Ordering pin: InternalUserSeeder must run AFTER BuiltInRoleSeeder (100) so the
+        // SystemServiceAccount role row exists when we look it up, AFTER BuiltInTeamSeeder
+        // (200), AFTER AdminUserSeeder (300) so audit columns reference a real user.
+        var seeder = new InternalUserSeeder();
+        seeder.Order.ShouldBe(350);
+    }
+
+    private async Task RunDataSeeders()
+    {
+        await Run<ILifetimeScope>(async scope =>
+        {
+            var runner = new DataSeederRunner(scope);
+            runner.Start();
+
+            await Task.CompletedTask;
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Authorization/BuiltInRoleSeederTests.cs
+++ b/tests/Squid.UnitTests/Services/Authorization/BuiltInRoleSeederTests.cs
@@ -53,4 +53,60 @@ public class BuiltInRoleSeederTests
             role.Description.ShouldNotBeNullOrWhiteSpace($"Role '{role.Name}' has no description");
         }
     }
+
+    // ─── SystemServiceAccount ──────────────────────────────────────────────
+    // Reserved role used by the InternalUser bootstrap key (Tentacle install
+    // scripts). Pinned narrowly: MachineView + MachineCreate + MachineEdit
+    // only. No MachineDelete, no account / env / task. Any drift here directly
+    // affects bootstrap-key blast radius -- it MUST stay least-privilege.
+
+    [Fact]
+    public void SystemServiceAccount_HasExactlyThreeMachinePermissions()
+    {
+        BuiltInRoles.SystemServiceAccount.Permissions.Count.ShouldBe(3,
+            customMessage: "SystemServiceAccount is the bootstrap-key role -- it must stay narrow. " +
+                          "Any expansion increases blast radius if the shared bootstrap key leaks.");
+
+        BuiltInRoles.SystemServiceAccount.Permissions.ShouldContain(Permission.MachineView);
+        BuiltInRoles.SystemServiceAccount.Permissions.ShouldContain(Permission.MachineCreate);
+        BuiltInRoles.SystemServiceAccount.Permissions.ShouldContain(Permission.MachineEdit);
+    }
+
+    [Fact]
+    public void SystemServiceAccount_DoesNotGrantMachineDelete()
+    {
+        BuiltInRoles.SystemServiceAccount.Permissions.ShouldNotContain(Permission.MachineDelete,
+            customMessage: "Bootstrap key MUST NOT be able to delete machines. " +
+                          "Octopus's registration-token equivalent also withholds Delete.");
+    }
+
+    [Fact]
+    public void SystemServiceAccount_DoesNotGrantDeploymentOrAccountOrEnvironmentPermissions()
+    {
+        var forbidden = new[]
+        {
+            Permission.DeploymentCreate, Permission.DeploymentView,
+            Permission.AccountCreate, Permission.AccountView,
+            Permission.EnvironmentCreate, Permission.EnvironmentView,
+            Permission.TaskCreate, Permission.TaskCancel,
+        };
+
+        foreach (var permission in forbidden)
+        {
+            BuiltInRoles.SystemServiceAccount.Permissions.ShouldNotContain(permission,
+                customMessage: $"SystemServiceAccount must NOT grant {permission}. " +
+                              $"Bootstrap key is single-purpose (machine register) -- adding permissions " +
+                              $"expands what a leaked key can do.");
+        }
+    }
+
+    [Fact]
+    public void SystemServiceAccount_NameAndDescriptionFlagItAsReserved()
+    {
+        // Operator-facing warning: don't assign to humans. Pinned so a future
+        // rename doesn't accidentally drop the warning from the description.
+        BuiltInRoles.SystemServiceAccount.Name.ShouldBe("System Service Account");
+        BuiltInRoles.SystemServiceAccount.Description.ShouldContain("Do NOT assign to human users",
+            customMessage: "Description must explicitly warn against assigning to humans.");
+    }
 }

--- a/tests/Squid.UnitTests/Services/Authorization/PermissionRoleResolverTests.cs
+++ b/tests/Squid.UnitTests/Services/Authorization/PermissionRoleResolverTests.cs
@@ -16,22 +16,39 @@ public class PermissionRoleResolverTests
     [Fact]
     public void GetBuiltInRolesGranting_MachineCreate_ReturnsSpaceOwnerAndEnvironmentManager()
     {
-        // Operator-facing contract pinned: the built-in roles that ship with
-        // MachineCreate permission. Tentacle's PR 2 install-script hint
-        // explicitly names these — drift breaks the operator UX.
+        // Operator-facing contract pinned: the built-in roles operators can SAFELY
+        // assign to humans to grant MachineCreate. Tentacle's install-script hint
+        // and the structured 403 response both surface this exact list.
         //
-        // System Administrator deliberately does NOT have MachineCreate — it's
-        // a system-level role (manage spaces, users, teams), not a space-
-        // resource role. Machines live inside a space, so MachineCreate ships
-        // on space-scoped roles only.
+        // Two deliberate exclusions:
+        // - System Administrator: system-level role (spaces/users/teams), not space-resource
+        // - System Service Account: IsReservedForSystem=true (bootstrap-key only, must not be
+        //   suggested to humans -- defeats least-privilege isolation)
         var roles = PermissionRoleResolver.GetBuiltInRolesGranting(Permission.MachineCreate);
 
         roles.ShouldContain("Environment Manager");
         roles.ShouldContain("Space Owner");
         roles.ShouldNotContain("System Administrator", customMessage:
-            "System Administrator is a system-level role and does not grant space-scoped MachineCreate. " +
-            "If this changed in BuiltInRoles.SystemAdministrator, update the install-script hint AND this test.");
+            "System Administrator is a system-level role and does not grant space-scoped MachineCreate.");
+        roles.ShouldNotContain("System Service Account", customMessage:
+            "System Service Account is IsReservedForSystem=true -- operator-facing hints MUST filter it out. " +
+            "Suggesting it would lead operators to assign a system role to humans, breaking least-privilege.");
         roles.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetBuiltInRolesGranting_IncludeSystemReserved_RevealsSystemServiceAccount()
+    {
+        // Inverse pin: when callers explicitly opt in (internal callers like seeders /
+        // diagnostics), the system-reserved role IS visible. Without this branch the
+        // installation seeder couldn't programmatically find which role to assign to
+        // InternalUser for MachineCreate.
+        var roles = PermissionRoleResolver.GetBuiltInRolesGranting(Permission.MachineCreate, includeSystemReserved: true);
+
+        roles.ShouldContain("Environment Manager");
+        roles.ShouldContain("Space Owner");
+        roles.ShouldContain("System Service Account");
+        roles.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -57,6 +74,8 @@ public class PermissionRoleResolverTests
         hint.ShouldContain("Space Owner");
         hint.ShouldNotContain("System Administrator", customMessage:
             "System Administrator does not grant space-scoped MachineCreate. Suggesting it would mislead operators.");
+        hint.ShouldNotContain("System Service Account", customMessage:
+            "System Service Account is IsReservedForSystem=true -- operator hint must filter it out.");
         // The hint must direct operators to one of two remediation paths.
         hint.ShouldContain("Assign one of these roles");
         hint.ShouldContain("add 'MachineCreate'");


### PR DESCRIPTION
## Summary

Phase 2 of the Tentacle install-script bootstrap-key redesign. **Re-opened after PR #335 was auto-closed when its base (PR #334) merged + deleted its branch.**

\`InternalUserSeeder\` (Order=350) ensures:
- \`user_account\` row id=8888 exists (raw SQL INSERT — EF rejects explicit Id for sequence-default columns)
- "Internal Service Accounts" team exists in space 0 with warning description
- \`SystemServiceAccount\` role assigned to team with \`SpaceId=null\` (cross-space)
- InternalUser is a team member
- Normalises legacy \`display_name='internal_user'\` (from \`001_initial_schema.sql\`) to canonical \`'System'\`

End-to-end integration test \`SeedRuns_InternalUserHasMachineCreatePermission_ViaAuthorizationService\` walks the full \`IAuthorizationService.CheckPermissionAsync\` path — if this passes, register calls carrying InternalUser-owned API keys will pass MachineCreate.

Least-privilege test \`SeedRuns_InternalUserDoesNotHaveMachineDelete\` guards against role widening.

## Test plan

- [x] Unit: 5230/5230 pass
- [x] Integration: 8 new tests pin DB-level invariants
- [x] Build: zero errors
- [x] CI: fix for legacy display_name normalisation merged on this branch (commit \`7b67f8b6\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)