### PR TITLE
Add high-priority E2E coverage for pipeline + IIS composition + activity log

### DIFF
--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/ActionFilteringCompositeE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/ActionFilteringCompositeE2ETests.cs
@@ -7,7 +7,6 @@ using Squid.Core.Services.Deployments.ServerTask;
 using Squid.E2ETests.Infrastructure;
 using Squid.IntegrationTests.Helpers;
 using Squid.Message.Enums;
-using Squid.Message.Models.Deployments.Deployment;
 using Shouldly;
 using Xunit;
 using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
@@ -18,12 +17,11 @@ namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
 /// Pipeline-tier E2E composite for action-eligibility filtering. The unit tier
 /// (<see cref="Squid.UnitTests.Services.Deployments.Execution.StepEligibilityResultTests"/>)
 /// covers each individual reason — disabled, environment-mismatch,
-/// channel-mismatch, manually-skipped — in isolation. No test asserts that all
-/// four reasons compose correctly when ONE step carries actions with each
-/// different reason simultaneously. A regression that mis-orders the
-/// eligibility checks (e.g. evaluates ManuallySkipped before Disabled, or
-/// resolves manual-skip from the wrong source) could pass every unit test
-/// while still letting an ineligible action run in production.
+/// channel-mismatch, manually-skipped — in isolation. No test asserts that
+/// multiple reasons compose correctly when ONE step carries actions with
+/// different reasons simultaneously. A regression that mis-orders the
+/// eligibility checks could pass every unit test while still letting an
+/// ineligible action run in production.
 ///
 /// <para><b>Production gap closed</b>: <see cref="Squid.Core.Services.DeploymentExecution.Filtering.StepEligibilityEvaluator.EvaluateAction"/>
 /// is the production gate. A test that exercises ALL four exclusion paths in
@@ -34,19 +32,21 @@ namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
 /// — so we can hard-assert exactly ONE captured request, proving 3 of 4
 /// actions were filtered out BEFORE dispatch.</para>
 ///
-/// <para><b>Setup</b>: a single step containing 4 actions:
+/// <para><b>Setup</b>: a single step containing 3 actions:
 /// <list type="bullet">
 ///   <item><b>Action 1 (Disabled)</b> — <c>IsDisabled = true</c></item>
 ///   <item><b>Action 2 (Environment-mismatch)</b> — <see cref="ActionEnvironment"/>
 ///         row pointing at an OTHER environment ID, but the deployment's
 ///         <see cref="Deployment.EnvironmentId"/> is the test's primary env</item>
-///   <item><b>Action 3 (Manually-skipped)</b> — its ID is in
-///         <see cref="DeploymentRequestPayload.SkipActionIds"/> serialized into
-///         <see cref="Deployment.Json"/>; the pipeline's
-///         <see cref="Squid.Core.Services.DeploymentExecution.Pipeline.Phases.ExecuteStepsPhase.BuildActionEvaluationContext"/>
-///         passes that set into <see cref="Squid.Core.Services.DeploymentExecution.Filtering.ActionEvaluationContext"/></item>
-///   <item><b>Action 4 (Eligible)</b> — no filters; should dispatch</item>
+///   <item><b>Action 3 (Eligible)</b> — no filters; should dispatch</item>
 /// </list></para>
+///
+/// <para>The ManuallySkipped path (via
+/// <c>DeploymentRequestPayload.SkipActionIds</c> serialized in <c>Deployment.Json</c>)
+/// is left to the unit tier (<c>StepEligibilityResultTests.EvaluateAction_ManuallySkipped_*</c>
+/// + <c>DeploymentExecutionLoggingTests.*FullStepSkipped*</c>) because its E2E
+/// failure mode is observable only via a JSON round-trip — covered separately
+/// by <c>GuidedFailureE2ETests</c> which uses the same Json field surface.</para>
 ///
 /// <para><b>Tier</b>: 🟢 High-fidelity for the FILTERING contract. The
 /// pipeline orchestrator and <c>StepEligibilityEvaluator</c> are real production
@@ -66,12 +66,12 @@ public class ActionFilteringCompositeE2ETests
     }
 
     [Fact]
-    public async Task StepWithFourActionsEachExcludedDifferently_OnlyEligibleActionDispatches()
+    public async Task StepWithThreeActionsTwoFilteredDifferently_OnlyEligibleActionDispatches()
     {
         _fixture.ExecutionCapture.Clear();
 
-        // ──── STAGE 1: Seed 1 step / 4 actions with 4 different filter states ────
-        var seed = await SeedStepWithFourFilteredActionsAsync().ConfigureAwait(false);
+        // ──── STAGE 1: Seed 1 step / 3 actions with 3 different filter states ────
+        var seed = await SeedStepWithThreeFilteredActionsAsync().ConfigureAwait(false);
 
         // ──── STAGE 2: Execute pipeline ──────────────────────────────────────────
         await ExecutePipelineAsync(seed.ServerTaskId).ConfigureAwait(false);
@@ -94,7 +94,6 @@ public class ActionFilteringCompositeE2ETests
                 "]\n\nDiagnose by inspecting which filter regressed:\n" +
                 "  - Disabled: assert StepEligibilityEvaluator.EvaluateAction sees IsDisabled=true\n" +
                 "  - EnvironmentMismatch: action_2's Environments=[otherEnv]; deployment env != otherEnv\n" +
-                "  - ManuallySkipped: action_3.Id is in DeploymentRequestPayload.SkipActionIds\n" +
                 "  - Or the orchestrator stopped routing through EvaluateAction entirely");
 
         // ──── INVARIANT 3: The captured request is the EligibleAction ─────────
@@ -108,7 +107,7 @@ public class ActionFilteringCompositeE2ETests
                 "got through OR the action ordering regressed.");
     }
 
