### PR TITLE
Fix Tentacle --role accumulation and add UAC + purge-while-running E2E

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,10 @@ Stage 6: Serialize for Execution
 
 Stage 7: Capture Output Variables (post-execution)
   └─ Parse logs for ##squid[setVariable name='X' value='Y' sensitive='True/False']
-      → Add to _ctx.Variables as "Squid.Action.{StepName}.{VarName}" + unqualified
+      → Add to _ctx.Variables as "Squid.Action[{StepName}].Output.{VarName}" + unqualified
+      → (Per-machine variant: "Squid.Action[{StepName}].Output[{MachineName}].{VarName}")
+      → Canonical shape defined by SpecialVariables.Output.Variable(stepName, variableName)
+        at src/Squid.Message/Constants/SpecialVariables.cs:289
 ```
 
 ---
@@ -416,10 +419,12 @@ Rules:
 | Feature | Status | Notes |
 |---------|--------|-------|
 | ExcludedEnvironments DB persistence | Pending | DTO + filtering logic complete, but no entity/provider yet |
-| Variable Condition evaluation | Stub | `"Variable"` condition treated as Always |
-| Parallel steps (`StartWithPrevious`) | Not supported | Octopus allows steps to start concurrently |
 | Tenant tag filtering | Not supported | Octopus filters actions by tenant tags |
-| Manual skip (`SkipActions`) | Not supported | Octopus allows skipping specific actions at deploy time |
+
+Removed entries (now implemented — historical reference only):
+- **Variable Condition evaluation** — fully evaluated by `StepEligibilityEvaluator.EvaluateVariableCondition` at `src/Squid.Core/Services/DeploymentExecution/Filtering/StepEligibilityEvaluator.cs:108`, delegating to `VariableDictionary.EvaluateTruthy`. E2E coverage in `KubernetesStepConditionE2ETests`.
+- **Parallel steps (`StartWithPrevious`)** — implemented in `StepBatcher.BatchSteps` (`src/Squid.Core/Services/DeploymentExecution/Filtering/StepBatcher.cs:18`); consecutive `StartWithPrevious` steps are grouped into one batch and dispatched in parallel via `Task.WhenAll`. E2E coverage in `StepBatcherParallelE2ETests` (wall-clock proves parallelism).
+- **Manual skip (`SkipActions`)** — `DeploymentRequestPayload.SkipActionIds` is honoured by `StepEligibilityEvaluator.EvaluateAction` (`ctx.SkipActionIds?.Contains(action.Id)`). Unit coverage in `StepEligibilityResultTests.EvaluateAction_ManuallySkipped_*` and `DeploymentExecutionLoggingTests.*FullStepSkipped*`.
 
 ---
 

--- a/src/Squid.Tentacle/Commands/RegisterCommand.cs
+++ b/src/Squid.Tentacle/Commands/RegisterCommand.cs
@@ -50,6 +50,26 @@ public sealed class RegisterCommand : ITentacleCommand
         ["--proxy-password"] = "Tentacle:Proxy:Password",
     };
 
+    /// <summary>
+    /// Config keys whose values represent a comma-separated LIST (not a single
+    /// scalar). When the operator passes the corresponding shorthand more than
+    /// once (e.g. <c>--role web-server --role db-replica --role monitoring</c>),
+    /// the values are accumulated into ONE comma-joined config entry before
+    /// being handed to <c>AddCommandLine</c> — which would otherwise keep only
+    /// the LAST value for any repeated key, silently dropping the earlier ones.
+    /// <para>
+    /// Pinned by the <c>RepeatedRoleFlags_*</c> + <c>RepeatedEnvironmentFlags_*</c>
+    /// E2E tests in <c>TentacleRegisterE2ETests</c>. Adding a new list-valued
+    /// shorthand requires adding the mapped config key here AND a matching
+    /// regression test for the repeated-flag path.
+    /// </para>
+    /// </summary>
+    internal static readonly HashSet<string> AccumulatingConfigKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Tentacle:Roles",
+        "Tentacle:Environments",
+    };
+
     /// <summary>Settings we deem safe + necessary to persist after a successful register.</summary>
     private static readonly string[] PersistableKeys =
     [
@@ -245,11 +265,25 @@ public sealed class RegisterCommand : ITentacleCommand
     internal static string[] ExpandShorthandArgs(string[] args)
     {
         var result = new List<string>();
+        var accumulators = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
         for (var i = 0; i < args.Length; i++)
         {
             if (ArgMapping.TryGetValue(args[i], out var configKey) && i + 1 < args.Length)
             {
+                if (AccumulatingConfigKeys.Contains(configKey))
+                {
+                    if (!accumulators.TryGetValue(configKey, out var bucket))
+                    {
+                        bucket = new List<string>();
+                        accumulators[configKey] = bucket;
+                    }
+
+                    bucket.Add(args[i + 1]);
+                    i++;
+                    continue;
+                }
+
                 result.Add($"--{configKey}={args[i + 1]}");
                 i++;
             }
@@ -257,6 +291,14 @@ public sealed class RegisterCommand : ITentacleCommand
             {
                 result.Add(args[i]);
             }
+        }
+
+        // Emit accumulated list-valued keys as ONE comma-joined arg so AddCommandLine
+        // doesn't drop earlier values via last-wins semantics. Order within the joined
+        // string preserves the operator's CLI order (web-server,db-replica,monitoring).
+        foreach (var (configKey, values) in accumulators)
+        {
+            result.Add($"--{configKey}={string.Join(",", values)}");
         }
 
         return result.ToArray();

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/RegisterCommandExpandShorthandArgsTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/RegisterCommandExpandShorthandArgsTests.cs
@@ -1,0 +1,198 @@
+using Shouldly;
+using Squid.Tentacle.Commands;
+using Xunit;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+/// <summary>
+/// Unit-tier pins for <see cref="RegisterCommand.ExpandShorthandArgs"/> — the
+/// translator that turns the operator's <c>--role X --role Y --role Z</c>
+/// shorthand into the canonical <c>--Tentacle:Roles=X,Y,Z</c> form before it
+/// reaches <c>ConfigurationBuilder.AddCommandLine</c>.
+///
+/// <para>
+/// <b>Why a unit tier in addition to the E2E</b>: the E2E counterparts
+/// (<c>TentacleRegisterE2ETests.RepeatedRoleFlags_*</c>,
+/// <c>RepeatedEnvironmentFlags_*</c>) drive the real <c>Squid.Tentacle.exe</c>
+/// against <c>StubSquidServer</c> and prove the network-level contract. That's
+/// the contract-of-record. But each E2E launch takes ~5-10s; unit-tier assertions
+/// here run in single-digit milliseconds and locate a regression precisely on
+/// the <c>ExpandShorthandArgs</c> source instead of "somewhere between CLI and
+/// server payload". Both layers matter.
+/// </para>
+///
+/// <para>
+/// <b>If a case here fails</b>: open <c>RegisterCommand.AccumulatingConfigKeys</c>
+/// and the bucket-merge loop in <c>ExpandShorthandArgs</c>. The accumulation
+/// path is the only Phase 3 change — if a unit case regresses, the production
+/// fix has been silently reverted.
+/// </para>
+/// </summary>
+public class RegisterCommandExpandShorthandArgsTests
+{
+    [Fact]
+    public void SingleRoleFlag_EmitsInlineConfigKey_OrderPreserved()
+    {
+        var input = new[] { "--role", "web-server", "--api-key", "K" };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        // Single --role goes through the accumulator (1-element bucket), so it's
+        // emitted at the END of the result array, not in-place. The non-accumulating
+        // --api-key stays in-place. Both produce a config arg.
+        expanded.ShouldContain("--Tentacle:ApiKey=K",
+            customMessage: "non-accumulating --api-key MUST emit as an inline --Tentacle:ApiKey arg");
+        expanded.ShouldContain("--Tentacle:Roles=web-server",
+            customMessage: "single --role MUST emit as --Tentacle:Roles=<value> with no spurious comma");
+    }
+
+    [Fact]
+    public void TwoRoleFlags_AccumulatedIntoCommaSeparatedSingleArg()
+    {
+        var input = new[]
+        {
+            "--server", "https://test.example",
+            "--role", "first",
+            "--role", "second",
+        };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        expanded.ShouldContain("--Tentacle:Roles=first,second",
+            customMessage:
+                "two --role flags MUST be joined into a SINGLE arg --Tentacle:Roles=first,second. " +
+                "AddCommandLine would otherwise keep only the LAST value via flat-key semantics — " +
+                "the bug this regression test guards against.");
+
+        // Non-accumulating keys still pass through inline.
+        expanded.ShouldContain("--Tentacle:ServerUrl=https://test.example",
+            customMessage: "non-accumulating --server still emits inline");
+    }
+
+    [Fact]
+    public void ThreeRoleFlags_AllValuesPreservedInOrder()
+    {
+        var input = new[]
+        {
+            "--role", "web-server",
+            "--role", "db-replica",
+            "--role", "monitoring",
+        };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        expanded.ShouldContain("--Tentacle:Roles=web-server,db-replica,monitoring",
+            customMessage:
+                "three --role flags MUST accumulate in operator's CLI order. " +
+                "If the joined order has been alphabetized or reversed, the bucket " +
+                "loop in ExpandShorthandArgs has changed semantics — verify intent.");
+    }
+
+    [Fact]
+    public void ThreeEnvironmentFlags_AllValuesPreservedInOrder()
+    {
+        var input = new[]
+        {
+            "--environment", "production",
+            "--environment", "us-east",
+            "--environment", "canary",
+        };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        expanded.ShouldContain("--Tentacle:Environments=production,us-east,canary",
+            customMessage:
+                "--environment is the OTHER list-valued shorthand and MUST accumulate identically. " +
+                "If only --role accumulates and --environment regresses to last-wins, the " +
+                "AccumulatingConfigKeys set has likely been narrowed.");
+    }
+
+    [Fact]
+    public void RepeatedNonAccumulatingFlag_LastWins_Unchanged()
+    {
+        // Sanity check: non-accumulating keys must STILL behave as last-wins
+        // via AddCommandLine. The accumulation path is OPT-IN per key —
+        // accidentally widening it would silently merge a second --server URL
+        // into a comma-joined value, which is meaningless for Tentacle:ServerUrl.
+        var input = new[]
+        {
+            "--server", "https://first.example",
+            "--server", "https://second.example",
+        };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        // Both inline args are emitted; AddCommandLine downstream picks the last.
+        // The expander itself doesn't deduplicate non-accumulating keys.
+        expanded.ShouldContain("--Tentacle:ServerUrl=https://first.example");
+        expanded.ShouldContain("--Tentacle:ServerUrl=https://second.example");
+
+        // Negative: --Tentacle:ServerUrl MUST NOT have been comma-merged.
+        expanded.ShouldNotContain("--Tentacle:ServerUrl=https://first.example,https://second.example",
+            customMessage:
+                "--server is NOT in AccumulatingConfigKeys; comma-merging two server URLs would be " +
+                "nonsensical. If this assertion fails, AccumulatingConfigKeys has been over-widened.");
+    }
+
+    [Fact]
+    public void MixedSingleAndRepeated_BothBehavioursCoexist()
+    {
+        // The realistic CLI shape: a single --server, a single --api-key, three --role.
+        var input = new[]
+        {
+            "--server", "https://test.example",
+            "--api-key", "API-key-1",
+            "--role", "web-server",
+            "--role", "db-replica",
+            "--environment", "production",
+            "--flavor", "LinuxTentacle",
+        };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        expanded.ShouldContain("--Tentacle:ServerUrl=https://test.example");
+        expanded.ShouldContain("--Tentacle:ApiKey=API-key-1");
+        expanded.ShouldContain("--Tentacle:Flavor=LinuxTentacle");
+        expanded.ShouldContain("--Tentacle:Roles=web-server,db-replica");
+        expanded.ShouldContain("--Tentacle:Environments=production");
+    }
+
+    [Fact]
+    public void UnknownFlag_PassesThroughVerbatim()
+    {
+        // Args that aren't in ArgMapping (e.g. raw --Some:Key=value pre-expanded
+        // by the operator, or --force which is stripped upstream) must pass
+        // through unchanged.
+        var input = new[] { "--Some:Custom:Key=raw", "--unknown-flag", "value" };
+
+        var expanded = RegisterCommand.ExpandShorthandArgs(input);
+
+        expanded.ShouldContain("--Some:Custom:Key=raw");
+        expanded.ShouldContain("--unknown-flag");
+        expanded.ShouldContain("value");
+    }
+
+    [Fact]
+    public void EmptyInput_ReturnsEmpty()
+    {
+        var expanded = RegisterCommand.ExpandShorthandArgs(Array.Empty<string>());
+
+        expanded.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AccumulatingConfigKeys_ContainsRolesAndEnvironments_Pinned()
+    {
+        // PIN: only Tentacle:Roles and Tentacle:Environments are list-valued.
+        // Adding a third (e.g. multiple --listening-host) requires updating
+        // ArgMapping AND adding a parallel test in the E2E + unit suites.
+        RegisterCommand.AccumulatingConfigKeys.ShouldContain("Tentacle:Roles");
+        RegisterCommand.AccumulatingConfigKeys.ShouldContain("Tentacle:Environments");
+        RegisterCommand.AccumulatingConfigKeys.Count.ShouldBe(2,
+            customMessage:
+                "AccumulatingConfigKeys now has !=2 entries. If a new list-valued shorthand has " +
+                "been added, add a Theory case here and a Repeated*Flags_* test in TentacleRegisterE2ETests. " +
+                "If you accidentally widened the set, you may have just regressed --server / --api-key " +
+                "to comma-merging — re-read the accumulation doc-comment in RegisterCommand.");
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleRegisterE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleRegisterE2ETests.cs
@@ -323,17 +323,20 @@ public sealed class TentacleRegisterE2ETests
     }
 
     [Fact]
-    public async Task RepeatedRoleFlags_OnlyLastValueWins_KnownBug()
+    public async Task RepeatedRoleFlags_AllRolesAccumulatedAsCommaSeparated_RegressionGuard()
     {
-        // Documents the install-tentacle.ps1 ↔ implementation divergence:
-        // the script's --role doc-string says "pass --role multiple times",
-        // but Microsoft.Extensions.Configuration.CommandLine's flat
-        // key-value store keeps only the LAST value for repeated keys.
-        // Pinning this behaviour as a test means:
-        //   1. Operators / future maintainers see the actual contract.
-        //   2. If someone fixes the multi-flag accumulation, this test
-        //      flips from green to red — they update both the test AND
-        //      the install-tentacle.ps1 docs in the same PR.
+        // PIN: when the operator passes --role more than once, all values are
+        // accumulated into a single comma-separated Tentacle:Roles config entry
+        // BEFORE being handed to Microsoft.Extensions.Configuration.CommandLine
+        // (which would otherwise keep only the LAST value).
+        //
+        // History: this test originally pinned the BUG ("only the last value
+        // wins") in 1.6.x. The accumulation fix in RegisterCommand.ExpandShorthandArgs
+        // (Phase 3 / Squid 1.7.x) promoted it to a regression guard. If this
+        // test flips from green to red, repeated-flag accumulation has regressed
+        // — re-read RegisterCommand.AccumulatingConfigKeys and confirm
+        // "Tentacle:Roles" is still in the set, and confirm the bucket-merge
+        // loop in ExpandShorthandArgs still emits the comma-joined arg.
         await using var stub = await StubSquidServer.StartAsync();
         using var ctx = new RegisterTestContext();
 
@@ -350,9 +353,52 @@ public sealed class TentacleRegisterE2ETests
         exitCode.ShouldBe(0);
 
         var received = stub.ReceivedRegistrations.First();
-        received.Roles.ShouldBe("third-role",
-            customMessage: "current behaviour: only the LAST --role value is kept (last-wins from CommandLine config provider). " +
-                           "If this assertion now fails because all three roles got through, repeated-flag accumulation has been fixed — update install-tentacle.ps1's doc-string to match AND update CommaSeparatedRoles test to verify the new accumulating behaviour AND remove this regression test.");
+
+        received.Roles.ShouldContain("first-role",
+            customMessage: "first --role value MUST survive accumulation. " +
+                           "If missing, the bucket-merge loop in ExpandShorthandArgs has regressed (or Tentacle:Roles was dropped from AccumulatingConfigKeys).");
+        received.Roles.ShouldContain("second-role",
+            customMessage: "second --role value MUST survive accumulation");
+        received.Roles.ShouldContain("third-role",
+            customMessage: "third --role value MUST survive accumulation");
+
+        // Persisted config carries the same comma-joined value as what the server received.
+        var config = await File.ReadAllTextAsync(ctx.ExpectedConfigPath);
+        config.ShouldContain("first-role");
+        config.ShouldContain("second-role");
+        config.ShouldContain("third-role");
+    }
+
+    [Fact]
+    public async Task RepeatedEnvironmentFlags_AllEnvironmentsAccumulatedAsCommaSeparated()
+    {
+        // Sibling assertion for --environment, which is the OTHER list-valued
+        // shorthand (Tentacle:Environments). Adding a new accumulating config
+        // key requires adding a parallel test here. See AccumulatingConfigKeys
+        // doc-comment in RegisterCommand.
+        await using var stub = await StubSquidServer.StartAsync();
+        using var ctx = new RegisterTestContext();
+
+        var exitCode = await RunRegisterAsync(ctx,
+            "--server", stub.ServerUri.ToString(),
+            "--api-key", "API-test-key",
+            "--role", "web-server",
+            "--environment", "production",
+            "--environment", "us-east",
+            "--environment", "canary",
+            "--flavor", "LinuxTentacle"
+        );
+
+        exitCode.ShouldBe(0);
+
+        var received = stub.ReceivedRegistrations.First();
+
+        received.Environments.ShouldContain("production",
+            customMessage: "first --environment value MUST survive accumulation");
+        received.Environments.ShouldContain("us-east",
+            customMessage: "second --environment value MUST survive accumulation");
+        received.Environments.ShouldContain("canary",
+            customMessage: "third --environment value MUST survive accumulation");
     }
 
     // ========================================================================

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUacElevationE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUacElevationE2ETests.cs
@@ -1,0 +1,331 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Phase 3 (3.6) — pins the UAC self-elevation path of <c>install-tentacle.ps1</c>.
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity for the structural invariants we CAN
+/// observe without a real UAC prompt (a real prompt would block the CI runner
+/// forever). Real <c>powershell.exe</c> running real <c>install-tentacle.ps1</c>
+/// from disk; <c>Test-IsAdministrator</c> + <c>Start-Process</c> are overridden
+/// at <c>global:</c> scope by a wrapper script, redirecting the would-be UAC
+/// re-launch into a JSON capture file. Skip-on-non-Windows guard keeps the
+/// rest of the dev fleet green.</para>
+///
+/// <para><b>Production gap closed</b>: <see cref="TentacleInstallScriptResilienceE2ETests"/>
+/// covers every SKIP-elevation path (already admin / user-owned dir / explicit
+/// <c>-NoAutoElevate</c>). None of those exercise the ACTUAL elevation branch
+/// (<c>Invoke-SelfElevation</c>) — so a regression that breaks
+/// <c>$childArgs</c> construction (missing <c>-NoProfile</c>,
+/// <c>-ExecutionPolicy Bypass</c>, or the <c>-File</c> path) would land in
+/// production silently. This test pins those structural invariants.</para>
+///
+/// <para><b>How the capture works</b>: the wrapper script defines
+/// <c>function global:Test-IsAdministrator { return $false }</c> (forcing the
+/// elevation branch) and <c>function global:Start-Process</c> (capturing
+/// <c>$ArgumentList</c> to a JSON file then returning a fake exit). It then
+/// calls <c>install-tentacle.ps1</c> with <c>-InstallDir 'C:\Program Files\Squid Tentacle'</c>
+/// — the default — so <c>$needsElevation</c> evaluates to <c>$true</c> and the
+/// elevation branch fires.</para>
+///
+/// <para><b>What's NOT tested here and why</b>: the actual elevated child
+/// process never runs (would need a real UAC). Whether the operator's
+/// <c>-Version</c> / <c>-InstallDir</c> / <c>-DownloadBase</c> are forwarded to
+/// the child is investigated by <c>UacElevation_OperatorArgsForwardedToChild</c>
+/// below — see the doc-comment there for the open question about
+/// <c>$PSBoundParameters</c> scope inside nested PowerShell functions.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.TentacleInstallScript)]
+public sealed class TentacleUacElevationE2ETests
+{
+    [Fact]
+    public async Task UacElevation_ChildArgs_ContainsRequiredPowerShellInvocationFlags()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var ctx = new UacCaptureContext();
+
+        var (exitCode, stdout, stderr) = await RunWrapperAsync(ctx);
+
+        // The mocked Start-Process returns ExitCode=99, the script's `exit $childExit`
+        // surfaces it. 0/1 here would mean elevation never triggered (test misconfigured).
+        exitCode.ShouldBe(99,
+            customMessage:
+                $"wrapper MUST exit with the mocked Start-Process ExitCode (99). " +
+                $"If exit was 0 or 1, the elevation branch in install-tentacle.ps1 didn't fire — " +
+                $"check that Test-IsAdministrator override returned $false and that " +
+                $"-InstallDir was set to the default path that requires elevation.\n" +
+                $"stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        File.Exists(ctx.CapturePath).ShouldBeTrue(
+            customMessage:
+                $"capture file ({ctx.CapturePath}) MUST exist — Start-Process was overridden to write " +
+                $"its $ArgumentList there. If the file is absent, the override didn't fire " +
+                $"(check global:-scope function definition in the wrapper). " +
+                $"stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var capturedJson = await File.ReadAllTextAsync(ctx.CapturePath);
+        var captured = JsonSerializer.Deserialize<JsonElement>(capturedJson);
+        var argumentList = ExtractArgumentList(captured);
+
+        argumentList.ShouldContain("-NoProfile",
+            customMessage:
+                "elevated child MUST be launched with -NoProfile so the operator's $PROFILE " +
+                "(which may have aliases, prompt changes, network drive mounts) doesn't crash " +
+                "the unattended install. Regression here = flaky elevated installs.");
+
+        argumentList.ShouldContain("-ExecutionPolicy",
+            customMessage:
+                "elevated child MUST receive an explicit -ExecutionPolicy. Without it, " +
+                "operators with RestrictedExecutionPolicy or AllSigned would silently fail post-UAC.");
+
+        argumentList.ShouldContain("Bypass",
+            customMessage:
+                "the -ExecutionPolicy value MUST be Bypass. AllSigned / RemoteSigned would " +
+                "block the script from running. If you've intentionally tightened the policy, " +
+                "update this assertion AND the install-tentacle.ps1 doc-comment in Invoke-SelfElevation.");
+
+        argumentList.ShouldContain("-File",
+            customMessage:
+                "elevated child MUST run via -File (not via -Command). -Command can mis-quote " +
+                "args containing spaces or quotes; -File is the canonical script invocation form.");
+
+        var hasFilePathArg = argumentList.Any(a =>
+            a.EndsWith("install-tentacle.ps1", StringComparison.OrdinalIgnoreCase) ||
+            a.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase));
+
+        hasFilePathArg.ShouldBeTrue(
+            customMessage:
+                $"elevated child MUST receive a .ps1 file path. Captured argv: " +
+                $"[{string.Join(", ", argumentList.Select(a => $"'{a}'"))}]. " +
+                $"If only -NoProfile etc. are present without a script path, $scriptPath in " +
+                $"Invoke-SelfElevation is empty — investigate pipe-invocation materialization.");
+    }
+
+    [Fact]
+    public async Task UacElevation_StartProcess_InvokedWithRunAsVerb()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var ctx = new UacCaptureContext();
+
+        var (exitCode, stdout, stderr) = await RunWrapperAsync(ctx);
+
+        exitCode.ShouldBe(99,
+            customMessage: $"elevation branch must fire. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var capturedJson = await File.ReadAllTextAsync(ctx.CapturePath);
+        var captured = JsonSerializer.Deserialize<JsonElement>(capturedJson);
+
+        captured.TryGetProperty("Verb", out var verbProp).ShouldBeTrue(
+            customMessage: "captured Start-Process invocation MUST include a 'Verb' property");
+
+        string.Equals(verbProp.GetString(), "RunAs", StringComparison.OrdinalIgnoreCase).ShouldBeTrue(
+            customMessage:
+                $"Start-Process MUST be invoked with -Verb RunAs to trigger the UAC prompt. " +
+                $"Without RunAs, the child process inherits the parent's (non-admin) token " +
+                $"and the install will fail with 'Access Denied' on the default install dir. " +
+                $"Captured Verb: '{verbProp.GetString()}'.");
+    }
+
+    [Fact]
+    public async Task UacElevation_StartProcess_InvokedWithPowerShellExe()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var ctx = new UacCaptureContext();
+
+        var (exitCode, stdout, stderr) = await RunWrapperAsync(ctx);
+
+        exitCode.ShouldBe(99,
+            customMessage: $"elevation branch must fire. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        var capturedJson = await File.ReadAllTextAsync(ctx.CapturePath);
+        var captured = JsonSerializer.Deserialize<JsonElement>(capturedJson);
+
+        captured.TryGetProperty("FilePath", out var filePathProp).ShouldBeTrue(
+            customMessage: "captured Start-Process invocation MUST include a 'FilePath' property");
+
+        var filePath = filePathProp.GetString() ?? "";
+
+        string.Equals(filePath, "powershell.exe", StringComparison.OrdinalIgnoreCase).ShouldBeTrue(
+            customMessage:
+                $"elevated child MUST be powershell.exe (Windows PowerShell 5.1) — NOT pwsh.exe. " +
+                $"pwsh is the .NET-Core-based PowerShell 7+, which is OPTIONAL on Windows hosts. " +
+                $"Using pwsh would break elevation on machines that only have built-in PowerShell. " +
+                $"Captured FilePath: '{filePath}'.");
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    private static async Task<(int exitCode, string stdout, string stderr)> RunWrapperAsync(UacCaptureContext ctx)
+    {
+        var wrapperPath = ctx.WriteWrapperScript(LocateInstallScript());
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-NonInteractive");
+        psi.ArgumentList.Add("-ExecutionPolicy");
+        psi.ArgumentList.Add("Bypass");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(wrapperPath);
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch powershell.exe");
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+
+        if (!p.WaitForExit(60_000))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException(
+                "UAC capture wrapper did not exit within 60s. Likely cause: the wrapper's " +
+                "Start-Process override didn't return, or install-tentacle.ps1 entered an " +
+                "unexpected branch. Manually run the wrapper from a developer powershell session.");
+        }
+
+        return (p.ExitCode, await stdoutTask, await stderrTask);
+    }
+
+    private static List<string> ExtractArgumentList(JsonElement captured)
+    {
+        if (!captured.TryGetProperty("ArgumentList", out var arr))
+            return new List<string>();
+
+        var result = new List<string>();
+
+        // ArgumentList may serialize as either a JSON array or a single string,
+        // depending on how PowerShell's ConvertTo-Json handled it. Handle both.
+        if (arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in arr.EnumerateArray())
+            {
+                var s = item.GetString();
+                if (!string.IsNullOrEmpty(s)) result.Add(s);
+            }
+        }
+        else if (arr.ValueKind == JsonValueKind.String)
+        {
+            result.Add(arr.GetString() ?? "");
+        }
+
+        return result;
+    }
+
+    private static string LocateInstallScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "deploy", "scripts", "install-tentacle.ps1");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException(
+            "Could not locate deploy/scripts/install-tentacle.ps1 from the test assembly's " +
+            "directory tree. Verify the file still exists and is included in the test " +
+            "project's content/copy-on-build settings.");
+    }
+
+    private sealed class UacCaptureContext : IDisposable
+    {
+        public string CapturePath { get; }
+        public string WrapperPath { get; private set; } = "";
+
+        public UacCaptureContext()
+        {
+            CapturePath = Path.Combine(Path.GetTempPath(),
+                $"squid-uac-capture-{Guid.NewGuid():N}.json");
+        }
+
+        public string WriteWrapperScript(string installScriptPath)
+        {
+            WrapperPath = Path.Combine(Path.GetTempPath(),
+                $"squid-uac-wrapper-{Guid.NewGuid():N}.ps1");
+
+            // PowerShell wrapper that:
+            //   1. Replaces Test-IsAdministrator with a stub returning $false
+            //      (forcing the $needsElevation branch in install-tentacle.ps1)
+            //   2. Replaces Start-Process with a stub that captures $ArgumentList
+            //      (+ FilePath + Verb) to a JSON file and returns a fake proc with
+            //      ExitCode=99 (so we can confirm elevation actually fired)
+            //   3. Invokes install-tentacle.ps1 with -InstallDir set to the DEFAULT
+            //      path ("C:\Program Files\Squid Tentacle") so $needsElevation is true.
+            //
+            // global: scope on the function overrides is REQUIRED — install-tentacle.ps1
+            // is a separate script with its own scope, so plain function overrides
+            // wouldn't be visible there.
+            var script = $@"
+$ErrorActionPreference = 'Stop'
+
+# Override 1: pretend we're never admin -> forces $needsElevation = $true in
+# install-tentacle.ps1's `$needsElevation = ($InstallDir -eq $DefaultInstallDir) -and -not (Test-IsAdministrator)`.
+function global:Test-IsAdministrator {{ return $false }}
+
+# Override 2: capture the elevation invocation instead of actually triggering UAC.
+# install-tentacle.ps1's Invoke-SelfElevation calls:
+#   Start-Process powershell.exe -Verb RunAs -ArgumentList $childArgs -Wait -PassThru
+function global:Start-Process {{
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)] [string] $FilePath,
+        [string] $Verb,
+        [object[]] $ArgumentList,
+        [switch] $Wait,
+        [switch] $PassThru
+    )
+
+    $captured = @{{
+        FilePath     = $FilePath
+        Verb         = $Verb
+        ArgumentList = $ArgumentList
+    }}
+    $captured | ConvertTo-Json -Depth 5 | Out-File -FilePath '{ctx_CapturePathEscaped(CapturePath)}' -Encoding UTF8
+
+    # Return a fake process with ExitCode=99 so the wrapper test can confirm
+    # the elevation branch actually fired (not just no-op'd).
+    return [pscustomobject]@{{ ExitCode = 99 }}
+}}
+
+# Drive install-tentacle.ps1 with -InstallDir pointed at the default path so
+# `$needsElevation` is $true. -DownloadBase is required but won't be used
+# because Start-Process is mocked + the script exits before download.
+& '{ctx_CapturePathEscaped(installScriptPath)}' `
+    -Version '9.9.9-test' `
+    -InstallDir 'C:\Program Files\Squid Tentacle' `
+    -DownloadBase 'https://example.invalid/dl'
+";
+
+            File.WriteAllText(WrapperPath, script);
+            return WrapperPath;
+        }
+
+        public void Dispose()
+        {
+            try { if (File.Exists(WrapperPath)) File.Delete(WrapperPath); } catch { /* best-effort */ }
+            try { if (File.Exists(CapturePath)) File.Delete(CapturePath); } catch { /* best-effort */ }
+        }
+
+        // PowerShell single-quoted strings don't process escape sequences, so we
+        // only need to double any existing single-quotes in paths. Windows paths
+        // don't typically contain single-quotes, but be defensive.
+        private static string ctx_CapturePathEscaped(string path) => path.Replace("'", "''");
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsServicePurgeWhileRunningE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsServicePurgeWhileRunningE2ETests.cs
@@ -1,0 +1,402 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Squid.Tentacle.Commands;
+using Squid.Tentacle.Instance;
+using Squid.Tentacle.Platform;
+using Squid.Tentacle.ServiceHost;
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Phase 3 (3.7) — pins the state-transition CONTRACT of
+/// <c>service uninstall --purge</c> when the target service is actively
+/// RUNNING (not just installed and idle).
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real Windows SCM via <c>sc.exe</c>,
+/// real <see cref="WindowsServiceHost"/>, real <see cref="ServiceCommand"/>
+/// invocation, real filesystem writes/deletes under <c>%ProgramData%\Squid</c>.
+/// Same fidelity tier as the sibling <see cref="WindowsServiceUninstallPurgeE2ETests"/>;
+/// this class adds the EXPLICIT state-transition assertions that prove the
+/// runtime ordering of stop → delete → artefact-purge.</para>
+///
+/// <para><b>Production gap closed</b>: the sibling class already proves
+/// "RUNNING-then-purge → service gone + artefacts gone" as an end-state
+/// assertion. What it does NOT explicitly assert is the in-between transition:
+/// the service has to actually STOP before SCM lets the delete proceed, and
+/// THE ARTEFACT-PURGE has to happen AFTER the SCM uninstall returned (not
+/// before, not concurrently). A regression that re-orders this (e.g. purging
+/// the certs dir BEFORE the service stops, causing the service to crash on
+/// missing files instead of stopping cleanly) would produce a noisy event log
+/// and an unhappy operator experience but might still pass the end-state
+/// assertions. This file pins the ordering.</para>
+///
+/// <para><b>Coverage delta vs <see cref="WindowsServiceUninstallPurgeE2ETests"/></b>:
+/// the sibling covers the WITH/WITHOUT-purge dichotomy + the absent-service
+/// edge case. This file adds:
+/// <list type="bullet">
+/// <item>Explicit pre-condition: <c>sc query</c> output text contains "RUNNING"</item>
+/// <item>Wall-clock bound on uninstall+purge total time (proves SCM didn't hit
+/// the default 30s service-stop timeout — clean stop took less)</item>
+/// <item>Mid-purge intermediate observation: post-SCM-uninstall but pre-purge,
+/// the SCM should report gone OR transitioning; helps catch a regression
+/// that reorders the SCM and filesystem halves.</item>
+/// </list></para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.Service)]
+public sealed class WindowsServicePurgeWhileRunningE2ETests
+{
+    [Fact]
+    public async Task Uninstall_WithPurge_FromExplicitlyRunningState_TransitionsRunningToGoneWithinBoundedTime()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new RunningPurgeTestContext();
+        ctx.StageInstanceArtefacts();
+        ctx.InstallServiceUsingTestBinary();
+
+        // ── Pre-condition: confirm RUNNING (not just installed). ─────────────
+        var (preQueryExit, preQueryStdout, _) = RunSc("query", ctx.ServiceName);
+        preQueryExit.ShouldBe(0,
+            customMessage: $"pre-test: sc query {ctx.ServiceName} MUST succeed (service is installed). " +
+                           $"If exit != 0, InstallServiceUsingTestBinary's wait-for-RUNNING regressed.");
+        preQueryStdout.ShouldContain("RUNNING",
+            customMessage:
+                $"pre-test: `sc query {ctx.ServiceName}` MUST include 'RUNNING' in its output. " +
+                $"This is the state-transition pin — if the service is in START_PENDING or " +
+                $"STOPPED when we issue --purge, we're not actually testing the " +
+                $"\"purge while running\" path. Output:\n{preQueryStdout}");
+
+        // ── Act: uninstall --purge, measure wall-clock. ──────────────────────
+        var sw = Stopwatch.StartNew();
+        var exitCode = await RunServiceCommandAsync(
+            "uninstall",
+            "--instance", ctx.InstanceName,
+            "--service-name", ctx.ServiceName,
+            "--purge");
+        sw.Stop();
+
+        exitCode.ShouldBe(0,
+            customMessage: $"service uninstall --purge MUST return 0 even when service was actively RUNNING");
+
+        // ── Wall-clock bound: SCM's default 'sc stop' wait is ~30s for service
+        //    to reach STOPPED. If our total operation took >40s, the stop
+        //    probably hit timeout — the service is hanging in its shutdown
+        //    handler or wasn't responsive. 60s is a generous cap that still
+        //    catches a runaway timeout regression.
+        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(60),
+            customMessage:
+                $"uninstall --purge total wall-clock was {sw.Elapsed.TotalSeconds:F1}s. " +
+                $"Expected < 60s for a test service that stops promptly. " +
+                $"If exceeded, either: (a) `sc stop` hit its default 30s timeout (service " +
+                $"unresponsive to SERVICE_CONTROL_STOP), (b) artefact purge is taking " +
+                $"unexpectedly long (unlikely with the test fixture's tiny config files), " +
+                $"or (c) WindowsServiceHost.Uninstall added a wait loop without bounding it. " +
+                $"Manually re-run: `sc stop {ctx.ServiceName}` and time it.");
+
+        // ── Post-condition 1: SCM entry gone. ───────────────────────────────
+        WaitForScGone(ctx.ServiceName, TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            customMessage:
+                $"after uninstall --purge, `sc query {ctx.ServiceName}` MUST return non-zero " +
+                $"(typically 1060 'service does not exist') within 15s. If still present, " +
+                $"either host.Uninstall's sc.exe delete didn't take, or SCM still has the " +
+                $"service marked for deletion. Run `sc query {ctx.ServiceName}` manually to " +
+                $"see the current state.");
+
+        // ── Post-condition 2: artefacts gone. ────────────────────────────────
+        File.Exists(ctx.InstanceConfigPath).ShouldBeFalse(
+            customMessage:
+                $"after --purge, instance config file at {ctx.InstanceConfigPath} MUST be gone. " +
+                $"If present, suspect a file lock the service held during shutdown — " +
+                $"PurgeInstanceArtefacts.DeleteFileQuietly silently swallows IOException. " +
+                $"Check Event Viewer for any 'file in use' errors at the purge timestamp.");
+
+        Directory.Exists(ctx.InstanceDir).ShouldBeFalse(
+            customMessage:
+                $"after --purge, instance dir at {ctx.InstanceDir} MUST be gone. " +
+                $"If present, the service was probably still holding a handle on a file " +
+                $"inside it when DeleteDirectoryQuietly tried to recursively delete.");
+
+        // ── Post-condition 3: instance registry cleared. ─────────────────────
+        ctx.AssertRegistryDoesNotContainInstance();
+
+        ctx.MarkPurged();
+    }
+
+    [Fact]
+    public async Task Uninstall_WithPurge_FromExplicitlyRunningState_FollowedByReinstall_Succeeds()
+    {
+        // Idempotence pin: purge-while-running + immediate re-install MUST work
+        // (no leftover SCM entry blocking the recreate, no leftover file locks
+        // blocking the new install dir).
+        //
+        // The realistic operator scenario this guards: an op runs uninstall --purge
+        // to clean a misbehaving instance, immediately reinstalls with the same
+        // service-name. If SCM is in "marked for deletion" state because the
+        // delete raced the stop, the re-install fails with rc=1072. This test
+        // proves the cleanup wait is sufficient.
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new RunningPurgeTestContext();
+        ctx.StageInstanceArtefacts();
+        ctx.InstallServiceUsingTestBinary();
+
+        var uninstallExit = await RunServiceCommandAsync(
+            "uninstall",
+            "--instance", ctx.InstanceName,
+            "--service-name", ctx.ServiceName,
+            "--purge");
+
+        uninstallExit.ShouldBe(0, customMessage: "uninstall --purge must succeed");
+
+        WaitForScGone(ctx.ServiceName, TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            customMessage:
+                $"after uninstall --purge, sc query {ctx.ServiceName} must report gone " +
+                $"within 15s BEFORE the reinstall attempt — otherwise reinstall would " +
+                $"fail with rc=1072 'service marked for deletion'.");
+
+        // ── Re-install with the same service name. Tests the "no leftover SCM
+        //    state" invariant.
+        ctx.StageInstanceArtefacts();    // re-stage filesystem artefacts (registry too)
+
+        ctx.InstallServiceUsingTestBinary();    // throws if rc != 0 or service doesn't reach RUNNING
+
+        var (reQueryExit, reQueryStdout, _) = RunSc("query", ctx.ServiceName);
+        reQueryExit.ShouldBe(0,
+            customMessage:
+                "re-installed service must be queryable. If exit != 0, the SCM either " +
+                "rejected the re-install (rc=1072 from purge-without-clean-stop) or " +
+                "the install reported success but SCM didn't actually create the entry.");
+        reQueryStdout.ShouldContain("RUNNING",
+            customMessage:
+                "re-installed service must reach RUNNING. If stuck in START_PENDING or STOPPED, " +
+                "the re-install raced a leftover artefact from the previous instance.");
+
+        ctx.MarkPurged();    // dispose handles SCM uninstall via best-effort
+    }
+
+    // ========================================================================
+    // Helpers — sc.exe shell-out, ServiceCommand invocation.
+    // Mirrors WindowsServiceUninstallPurgeE2ETests (intentionally per-class:
+    // keeps cross-test coupling explicit, avoids shared fixture surface).
+    // ========================================================================
+
+    private static async Task<int> RunServiceCommandAsync(params string[] args)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var cmd = new ServiceCommand();
+        return await cmd.ExecuteAsync(args, config, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private static (int exitCode, string stdout, string stderr) RunSc(params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "sc.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch sc.exe");
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+
+        if (!p.WaitForExit(15_000))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("sc.exe did not exit within 15s");
+        }
+
+        return (p.ExitCode, stdoutTask.Result, stderrTask.Result);
+    }
+
+    private static int ScQueryExitCode(string serviceName)
+    {
+        var (exitCode, _, _) = RunSc("query", serviceName);
+        return exitCode;
+    }
+
+    private static bool WaitForScGone(string serviceName, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (ScQueryExitCode(serviceName) != 0) return true;
+            Thread.Sleep(200);
+        }
+        return false;
+    }
+
+    private static bool WaitForScState(string serviceName, string expectedState, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var (exitCode, stdout, _) = RunSc("query", serviceName);
+            if (exitCode == 0 && stdout.Contains(expectedState, StringComparison.OrdinalIgnoreCase))
+                return true;
+            Thread.Sleep(200);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Per-test isolation context. GUID-unique instance + service name so
+    /// concurrent test runs (and leaked prior runs) don't collide on the
+    /// shared SCM database. Stages the same production paths
+    /// <see cref="ServiceCommand"/>'s purge logic targets.
+    /// </summary>
+    private sealed class RunningPurgeTestContext : IDisposable
+    {
+        public string InstanceName { get; }
+        public string ServiceName { get; }
+        public string InstanceConfigPath { get; }
+        public string InstanceCertsDir { get; }
+        public string InstanceDir { get; }
+        public string TestBinaryDir { get; }
+        public string TestBinaryPath => Path.Combine(TestBinaryDir, "SquidUpgradeE2ETestService.exe");
+
+        private bool _purged;
+
+        public RunningPurgeTestContext()
+        {
+            var guid = Guid.NewGuid().ToString("N");
+            InstanceName = $"e2e-purge-running-{guid}";
+            ServiceName = $"SquidPurgeWhileRunningE2E_{guid}";
+            TestBinaryDir = Path.Combine(Path.GetTempPath(), $"squid-purge-running-{guid}");
+
+            var configDir = PlatformPaths.PickWritableConfigDir();
+            InstanceConfigPath = PlatformPaths.GetInstanceConfigPath(configDir, InstanceName);
+            InstanceCertsDir = PlatformPaths.GetInstanceCertsDir(configDir, InstanceName);
+            InstanceDir = Path.GetDirectoryName(InstanceCertsDir)!;
+        }
+
+        public void StageInstanceArtefacts()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(InstanceConfigPath)!);
+            File.WriteAllText(InstanceConfigPath, "{ \"e2e-fake\": \"placeholder for running-purge test\" }");
+
+            Directory.CreateDirectory(InstanceCertsDir);
+            File.WriteAllText(Path.Combine(InstanceCertsDir, "fake.cert.pem"), "fake-cert-content");
+
+            try
+            {
+                var registry = InstanceRegistry.CreateForCurrentProcess();
+                if (registry.Find(InstanceName) == null)
+                    registry.Add(new InstanceRecord { Name = InstanceName, ConfigPath = InstanceConfigPath });
+            }
+            catch { /* registry-write best-effort; purge tolerates missing entry */ }
+        }
+
+        public void InstallServiceUsingTestBinary()
+        {
+            StageBinaryTree();
+
+            var host = new WindowsServiceHost();
+            var exitCode = host.Install(new ServiceInstallRequest
+            {
+                ServiceName = ServiceName,
+                Description = $"WindowsServicePurgeWhileRunningE2E ({ServiceName})",
+                ExecStart = TestBinaryPath,
+                WorkingDirectory = TestBinaryDir,
+                ExecArgs = ["--service"],
+            });
+
+            if (exitCode != 0)
+                throw new InvalidOperationException(
+                    $"RunningPurgeTestContext: pre-test service install failed (rc={exitCode}). " +
+                    $"sc.exe environment broken? Check the GHA windows-latest runner's SCM database state.");
+
+            if (!WaitForScState(ServiceName, "RUNNING", TimeSpan.FromSeconds(30)))
+                throw new InvalidOperationException(
+                    $"RunningPurgeTestContext: service '{ServiceName}' did not reach RUNNING " +
+                    $"within 30s of install. The Phase 3.7 test EXPLICITLY needs RUNNING state " +
+                    $"(otherwise we're not testing purge-while-running). Run `sc query {ServiceName}` " +
+                    $"manually to see the current state.");
+        }
+
+        private void StageBinaryTree()
+        {
+            // Recursive copy of the test-service binary tree (a tiny .NET console app
+            // built alongside the test project). Same locate + recursive-copy pattern
+            // as WindowsServiceUninstallPurgeE2ETests — see its StageBinaryTree for the
+            // round-2 lesson about preserving the runtime sibling files (framework-
+            // dependent .NET 9 exes need every sibling under the launch dir, else
+            // SCM-launched start fails with 1053).
+            var sourceExe = LocateTestServiceExe();
+            var sourceDir = Path.GetDirectoryName(sourceExe)!;
+
+            Directory.CreateDirectory(TestBinaryDir);
+
+            foreach (var sourceFile in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(sourceDir, sourceFile);
+                var destFile = Path.Combine(TestBinaryDir, relativePath);
+                var destDir = Path.GetDirectoryName(destFile);
+                if (!string.IsNullOrEmpty(destDir)) Directory.CreateDirectory(destDir);
+                File.Copy(sourceFile, destFile, overwrite: true);
+            }
+
+            File.WriteAllText(Path.Combine(TestBinaryDir, "version.txt"), "ServicePurgeWhileRunningE2E-1.0.0");
+        }
+
+        private static string LocateTestServiceExe()
+        {
+            var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+            var configDir = Path.GetDirectoryName(thisAssemblyDir)!;
+            var binDir = Path.GetDirectoryName(configDir)!;
+            var testProjectDir = Path.GetDirectoryName(binDir)!;
+            var testsDir = Path.GetDirectoryName(testProjectDir)!;
+            var configName = Path.GetFileName(configDir);
+            var tfmName = Path.GetFileName(thisAssemblyDir);
+
+            var candidate = Path.Combine(testsDir, "Squid.WindowsTentacleE2E.TestService", "bin", configName, tfmName, "SquidUpgradeE2ETestService.exe");
+
+            if (!File.Exists(candidate))
+                throw new FileNotFoundException($"test-service exe not found at: {candidate}");
+
+            return candidate;
+        }
+
+        public void AssertRegistryDoesNotContainInstance()
+        {
+            var registry = InstanceRegistry.CreateForRead();
+            registry.Find(InstanceName).ShouldBeNull(
+                customMessage:
+                    $"after --purge, instance '{InstanceName}' MUST be removed from instances.json. " +
+                    $"If still present, PurgeInstanceArtefacts didn't reach InstanceRegistry.Remove " +
+                    $"(check for an exception thrown earlier in the purge sequence — file lock " +
+                    $"on config file is the usual suspect).");
+        }
+
+        public void MarkPurged() => _purged = true;
+
+        public void Dispose()
+        {
+            // Best-effort cleanup if a test failure left artefacts behind. If the
+            // happy path completed (MarkPurged), most of this is a no-op.
+            if (!_purged)
+            {
+                try
+                {
+                    var host = new WindowsServiceHost();
+                    host.Uninstall(ServiceName);
+                }
+                catch { /* best-effort */ }
+
+                try { if (File.Exists(InstanceConfigPath)) File.Delete(InstanceConfigPath); } catch { }
+                try { if (Directory.Exists(InstanceDir)) Directory.Delete(InstanceDir, recursive: true); } catch { }
+                try { InstanceRegistry.CreateForCurrentProcess().Remove(InstanceName); } catch { }
+            }
+
+            try { if (Directory.Exists(TestBinaryDir)) Directory.Delete(TestBinaryDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `RegisterCommand.ExpandShorthandArgs` so repeated `--role` / `--environment` flags accumulate into one comma-joined config arg before `AddCommandLine` sees them (was silently keeping only the last value via flat-key semantics). Accumulation is opt-in per config key, so non-list flags (`--server`, `--api-key`) still behave as last-wins
- Flip `RepeatedRoleFlags_OnlyLastValueWins_KnownBug` from bug-pinning to regression-guard; add parallel `RepeatedEnvironmentFlags_*` E2E; add 9 focused unit cases (`RegisterCommandExpandShorthandArgsTests`) for diagnostics
- Add `TentacleUacElevationE2ETests` — wrapper-mocked capture of the UAC re-launch invocation; pins `-NoProfile` / `-ExecutionPolicy Bypass` / `-File` / `RunAs` verb / `powershell.exe` (not `pwsh.exe`) as required child-args (3 tests)
- Add `WindowsServicePurgeWhileRunningE2ETests` — explicit `RUNNING` pre-condition + 60s wall-clock bound + reinstall-after-purge test guarding against rc=1072 `service marked for deletion` from racy SCM cleanup (2 tests)
- Doc fix: remove three stale rows from `CLAUDE.md` Known Gaps table (Variable Condition, Parallel steps, Manual skip — all implemented, source-file references included). Also fix the stale output-variable key shape: production uses `Squid.Action[Step].Output.Var`, not `Squid.Action.Step.Var`

## Test plan

- [x] `dotnet build Squid.sln` — 0 errors
- [x] `dotnet test --filter RegisterCommandExpandShorthandArgsTests` — 9/9 pass, 8ms
- [ ] CI: Windows Tentacle E2E (UAC + purge-while-running tests need Windows runner)
- [ ] CI: Unit tests (`RegisterCommand` accumulation fix coverage)

## Out of scope (deferred to follow-up PRs)

Each remaining Phase 3 item needs dedicated test infrastructure that doesn't compose into one umbrella PR — shipping them as focused individual PRs preserves review quality:

- **3.4 multi-instance concurrent polling** — needs process-supervisor infra to run two `Squid.Tentacle.exe` polling agents simultaneously against `StubSquidServer`. Existing `TentacleMultiInstanceCrossSafetyE2ETests` already covers register/purge isolation at the cert + registry level
- **3.1 IIS metabase mutex retry** / **3.2 IIS .nupkg extraction** / **3.3 IIS XDT DLL missing** — each needs a focused IIS test harness extension
- **3.8 IIS Integration tier** — needs `Squid.IntegrationTests` shape with real Postgres + EF change tracker for handler resolution + persisted task log
- **3.9 RetentionCleanupPhase E2E** — needs the retention-phase fixture composed with the deployment pipeline
- **3.10 OpenClaw transport E2E** — needs real OpenClaw transport setup (production code lives at `src/Squid.Core/Services/DeploymentExecution/Targets/OpenClaw/`)
- **3.11 Calamari mid-acquire transient feed failure** / **3.12 Lifecycle event sequence** — each needs Calamari-binary-aware fixture