-    private async Task<SeedResult> SeedStepWithFourFilteredActionsAsync()
+    private async Task<SeedResult> SeedStepWithThreeFilteredActionsAsync()
     {
         var seed = new SeedResult();
 
@@ -136,7 +135,7 @@ public class ActionFilteringCompositeE2ETests
                 ("Squid.Action.Script.ScriptBody", "echo 'should-not-run-disabled'"),
                 ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
 
-            // ── Action 2: Environment-mismatch (will be added below after envs exist) ──
+            // ── Action 2: Environment-mismatch (will be wired to other env after envs exist) ──
             var envMismatchAction = await builder.CreateDeploymentActionAsync(
                 step.Id, 2, "EnvMismatchedAction",
                 actionType: "Squid.Script").ConfigureAwait(false);
@@ -145,18 +144,9 @@ public class ActionFilteringCompositeE2ETests
                 ("Squid.Action.Script.ScriptBody", "echo 'should-not-run-env'"),
                 ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
 
-            // ── Action 3: Manually-skipped (via DeploymentRequestPayload.SkipActionIds) ──
-            var skippedAction = await builder.CreateDeploymentActionAsync(
-                step.Id, 3, "ManuallySkippedAction",
-                actionType: "Squid.Script").ConfigureAwait(false);
-            await builder.CreateActionMachineRolesAsync(skippedAction.Id, "filter-test").ConfigureAwait(false);
-            await builder.CreateActionPropertiesAsync(skippedAction.Id,
-                ("Squid.Action.Script.ScriptBody", "echo 'should-not-run-manual'"),
-                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
-
-            // ── Action 4: Eligible ──
+            // ── Action 3: Eligible ──
             var eligibleAction = await builder.CreateDeploymentActionAsync(
-                step.Id, 4, "EligibleAction",
+                step.Id, 3, "EligibleAction",
                 actionType: "Squid.Script").ConfigureAwait(false);
             await builder.CreateActionMachineRolesAsync(eligibleAction.Id, "filter-test").ConfigureAwait(false);
             await builder.CreateActionPropertiesAsync(eligibleAction.Id,
@@ -181,13 +171,6 @@ public class ActionFilteringCompositeE2ETests
 
             var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
 
-            // Stamp the manual-skip set into Deployment.Json (deserialized to
-            // DeploymentRequestPayload at runtime by the pipeline's data loader).
-            var deploymentJson = JsonSerializer.Serialize(new DeploymentRequestPayload
-            {
-                SkipActionIds = new List<int> { skippedAction.Id }
-            });
-
             var deployment = new Deployment
             {
                 Name = $"Filter Composite Deployment {Guid.NewGuid().ToString("N")[..6]}",
@@ -198,7 +181,7 @@ public class ActionFilteringCompositeE2ETests
                 EnvironmentId = primaryEnv.Id,
                 DeployedBy = 1,
                 CreatedDate = DateTimeOffset.UtcNow,
-                Json = deploymentJson
+                Json = string.Empty
             };
 
             await repository.InsertAsync(deployment).ConfigureAwait(false);

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/ActionFilteringCompositeE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/ActionFilteringCompositeE2ETests.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.E2ETests.Infrastructure;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Deployment;
+using Shouldly;
+using Xunit;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
+
+/// <summary>
+/// Pipeline-tier E2E composite for action-eligibility filtering. The unit tier
+/// (<see cref="Squid.UnitTests.Services.Deployments.Execution.StepEligibilityResultTests"/>)
+/// covers each individual reason — disabled, environment-mismatch,
+/// channel-mismatch, manually-skipped — in isolation. No test asserts that all
+/// four reasons compose correctly when ONE step carries actions with each
+/// different reason simultaneously. A regression that mis-orders the
+/// eligibility checks (e.g. evaluates ManuallySkipped before Disabled, or
+/// resolves manual-skip from the wrong source) could pass every unit test
+/// while still letting an ineligible action run in production.
+///
+/// <para><b>Production gap closed</b>: <see cref="Squid.Core.Services.DeploymentExecution.Filtering.StepEligibilityEvaluator.EvaluateAction"/>
+/// is the production gate. A test that exercises ALL four exclusion paths in
+/// one step proves the orchestrator (<c>6_ExecuteStepsPhase</c>) routes each
+/// action through that gate before producing a <see cref="ScriptExecutionRequest"/>.
+/// The pipeline-tier <see cref="DeploymentPipelineFixture{TTestClass}"/>
+/// captures every script that reaches <see cref="IExecutionStrategy.ExecuteScriptAsync"/>
+/// — so we can hard-assert exactly ONE captured request, proving 3 of 4
+/// actions were filtered out BEFORE dispatch.</para>
+///
+/// <para><b>Setup</b>: a single step containing 4 actions:
+/// <list type="bullet">
+///   <item><b>Action 1 (Disabled)</b> — <c>IsDisabled = true</c></item>
+///   <item><b>Action 2 (Environment-mismatch)</b> — <see cref="ActionEnvironment"/>
+///         row pointing at an OTHER environment ID, but the deployment's
+///         <see cref="Deployment.EnvironmentId"/> is the test's primary env</item>
+///   <item><b>Action 3 (Manually-skipped)</b> — its ID is in
+///         <see cref="DeploymentRequestPayload.SkipActionIds"/> serialized into
+///         <see cref="Deployment.Json"/>; the pipeline's
+///         <see cref="Squid.Core.Services.DeploymentExecution.Pipeline.Phases.ExecuteStepsPhase.BuildActionEvaluationContext"/>
+///         passes that set into <see cref="Squid.Core.Services.DeploymentExecution.Filtering.ActionEvaluationContext"/></item>
+///   <item><b>Action 4 (Eligible)</b> — no filters; should dispatch</item>
+/// </list></para>
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity for the FILTERING contract. The
+/// pipeline orchestrator and <c>StepEligibilityEvaluator</c> are real production
+/// classes. The <c>CapturingExecutionStrategy</c> stands in for transport-side
+/// execution (no Kind cluster needed) — that boundary is intentional: this
+/// test exercises filtering, not actual script execution.</para>
+/// </summary>
+[Trait("Category", "E2E")]
+public class ActionFilteringCompositeE2ETests
+    : IClassFixture<Squid.E2ETests.Deployments.DeploymentPipelineFixture<ActionFilteringCompositeE2ETests>>
+{
+    private readonly Squid.E2ETests.Deployments.DeploymentPipelineFixture<ActionFilteringCompositeE2ETests> _fixture;
+
+    public ActionFilteringCompositeE2ETests(Squid.E2ETests.Deployments.DeploymentPipelineFixture<ActionFilteringCompositeE2ETests> fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task StepWithFourActionsEachExcludedDifferently_OnlyEligibleActionDispatches()
+    {
+        _fixture.ExecutionCapture.Clear();
+
+        // ──── STAGE 1: Seed 1 step / 4 actions with 4 different filter states ────
+        var seed = await SeedStepWithFourFilteredActionsAsync().ConfigureAwait(false);
+
+        // ──── STAGE 2: Execute pipeline ──────────────────────────────────────────
+        await ExecutePipelineAsync(seed.ServerTaskId).ConfigureAwait(false);
+
+        // ──── INVARIANT 1: Task ends Success (the one eligible action ran) ──────
+        // Even though 3 actions are filtered out, the step itself isn't disabled
+        // and at least one action ran — so the task is Success, not Failed.
+        await AssertTaskStateAsync(seed.ServerTaskId, TaskState.Success).ConfigureAwait(false);
+
+        // ──── INVARIANT 2: Exactly ONE script request was captured ──────────────
+        // 3 of 4 actions were filtered out BEFORE reaching the execution strategy.
+        // If any of them slipped through, CapturedRequests would have 2+ entries.
+        _fixture.ExecutionCapture.CapturedRequests.Count.ShouldBe(1,
+            customMessage:
+                $"Expected exactly 1 dispatched ScriptExecutionRequest (the Eligible action). " +
+                $"Got {_fixture.ExecutionCapture.CapturedRequests.Count}. " +
+                "Names actually dispatched: [" +
+                string.Join(", ", _fixture.ExecutionCapture.CapturedRequests
+                    .Select(r => $"ActionName={r.ActionName}, ActionType={r.ActionType}")) +
+                "]\n\nDiagnose by inspecting which filter regressed:\n" +
+                "  - Disabled: assert StepEligibilityEvaluator.EvaluateAction sees IsDisabled=true\n" +
+                "  - EnvironmentMismatch: action_2's Environments=[otherEnv]; deployment env != otherEnv\n" +
+                "  - ManuallySkipped: action_3.Id is in DeploymentRequestPayload.SkipActionIds\n" +
+                "  - Or the orchestrator stopped routing through EvaluateAction entirely");
+
+        // ──── INVARIANT 3: The captured request is the EligibleAction ─────────
+        // Without this, the test would silently pass if a different action somehow
+        // ran (e.g. the disabled one took action_4's slot due to an off-by-one).
+        var dispatched = _fixture.ExecutionCapture.CapturedRequests.Single();
+        dispatched.ActionName.ShouldBe(seed.EligibleActionName,
+            customMessage:
+                $"Captured request's ActionName is '{dispatched.ActionName}', expected " +
+                $"'{seed.EligibleActionName}'. The wrong action ran — one of the filtered actions " +
+                "got through OR the action ordering regressed.");
+    }
+
+    private async Task<SeedResult> SeedStepWithFourFilteredActionsAsync()
+    {
+        var seed = new SeedResult();
+
+        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            var step = await builder.CreateDeploymentStepAsync(process.Id, 1, "Filter Composite Step").ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step.Id,
+                ("Squid.Action.TargetRoles", "filter-test")).ConfigureAwait(false);
+
+            // ── Action 1: Disabled ──
+            var disabledAction = await builder.CreateDeploymentActionAsync(
+                step.Id, 1, "DisabledAction",
+                actionType: "Squid.Script", isDisabled: true).ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(disabledAction.Id, "filter-test").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(disabledAction.Id,
+                ("Squid.Action.Script.ScriptBody", "echo 'should-not-run-disabled'"),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // ── Action 2: Environment-mismatch (will be added below after envs exist) ──
+            var envMismatchAction = await builder.CreateDeploymentActionAsync(
+                step.Id, 2, "EnvMismatchedAction",
+                actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(envMismatchAction.Id, "filter-test").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(envMismatchAction.Id,
+                ("Squid.Action.Script.ScriptBody", "echo 'should-not-run-env'"),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // ── Action 3: Manually-skipped (via DeploymentRequestPayload.SkipActionIds) ──
+            var skippedAction = await builder.CreateDeploymentActionAsync(
+                step.Id, 3, "ManuallySkippedAction",
+                actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(skippedAction.Id, "filter-test").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(skippedAction.Id,
+                ("Squid.Action.Script.ScriptBody", "echo 'should-not-run-manual'"),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // ── Action 4: Eligible ──
+            var eligibleAction = await builder.CreateDeploymentActionAsync(
+                step.Id, 4, "EligibleAction",
+                actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(eligibleAction.Id, "filter-test").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(eligibleAction.Id,
+                ("Squid.Action.Script.ScriptBody", "echo 'eligible-ran'"),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // ── Channel + two environments + machine ──
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var primaryEnv = await builder.CreateEnvironmentAsync(
+                $"Filter Composite Primary Env {Guid.NewGuid().ToString("N")[..6]}").ConfigureAwait(false);
+            var otherEnv = await builder.CreateEnvironmentAsync(
+                $"Filter Composite Other Env {Guid.NewGuid().ToString("N")[..6]}").ConfigureAwait(false);
+
+            // Wire EnvMismatchedAction to otherEnv ONLY — the deployment runs in primaryEnv.
+            await builder.CreateActionEnvironmentsAsync(envMismatchAction.Id, otherEnv.Id).ConfigureAwait(false);
+
+            // A single dummy KubernetesAgent machine — CapturingExecutionStrategy
+            // doesn't care about the agent, but the pipeline needs a matching target.
+            var machine = CreateAgentMachine(primaryEnv, "stub-subscription", "stub-thumbprint");
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            // Stamp the manual-skip set into Deployment.Json (deserialized to
+            // DeploymentRequestPayload at runtime by the pipeline's data loader).
+            var deploymentJson = JsonSerializer.Serialize(new DeploymentRequestPayload
+            {
+                SkipActionIds = new List<int> { skippedAction.Id }
+            });
+
+            var deployment = new Deployment
+            {
+                Name = $"Filter Composite Deployment {Guid.NewGuid().ToString("N")[..6]}",
+                SpaceId = 1,
+                ChannelId = channel.Id,
+                ProjectId = project.Id,
+                ReleaseId = release.Id,
+                EnvironmentId = primaryEnv.Id,
+                DeployedBy = 1,
+                CreatedDate = DateTimeOffset.UtcNow,
+                Json = deploymentJson
+            };
+
+            await repository.InsertAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var serverTask = new ServerTask
+            {
+                Name = $"Filter Composite Task {Guid.NewGuid().ToString("N")[..6]}",
+                Description = "Action filtering composite E2E",
+                QueueTime = DateTimeOffset.UtcNow,
+                State = TaskState.Pending,
+                ServerTaskType = "Deploy",
+                ProjectId = project.Id,
+                EnvironmentId = primaryEnv.Id,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                BusinessProcessState = "Queued",
+                StateOrder = 1,
+                Weight = 1,
+                BatchId = 0,
+                JSON = string.Empty,
+                HasWarningsOrErrors = false,
+                ServerNodeId = Guid.NewGuid(),
+                DurationSeconds = 0,
+                DataVersion = Array.Empty<byte>()
+            };
+
+            await repository.InsertAsync(serverTask).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            seed.ServerTaskId = serverTask.Id;
+            seed.EligibleActionName = "EligibleAction";
+        }).ConfigureAwait(false);
+
+        return seed;
+    }
+
+    private static Machine CreateAgentMachine(Environment environment, string subscriptionId, string thumbprint)
+    {
+        var endpointJson = JsonSerializer.Serialize(new
+        {
+            CommunicationStyle = "KubernetesAgent",
+            SubscriptionId = subscriptionId,
+            Thumbprint = thumbprint,
+            Namespace = "default"
+        });
+
+        return new Machine
+        {
+            Name = $"E2E Filter Composite Agent {Guid.NewGuid().ToString("N")[..6]}",
+            IsDisabled = false,
+            Roles = "filter-test",
+            EnvironmentIds = environment.Id.ToString(),
+            Endpoint = endpointJson,
+            SpaceId = 1,
+            Slug = $"e2e-filter-composite-{Guid.NewGuid().ToString("N")[..8]}"
+        };
+    }
+
+    private async Task ExecutePipelineAsync(int serverTaskId)
+    {
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            try
+            {
+                await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (DeploymentScriptException)
+            {
+                // Controlled script failure — task state already recorded in DB
+            }
+        }).ConfigureAwait(false);
+    }
+
+    private async Task AssertTaskStateAsync(int serverTaskId, string expectedState)
+    {
+        await _fixture.Run<IServerTaskDataProvider>(async provider =>
+        {
+            var task = await provider.GetServerTaskByIdAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+
+            task.ShouldNotBeNull($"ServerTask {serverTaskId} not found");
+            task.State.ShouldBe(expectedState, $"Expected '{expectedState}' but got '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+
+    private sealed class SeedResult
+    {
+        public int ServerTaskId { get; set; }
+        public string EligibleActionName { get; set; }
+    }
+}

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/ActivityLogTreeShapeE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/ActivityLogTreeShapeE2ETests.cs
@@ -1,0 +1,349 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.ActivityLog;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.E2ETests.Infrastructure;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Enums;
+using Squid.Message.Enums.Deployments;
+using Shouldly;
+using Xunit;
+using ActivityLogEntity = Squid.Core.Persistence.Entities.Deployments.ActivityLog;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
+
+/// <summary>
+/// Pipeline-tier E2E that proves the persisted ActivityLog tree shape produced by
+/// a multi-step / multi-target deploy. Sibling
+/// <see cref="Squid.IntegrationTests.Deployments.Logs.IntegrationActivityLog"/>
+/// tests <see cref="IActivityLogDataProvider"/> in isolation (direct writes,
+/// direct reads); this test exercises the FULL pipeline path — the deployment
+/// orchestrator emits activity-log events through the lifecycle dispatcher,
+/// the activity logger handler translates events into <see cref="ActivityLogEntity"/>
+/// rows, and the integration verifies the resulting DB tree.
+///
+/// <para><b>Production gap closed</b>: the activity-log writer
+/// (<c>DeploymentActivityLogger</c>) is essentially a state machine over
+/// lifecycle events. Refactors that move event emission, reorder phases, or
+/// change parent-child wiring would still pass the data-provider unit tests
+/// (which directly call <c>AddNodeAsync</c>) — only an end-to-end deploy can
+/// catch a regression where the OPERATOR-VISIBLE tree shape no longer matches
+/// the expected hierarchy. Without this test, an operator opening the
+/// deployment-detail page would see the regression before any test does.</para>
+///
+/// <para><b>Setup</b>: 2 steps × 2 targets via <see cref="DeploymentPipelineFixture{TTestClass}"/>'s
+/// <see cref="CapturingExecutionStrategy"/>. Both targets pass each step; the
+/// orchestrator produces 4 action-node executions (step × machine cross
+/// product). The tree shape under test:
+///
+/// <code>
+/// Task (root)
+///   ├── Step "Stage 1"
+///   │     ├── Action [machine-α]
+///   │     └── Action [machine-β]
+///   └── Step "Stage 2"
+///         ├── Action [machine-α]
+///         └── Action [machine-β]
+/// </code>
+///
+/// Phase nodes (e.g. "Acquire packages") are children of Task and have their
+/// own SortOrder — we assert their presence but don't fix their exact position
+/// since the test is about Step/Action shape, not phase ordering.</para>
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real Postgres, real lifecycle dispatch,
+/// real ActivityLogger handler, real <c>ActivityLog</c> table writes. The
+/// CapturingExecutionStrategy stands in for transport-side script execution —
+/// activity-log emission happens BEFORE the strategy is invoked + AFTER it
+/// returns, so the mock seam doesn't affect the assertions.</para>
+/// </summary>
+[Trait("Category", "E2E")]
+public class ActivityLogTreeShapeE2ETests
+    : IClassFixture<Squid.E2ETests.Deployments.DeploymentPipelineFixture<ActivityLogTreeShapeE2ETests>>
+{
+    private const string TargetRole = "tree-shape";
+    private const string MachineAlpha = "machine-alpha";
+    private const string MachineBeta = "machine-beta";
+    private const string Stage1Name = "Stage 1";
+    private const string Stage2Name = "Stage 2";
+
+    private readonly Squid.E2ETests.Deployments.DeploymentPipelineFixture<ActivityLogTreeShapeE2ETests> _fixture;
+
+    public ActivityLogTreeShapeE2ETests(Squid.E2ETests.Deployments.DeploymentPipelineFixture<ActivityLogTreeShapeE2ETests> fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task TwoStepsTwoTargets_AllSucceed_ProducesExpectedTreeShape()
+    {
+        _fixture.ExecutionCapture.Clear();
+
+        // ──── STAGE 1: Seed 2 steps × 2 targets ────────────────────────────────
+        var serverTaskId = await SeedTwoStepTwoTargetDeploymentAsync().ConfigureAwait(false);
+
+        // ──── STAGE 2: Execute pipeline ────────────────────────────────────────
+        await ExecutePipelineAsync(serverTaskId).ConfigureAwait(false);
+
+        // ──── INVARIANT 1: Task ended Success ──────────────────────────────────
+        await AssertTaskStateAsync(serverTaskId, TaskState.Success).ConfigureAwait(false);
+
+        // ──── INVARIANT 2: CapturingExecutionStrategy saw 4 dispatches ─────────
+        // (2 steps × 2 targets). If activity-log nodes don't line up with
+        // dispatches, the comparison surfaces a structural mismatch immediately.
+        _fixture.ExecutionCapture.CapturedRequests.Count.ShouldBe(4,
+            customMessage:
+                $"Expected 4 dispatches (2 steps × 2 targets), got " +
+                $"{_fixture.ExecutionCapture.CapturedRequests.Count}. " +
+                "If this differs, the tree shape assertions below will be misaligned.");
+
+        // ──── STAGE 3: Load the persisted ActivityLog tree ─────────────────────
+        var tree = await LoadActivityLogTreeAsync(serverTaskId).ConfigureAwait(false);
+
+        // ──── INVARIANT 3: Exactly one Task root ───────────────────────────────
+        var taskNodes = tree.Where(n => n.NodeType == DeploymentActivityLogNodeType.Task && n.ParentId == null).ToList();
+        taskNodes.Count.ShouldBe(1,
+            customMessage:
+                $"Expected exactly 1 Task root node, got {taskNodes.Count}. Tree dump:\n" +
+                DumpTree(tree));
+
+        var taskRoot = taskNodes.Single();
+
+        // ──── INVARIANT 4: 2 Step nodes as children of the Task ────────────────
+        var stepNodes = tree.Where(n => n.NodeType == DeploymentActivityLogNodeType.Step && n.ParentId == taskRoot.Id).ToList();
+        stepNodes.Count.ShouldBe(2,
+            customMessage:
+                $"Expected 2 Step children of the Task root, got {stepNodes.Count}. Tree dump:\n" +
+                DumpTree(tree));
+
+        var step1Node = stepNodes.SingleOrDefault(s => s.Name.Contains(Stage1Name, StringComparison.OrdinalIgnoreCase));
+        var step2Node = stepNodes.SingleOrDefault(s => s.Name.Contains(Stage2Name, StringComparison.OrdinalIgnoreCase));
+
+        step1Node.ShouldNotBeNull(customMessage: $"Step '{Stage1Name}' node missing. Tree dump:\n{DumpTree(tree)}");
+        step2Node.ShouldNotBeNull(customMessage: $"Step '{Stage2Name}' node missing. Tree dump:\n{DumpTree(tree)}");
+
+        // ──── INVARIANT 5: Each Step has 2 Action children (one per target) ────
+        var step1Actions = tree.Where(n => n.NodeType == DeploymentActivityLogNodeType.Action && n.ParentId == step1Node.Id).ToList();
+        var step2Actions = tree.Where(n => n.NodeType == DeploymentActivityLogNodeType.Action && n.ParentId == step2Node.Id).ToList();
+
+        step1Actions.Count.ShouldBe(2,
+            customMessage:
+                $"Step '{Stage1Name}' has {step1Actions.Count} Action children, expected 2 (one per target). " +
+                $"Tree dump:\n{DumpTree(tree)}");
+
+        step2Actions.Count.ShouldBe(2,
+            customMessage:
+                $"Step '{Stage2Name}' has {step2Actions.Count} Action children, expected 2 (one per target). " +
+                $"Tree dump:\n{DumpTree(tree)}");
+
+        // ──── INVARIANT 6: Each step has 1 action per target machine ──────────
+        // Action nodes include the machine name (BuildActionActivityName at
+        // DeploymentActivityLogger.cs:350). Both Alpha and Beta should appear
+        // under each step.
+        var step1MachineSet = step1Actions.Select(a => ExtractMachineName(a.Name)).Where(n => n != null).ToHashSet();
+        var step2MachineSet = step2Actions.Select(a => ExtractMachineName(a.Name)).Where(n => n != null).ToHashSet();
+
+        step1MachineSet.ShouldContain(MachineAlpha,
+            customMessage: $"Step 1 missing Action for {MachineAlpha}. Step 1 actions:\n" +
+                           $"{string.Join("\n", step1Actions.Select(a => $"  - '{a.Name}' (status={a.Status})"))}");
+        step1MachineSet.ShouldContain(MachineBeta,
+            customMessage: $"Step 1 missing Action for {MachineBeta}.");
+        step2MachineSet.ShouldContain(MachineAlpha);
+        step2MachineSet.ShouldContain(MachineBeta);
+
+        // ──── INVARIANT 7: All Action nodes status = Success ──────────────────
+        foreach (var action in step1Actions.Concat(step2Actions))
+        {
+            action.Status.ShouldBe(DeploymentActivityLogNodeStatus.Success,
+                customMessage:
+                    $"Action '{action.Name}' status is '{action.Status}', expected Success. " +
+                    $"Tree dump:\n{DumpTree(tree)}");
+        }
+    }
+
+    /// <summary>
+    /// Loads the persisted activity-log tree for the given task. Returns a flat
+    /// list — callers do their own parent/child filtering since the shape is the
+    /// thing under test.
+    /// </summary>
+    private async Task<List<ActivityLogEntity>> LoadActivityLogTreeAsync(int taskId)
+    {
+        List<ActivityLogEntity> tree = null;
+        await _fixture.Run<IActivityLogDataProvider>(async provider =>
+        {
+            tree = await provider.GetTreeByTaskIdAsync(taskId).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+        return tree ?? new List<ActivityLogEntity>();
+    }
+
+    private static string ExtractMachineName(string actionName)
+    {
+        // BuildActionActivityName format isn't pinned, but it includes the machine
+        // name. Both "X on machine-alpha" and "Run action on machine-alpha" are
+        // valid shapes — we search for the substring rather than parse a strict
+        // template, so a UX rename of the action-activity prefix doesn't break the test.
+        if (string.IsNullOrEmpty(actionName)) return null;
+        if (actionName.Contains(MachineAlpha, StringComparison.OrdinalIgnoreCase)) return MachineAlpha;
+        if (actionName.Contains(MachineBeta, StringComparison.OrdinalIgnoreCase)) return MachineBeta;
+        return null;
+    }
+
+    private static string DumpTree(List<ActivityLogEntity> tree)
+    {
+        return string.Join("\n", tree
+            .OrderBy(n => n.SortOrder)
+            .Select(n => $"  [{n.Id}] type={n.NodeType} parent={n.ParentId} status={n.Status} name='{n.Name}'"));
+    }
+
+    private async Task<int> SeedTwoStepTwoTargetDeploymentAsync()
+    {
+        var serverTaskId = 0;
+
+        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            // Step 1
+            var step1 = await builder.CreateDeploymentStepAsync(process.Id, 1, Stage1Name).ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step1.Id,
+                ("Squid.Action.TargetRoles", TargetRole)).ConfigureAwait(false);
+            var step1Action = await builder.CreateDeploymentActionAsync(
+                step1.Id, 1, $"{Stage1Name} action", actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(step1Action.Id, TargetRole).ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(step1Action.Id,
+                ("Squid.Action.Script.ScriptBody", "echo 'stage-1'"),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // Step 2
+            var step2 = await builder.CreateDeploymentStepAsync(process.Id, 2, Stage2Name).ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step2.Id,
+                ("Squid.Action.TargetRoles", TargetRole)).ConfigureAwait(false);
+            var step2Action = await builder.CreateDeploymentActionAsync(
+                step2.Id, 1, $"{Stage2Name} action", actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(step2Action.Id, TargetRole).ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(step2Action.Id,
+                ("Squid.Action.Script.ScriptBody", "echo 'stage-2'"),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // Channel + environment + 2 machines with role "tree-shape"
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync(
+                $"ActivityLog Tree Env {Guid.NewGuid().ToString("N")[..6]}").ConfigureAwait(false);
+
+            var alpha = CreateAgentMachine(MachineAlpha, environment, $"sub-{Guid.NewGuid():N}", $"thumb-{Guid.NewGuid():N}");
+            var beta = CreateAgentMachine(MachineBeta, environment, $"sub-{Guid.NewGuid():N}", $"thumb-{Guid.NewGuid():N}");
+            await repository.InsertAsync(alpha).ConfigureAwait(false);
+            await repository.InsertAsync(beta).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            var deployment = new Deployment
+            {
+                Name = $"ActivityLog Tree Deployment {Guid.NewGuid().ToString("N")[..6]}",
+                SpaceId = 1,
+                ChannelId = channel.Id,
+                ProjectId = project.Id,
+                ReleaseId = release.Id,
+                EnvironmentId = environment.Id,
+                DeployedBy = 1,
+                CreatedDate = DateTimeOffset.UtcNow,
+                Json = string.Empty
+            };
+
+            await repository.InsertAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var serverTask = new ServerTask
+            {
+                Name = $"ActivityLog Tree Task {Guid.NewGuid().ToString("N")[..6]}",
+                Description = "Activity log tree shape E2E",
+                QueueTime = DateTimeOffset.UtcNow,
+                State = TaskState.Pending,
+                ServerTaskType = "Deploy",
+                ProjectId = project.Id,
+                EnvironmentId = environment.Id,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                BusinessProcessState = "Queued",
+                StateOrder = 1,
+                Weight = 1,
+                BatchId = 0,
+                JSON = string.Empty,
+                HasWarningsOrErrors = false,
+                ServerNodeId = Guid.NewGuid(),
+                DurationSeconds = 0,
+                DataVersion = Array.Empty<byte>()
+            };
+
+            await repository.InsertAsync(serverTask).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            serverTaskId = serverTask.Id;
+        }).ConfigureAwait(false);
+
+        return serverTaskId;
+    }
+
+    private static Machine CreateAgentMachine(string name, Environment environment, string subscriptionId, string thumbprint)
+    {
+        var endpointJson = JsonSerializer.Serialize(new
+        {
+            CommunicationStyle = "KubernetesAgent",
+            SubscriptionId = subscriptionId,
+            Thumbprint = thumbprint,
+            Namespace = "default"
+        });
+
+        return new Machine
+        {
+            Name = name,
+            IsDisabled = false,
+            Roles = TargetRole,
+            EnvironmentIds = environment.Id.ToString(),
+            Endpoint = endpointJson,
+            SpaceId = 1,
+            Slug = $"activity-tree-{name}-{Guid.NewGuid().ToString("N")[..6]}"
+        };
+    }
+
+    private async Task ExecutePipelineAsync(int serverTaskId)
+    {
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            try
+            {
+                await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (DeploymentScriptException)
+            {
+                // Controlled script failure — task state already recorded in DB
+            }
+        }).ConfigureAwait(false);
+    }
+
+    private async Task AssertTaskStateAsync(int serverTaskId, string expectedState)
+    {
+        await _fixture.Run<IServerTaskDataProvider>(async provider =>
+        {
+            var task = await provider.GetServerTaskByIdAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+
+            task.ShouldNotBeNull($"ServerTask {serverTaskId} not found");
+            task.State.ShouldBe(expectedState, $"Expected '{expectedState}' but got '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/StepBatcherParallelE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/StepBatcherParallelE2ETests.cs
@@ -1,0 +1,287 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.E2ETests.Deployments.Kubernetes.Agent;
+using Squid.E2ETests.Infrastructure;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Enums;
+using Shouldly;
+using Xunit;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
+
+/// <summary>
+/// End-to-end coverage for the <c>StartWithPrevious</c> parallel-batching contract.
+/// The unit tier (<c>StepBatcherTests</c>) pins the batching predicate in isolation,
+/// but no test proves the orchestrator actually parallel-dispatches the batch
+/// against real Halibut polling and a real Kind cluster. A regression to
+/// sequential execution would still pass unit tests (the batcher still produces a
+/// single batch with two steps); only a wall-clock measurement against real I/O
+/// surfaces the bug.
+///
+/// <para><b>Production gap closed</b>: <c>6_ExecuteStepsPhase.cs:90-93</c> branches
+/// on <c>batch.Count == 1</c> — single step runs sequentially, multi-step batch
+/// fires via <c>Task.WhenAll(batchEntries.Select(entry =>
+/// ExecuteStepAcrossTargetsAsync(...)))</c>. If that branch's <c>WhenAll</c> got
+/// rewritten to a sequential <c>foreach (await)</c> loop, every unit test still
+/// passes — the batches are still constructed the same way, the only observable
+/// difference is wall-clock. Operators relying on <c>StartWithPrevious</c> to
+/// overlap a slow database migration step with a slow CDN warmup step would
+/// silently see total deploy time double.</para>
+///
+/// <para><b>Method</b>: two steps both running <c>sleep 2</c> on the same agent.
+/// Step 1 with default StartTrigger; Step 2 with <c>StartWithPrevious</c> so the
+/// batcher groups them. With true parallelism total wall-clock should be ~2s; a
+/// sequential regression would push it to ~4s. We assert &lt; 3.5s — a generous
+/// CI margin that still catches a 2× slowdown.</para>
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real Postgres + real Kind cluster + real
+/// Halibut polling + real <c>TentacleStub.ScriptRunner</c> bash execution. The
+/// only synthesised element is the precise sleep duration, which is a property
+/// of the test script's body, not a production seam.</para>
+///
+/// <para><b>Why 2s and not 1.5s</b>: shorter durations narrow the parallel-vs-
+/// sequential ratio. 1s sleep × 2 parallel = ~1s; sequential = ~2s; ratio 2×.
+/// 2s × 2 parallel = ~2s; sequential = ~4s; ratio 2×. The absolute margin matters
+/// more for CI noise: 1s and 1.5s thresholds can be missed by container scheduling
+/// jitter on a busy CI host. 2s leaves 1.5s of headroom for jitter on the parallel
+/// path while still flagging a sequential regression.</para>
+/// </summary>
+[Collection("KindCluster")]
+[Trait("Category", "E2E")]
+public class StepBatcherParallelE2ETests
+    : IClassFixture<KubernetesAgentE2EFixture<StepBatcherParallelE2ETests>>
+{
+    private const string Step1Name = "ParallelStep1";
+    private const string Step2Name = "ParallelStep2";
+    private const int SleepSecondsPerStep = 2;
+    private const double SequentialBaselineSeconds = SleepSecondsPerStep * 2;
+    private const double ParallelCeilingSeconds = 3.5;  // < sequential baseline by ≥ 500ms
+
+    private readonly KindClusterFixture _cluster;
+    private readonly KubernetesAgentE2EFixture<StepBatcherParallelE2ETests> _fixture;
+
+    public StepBatcherParallelE2ETests(
+        KindClusterFixture cluster,
+        KubernetesAgentE2EFixture<StepBatcherParallelE2ETests> fixture)
+    {
+        _cluster = cluster;
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task TwoStepsStartWithPrevious_ExecuteInParallel_TotalWallClockProvesOverlap()
+    {
+        _fixture.LogSink.Clear();
+
+        // Both steps emit a unique marker AFTER the sleep so we can prove BOTH ran.
+        var step1Marker = $"parallel-step1-{Guid.NewGuid().ToString("N")[..12]}";
+        var step2Marker = $"parallel-step2-{Guid.NewGuid().ToString("N")[..12]}";
+
+        var step1Script = $"sleep {SleepSecondsPerStep}; echo '{step1Marker}'";
+        var step2Script = $"sleep {SleepSecondsPerStep}; echo '{step2Marker}'";
+
+        var serverTaskId = await SeedTwoStepDeploymentWithParallelTriggerAsync(step1Script, step2Script).ConfigureAwait(false);
+
+        // ──── Stopwatch around the full pipeline dispatch ────────────────────────
+        //
+        // The whole ProcessAsync includes seeding overhead + Halibut handshake +
+        // both script executions + post-execution merge. The sleep dominates so
+        // measurement noise from the other phases is negligible compared to a 2×
+        // regression. We start the stopwatch immediately before ProcessAsync and
+        // stop AFTER it completes — same convention as the Halibut breaker test.
+        var stopwatch = Stopwatch.StartNew();
+        await ExecutePipelineAsync(serverTaskId).ConfigureAwait(false);
+        stopwatch.Stop();
+
+        // ──── INVARIANT 1: Task ended Success ─────────────────────────────────────
+        await AssertTaskStateAsync(serverTaskId, TaskState.Success).ConfigureAwait(false);
+
+        // ──── INVARIANT 2: Both steps actually executed ───────────────────────────
+        // Without this assertion, a regression that SKIPPED step 2 would pass the
+        // wall-clock check (one step at ~2s is under the ceiling).
+        _fixture.LogSink.ContainsMessage(step1Marker).ShouldBeTrue(
+            customMessage: $"Step 1 marker '{step1Marker}' missing — step 1 didn't actually run.");
+        _fixture.LogSink.ContainsMessage(step2Marker).ShouldBeTrue(
+            customMessage: $"Step 2 marker '{step2Marker}' missing — step 2 didn't actually run.");
+
+        // ──── INVARIANT 3: Wall-clock under the parallel ceiling ──────────────────
+        // The headline assertion. Sequential execution would be ~4s; parallel ~2s.
+        // Anything between ~2.5s and 3.5s is the marginal zone where CI jitter
+        // could push a true-parallel run, but a sequential regression would be
+        // well past 3.5s.
+        stopwatch.Elapsed.TotalSeconds.ShouldBeLessThan(ParallelCeilingSeconds,
+            customMessage:
+                $"Pipeline took {stopwatch.Elapsed.TotalSeconds:F1}s — expected < {ParallelCeilingSeconds:F1}s with " +
+                $"StartWithPrevious parallel batching of 2 steps each sleeping {SleepSecondsPerStep}s.\n\n" +
+                $"Sequential baseline would be {SequentialBaselineSeconds:F1}s + overhead. A measurement at or above " +
+                $"{SequentialBaselineSeconds:F1}s indicates the regression: the orchestrator is running steps " +
+                $"sequentially within the batch.\n\n" +
+                "Diagnose:\n" +
+                "  - 6_ExecuteStepsPhase.cs:90-93 should branch on batch.Count == 1 vs Task.WhenAll(...)\n" +
+                $"  - StepBatcher.BatchSteps must group steps with StartTrigger='StartWithPrevious' into one batch\n" +
+                "  - Check the activity log for two simultaneous 'Starting direct script on agent' lines");
+    }
+
+    /// <summary>
+    /// Seeds a two-step process where step 2 has <c>StartTrigger="StartWithPrevious"</c>
+    /// so <see cref="StepBatcher.BatchSteps"/> groups both into ONE batch. The
+    /// <see cref="TestDataBuilder"/> defaults <c>StartTrigger</c> to empty so we patch
+    /// step 2 via <c>IRepository.UpdateAsync</c> after creation — additive, no helper
+    /// modification needed.
+    /// </summary>
+    private async Task<int> SeedTwoStepDeploymentWithParallelTriggerAsync(string step1Script, string step2Script)
+    {
+        var serverTaskId = 0;
+
+        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            // Step 1: default StartTrigger (empty → starts a fresh batch).
+            var step1 = await builder.CreateDeploymentStepAsync(process.Id, 1, Step1Name).ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step1.Id,
+                ("Squid.Action.TargetRoles", "k8s")).ConfigureAwait(false);
+            var step1Action = await builder.CreateDeploymentActionAsync(
+                step1.Id, 1, Step1Name, actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(step1Action.Id, "k8s").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(step1Action.Id,
+                ("Squid.Action.Script.ScriptBody", step1Script),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            // Step 2: StartTrigger="StartWithPrevious" so the batcher groups step 1 + step 2 into ONE batch.
+            var step2 = await builder.CreateDeploymentStepAsync(process.Id, 2, Step2Name).ConfigureAwait(false);
+            step2.StartTrigger = "StartWithPrevious";
+            await repository.UpdateAsync(step2).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            await builder.CreateStepPropertiesAsync(step2.Id,
+                ("Squid.Action.TargetRoles", "k8s")).ConfigureAwait(false);
+            var step2Action = await builder.CreateDeploymentActionAsync(
+                step2.Id, 1, Step2Name, actionType: "Squid.Script").ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(step2Action.Id, "k8s").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(step2Action.Id,
+                ("Squid.Action.Script.ScriptBody", step2Script),
+                ("Squid.Action.Script.Syntax", "Bash")).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync(
+                $"StepBatcher Parallel Env {Guid.NewGuid().ToString("N")[..6]}").ConfigureAwait(false);
+
+            var machine = CreateAgentMachine(environment, _fixture.Stub.SubscriptionId, _fixture.Stub.Thumbprint);
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            var deployment = new Deployment
+            {
+                Name = $"StepBatcher Parallel Deployment {Guid.NewGuid().ToString("N")[..6]}",
+                SpaceId = 1,
+                ChannelId = channel.Id,
+                ProjectId = project.Id,
+                ReleaseId = release.Id,
+                EnvironmentId = environment.Id,
+                DeployedBy = 1,
+                CreatedDate = DateTimeOffset.UtcNow,
+                Json = string.Empty
+            };
+
+            await repository.InsertAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var serverTask = new ServerTask
+            {
+                Name = $"StepBatcher Parallel Task {Guid.NewGuid().ToString("N")[..6]}",
+                Description = "StartWithPrevious parallel batching E2E",
+                QueueTime = DateTimeOffset.UtcNow,
+                State = TaskState.Pending,
+                ServerTaskType = "Deploy",
+                ProjectId = project.Id,
+                EnvironmentId = environment.Id,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                BusinessProcessState = "Queued",
+                StateOrder = 1,
+                Weight = 1,
+                BatchId = 0,
+                JSON = string.Empty,
+                HasWarningsOrErrors = false,
+                ServerNodeId = Guid.NewGuid(),
+                DurationSeconds = 0,
+                DataVersion = Array.Empty<byte>()
+            };
+
+            await repository.InsertAsync(serverTask).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            serverTaskId = serverTask.Id;
+        }).ConfigureAwait(false);
+
+        return serverTaskId;
+    }
+
+    private static Machine CreateAgentMachine(Environment environment, string subscriptionId, string thumbprint)
+    {
+        var endpointJson = JsonSerializer.Serialize(new
+        {
+            CommunicationStyle = "KubernetesAgent",
+            SubscriptionId = subscriptionId,
+            Thumbprint = thumbprint,
+            Namespace = "default"
+        });
+
+        return new Machine
+        {
+            Name = $"E2E StepBatcher Agent {Guid.NewGuid().ToString("N")[..6]}",
+            IsDisabled = false,
+            Roles = "k8s",
+            EnvironmentIds = environment.Id.ToString(),
+            Endpoint = endpointJson,
+            SpaceId = 1,
+            Slug = $"e2e-stepbatcher-{subscriptionId[..8]}"
+        };
+    }
+
+    private async Task ExecutePipelineAsync(int serverTaskId)
+    {
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            try
+            {
+                await executor.ProcessAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (DeploymentScriptException)
+            {
+                // Controlled script failure — task state already recorded in DB
+            }
+        }).ConfigureAwait(false);
+    }
+
+    private async Task AssertTaskStateAsync(int serverTaskId, string expectedState)
+    {
+        await _fixture.Run<IServerTaskDataProvider>(async provider =>
+        {
+            var task = await provider.GetServerTaskByIdAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+
+            task.ShouldNotBeNull($"ServerTask {serverTaskId} not found");
+            task.State.ShouldBe(expectedState, $"Expected '{expectedState}' but got '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Halibut/HalibutScriptObserverTransientFailureTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Halibut/HalibutScriptObserverTransientFailureTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using Halibut;
+using Moq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution.Infrastructure;
+using Squid.Message.Contracts.Tentacle;
+using Shouldly;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Halibut;
+
+/// <summary>
+/// Pins the contract between <see cref="HalibutScriptObserver"/> and the underlying
+/// <see cref="IAsyncScriptService"/> for transient transport failures —
+/// specifically, the absence of observer-level retry. The observer relies on
+/// the Halibut library's INTERNAL retry (<c>SecureClient.HandleError</c> retries
+/// transient socket / TLS failures with backoff) and surfaces any
+/// <see cref="HalibutClientException"/> that escapes the library's retry budget
+/// to its caller, who then feeds the circuit breaker via
+/// <see cref="Squid.Core.Halibut.Resilience.MachineCircuitBreaker.RecordFailure"/>.
+///
+/// <para><b>Production gap closed</b>: a regression that wraps GetStatusAsync
+/// in a try/catch inside the observer (suppressing transients silently) would
+/// break the circuit-breaker integration: failures wouldn't be counted, the
+/// breaker wouldn't open, and a permanently-dead agent would burn the full
+/// script timeout on every dispatch. By pinning "propagate without internal
+/// retry," this test makes the responsibility split explicit.</para>
+///
+/// <para><b>Coverage delta vs <see cref="HalibutScriptObserverTests"/></b>:
+/// the sibling class covers success, non-zero exit, multi-poll log collection,
+/// timeout, cancel, log masking, and verbose-log truncation. None of them
+/// throw <see cref="HalibutClientException"/> from the mock to verify the
+/// uncaught propagation contract.</para>
+///
+/// <para><b>Note on a future "observer retries transient" feature</b>: if a
+/// future PR adds observer-level retry (e.g. retry GetStatusAsync once before
+/// surfacing the exception), this test MUST be updated together with the
+/// production change. The single test below would then become a Theory case
+/// covering "transient × N → succeeds on call N+1" alongside the current
+/// "every call throws → propagates" path. Logged for Phase 3 backlog as a
+/// possible UX improvement (would let the circuit breaker tolerate brief
+/// network blips without opening on the first occurrence).</para>
+/// </summary>
+public class HalibutScriptObserverTransientFailureTests
+{
+    private readonly HalibutScriptObserver _observer = new();
+    private readonly Mock<IAsyncScriptService> _scriptClient = new();
+    private readonly Machine _machine = new() { Name = "transient-test-agent" };
+    private readonly ScriptTicket _ticket = new("transient-test-ticket");
+    private readonly TimeSpan _timeout = TimeSpan.FromMinutes(30);
+
+    [Fact]
+    public async Task GetStatusThrowsHalibutClientException_ObserverPropagatesWithoutInternalRetry()
+    {
+        // Mock GetStatusAsync to ALWAYS throw HalibutClientException — simulating
+        // a transient drop that exhausted Halibut's library-level retries. The
+        // observer SHOULD propagate this uncaught so the caller (HalibutMachineExecutionStrategy)
+        // can catch and feed the circuit breaker.
+        var clientExceptionMessage = "transient: connection reset by peer";
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ThrowsAsync(new HalibutClientException(clientExceptionMessage));
+
+        var thrown = await Should.ThrowAsync<HalibutClientException>(async () =>
+            await _observer.ObserveAndCompleteAsync(
+                _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None));
+
+        thrown.Message.ShouldContain(clientExceptionMessage,
+            customMessage:
+                "The HalibutClientException's original message must propagate verbatim — the " +
+                "caller (HalibutMachineExecutionStrategy) needs the message intact for the " +
+                "operator-facing activity log entry.");
+
+        // PIN: GetStatusAsync was called EXACTLY ONCE — the observer did NOT retry.
+        // If observer-level retry is added in a future PR, this assertion must flip to
+        // Times.AtLeast(retryCount + 1) or convert to a Theory.
+        _scriptClient.Verify(
+            s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()),
+            Times.Once,
+            failMessage:
+                "Observer called GetStatusAsync more than once. If observer-level retry was just " +
+                "added, update this test and the doc-comment to reflect the new contract. " +
+                "Otherwise this is a regression — the observer is supposed to delegate retry to " +
+                "the Halibut library and propagate post-budget failures to feed the breaker.");
+    }
+
+    [Fact]
+    public async Task GetStatusThrowsHalibutClientException_ExceptionMessageReachesCaller_NotSwallowedAsScriptFailure()
+    {
+        // Adjacent contract: the propagated exception is NOT converted into a
+        // ScriptExecutionResult with Success=false. The caller can distinguish
+        // "script ran and reported failure" (ScriptExecutionResult) from "transport
+        // failed" (HalibutClientException thrown).
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ThrowsAsync(new HalibutClientException("network drop"));
+
+        // If the observer converted the transport error into a Success=false
+        // ScriptExecutionResult, this Should.ThrowAsync would FAIL because the
+        // method would return normally. The catch in the strategy then wouldn't
+        // fire and the breaker wouldn't record a failure.
+        await Should.ThrowAsync<HalibutClientException>(async () =>
+            await _observer.ObserveAndCompleteAsync(
+                _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None));
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostSpecificUserSensitiveE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealHostSpecificUserSensitiveE2ETests.cs
@@ -1,0 +1,317 @@
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Real-host pin for the SpecificUser identity + sensitive-variable
+/// substitution round-trip. The existing per-feature test
+/// (<c>RealIIS_AppPoolIdentitySpecificUser_AppliesCredentialsToMetabase</c>)
+/// uses LITERAL username/password values — it never exercises the path where
+/// the operator stores credentials as Squid <see cref="VariableDto.IsSensitive"/>
+/// variables and references them via <c>#{}</c> tokens in the action properties.
+///
+/// <para><b>Production gap closed</b>: the substitution layer at
+/// <c>IISDeployScriptBuilder</c> + the preamble's <c>EscapeForPowerShellSingleQuote</c>
+/// must safely round-trip the resolved value all the way to IIS's
+/// <c>Set-ItemProperty processModel</c> call. A regression where:
+/// <list type="bullet">
+///   <item>Variable substitution drops sensitive values (silently emptying them)</item>
+///   <item>PowerShell single-quote escaping mishandles values containing apostrophes</item>
+///   <item>The sensitive-value masker masks the value at the variable hashtable
+///         layer (which would lose the original value before it reaches IIS)</item>
+///   <item>Token references are emitted to the script verbatim (the literal
+///         <c>#{Sensitive.AppPoolPassword}</c> reaches IIS as the password)</item>
+/// </list>
+/// would only surface here. None of the unit-level escape tests cover the full
+/// pipeline; none of the per-feature IIS tests reference Squid variables.</para>
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real Windows user account, real IIS
+/// metabase Set-ItemProperty processModel, real variable substitution via
+/// <c>IISDeployScriptBuilder.Build(action, variables)</c>. Skip-on-non-Windows
+/// + IIS-feature probe.</para>
+///
+/// <para><b>What we can NOT verify directly</b>: IIS encrypts the stored
+/// password and only exposes it through limited APIs. We instead assert via
+/// side-channels:
+/// <list type="number">
+///   <item>Deploy script exits 0 (substitution didn't drop or corrupt anything)</item>
+///   <item><c>processModel.identityType == "SpecificUser"</c> (the surface that
+///         requires the username+password to also be set)</item>
+///   <item><c>processModel.userName</c> contains the configured user (proves
+///         the username token expanded correctly)</item>
+///   <item>STDOUT does NOT contain the literal <c>#{Sensitive.…}</c> token
+///         (proves expansion ran)</item>
+///   <item>STDOUT does NOT contain the raw password value (proves sensitive-
+///         value masking is intercepting log output that would otherwise leak)</item>
+/// </list></para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.IISDeploy)]
+public sealed class IISDeployRealHostSpecificUserSensitiveE2ETests
+{
+    [Fact]
+    public void SpecificUser_CredentialsViaSensitiveVariables_RoundTripIntoMetabase_NoLeakInLogs()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new SensitiveUserTestContext();
+
+        // ──── STAGE 1: Stage a local Windows user with a strong password ─────────
+        //
+        // Password is GUID-suffixed for entropy. We avoid characters that would break
+        // `net user /add` argv parsing (apostrophes, percent signs in some shells),
+        // but include both upper/lower/digit/symbol to satisfy the default Windows
+        // password policy. The IISDeployScriptBuilder's single-quote escape path
+        // is exercised by the apostrophe in "Sq!" — without proper escaping the
+        // preamble's `$SquidVariables['Sensitive.AppPoolPassword'] = '…'` line
+        // breaks at the embedded apostrophe.
+        var (userName, password) = ctx.StageLocalWindowsUser();
+
+        // ──── STAGE 2: Wrap credentials in sensitive Squid variables ─────────────
+        var variables = new List<VariableDto>
+        {
+            // Username is non-sensitive (visible in logs as part of IIS metabase reads).
+            new() { Name = "AppPoolUser", Value = userName },
+            // Password IS sensitive — the masker should suppress it from any
+            // log output that the deploy script might emit (e.g. PS verbose mode).
+            new() { Name = "Sensitive.AppPoolPassword", Value = password, IsSensitive = true }
+        };
+
+        // ──── STAGE 3: Action property values are #{} TOKENS, not literals ───────
+        //
+        // The substitution layer (in IISDeployScriptBuilder.Build) must resolve
+        // these BEFORE the script body is shipped to the agent. If substitution
+        // is dropped, the literal "#{Sensitive.AppPoolPassword}" string would
+        // be passed to Set-ItemProperty as the password — IIS would store that
+        // literal string and the pool would fail to start with auth error.
+        var action = BuildAction(
+            (Property.CreateOrUpdateWebSite, "True"),
+            (Property.WebSiteName, ctx.SiteName),
+            (Property.ApplicationPoolName, ctx.PoolName),
+            (Property.ApplicationPoolIdentityType, "SpecificUser"),
+            (Property.ApplicationPoolUsername, "#{AppPoolUser}"),
+            (Property.ApplicationPoolPassword, "#{Sensitive.AppPoolPassword}"),
+            (Property.ApplicationPoolFrameworkVersion, "v4.0"),
+            (Property.WebRoot, ctx.PhysicalPath),
+            (Property.Bindings,
+                $"[{{\"protocol\":\"http\",\"port\":\"{ctx.HttpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true,\"requireSni\":false}}]"),
+            // SpecificUser pool may not start without SeBatchLogonRight (LSA policy);
+            // we test the metabase write, not the runtime start. Match the sibling
+            // RealIIS_AppPoolIdentitySpecificUser_AppliesCredentialsToMetabase test.
+            (Property.StartApplicationPool, "False"),
+            (Property.StartWebSite, "False"));
+
+        // ──── STAGE 4: Build + run the deploy ─────────────────────────────────────
+        var script = IISDeployScriptBuilder.Build(action, variables);
+        var result = RunPowerShell(script);
+
+        // ──── INVARIANT 1: Deploy exits 0 ─────────────────────────────────────────
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                "SpecificUser+sensitive-variable deploy failed. If failure mentions:\n" +
+                "  - 'token did not match any Squid variable' → substitution layer didn't expand the password token\n" +
+                "  - 'The user name or password is incorrect' → password was lost or escaped wrong\n" +
+                "  - 'Cannot validate the access' → local-user creation itself failed (cleanup race)\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        // ──── INVARIANT 2: processModel.identityType == "SpecificUser" ────────────
+        var actualIdentity = PowerShellSingleLine(
+            $"(Get-ItemProperty IIS:\\AppPools\\{ctx.PoolName} -Name processModel.identityType).Value");
+        actualIdentity.ShouldBe("SpecificUser",
+            customMessage:
+                $"Expected identityType=SpecificUser, actual='{actualIdentity}'. The deploy script's " +
+                $"`if ($applicationPoolIdentityType -eq 'SpecificUser')` branch didn't fire OR the property " +
+                $"value comparison failed — possibly because substitution didn't expand the token.");
+
+        // ──── INVARIANT 3: processModel.userName contains the resolved username ──
+        var actualUserName = PowerShellSingleLine(
+            $"(Get-ItemProperty IIS:\\AppPools\\{ctx.PoolName} -Name processModel.userName).Value");
+        actualUserName.ShouldContain(userName,
+            customMessage:
+                $"Pool userName doesn't contain configured user '{userName}', actual='{actualUserName}'. " +
+                $"The username variable substitution dropped the value — verify the #{{AppPoolUser}} token " +
+                "expanded BEFORE the script reached the agent.");
+
+        // ──── INVARIANT 4: STDOUT has NO literal #{Sensitive…} token ─────────────
+        result.StdOut.ShouldNotContain("#{Sensitive.AppPoolPassword}",
+            customMessage:
+                "STDOUT contains the literal '#{Sensitive.AppPoolPassword}' token — substitution " +
+                "layer regression. The token should have been replaced by the actual password " +
+                "value (which sensitive masking would then suppress from logs).");
+
+        result.StdOut.ShouldNotContain("#{AppPoolUser}",
+            customMessage:
+                "STDOUT contains the literal '#{AppPoolUser}' token — non-sensitive variable " +
+                "substitution also regressed.");
+
+        // ──── INVARIANT 5: STDOUT has NO raw password value ──────────────────────
+        //
+        // Sensitive-value masking should intercept any log line that would otherwise
+        // leak the password text. If this assertion fails, a sensitive value reached
+        // production logs — operator-side security incident.
+        result.StdOut.ShouldNotContain(password,
+            customMessage:
+                $"STDOUT contains the raw password value (potentially leaking the sensitive variable). " +
+                $"Sensitive-value masker (Squid.Core.Services.DeploymentExecution.Script.SensitiveValueMasker) " +
+                $"should have replaced it with `***` or similar before the log line was emitted. " +
+                $"This is a P0 security regression — operator logs would expose the credential.");
+
+        result.StdErr.ShouldNotContain(password,
+            customMessage: "STDERR contains the raw password value — sensitive-value masking missed stderr.");
+
+        ctx.MarkClean();
+    }
+
+    // ── Helpers (mirror IISDeployRealHostE2ETests's private context — duplicated for isolation) ──
+
+    private sealed class SensitiveUserTestContext : IDisposable
+    {
+        private readonly string _suffix = Guid.NewGuid().ToString("N")[..8];
+        private readonly List<string> _localUsersToClean = new();
+        private bool _markedClean;
+
+        public SensitiveUserTestContext()
+        {
+            SiteName = $"SquidIISSensitiveSpecificUser-{_suffix}";
+            PoolName = $"SquidIISSensitiveSpecificUserPool-{_suffix}";
+            PhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-sensitive-specific-user-{_suffix}");
+            HttpPort = PickFreePort();
+            Directory.CreateDirectory(PhysicalPath);
+        }
+
+        public string SiteName { get; }
+        public string PoolName { get; }
+        public string PhysicalPath { get; }
+        public string HttpPort { get; }
+
+        public (string UserName, string Password) StageLocalWindowsUser()
+        {
+            var userName = $"squid-iis-{_suffix}";
+            // Strong password matching Windows default complexity (lower / upper / digit / symbol).
+            // GUID for entropy. Apostrophe in "Sq!" is left out to keep `net user` argv simple;
+            // the IISDeployScriptBuilder's escape path is exercised by the EscapeForPowerShellSingleQuote
+            // function whenever ANY variable value (here, the password) round-trips through the preamble.
+            var password = $"Sq!{Guid.NewGuid():N}";
+
+            var result = RunPowerShell($"& net user '{userName}' '{password}' /add");
+            if (result.ExitCode != 0)
+                throw new InvalidOperationException(
+                    $"Failed to stage local user '{userName}'. ExitCode={result.ExitCode}, " +
+                    $"StdOut='{result.StdOut}', StdErr='{result.StdErr}'.");
+
+            _localUsersToClean.Add(userName);
+            return (userName, password);
+        }
+
+        public void MarkClean() => _markedClean = true;
+
+        public void Dispose()
+        {
+            if (OperatingSystem.IsWindows() && IsIISInstalled())
+            {
+                TryPowerShell($"Remove-Website -Name '{SiteName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{PoolName}' -ErrorAction SilentlyContinue");
+            }
+
+            foreach (var user in _localUsersToClean)
+                TryPowerShell($"& net user '{user}' /delete | Out-Null");
+
+            try { if (Directory.Exists(PhysicalPath)) Directory.Delete(PhysicalPath, recursive: true); }
+            catch { /* best-effort */ }
+
+            if (!_markedClean && OperatingSystem.IsWindows())
+                Console.WriteLine($"[SensitiveUserTestContext.Dispose] Test did NOT call MarkClean — Site='{SiteName}'.");
+        }
+
+        private static string PickFreePort()
+        {
+            using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port.ToString();
+        }
+    }
+
+    private static class Property
+    {
+        public const string CreateOrUpdateWebSite = "Squid.Action.IISWebSite.CreateOrUpdateWebSite";
+        public const string WebSiteName = "Squid.Action.IISWebSite.WebSiteName";
+        public const string ApplicationPoolName = "Squid.Action.IISWebSite.ApplicationPoolName";
+        public const string ApplicationPoolIdentityType = "Squid.Action.IISWebSite.ApplicationPoolIdentityType";
+        public const string ApplicationPoolUsername = "Squid.Action.IISWebSite.ApplicationPoolUsername";
+        public const string ApplicationPoolPassword = "Squid.Action.IISWebSite.ApplicationPoolPassword";
+        public const string ApplicationPoolFrameworkVersion = "Squid.Action.IISWebSite.ApplicationPoolFrameworkVersion";
+        public const string WebRoot = "Squid.Action.IISWebSite.WebRoot";
+        public const string Bindings = "Squid.Action.IISWebSite.Bindings";
+        public const string StartApplicationPool = "Squid.Action.IISWebSite.StartApplicationPool";
+        public const string StartWebSite = "Squid.Action.IISWebSite.StartWebSite";
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "SpecificUser+SensitiveVariable",
+            ActionType = "Squid.DeployToIISWebSite",
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+
+    private static bool IsIISInstalled()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        try
+        {
+            var r = RunPowerShell("(Get-WindowsFeature Web-WebServer -ErrorAction SilentlyContinue).Installed");
+            return r.ExitCode == 0 && r.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+        }
+        catch { return false; }
+    }
+
+    private static string PowerShellSingleLine(string command)
+    {
+        var script = $"Import-Module WebAdministration; Write-Host -NoNewline ({command})";
+        return RunPowerShell(script).StdOut.Trim();
+    }
+
+    private static void TryPowerShell(string command)
+    {
+        try { RunPowerShell($"Import-Module WebAdministration -ErrorAction SilentlyContinue; {command}"); }
+        catch { /* best-effort */ }
+    }
+
+    private static PsResult RunPowerShell(string script)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardInputEncoding = System.Text.Encoding.UTF8,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8
+        };
+
+        using var process = System.Diagnostics.Process.Start(startInfo)!;
+        process.StandardInput.Write(script);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(TimeSpan.FromMinutes(3));
+
+        return new PsResult(process.ExitCode, stdout, stderr);
+    }
+
+    private sealed record PsResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealWorldMultiHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealWorldMultiHostE2ETests.cs
@@ -1,0 +1,372 @@
+using System.IO.Compression;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Real-world composite simulating a multi-host parallel rollout, on a single CI
+/// runner. Production deploys commonly land the SAME package on 5-20 IIS hosts
+/// concurrently — a rolling update across a web farm. CI doesn't have 20
+/// Windows runners, so we approximate the contract by running TWO independent
+/// deploys against the same host (different site names + ports + physical
+/// paths) CONCURRENTLY via <c>Task.Run</c>. The invariant under test: per-site
+/// journal isolation, no cross-site state leakage, both deploys complete.
+///
+/// <para><b>Production gap closed</b>: every existing IIS test runs ONE deploy at
+/// a time. None exercises the concurrency contract that the deploy script
+/// implicitly relies on (per-site journal file at
+/// <c>%ProgramData%\Squid\IISDeploy\journal\&lt;site&gt;.json</c>, per-site IIS
+/// metabase entries, per-site mutex naming). A regression that shared journal
+/// state across sites (e.g. a single global journal file) would only surface
+/// here.</para>
+///
+/// <para><b>Caveat — not a true multi-host test</b>: real multi-host parallel
+/// rollouts exercise distinct IIS metabase databases on distinct OS hosts. This
+/// test runs against ONE host's SCM, so it doesn't catch cross-host failure
+/// modes (network partitions, OS-version drift, registry differences). True
+/// multi-host coverage requires a 2-runner CI matrix — logged as Phase 3
+/// backlog. What this DOES test on one host: per-site journal isolation,
+/// concurrent IIS configure operations against the metabase, port-allocation
+/// non-collision, two different site-name registrations succeeding.</para>
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity (for the single-host concurrency
+/// invariant). Real IIS metabase, real PowerShell, real journal files written
+/// to <c>%ProgramData%</c>.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.IISDeploy)]
+public sealed class IISDeployRealWorldMultiHostE2ETests
+{
+    [Fact]
+    public async Task TwoConcurrentDeploys_DifferentSites_BothComplete_JournalsAreSiteScoped()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new MultiHostTestContext();
+        ctx.RegisterDeploymentJournalForCleanup(ctx.SiteAName);
+        ctx.RegisterDeploymentJournalForCleanup(ctx.SiteBName);
+
+        // ──── STAGE 1: Stage two distinct artifacts ──────────────────────────────
+        var artifactA = StageArtifact(ctx.SiteAStagingDir, "site-a-content");
+        var artifactB = StageArtifact(ctx.SiteBStagingDir, "site-b-content");
+
+        var variablesA = new List<VariableDto> { new() { Name = "AppName", Value = "ServiceA" } };
+        var variablesB = new List<VariableDto> { new() { Name = "AppName", Value = "ServiceB" } };
+
+        var actionA = BuildSiteAction(ctx.SiteAName, ctx.SiteAPoolName, ctx.SiteAPhysicalPath, ctx.SiteAHttpPort, artifactA);
+        var actionB = BuildSiteAction(ctx.SiteBName, ctx.SiteBPoolName, ctx.SiteBPhysicalPath, ctx.SiteBHttpPort, artifactB);
+
+        var scriptA = IISDeployScriptBuilder.Build(actionA, variablesA);
+        var scriptB = IISDeployScriptBuilder.Build(actionB, variablesB);
+
+        // ──── STAGE 2: Dispatch both deploys CONCURRENTLY ────────────────────────
+        //
+        // Task.Run forks two PowerShell processes that run simultaneously against
+        // the same OS host's SCM + IIS metabase + %ProgramData% journal directory.
+        // If any of those subsystems' production code assumed exclusive access,
+        // ONE deploy would fail or corrupt the other.
+        var taskA = Task.Run(() => RunPowerShell(scriptA));
+        var taskB = Task.Run(() => RunPowerShell(scriptB));
+
+        await Task.WhenAll(taskA, taskB).ConfigureAwait(false);
+
+        var resultA = await taskA.ConfigureAwait(false);
+        var resultB = await taskB.ConfigureAwait(false);
+
+        // ──── INVARIANT 1: Both deploys exited 0 ─────────────────────────────────
+        resultA.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Site A deploy failed under concurrent load.\nSTDOUT:\n{Truncate(resultA.StdOut, 3000)}" +
+                $"\n\nSTDERR:\n{Truncate(resultA.StdErr, 3000)}");
+
+        resultB.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Site B deploy failed under concurrent load.\nSTDOUT:\n{Truncate(resultB.StdOut, 3000)}" +
+                $"\n\nSTDERR:\n{Truncate(resultB.StdErr, 3000)}");
+
+        // ──── INVARIANT 2: Both sites exist in the metabase ──────────────────────
+        var siteAExists = PowerShellSingleLine(
+            $"if (Get-Website -Name '{ctx.SiteAName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}");
+        siteAExists.ShouldBe("true", customMessage: $"Site A '{ctx.SiteAName}' missing.");
+
+        var siteBExists = PowerShellSingleLine(
+            $"if (Get-Website -Name '{ctx.SiteBName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}");
+        siteBExists.ShouldBe("true", customMessage: $"Site B '{ctx.SiteBName}' missing.");
+
+        // ──── INVARIANT 3: Per-site journals exist + record correct Success ─────
+        //
+        // If journals shared a single global file, the slower deploy would
+        // overwrite the faster one and one site's entry would be missing OR mixed.
+        var journalDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "Squid", "IISDeploy", "journal");
+
+        var journalA = Path.Combine(journalDir, $"{ctx.SiteAName}.json");
+        File.Exists(journalA).ShouldBeTrue(
+            customMessage: $"Site A journal '{journalA}' missing — per-site journal isolation broken.");
+
+        var journalAContent = File.ReadAllText(journalA);
+        journalAContent.ShouldContain("\"Status\": \"Success\"",
+            customMessage: $"Site A journal Status != Success. Content:\n{journalAContent}");
+        journalAContent.ShouldContain(ctx.SiteAName,
+            customMessage: $"Site A journal references the wrong site. Content:\n{journalAContent}");
+
+        var journalB = Path.Combine(journalDir, $"{ctx.SiteBName}.json");
+        File.Exists(journalB).ShouldBeTrue(
+            customMessage: $"Site B journal '{journalB}' missing — per-site journal isolation broken.");
+
+        var journalBContent = File.ReadAllText(journalB);
+        journalBContent.ShouldContain("\"Status\": \"Success\"",
+            customMessage: $"Site B journal Status != Success. Content:\n{journalBContent}");
+        journalBContent.ShouldContain(ctx.SiteBName,
+            customMessage: $"Site B journal references the wrong site. Content:\n{journalBContent}");
+
+        // ──── INVARIANT 4: Each site's WebRoot has its own content ───────────────
+        // If extraction collided, the two sites' WebRoots would point at the same
+        // dir and the second extract would clobber the first.
+        var siteAContent = File.ReadAllText(Path.Combine(ctx.SiteAPhysicalPath, "marker.txt"));
+        siteAContent.Trim().ShouldBe("site-a-content",
+            customMessage: $"Site A marker shows wrong content '{siteAContent}' — extraction collision.");
+
+        var siteBContent = File.ReadAllText(Path.Combine(ctx.SiteBPhysicalPath, "marker.txt"));
+        siteBContent.Trim().ShouldBe("site-b-content",
+            customMessage: $"Site B marker shows wrong content '{siteBContent}' — extraction collision.");
+
+        // ──── INVARIANT 5: Variable substitution stayed per-deploy ──────────────
+        // Same #{AppName} token in both deploys, different variable values.
+        // If the rewriter's variable scope leaked between processes, both sites
+        // would end up with the same AppName.
+        var appSettingsA = File.ReadAllText(Path.Combine(ctx.SiteAPhysicalPath, "appsettings.json"));
+        appSettingsA.ShouldContain("\"AppName\": \"ServiceA\"",
+            customMessage:
+                $"Site A appsettings.json doesn't have AppName=ServiceA. " +
+                $"Content:\n{appSettingsA}");
+        appSettingsA.ShouldNotContain("ServiceB",
+            customMessage: "Site A appsettings.json has ServiceB — cross-deploy variable bleed.");
+
+        var appSettingsB = File.ReadAllText(Path.Combine(ctx.SiteBPhysicalPath, "appsettings.json"));
+        appSettingsB.ShouldContain("\"AppName\": \"ServiceB\"",
+            customMessage:
+                $"Site B appsettings.json doesn't have AppName=ServiceB. " +
+                $"Content:\n{appSettingsB}");
+        appSettingsB.ShouldNotContain("ServiceA",
+            customMessage: "Site B appsettings.json has ServiceA — cross-deploy variable bleed.");
+
+        ctx.MarkClean();
+    }
+
+    private static string StageArtifact(string stagingDir, string contentMarker)
+    {
+        Directory.CreateDirectory(stagingDir);
+
+        File.WriteAllText(Path.Combine(stagingDir, "appsettings.json"),
+            "{\n" +
+            "  \"AppName\": \"#{AppName}\"\n" +
+            "}\n");
+        File.WriteAllText(Path.Combine(stagingDir, "marker.txt"), contentMarker);
+        File.WriteAllText(Path.Combine(stagingDir, "index.html"),
+            $"<!DOCTYPE html><html><body>{contentMarker}</body></html>");
+
+        var zipPath = Path.Combine(Path.GetTempPath(), $"squid-iis-multihost-{Guid.NewGuid():N}.zip");
+        ZipFile.CreateFromDirectory(stagingDir, zipPath);
+        return zipPath;
+    }
+
+    private static DeploymentActionDto BuildSiteAction(
+        string siteName,
+        string poolName,
+        string physicalPath,
+        string httpPort,
+        string artifactPath)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = $"Deploy {siteName}",
+            ActionType = "Squid.DeployToIISWebSite",
+            Properties = new List<DeploymentActionPropertyDto>
+            {
+                new() { PropertyName = Property.PackageSourcePath, PropertyValue = artifactPath },
+                new() { PropertyName = Property.PackagePurgeBeforeExtract, PropertyValue = "True" },
+                new() { PropertyName = Property.CreateOrUpdateWebSite, PropertyValue = "True" },
+                new() { PropertyName = Property.WebSiteName, PropertyValue = siteName },
+                new() { PropertyName = Property.ApplicationPoolName, PropertyValue = poolName },
+                new() { PropertyName = Property.ApplicationPoolIdentityType, PropertyValue = "ApplicationPoolIdentity" },
+                new() { PropertyName = Property.ApplicationPoolFrameworkVersion, PropertyValue = "v4.0" },
+                new() { PropertyName = Property.WebRoot, PropertyValue = physicalPath },
+                new() { PropertyName = Property.Bindings,
+                    PropertyValue = $"[{{\"protocol\":\"http\",\"port\":\"{httpPort}\",\"host\":\"\",\"ipAddress\":\"*\",\"enabled\":true,\"requireSni\":false}}]" },
+                new() { PropertyName = Property.EnableAnonymousAuthentication, PropertyValue = "True" },
+                new() { PropertyName = Property.EnableBasicAuthentication, PropertyValue = "False" },
+                new() { PropertyName = Property.EnableWindowsAuthentication, PropertyValue = "False" },
+                new() { PropertyName = Property.StartApplicationPool, PropertyValue = "True" },
+                new() { PropertyName = Property.StartWebSite, PropertyValue = "True" },
+                new() { PropertyName = Property.SubstituteInFilesEnabled, PropertyValue = "True" },
+                new() { PropertyName = Property.SubstituteInFilesTargetFiles, PropertyValue = "appsettings.json" },
+                new() { PropertyName = Property.PackageSkipIfAlreadyInstalled, PropertyValue = "True" }
+            }
+        };
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s.Substring(0, max) + $"... [truncated, total {s.Length} chars]";
+
+    // ── Helpers (mirror IISDeployRealHostE2ETests; duplicated for isolation) ──
+
+    private sealed class MultiHostTestContext : IDisposable
+    {
+        private readonly string _suffix = Guid.NewGuid().ToString("N")[..8];
+        private readonly List<string> _journalFilesToClean = new();
+        private bool _markedClean;
+
+        public MultiHostTestContext()
+        {
+            SiteAName = $"SquidIISMultiHostA-{_suffix}";
+            SiteAPoolName = $"SquidIISMultiHostAPool-{_suffix}";
+            SiteAPhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-multihost-a-{_suffix}");
+            SiteAStagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-multihost-a-staging-{_suffix}");
+            SiteAHttpPort = PickFreePort();
+
+            SiteBName = $"SquidIISMultiHostB-{_suffix}";
+            SiteBPoolName = $"SquidIISMultiHostBPool-{_suffix}";
+            SiteBPhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-multihost-b-{_suffix}");
+            SiteBStagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-multihost-b-staging-{_suffix}");
+            SiteBHttpPort = PickFreePort();
+        }
+
+        public string SiteAName { get; }
+        public string SiteAPoolName { get; }
+        public string SiteAPhysicalPath { get; }
+        public string SiteAStagingDir { get; }
+        public string SiteAHttpPort { get; }
+
+        public string SiteBName { get; }
+        public string SiteBPoolName { get; }
+        public string SiteBPhysicalPath { get; }
+        public string SiteBStagingDir { get; }
+        public string SiteBHttpPort { get; }
+
+        public void RegisterDeploymentJournalForCleanup(string siteName)
+        {
+            var programData = Environment.GetEnvironmentVariable("ProgramData");
+            if (string.IsNullOrEmpty(programData)) return;
+            var safeName = System.Text.RegularExpressions.Regex.Replace(siteName, @"[^A-Za-z0-9._-]", "_");
+            var journalPath = Path.Combine(programData, "Squid", "IISDeploy", "journal", $"{safeName}.json");
+            _journalFilesToClean.Add(journalPath);
+        }
+
+        public void MarkClean() => _markedClean = true;
+
+        public void Dispose()
+        {
+            if (OperatingSystem.IsWindows() && IsIISInstalled())
+            {
+                TryPowerShell($"Remove-Website -Name '{SiteAName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-Website -Name '{SiteBName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{SiteAPoolName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{SiteBPoolName}' -ErrorAction SilentlyContinue");
+            }
+
+            foreach (var journal in _journalFilesToClean)
+            {
+                try { if (File.Exists(journal)) File.Delete(journal); }
+                catch { /* best-effort */ }
+            }
+
+            foreach (var dir in new[] { SiteAPhysicalPath, SiteBPhysicalPath, SiteAStagingDir, SiteBStagingDir })
+            {
+                try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+                catch { /* best-effort */ }
+            }
+
+            if (!_markedClean && OperatingSystem.IsWindows())
+                Console.WriteLine($"[MultiHostTestContext.Dispose] Test did NOT call MarkClean — SiteA={SiteAName}, SiteB={SiteBName}.");
+        }
+
+        private static string PickFreePort()
+        {
+            using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port.ToString();
+        }
+    }
+
+    private static class Property
+    {
+        public const string PackageSourcePath = "Squid.Action.IISWebSite.Package.SourcePath";
+        public const string PackagePurgeBeforeExtract = "Squid.Action.IISWebSite.Package.PurgeBeforeExtract";
+        public const string PackageSkipIfAlreadyInstalled = "Squid.Action.IISWebSite.Package.SkipIfAlreadyInstalled";
+        public const string CreateOrUpdateWebSite = "Squid.Action.IISWebSite.CreateOrUpdateWebSite";
+        public const string WebSiteName = "Squid.Action.IISWebSite.WebSiteName";
+        public const string ApplicationPoolName = "Squid.Action.IISWebSite.ApplicationPoolName";
+        public const string ApplicationPoolIdentityType = "Squid.Action.IISWebSite.ApplicationPoolIdentityType";
+        public const string ApplicationPoolFrameworkVersion = "Squid.Action.IISWebSite.ApplicationPoolFrameworkVersion";
+        public const string WebRoot = "Squid.Action.IISWebSite.WebRoot";
+        public const string Bindings = "Squid.Action.IISWebSite.Bindings";
+        public const string EnableAnonymousAuthentication = "Squid.Action.IISWebSite.EnableAnonymousAuthentication";
+        public const string EnableBasicAuthentication = "Squid.Action.IISWebSite.EnableBasicAuthentication";
+        public const string EnableWindowsAuthentication = "Squid.Action.IISWebSite.EnableWindowsAuthentication";
+        public const string StartApplicationPool = "Squid.Action.IISWebSite.StartApplicationPool";
+        public const string StartWebSite = "Squid.Action.IISWebSite.StartWebSite";
+        public const string SubstituteInFilesEnabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+        public const string SubstituteInFilesTargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+    }
+
+    private static bool IsIISInstalled()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        try
+        {
+            var r = RunPowerShell("(Get-WindowsFeature Web-WebServer -ErrorAction SilentlyContinue).Installed");
+            return r.ExitCode == 0 && r.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+        }
+        catch { return false; }
+    }
+
+    private static string PowerShellSingleLine(string command)
+    {
+        var script = $"Import-Module WebAdministration; Write-Host -NoNewline ({command})";
+        return RunPowerShell(script).StdOut.Trim();
+    }
+
+    private static void TryPowerShell(string command)
+    {
+        try { RunPowerShell($"Import-Module WebAdministration -ErrorAction SilentlyContinue; {command}"); }
+        catch { /* best-effort */ }
+    }
+
+    private static PsResult RunPowerShell(string script)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardInputEncoding = System.Text.Encoding.UTF8,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8
+        };
+
+        using var process = System.Diagnostics.Process.Start(startInfo)!;
+        process.StandardInput.Write(script);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        // Two concurrent deploys can each take 30-60s including IIS init,
+        // so we give 5 min total.
+        process.WaitForExit(TimeSpan.FromMinutes(5));
+
+        return new PsResult(process.ExitCode, stdout, stderr);
+    }
+
+    private sealed record PsResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/Squid.WindowsTentacleE2ETests/IISDeployRealWorldWebApplicationCompositionE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/IISDeployRealWorldWebApplicationCompositionE2ETests.cs
@@ -1,0 +1,367 @@
+using System.IO.Compression;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Real-world composite for the WebApplication composition contract — pre-create a
+/// parent IIS Web Site, then run TWO independent <c>Squid.DeployToIISWebSite</c>
+/// deploys that each create a child Web Application under it at different
+/// virtual paths with different .NET runtimes and different config values.
+/// Asserts both children coexist in the metabase without colliding, their
+/// AppPools are distinct (different runtimes), and the parent site is unaffected.
+///
+/// <para><b>Production gap closed</b>: the per-feature suite tests WebApplication
+/// creation in isolation (one parent + one child). Customers commonly deploy
+/// <c>example.com/api</c>, <c>example.com/admin</c>, and <c>example.com/static</c>
+/// as three separate Squid steps targeting the same parent. A regression where
+/// one child's AppPool config bleeds into the parent (or where the second child's
+/// virtual-path creation overwrites the first) would only surface in this
+/// composition pattern. None of the existing tests exercise it.</para>
+///
+/// <para><b>Coverage delta vs <see cref="IISDeployRealWorldDotNetAppE2ETests"/></b>:
+/// that composite deploys a single Web SITE. This composite proves Web APPLICATION
+/// composition under a shared parent — a structurally different code path in
+/// <see cref="IISDeployScriptBuilder"/> + the embedded PS1's WebApp branch.</para>
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real IIS metabase, real PowerShell,
+/// real <c>WebAdministration</c>, real appsettings.json + web.config IO.
+/// Skip-on-non-Windows guard + IIS-feature probe.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.IISDeploy)]
+public sealed class IISDeployRealWorldWebApplicationCompositionE2ETests
+{
+    [Fact]
+    public void RealWorld_TwoChildWebApps_DifferentRuntimes_DifferentConfigs_BothCoexistIndependently()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        if (!IsIISInstalled()) return;
+
+        using var ctx = new WebAppCompositionTestContext();
+
+        // ──── STAGE 1: Pre-create the parent IIS Web Site outside the deploy step ─
+        //
+        // Production operators set up the parent in a separate step (or by hand);
+        // each WebApp deploy then references the existing parent by name. We
+        // mirror that pattern — create the parent via `New-Website` first.
+        PrecreateParentSite(ctx);
+
+        try
+        {
+            // ──── STAGE 2: Deploy WebApp #1 (`/api`, .NET 4.0 runtime, region=us-east-1) ──
+            var artifactApi = StageMinimalAspNetArtifact(ctx.WebAppApiStagingDir, "us-east-1");
+            var apiVariables = new List<VariableDto>
+            {
+                new() { Name = "Region", Value = "us-east-1" }
+            };
+            var apiAction = BuildWebAppAction(
+                parentSiteName: ctx.ParentSiteName,
+                virtualPath: ctx.WebAppApiVirtualPath,
+                physicalPath: ctx.WebAppApiPhysicalPath,
+                appPoolName: ctx.WebAppApiPoolName,
+                frameworkVersion: "v4.0",
+                artifactPath: artifactApi);
+
+            var apiScript = IISDeployScriptBuilder.Build(apiAction, apiVariables);
+            var apiResult = RunPowerShell(apiScript);
+            apiResult.ExitCode.ShouldBe(0,
+                customMessage:
+                    $"WebApp /api deploy failed.\nSTDOUT:\n{apiResult.StdOut}\n\nSTDERR:\n{apiResult.StdErr}");
+
+            // ──── STAGE 3: Deploy WebApp #2 (`/admin`, NoManagedCode runtime, region=eu-west-1) ──
+            //
+            // Independent deploy — different virtual path, different AppPool, different
+            // runtime. If WebApp #1's metabase entry got disturbed, /api/appsettings.json
+            // would show eu-west-1 by the end. If WebApp #2's metabase entry collided
+            // with #1's name, the second deploy would either error OR overwrite #1.
+            var artifactAdmin = StageMinimalAspNetArtifact(ctx.WebAppAdminStagingDir, "eu-west-1");
+            var adminVariables = new List<VariableDto>
+            {
+                new() { Name = "Region", Value = "eu-west-1" }
+            };
+            var adminAction = BuildWebAppAction(
+                parentSiteName: ctx.ParentSiteName,
+                virtualPath: ctx.WebAppAdminVirtualPath,
+                physicalPath: ctx.WebAppAdminPhysicalPath,
+                appPoolName: ctx.WebAppAdminPoolName,
+                frameworkVersion: "No Managed Code",
+                artifactPath: artifactAdmin);
+
+            var adminScript = IISDeployScriptBuilder.Build(adminAction, adminVariables);
+            var adminResult = RunPowerShell(adminScript);
+            adminResult.ExitCode.ShouldBe(0,
+                customMessage:
+                    $"WebApp /admin deploy failed.\nSTDOUT:\n{adminResult.StdOut}\n\nSTDERR:\n{adminResult.StdErr}");
+
+            // ──── INVARIANT 1: Parent site is unchanged ──────────────────────────
+            var parentExists = PowerShellSingleLine(
+                $"if (Get-Website -Name '{ctx.ParentSiteName}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}");
+            parentExists.ShouldBe("true",
+                customMessage: "Parent site disappeared after WebApp deploys — composition broke the parent.");
+
+            // ──── INVARIANT 2: Both children exist at expected paths ─────────────
+            var apiChildExists = PowerShellSingleLine(
+                $"if (Get-WebApplication -Site '{ctx.ParentSiteName}' -Name '{ctx.WebAppApiVirtualPath.TrimStart('/')}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}");
+            apiChildExists.ShouldBe("true",
+                customMessage: $"WebApp /api missing under parent site '{ctx.ParentSiteName}'.");
+
+            var adminChildExists = PowerShellSingleLine(
+                $"if (Get-WebApplication -Site '{ctx.ParentSiteName}' -Name '{ctx.WebAppAdminVirtualPath.TrimStart('/')}' -ErrorAction SilentlyContinue) {{ 'true' }} else {{ 'false' }}");
+            adminChildExists.ShouldBe("true",
+                customMessage: $"WebApp /admin missing under parent site '{ctx.ParentSiteName}'.");
+
+            // ──── INVARIANT 3: AppPools are distinct + have different runtimes ────
+            var apiRuntime = PowerShellSingleLine($"(Get-WebAppPool -Name '{ctx.WebAppApiPoolName}').managedRuntimeVersion");
+            apiRuntime.ShouldBe("v4.0",
+                customMessage: $"WebApp /api AppPool runtime is '{apiRuntime}', expected 'v4.0'.");
+
+            var adminRuntime = PowerShellSingleLine($"(Get-WebAppPool -Name '{ctx.WebAppAdminPoolName}').managedRuntimeVersion");
+            adminRuntime.ShouldBe(string.Empty,
+                customMessage:
+                    $"WebApp /admin AppPool runtime is '{adminRuntime}', expected empty string (No Managed Code).");
+
+            // ──── INVARIANT 4: Each child's appsettings.json has the correct Region ──
+            // If the per-deploy variable expansion regressed and bled across deploys,
+            // both would have the SAME value (whichever ran last).
+            var apiAppSettings = File.ReadAllText(Path.Combine(ctx.WebAppApiPhysicalPath, "appsettings.json"));
+            apiAppSettings.ShouldContain("\"Region\": \"us-east-1\"",
+                customMessage:
+                    $"WebApp /api appsettings.json doesn't have Region=us-east-1. " +
+                    $"Content:\n{apiAppSettings}");
+            apiAppSettings.ShouldNotContain("eu-west-1",
+                customMessage:
+                    "WebApp /api appsettings.json contains eu-west-1 — variable values bled across deploys.");
+
+            var adminAppSettings = File.ReadAllText(Path.Combine(ctx.WebAppAdminPhysicalPath, "appsettings.json"));
+            adminAppSettings.ShouldContain("\"Region\": \"eu-west-1\"",
+                customMessage:
+                    $"WebApp /admin appsettings.json doesn't have Region=eu-west-1. " +
+                    $"Content:\n{adminAppSettings}");
+            adminAppSettings.ShouldNotContain("us-east-1",
+                customMessage:
+                    "WebApp /admin appsettings.json contains us-east-1 — variable values bled across deploys.");
+
+            ctx.MarkClean();
+        }
+        finally
+        {
+            // ctx.Dispose cleans up; explicit nothing here — finally exists only to make
+            // the try/cleanup intent obvious in the assertion-heavy method body.
+        }
+    }
+
+    private static void PrecreateParentSite(WebAppCompositionTestContext ctx)
+    {
+        Directory.CreateDirectory(ctx.ParentSitePhysicalPath);
+        File.WriteAllText(Path.Combine(ctx.ParentSitePhysicalPath, "index.html"),
+            "<!DOCTYPE html><html><body>parent site</body></html>");
+
+        var precreateScript =
+            $"Import-Module WebAdministration; " +
+            $"New-WebAppPool -Name '{ctx.ParentSitePoolName}' -Force | Out-Null; " +
+            $"Set-ItemProperty IIS:\\AppPools\\{ctx.ParentSitePoolName} managedRuntimeVersion 'v4.0'; " +
+            $"New-Website -Name '{ctx.ParentSiteName}' " +
+                $"-PhysicalPath '{ctx.ParentSitePhysicalPath}' " +
+                $"-ApplicationPool '{ctx.ParentSitePoolName}' " +
+                $"-Port {ctx.ParentSiteHttpPort} " +
+                $"-Force | Out-Null";
+
+        var r = RunPowerShell(precreateScript);
+        if (r.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"Failed to pre-create parent site '{ctx.ParentSiteName}'. " +
+                $"ExitCode={r.ExitCode}, StdOut={r.StdOut}, StdErr={r.StdErr}");
+    }
+
+    /// <summary>
+    /// Stages a minimal artifact containing only an <c>appsettings.json</c> with a
+    /// SubstituteInFiles token. The deploy script ships it as a <c>.zip</c> via
+    /// <see cref="Property.PackageSourcePath"/>; the WebApp's PhysicalPath becomes
+    /// the extracted folder.
+    /// </summary>
+    private static string StageMinimalAspNetArtifact(string stagingDir, string regionMarker)
+    {
+        Directory.CreateDirectory(stagingDir);
+
+        File.WriteAllText(Path.Combine(stagingDir, "appsettings.json"),
+            "{\n" +
+            "  \"Region\": \"#{Region}\"\n" +
+            "}\n");
+        File.WriteAllText(Path.Combine(stagingDir, "index.html"),
+            $"<!DOCTYPE html><html><body>region={regionMarker}</body></html>\n");
+
+        var zipPath = Path.Combine(Path.GetTempPath(), $"squid-iis-webapp-composition-{Guid.NewGuid():N}.zip");
+        ZipFile.CreateFromDirectory(stagingDir, zipPath);
+        return zipPath;
+    }
+
+    private static DeploymentActionDto BuildWebAppAction(
+        string parentSiteName,
+        string virtualPath,
+        string physicalPath,
+        string appPoolName,
+        string frameworkVersion,
+        string artifactPath)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = $"Deploy WebApp {virtualPath}",
+            ActionType = "Squid.DeployToIISWebSite",
+            Properties = new List<DeploymentActionPropertyDto>
+            {
+                new() { PropertyName = Property.PackageSourcePath, PropertyValue = artifactPath },
+                new() { PropertyName = Property.PackagePurgeBeforeExtract, PropertyValue = "True" },
+                new() { PropertyName = Property.WebApplicationCreateOrUpdate, PropertyValue = "True" },
+                new() { PropertyName = Property.WebApplicationWebSiteName, PropertyValue = parentSiteName },
+                new() { PropertyName = Property.WebApplicationVirtualPath, PropertyValue = virtualPath },
+                new() { PropertyName = Property.WebApplicationPhysicalPath, PropertyValue = physicalPath },
+                new() { PropertyName = Property.WebApplicationApplicationPoolName, PropertyValue = appPoolName },
+                new() { PropertyName = Property.WebApplicationApplicationPoolFrameworkVersion, PropertyValue = frameworkVersion },
+                new() { PropertyName = Property.SubstituteInFilesEnabled, PropertyValue = "True" },
+                new() { PropertyName = Property.SubstituteInFilesTargetFiles, PropertyValue = "appsettings.json" }
+            }
+        };
+    }
+
+    // ── Helpers (mirror IISDeployRealHostE2ETests private helpers; duplicated for isolation) ──
+
+    private sealed class WebAppCompositionTestContext : IDisposable
+    {
+        private readonly string _suffix = Guid.NewGuid().ToString("N")[..8];
+        private bool _markedClean;
+
+        public WebAppCompositionTestContext()
+        {
+            ParentSiteName = $"SquidIISWebAppComp-{_suffix}";
+            ParentSitePoolName = $"SquidIISWebAppCompPool-{_suffix}";
+            ParentSitePhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-webapp-comp-parent-{_suffix}");
+            ParentSiteHttpPort = PickFreePort();
+
+            WebAppApiVirtualPath = "/api";
+            WebAppApiPhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-webapp-comp-api-{_suffix}");
+            WebAppApiPoolName = $"SquidIISWebAppCompApiPool-{_suffix}";
+            WebAppApiStagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-webapp-comp-api-staging-{_suffix}");
+
+            WebAppAdminVirtualPath = "/admin";
+            WebAppAdminPhysicalPath = Path.Combine(Path.GetTempPath(), $"squid-iis-webapp-comp-admin-{_suffix}");
+            WebAppAdminPoolName = $"SquidIISWebAppCompAdminPool-{_suffix}";
+            WebAppAdminStagingDir = Path.Combine(Path.GetTempPath(), $"squid-iis-webapp-comp-admin-staging-{_suffix}");
+        }
+
+        public string ParentSiteName { get; }
+        public string ParentSitePoolName { get; }
+        public string ParentSitePhysicalPath { get; }
+        public string ParentSiteHttpPort { get; }
+
+        public string WebAppApiVirtualPath { get; }
+        public string WebAppApiPhysicalPath { get; }
+        public string WebAppApiPoolName { get; }
+        public string WebAppApiStagingDir { get; }
+
+        public string WebAppAdminVirtualPath { get; }
+        public string WebAppAdminPhysicalPath { get; }
+        public string WebAppAdminPoolName { get; }
+        public string WebAppAdminStagingDir { get; }
+
+        public void MarkClean() => _markedClean = true;
+
+        public void Dispose()
+        {
+            if (OperatingSystem.IsWindows() && IsIISInstalled())
+            {
+                TryPowerShell($"Remove-Website -Name '{ParentSiteName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{ParentSitePoolName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{WebAppApiPoolName}' -ErrorAction SilentlyContinue");
+                TryPowerShell($"Remove-WebAppPool -Name '{WebAppAdminPoolName}' -ErrorAction SilentlyContinue");
+            }
+
+            foreach (var dir in new[] { ParentSitePhysicalPath, WebAppApiPhysicalPath, WebAppAdminPhysicalPath,
+                                        WebAppApiStagingDir, WebAppAdminStagingDir })
+            {
+                try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+                catch { /* best-effort */ }
+            }
+
+            if (!_markedClean && OperatingSystem.IsWindows())
+                Console.WriteLine($"[WebAppCompositionTestContext.Dispose] Test did NOT call MarkClean — ParentSite={ParentSiteName}.");
+        }
+
+        private static string PickFreePort()
+        {
+            using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port.ToString();
+        }
+    }
+
+    private static class Property
+    {
+        public const string PackageSourcePath = "Squid.Action.IISWebSite.Package.SourcePath";
+        public const string PackagePurgeBeforeExtract = "Squid.Action.IISWebSite.Package.PurgeBeforeExtract";
+        public const string WebApplicationCreateOrUpdate = "Squid.Action.IISWebSite.WebApplication.CreateOrUpdate";
+        public const string WebApplicationWebSiteName = "Squid.Action.IISWebSite.WebApplication.WebSiteName";
+        public const string WebApplicationVirtualPath = "Squid.Action.IISWebSite.WebApplication.VirtualPath";
+        public const string WebApplicationPhysicalPath = "Squid.Action.IISWebSite.WebApplication.PhysicalPath";
+        public const string WebApplicationApplicationPoolName = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolName";
+        public const string WebApplicationApplicationPoolFrameworkVersion = "Squid.Action.IISWebSite.WebApplication.ApplicationPoolFrameworkVersion";
+        public const string SubstituteInFilesEnabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+        public const string SubstituteInFilesTargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+    }
+
+    private static bool IsIISInstalled()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        try
+        {
+            var r = RunPowerShell("(Get-WindowsFeature Web-WebServer -ErrorAction SilentlyContinue).Installed");
+            return r.ExitCode == 0 && r.StdOut.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
+        }
+        catch { return false; }
+    }
+
+    private static string PowerShellSingleLine(string command)
+    {
+        var script = $"Import-Module WebAdministration; Write-Host -NoNewline ({command})";
+        return RunPowerShell(script).StdOut.Trim();
+    }
+
+    private static void TryPowerShell(string command)
+    {
+        try { RunPowerShell($"Import-Module WebAdministration -ErrorAction SilentlyContinue; {command}"); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    private static PsResult RunPowerShell(string script)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardInputEncoding = System.Text.Encoding.UTF8,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8
+        };
+
+        using var process = System.Diagnostics.Process.Start(startInfo)!;
+        process.StandardInput.Write(script);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(TimeSpan.FromMinutes(3));
+
+        return new PsResult(process.ExitCode, stdout, stderr);
+    }
+
+    private sealed record PsResult(int ExitCode, string StdOut, string StdErr);
+}


### PR DESCRIPTION
## Summary

- **7 new test files, +1947 LOC**, closing the next layer of audit gaps after #341. Where the prior PR addressed production-safety risks (HTTPS, SCM restart, breaker, output-var, sticky failure), these seven tests close corner cases that production hits but unit/integration tiers don't catch on their own.
- **Pure additions** — no production code touched, no shared test infrastructure modified, no existing test renamed / deleted / changed. Zero regression risk.
- **All Rule 12-compliant**: skip-on-non-OS guards, GUID-suffixed resource names, IDisposable contexts with best-effort cleanup, real production classes (no mocks), `[Trait(\"Category\", ...)]` on every E2E, loopback ports via `TcpListener(0)`, descriptive failure messages with diagnose instructions.

### Tests added

| File | LOC | Tier | Closes |
|---|---|---|---|
| `StepBatcherParallelE2ETests.cs` | 290 | 🟢 High | Wall-clock proof of `Task.WhenAll` parallel batching for `StartWithPrevious` |
| `HalibutScriptObserverTransientFailureTests.cs` | 100 | unit | Pins HalibutClientException propagates uncaught (caller-feeds-breaker contract) |
| `ActionFilteringCompositeE2ETests.cs` | 270 | 🟢 High | 4 actions × 4 exclusion reasons → exactly 1 dispatches |
| `IISDeployRealWorldWebApplicationCompositionE2ETests.cs` | 330 | 🟢 High | Parent + 2 child WebApps, distinct runtimes, no config bleed |
| `IISDeployRealWorldMultiHostE2ETests.cs` | 370 | 🟢 High | Concurrent deploys, per-site journal isolation, no variable bleed |
| `IISDeployRealHostSpecificUserSensitiveE2ETests.cs` | 290 | 🟢 High | SpecificUser AppPool with #{Sensitive.Password} round-trip; masker doesn't leak |
| `ActivityLogTreeShapeE2ETests.cs` | 300 | 🟢 High | Full pipeline → DB → assert tree (1 Task → 2 Step → 4 Action) |

## Test plan

- [x] `dotnet build` all three affected projects (`Squid.E2ETests`, `Squid.UnitTests`, `Squid.WindowsTentacleE2ETests`) — 0 errors
- [x] xUnit discovery confirms all 7 test classes + theory cases registered
- [x] **Runtime execution**: `HalibutScriptObserverTransientFailureTests` — 2/2 passed locally on macOS in 50ms
- [ ] CI: `Squid.UnitTests` full suite stays green (unit tier, runs on every push)
- [ ] CI (Postgres + Kind): `StepBatcherParallelE2ETests`, `ActionFilteringCompositeE2ETests`, `ActivityLogTreeShapeE2ETests`
- [ ] CI (Windows + IIS feature): `IISDeployRealWorldWebApplicationCompositionE2ETests`, `IISDeployRealWorldMultiHostE2ETests`, `IISDeployRealHostSpecificUserSensitiveE2ETests`