### PR TITLE
Implement NuGet feed search and version listing strategies

### DIFF
--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageSearch/NuGetPackageSearchStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageSearch/NuGetPackageSearchStrategy.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Http;
+
+namespace Squid.Core.Services.Deployments.ExternalFeeds.PackageSearch;
+
+/// <summary>
+/// Searches package IDs on a NuGet feed by query prefix. Tries V3
+/// <c>SearchQueryService</c> first (via the service index at
+/// <c>{feedUri}/index.json</c>); if that fails (404 / not a V3 feed / no
+/// <c>SearchQueryService</c> resource declared), falls back to V2 OData
+/// <c>/Search()</c>. The two-protocol dance mirrors
+/// <see cref="PackageNotes.NuGetPackageNotesStrategy"/>'s pattern — every
+/// NuGet feed type Squid supports speaks at least one of the two protocols.
+///
+/// <para><b>Why V3 first</b>: V3 is the modern protocol every public NuGet
+/// feed (NuGet.org, GitHub Packages NuGet, Azure Artifacts) and most modern
+/// private servers (BaGet, Sleet, ProGet) speak. V2 is the older OData
+/// protocol that older private NuGet.Server installations still serve
+/// exclusively (e.g. on-prem servers that haven't been upgraded).</para>
+///
+/// <para><b>Why prerelease + semVerLevel matter</b>: NuGet V3
+/// <c>SearchQueryService</c> defaults to <c>prerelease=false</c> +
+/// <c>semVerLevel</c> unset. A feed of only-prerelease packages (1.0.0-rc1)
+/// or SemVer 2.0 packages (1.0.0-beta.1+build.2) would silently return zero
+/// hits. We always send <c>prerelease=true</c> + <c>semVerLevel=2.0.0</c> so
+/// the operator sees every package the feed actually publishes.</para>
+///
+/// <para><b>Coverage note</b>: this was the Phase-3 missing piece that
+/// caused IIS deploy operators to see "no results" when picking ANY NuGet
+/// feed. Sibling sites <c>NuGetPackageVersionStrategy</c> closes the
+/// "selected the package, can't pick a version" half of the same bug.</para>
+/// </summary>
+public class NuGetPackageSearchStrategy(ISquidHttpClientFactory httpClientFactory) : IPackageSearchStrategy
+{
+    private static readonly TimeSpan SearchTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>NuGet V3 service-index resource <c>@type</c> prefix for the search endpoint.</summary>
+    internal const string SearchQueryServiceTypePrefix = "SearchQueryService";
+
+    /// <summary>OData namespace prefix used in V2 NuGet responses.</summary>
+    private const string DataServicesNamespace = "http://schemas.microsoft.com/ado/2007/08/dataservices";
+
+    public bool CanHandle(string feedType) =>
+        !string.IsNullOrWhiteSpace(feedType) && feedType.Contains("NuGet", StringComparison.OrdinalIgnoreCase);
+
+    public async Task<List<string>> SearchAsync(ExternalFeed feed, string query, int take, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(feed.FeedUri)) return [];
+        if (take <= 0) take = 20;
+
+        var headers = BuildAuthHeaders(feed);
+
+        var v3 = await TrySearchV3Async(feed.FeedUri, query, take, headers, ct).ConfigureAwait(false);
+
+        if (v3 != null) return v3;
+
+        return await SearchV2Async(feed.FeedUri, query, take, headers, ct).ConfigureAwait(false);
+    }
+
+    // ── V3 path ────────────────────────────────────────────────────────────────
+
+    private async Task<List<string>> TrySearchV3Async(string feedUri, string query, int take, Dictionary<string, string> headers, CancellationToken ct)
+    {
+        try
+        {
+            var serviceIndexUrl = $"{feedUri.TrimEnd('/')}/index.json";
+            var client = httpClientFactory.CreateClient(timeout: SearchTimeout, headers: headers);
+
+            using var indexResponse = await client.GetAsync(serviceIndexUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (!indexResponse.IsSuccessStatusCode) return null;
+
+            var indexJson = await indexResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var searchUrl = FindSearchQueryServiceUrl(indexJson);
+
+            if (searchUrl == null) return null;
+
+            var searchEndpoint = BuildV3SearchEndpoint(searchUrl, query, take);
+            var searchClient = httpClientFactory.CreateClient(timeout: SearchTimeout, headers: headers);
+
+            using var searchResponse = await searchClient.GetAsync(searchEndpoint, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (!searchResponse.IsSuccessStatusCode) return null;
+
+            var searchJson = await searchResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            return ParseV3SearchResponse(searchJson);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Walks the V3 service-index <c>resources</c> array looking for the first
+    /// resource whose <c>@type</c> starts with <c>SearchQueryService</c>
+    /// (versions <c>3.0.0-beta</c> / <c>3.0.0-rc</c> / <c>3.0.0</c> / <c>3.5.0</c>
+    /// all share that prefix). Returns the resource's <c>@id</c>, or null when
+    /// the feed isn't V3 / has no search service declared.
+    /// </summary>
+    internal static string FindSearchQueryServiceUrl(string serviceIndexJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(serviceIndexJson);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("resources", out var resources) || resources.ValueKind != JsonValueKind.Array)
+                return null;
+
+            foreach (var resource in resources.EnumerateArray())
+            {
+                if (!resource.TryGetProperty("@type", out var typeProp)) continue;
+
+                var type = typeProp.GetString();
+
+                if (type != null && type.StartsWith(SearchQueryServiceTypePrefix, StringComparison.Ordinal))
+                {
+                    if (resource.TryGetProperty("@id", out var idProp) && idProp.ValueKind == JsonValueKind.String)
+                        return idProp.GetString();
+                }
+            }
+
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    internal static string BuildV3SearchEndpoint(string searchServiceUrl, string query, int take)
+    {
+        var encodedQuery = Uri.EscapeDataString(query ?? string.Empty);
+        var separator = searchServiceUrl.Contains('?') ? "&" : "?";
+
+        // prerelease=true + semVerLevel=2.0.0 are non-negotiable: see class doc-comment.
+        return $"{searchServiceUrl}{separator}q={encodedQuery}&take={take}&prerelease=true&semVerLevel=2.0.0";
+    }
+
+    internal static List<string> ParseV3SearchResponse(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
+                return [];
+
+            var packages = new List<string>();
+
+            foreach (var item in data.EnumerateArray())
+            {
+                if (item.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String)
+                {
+                    var id = idProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(id)) packages.Add(id);
+                }
+            }
+
+            return packages;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    // ── V2 path ────────────────────────────────────────────────────────────────
+
+    private async Task<List<string>> SearchV2Async(string feedUri, string query, int take, Dictionary<string, string> headers, CancellationToken ct)
+    {
+        try
+        {
+            var url = BuildV2SearchUrl(feedUri, query, take);
+            var client = httpClientFactory.CreateClient(timeout: SearchTimeout, headers: headers);
+
+            using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode) return [];
+
+            var xml = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            return ParseV2SearchResponse(xml, take);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    internal static string BuildV2SearchUrl(string feedUri, string query, int take)
+    {
+        // OData string-literal escape: single quotes inside the string double up.
+        var escaped = (query ?? string.Empty).Replace("'", "''");
+        var encodedQuery = Uri.EscapeDataString($"'{escaped}'");
+
+        // includePrerelease=true matches V3's prerelease=true. semVerLevel=2.0.0 is
+        // a NuGet V2 extension some servers honour (NuGet.Server >= 3.4); harmless
+        // on older servers that ignore it.
+        return $"{feedUri.TrimEnd('/')}/Search()?$top={take}&searchTerm={encodedQuery}&includePrerelease=true&semVerLevel=2.0.0";
+    }
+
+    /// <summary>
+    /// Parses an OData Atom feed XML and extracts unique package IDs from
+    /// <c>&lt;entry&gt;&lt;m:properties&gt;&lt;d:Id&gt;</c>. Dedupes because V2
+    /// <c>/Search()</c> can return multiple entries per package (one per version)
+    /// when <c>$filter</c> isn't constraining to <c>IsLatestVersion</c>.
+    /// </summary>
+    internal static List<string> ParseV2SearchResponse(string xml, int take)
+    {
+        try
+        {
+            var doc = XDocument.Parse(xml);
+            XNamespace d = DataServicesNamespace;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var packages = new List<string>();
+
+            foreach (var idElement in doc.Descendants(d + "Id"))
+            {
+                var id = idElement.Value?.Trim();
+                if (string.IsNullOrWhiteSpace(id)) continue;
+                if (!seen.Add(id)) continue;
+
+                packages.Add(id);
+
+                if (packages.Count >= take) break;
+            }
+
+            return packages;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    // ── Auth ───────────────────────────────────────────────────────────────────
+
+    private static Dictionary<string, string> BuildAuthHeaders(ExternalFeed feed)
+    {
+        if (string.IsNullOrWhiteSpace(feed.Username) || string.IsNullOrWhiteSpace(feed.Password))
+            return null;
+
+        var encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{feed.Username}:{feed.Password}"));
+
+        return new Dictionary<string, string> { ["Authorization"] = $"Basic {encoded}" };
+    }
+}

--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/NuGetPackageVersionStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageVersion/NuGetPackageVersionStrategy.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Http;
+
+namespace Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+
+/// <summary>
+/// Enumerates every version of a NuGet package known to the feed. Tries V3
+/// <c>PackageBaseAddress</c> first (the flat container that serves
+/// <c>{base}/{id-lower}/index.json</c> with a <c>versions[]</c> array); on
+/// failure falls back to V2 OData <c>/FindPackagesById()</c> with inline
+/// next-link pagination.
+///
+/// <para><b>Critical contract note (per <see cref="IPackageVersionStrategy"/>)</b>:
+/// this method returns ALL upstream versions up to
+/// <see cref="PackageVersionEnumerationCap"/>. The caller —
+/// <c>ExternalFeedPackageVersionService</c> — applies
+/// <see cref="PackageVersionFilter.Apply"/> to do filter + semver sort + take.
+/// Don't pre-truncate here: a freshly pushed <c>1.1.0</c> can appear AFTER
+/// many lex-late <c>1.0.x-N</c> entries on a server that orders by upload
+/// time, and pre-truncation would hide it.</para>
+///
+/// <para><b>Package ID casing</b>: NuGet V3's flat container is case-sensitive
+/// (the path segment is always lowercase). NuGet package IDs are documented
+/// case-insensitive, so we lowercase before the V3 path lookup. V2 is
+/// case-insensitive in queries; we pass the operator's casing verbatim.</para>
+///
+/// <para><b>Coverage note</b>: closes the Phase-3 gap where IIS-deploy
+/// operators selecting a NuGet feed couldn't list versions even when they
+/// typed the exact package ID manually (the version dropdown stayed empty).
+/// Sibling <c>NuGetPackageSearchStrategy</c> closes the search half.</para>
+/// </summary>
+public class NuGetPackageVersionStrategy(ISquidHttpClientFactory httpClientFactory) : IPackageVersionStrategy
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>V3 service-index resource <c>@type</c> prefix for the flat-container endpoint.</summary>
+    internal const string PackageBaseAddressTypePrefix = "PackageBaseAddress";
+
+    private const string DataServicesNamespace = "http://schemas.microsoft.com/ado/2007/08/dataservices";
+    private const string AtomNamespace = "http://www.w3.org/2005/Atom";
+
+    public bool CanHandle(string feedType) =>
+        !string.IsNullOrWhiteSpace(feedType) && feedType.Contains("NuGet", StringComparison.OrdinalIgnoreCase);
+
+    public async Task<List<string>> ListVersionsAsync(ExternalFeed feed, string packageId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(packageId)) return [];
+        if (string.IsNullOrWhiteSpace(feed.FeedUri)) return [];
+
+        var headers = BuildAuthHeaders(feed);
+        var enumerationCap = PackageVersionEnumerationCap.Resolve();
+
+        var v3 = await TryListVersionsV3Async(feed.FeedUri, packageId, headers, enumerationCap, ct).ConfigureAwait(false);
+
+        if (v3 != null) return v3;
+
+        return await ListVersionsV2Async(feed.FeedUri, packageId, headers, enumerationCap, ct).ConfigureAwait(false);
+    }
+
+    // ── V3 path ────────────────────────────────────────────────────────────────
+
+    private async Task<List<string>> TryListVersionsV3Async(string feedUri, string packageId, Dictionary<string, string> headers, int enumerationCap, CancellationToken ct)
+    {
+        try
+        {
+            var serviceIndexUrl = $"{feedUri.TrimEnd('/')}/index.json";
+            var client = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
+
+            using var indexResponse = await client.GetAsync(serviceIndexUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (!indexResponse.IsSuccessStatusCode) return null;
+
+            var indexJson = await indexResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var packageBaseUrl = FindPackageBaseAddressUrl(indexJson);
+
+            if (packageBaseUrl == null) return null;
+
+            var versionsUrl = $"{packageBaseUrl.TrimEnd('/')}/{packageId.ToLowerInvariant()}/index.json";
+            var versionsClient = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
+
+            using var versionsResponse = await versionsClient.GetAsync(versionsUrl, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+            if (!versionsResponse.IsSuccessStatusCode) return null;
+
+            var versionsJson = await versionsResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            return ParseV3VersionsResponse(versionsJson, enumerationCap);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static string FindPackageBaseAddressUrl(string serviceIndexJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(serviceIndexJson);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("resources", out var resources) || resources.ValueKind != JsonValueKind.Array)
+                return null;
+
+            foreach (var resource in resources.EnumerateArray())
+            {
+                if (!resource.TryGetProperty("@type", out var typeProp)) continue;
+
+                var type = typeProp.GetString();
+
+                if (type != null && type.StartsWith(PackageBaseAddressTypePrefix, StringComparison.Ordinal))
+                {
+                    if (resource.TryGetProperty("@id", out var idProp) && idProp.ValueKind == JsonValueKind.String)
+                        return idProp.GetString();
+                }
+            }
+
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    internal static List<string> ParseV3VersionsResponse(string json, int enumerationCap)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("versions", out var versions) || versions.ValueKind != JsonValueKind.Array)
+                return [];
+
+            var result = new List<string>();
+
+            foreach (var item in versions.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String) continue;
+                var v = item.GetString();
+
+                if (string.IsNullOrWhiteSpace(v)) continue;
+
+                result.Add(v);
+
+                if (result.Count >= enumerationCap) break;
+            }
+
+            return result;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    // ── V2 path (with inline OData <link rel="next"> pagination) ─────────────
+
+    private async Task<List<string>> ListVersionsV2Async(string feedUri, string packageId, Dictionary<string, string> headers, int enumerationCap, CancellationToken ct)
+    {
+        try
+        {
+            var url = BuildV2VersionsUrl(feedUri, packageId);
+            var versions = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var pageBudget = 50;    // belt-and-braces: cap on page count even if cap not reached
+
+            while (!string.IsNullOrWhiteSpace(url) && versions.Count < enumerationCap && pageBudget-- > 0)
+            {
+                var client = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
+
+                using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode) break;
+
+                var xml = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                var (pageVersions, nextLink) = ParseV2VersionsResponse(xml);
+
+                foreach (var v in pageVersions)
+                {
+                    if (!seen.Add(v)) continue;
+                    versions.Add(v);
+
+                    if (versions.Count >= enumerationCap) break;
+                }
+
+                url = nextLink;
+            }
+
+            return versions;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    internal static string BuildV2VersionsUrl(string feedUri, string packageId)
+    {
+        var escaped = (packageId ?? string.Empty).Replace("'", "''");
+        var encodedId = Uri.EscapeDataString($"'{escaped}'");
+
+        // semVerLevel=2.0.0 ensures SemVer 2.0 versions (e.g. 1.0.0-beta.1+build.2)
+        // aren't silently dropped by servers honouring the extension. Older
+        // NuGet.Server installations ignore unknown params, so this is safe to send
+        // unconditionally.
+        return $"{feedUri.TrimEnd('/')}/FindPackagesById()?id={encodedId}&semVerLevel=2.0.0";
+    }
+
+    /// <summary>
+    /// Parses one page of an OData Atom feed response. Returns the versions
+    /// extracted from <c>&lt;entry&gt;&lt;m:properties&gt;&lt;d:Version&gt;</c>
+    /// (prefers <c>&lt;d:NormalizedVersion&gt;</c> when present) and the
+    /// <c>&lt;link rel="next"&gt;</c> URL for the next page, or null when
+    /// the page has no continuation.
+    /// </summary>
+    internal static (List<string> versions, string nextLink) ParseV2VersionsResponse(string xml)
+    {
+        try
+        {
+            var doc = XDocument.Parse(xml);
+            XNamespace d = DataServicesNamespace;
+            XNamespace atom = AtomNamespace;
+
+            var versions = new List<string>();
+
+            foreach (var entry in doc.Descendants(atom + "entry"))
+            {
+                var properties = entry.Descendants(d + "NormalizedVersion").FirstOrDefault()
+                                ?? entry.Descendants(d + "Version").FirstOrDefault();
+
+                var version = properties?.Value?.Trim();
+
+                if (!string.IsNullOrWhiteSpace(version)) versions.Add(version);
+            }
+
+            var nextLink = doc.Descendants(atom + "link")
+                .FirstOrDefault(link =>
+                {
+                    var rel = link.Attribute("rel")?.Value;
+                    return string.Equals(rel, "next", StringComparison.OrdinalIgnoreCase);
+                })?.Attribute("href")?.Value;
+
+            return (versions, nextLink);
+        }
+        catch
+        {
+            return (new List<string>(), null);
+        }
+    }
+
+    // ── Auth ───────────────────────────────────────────────────────────────────
+
+    private static Dictionary<string, string> BuildAuthHeaders(ExternalFeed feed)
+    {
+        if (string.IsNullOrWhiteSpace(feed.Username) || string.IsNullOrWhiteSpace(feed.Password))
+            return null;
+
+        var encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{feed.Username}:{feed.Password}"));
+
+        return new Dictionary<string, string> { ["Authorization"] = $"Basic {encoded}" };
+    }
+}

--- a/tests/Squid.IntegrationTests/Services/Deployments/ExternalFeeds/NuGetFeedLiveIntegrationTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/ExternalFeeds/NuGetFeedLiveIntegrationTests.cs
@@ -1,0 +1,262 @@
+using System.Net.Http;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageSearch;
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+using Squid.Core.Services.Http;
+
+namespace Squid.IntegrationTests.Services.Deployments.ExternalFeeds;
+
+/// <summary>
+/// Live integration tests driving <see cref="NuGetPackageSearchStrategy"/> and
+/// <see cref="NuGetPackageVersionStrategy"/> against a real operator NuGet feed
+/// (<c>https://nuget.sjfood.us/nuget</c>) — the same feed bound in the SquidWeb
+/// frontend during the IIS-deploy smoke validation that surfaced the original
+/// "search returns nothing" bug. Provides end-to-end confidence that:
+///
+/// <list type="number">
+/// <item><b>The V2 fallback actually works</b> against a V2-only NuGet.Server
+///       installation. Operator NuGet.Server (private mirrors, on-prem feeds)
+///       commonly serve V2 only — V3 service index returns 404. The unit suite
+///       exercises both protocols with mocked HTTP, but only a live call against
+///       a real V2-only server proves the fallback path is correct.</item>
+/// <item><b>The OData XML parser handles real-world responses</b> with their
+///       namespace prefixes, optional fields, mixed-case casing, and inline
+///       pagination links exactly as the OData spec describes.</item>
+/// <item><b>The chained search → version flow works</b> — pick a package via
+///       search, then list its versions. This is the exact UX path an operator
+///       drives from the IIS-deploy step UI's Package selector.</item>
+/// </list>
+///
+/// <para><b>Tier (per Rule 12)</b>: 🟢 High-fidelity for the strategy code under
+/// test (real production class + real HTTP); 🟡 Medium-fidelity for the broader
+/// service composition since we don't drive the request through
+/// <c>ExternalFeedPackageSearchService</c> + DI — the tests instantiate the
+/// strategies directly with a thin <c>ISquidHttpClientFactory</c> wrapper that
+/// returns plain <c>HttpClient</c>. The service layer is already covered by
+/// <c>ExternalFeedPackageSearchServiceTests</c> (unit tier).</para>
+///
+/// <para><b>Network skip semantics</b>: every <c>[Fact]</c> probes connectivity
+/// to the feed root in a 5s timeout before running the actual assertion. If the
+/// feed is unreachable (operator's mirror down, CI runner without egress), the
+/// test returns CLEANLY without failing. This is the same skip-on-disconnect
+/// philosophy as the Kind cluster fixture in <c>Squid.E2ETests</c>.</para>
+///
+/// <para><b>Assertion style — resilient, not brittle</b>: assertions check
+/// "non-empty result" + "chained flow works" rather than pinning specific
+/// package IDs / versions. The feed's contents can drift; tests must not. The
+/// only fixed assertion is on the search-then-version round-trip
+/// (any → any), proving the protocol contract end-to-end.</para>
+/// </summary>
+[Trait("Category", "LiveNuGetFeed")]
+public class NuGetFeedLiveIntegrationTests
+{
+    private const string LiveFeedUri = "https://nuget.sjfood.us/nuget";
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task SearchAsync_EmptyQuery_ReturnsAtLeastOnePackage_AgainstLiveV2Feed()
+    {
+        if (!await IsFeedReachableAsync().ConfigureAwait(false)) return;
+
+        var strategy = new NuGetPackageSearchStrategy(new LiveHttpClientFactory());
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = LiveFeedUri };
+
+        var packages = await strategy.SearchAsync(feed, "", 20, CancellationToken.None).ConfigureAwait(false);
+
+        packages.ShouldNotBeNull();
+        packages.Count.ShouldBeGreaterThan(0,
+            customMessage:
+                $"Search with empty query against {LiveFeedUri} MUST return at least one package. " +
+                $"If empty, either the V2 fallback isn't engaging on a V2-only feed, or the OData XML " +
+                $"parser isn't extracting <d:Id> elements. Manual diagnose: " +
+                $"`curl '{LiveFeedUri}/Search()?$top=3&searchTerm='''''&includePrerelease=true' | xmllint --format -` " +
+                $"should show <entry> elements with <d:Id> children.");
+    }
+
+    [Fact]
+    public async Task SearchAsync_DedupsPackageIdsAcrossVersions_AgainstLiveV2Feed()
+    {
+        // V2 /Search() returns one entry per (id, version) pair, so a package with N
+        // versions yields N entries. The parser MUST dedupe so the UI dropdown shows
+        // each package ID exactly once. Verifies on the LIVE feed because this is the
+        // single most-likely silent failure (parser regression: results show as
+        // PackageA, PackageA, PackageA, ... instead of unique IDs).
+        if (!await IsFeedReachableAsync().ConfigureAwait(false)) return;
+
+        var strategy = new NuGetPackageSearchStrategy(new LiveHttpClientFactory());
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = LiveFeedUri };
+
+        var packages = await strategy.SearchAsync(feed, "", 50, CancellationToken.None).ConfigureAwait(false);
+
+        var distinctCount = packages.Distinct(StringComparer.OrdinalIgnoreCase).Count();
+
+        distinctCount.ShouldBe(packages.Count,
+            customMessage:
+                $"Search results MUST be unique by package ID. Got {packages.Count} results but only " +
+                $"{distinctCount} distinct IDs — the V2 OData parser is not deduping. The UI would show " +
+                $"duplicate options in the package dropdown. Suspect: ParseV2SearchResponse's HashSet logic.");
+    }
+
+    [Fact]
+    public async Task ChainedSearchAndListVersions_OnLiveFeed_ReturnsAtLeastOneVersionForFirstHit()
+    {
+        // The full UX path: operator selects a NuGet feed → searches → picks a package
+        // → version dropdown populates. This test exercises the chain end-to-end.
+        // Resilient: doesn't assume specific package contents; picks whatever the first
+        // search hit is and asserts that THAT package has at least one version.
+        if (!await IsFeedReachableAsync().ConfigureAwait(false)) return;
+
+        var searchStrategy = new NuGetPackageSearchStrategy(new LiveHttpClientFactory());
+        var versionStrategy = new NuGetPackageVersionStrategy(new LiveHttpClientFactory());
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = LiveFeedUri };
+
+        var packages = await searchStrategy.SearchAsync(feed, "", 5, CancellationToken.None).ConfigureAwait(false);
+
+        packages.Count.ShouldBeGreaterThan(0,
+            customMessage:
+                "Chained flow pre-condition: search MUST return at least one package. " +
+                "If 0, the chained-flow test cannot verify version listing.");
+
+        var firstPackageId = packages[0];
+        var versions = await versionStrategy.ListVersionsAsync(feed, firstPackageId, CancellationToken.None).ConfigureAwait(false);
+
+        versions.ShouldNotBeNull();
+        versions.Count.ShouldBeGreaterThan(0,
+            customMessage:
+                $"After search returned '{firstPackageId}', ListVersionsAsync against the same feed " +
+                $"MUST return at least one version. If 0, the version strategy's V2 fallback isn't " +
+                $"engaging or the OData XML parser isn't extracting <d:Version>/<d:NormalizedVersion>. " +
+                $"Manual diagnose: " +
+                $"`curl \"{LiveFeedUri}/FindPackagesById()?id='{firstPackageId}'&semVerLevel=2.0.0\" | xmllint --format -` " +
+                $"should show <entry> elements with version data.");
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_CaseInsensitivePackageId_AgainstLiveV2Feed()
+    {
+        // NuGet package IDs are documented case-insensitive. The V3 flat-container
+        // path is case-sensitive (we lowercase before lookup); V2 OData is
+        // case-insensitive natively. This test catches a regression where the
+        // strategy accidentally case-folds the operator's input in a way that
+        // breaks V2 lookups (e.g. lowercasing for V3 then passing the lowercased
+        // form into the V2 fallback URL — which would break some V2 servers that
+        // do case-sensitive comparison despite the spec).
+        if (!await IsFeedReachableAsync().ConfigureAwait(false)) return;
+
+        var searchStrategy = new NuGetPackageSearchStrategy(new LiveHttpClientFactory());
+        var versionStrategy = new NuGetPackageVersionStrategy(new LiveHttpClientFactory());
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = LiveFeedUri };
+
+        var packages = await searchStrategy.SearchAsync(feed, "", 1, CancellationToken.None).ConfigureAwait(false);
+
+        if (packages.Count == 0) return;    // Feed is empty — skip the case-insensitive sub-check
+
+        var operatorCasing = packages[0];
+        var uppercased = operatorCasing.ToUpperInvariant();
+        var lowercased = operatorCasing.ToLowerInvariant();
+
+        var versionsOperator = await versionStrategy.ListVersionsAsync(feed, operatorCasing, CancellationToken.None).ConfigureAwait(false);
+        var versionsUpper = await versionStrategy.ListVersionsAsync(feed, uppercased, CancellationToken.None).ConfigureAwait(false);
+        var versionsLower = await versionStrategy.ListVersionsAsync(feed, lowercased, CancellationToken.None).ConfigureAwait(false);
+
+        versionsOperator.Count.ShouldBeGreaterThan(0,
+            customMessage:
+                $"Baseline: ListVersionsAsync('{operatorCasing}') MUST find versions. " +
+                "If 0, the chained flow itself is broken — not a casing issue.");
+
+        // The other two cases SHOULD produce the same count IF the feed implements
+        // case-insensitive lookups (NuGet.Server / BaGet / NuGet.org all do). A
+        // non-compliant feed wouldn't, in which case we accept "either equal OR 0"
+        // — we only fail when the count is NEITHER zero NOR equal (which would
+        // indicate a partial-match bug specific to our strategy).
+        AssertCaseInsensitiveCountMatches(versionsOperator.Count, versionsUpper.Count, $"{operatorCasing} vs {uppercased}");
+        AssertCaseInsensitiveCountMatches(versionsOperator.Count, versionsLower.Count, $"{operatorCasing} vs {lowercased}");
+    }
+
+    private static void AssertCaseInsensitiveCountMatches(int expected, int actual, string casePair)
+    {
+        var acceptable = actual == expected || actual == 0;
+
+        acceptable.ShouldBeTrue(
+            customMessage:
+                $"Case-insensitive lookup mismatch ({casePair}): expected {expected} versions, " +
+                $"got {actual}. Either a server-side case-sensitive comparison (acceptable, will be 0) " +
+                $"OR a partial parsing bug in our strategy (NOT acceptable). If the live feed lookup " +
+                $"returns a non-zero, non-matching count, the strategy is finding SOMETHING but not " +
+                $"the full set — investigate URL encoding or partial-match parsing.");
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithBogusQueryNotInFeed_ReturnsEmptyOrFewResults_AgainstLiveV2Feed()
+    {
+        // Behavioural sanity check: a query that's extremely unlikely to match
+        // anything must return a small / empty result set, NOT a server error.
+        // If a parser regression makes us misinterpret "no results" as "all results"
+        // (e.g. by ignoring the search term), this would catch it.
+        if (!await IsFeedReachableAsync().ConfigureAwait(false)) return;
+
+        var strategy = new NuGetPackageSearchStrategy(new LiveHttpClientFactory());
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = LiveFeedUri };
+
+        var packages = await strategy.SearchAsync(feed, "qqq-bogus-no-package-with-this-name-zzz-9999", 20, CancellationToken.None).ConfigureAwait(false);
+
+        // Either empty (most likely) or very few — never 20+ since the searchTerm
+        // is enforced by the server. If 20+, something's wrong with the URL
+        // construction (searchTerm not actually being applied).
+        packages.Count.ShouldBeLessThan(20,
+            customMessage:
+                $"Bogus-query search MUST be filtered by the server. Got {packages.Count} results — " +
+                $"if 20 (the take limit), the searchTerm parameter isn't being honoured. Either the " +
+                $"OData URL is malformed (missing quoting / escaping) or the server is ignoring the param.");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static async Task<bool> IsFeedReachableAsync()
+    {
+        try
+        {
+            using var client = new HttpClient { Timeout = ProbeTimeout };
+            using var response = await client.GetAsync($"{LiveFeedUri}/$metadata").ConfigureAwait(false);
+
+            // Any 2xx OR 4xx response means the server is up and responding (4xx is fine —
+            // it means we reached the host but the path was wrong). 5xx or transport
+            // failure = server unreachable / down — skip the test.
+            return (int)response.StatusCode < 500;
+        }
+        catch (HttpRequestException) { return false; }
+        catch (TaskCanceledException) { return false; }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ISquidHttpClientFactory"/> that returns a real
+    /// <see cref="HttpClient"/>. The strategies only call <see cref="ISquidHttpClientFactory.CreateClient"/>;
+    /// the other methods throw so any future regression that uses them is caught.
+    /// </summary>
+    private sealed class LiveHttpClientFactory : ISquidHttpClientFactory
+    {
+        public HttpClient CreateClient(TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null)
+        {
+            var client = new HttpClient();
+
+            if (timeout.HasValue) client.Timeout = timeout.Value;
+
+            if (headers != null)
+            {
+                foreach (var h in headers)
+                    client.DefaultRequestHeaders.Add(h.Key, h.Value);
+            }
+
+            return client;
+        }
+
+        public Task<T> GetAsync<T>(string requestUrl, CancellationToken cancellationToken, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false) => throw new NotImplementedException();
+        public Task<T> PostAsync<T>(string requestUrl, HttpContent content, CancellationToken cancellationToken, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false) => throw new NotImplementedException();
+        public Task<T> PutAsync<T>(string requestUrl, HttpContent content = null, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<T> DeleteAsync<T>(string requestUrl, HttpContent content = null, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<T> PostAsJsonAsync<T>(string requestUrl, object value, CancellationToken cancellationToken, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false) => throw new NotImplementedException();
+        public Task<HttpResponseMessage> PostAsJsonAsync(string requestUrl, object value, CancellationToken cancellationToken, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true) => throw new NotImplementedException();
+        public Task<T> PostAsStreamAsync<T>(string requestUrl, object value, CancellationToken cancellationToken, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false) => throw new NotImplementedException();
+        public Task<T> PostAsMultipartAsync<T>(string requestUrl, Dictionary<string, string> formData, Dictionary<string, (byte[], string)> fileData, CancellationToken cancellationToken, TimeSpan? timeout = null, bool beginScope = false, Dictionary<string, string> headers = null, bool shouldLogError = true, bool isNeedToReadErrorContent = false) => throw new NotImplementedException();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageSearchStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageSearchStrategyTests.cs
@@ -1,0 +1,463 @@
+using System.Net;
+using System.Net.Http;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageSearch;
+using Squid.Core.Services.Http;
+
+namespace Squid.UnitTests.Services.Deployments.ExternalFeeds;
+
+public class NuGetPackageSearchStrategyTests
+{
+    private readonly Mock<ISquidHttpClientFactory> _httpClientFactory = new();
+
+    // ── CanHandle ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("NuGet", true)]
+    [InlineData("NuGet Feed", true)]
+    [InlineData("nuget", true)]
+    [InlineData("NUGET", true)]
+    [InlineData("Docker", false)]
+    [InlineData("GitHub", false)]
+    [InlineData("Helm", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void CanHandle_ShouldMatchNuGetFeedTypesCaseInsensitively(string feedType, bool expected)
+    {
+        var sut = CreateSut();
+
+        sut.CanHandle(feedType).ShouldBe(expected);
+    }
+
+    // ── V3 service-index parsing ──────────────────────────────────────────────
+
+    [Fact]
+    public void FindSearchQueryServiceUrl_ShouldReturnUrl_ForValidServiceIndex()
+    {
+        var indexJson = """
+            {
+              "version": "3.0.0",
+              "resources": [
+                {
+                  "@id": "https://example.com/v3/registration/",
+                  "@type": "RegistrationsBaseUrl/3.6.0"
+                },
+                {
+                  "@id": "https://example.com/v3/search?q=",
+                  "@type": "SearchQueryService/3.5.0"
+                },
+                {
+                  "@id": "https://example.com/v3-flatcontainer/",
+                  "@type": "PackageBaseAddress/3.0.0"
+                }
+              ]
+            }
+            """;
+
+        var url = NuGetPackageSearchStrategy.FindSearchQueryServiceUrl(indexJson);
+
+        url.ShouldBe("https://example.com/v3/search?q=",
+            customMessage:
+                "FindSearchQueryServiceUrl MUST locate the SearchQueryService resource by @type prefix and " +
+                "return its @id. If null/wrong, the V3 path silently falls through to V2.");
+    }
+
+    [Fact]
+    public void FindSearchQueryServiceUrl_ShouldMatchAnySearchQueryServiceVersion()
+    {
+        // NuGet has SearchQueryService versions 3.0.0-beta, 3.0.0-rc, 3.0.0, 3.5.0.
+        // Our prefix match must accept all of them.
+        foreach (var typeVersion in new[]
+        {
+            "SearchQueryService",
+            "SearchQueryService/3.0.0-beta",
+            "SearchQueryService/3.0.0-rc",
+            "SearchQueryService/3.0.0",
+            "SearchQueryService/3.5.0",
+        })
+        {
+            var indexJson = $$"""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    { "@id": "https://example.com/search", "@type": "{{typeVersion}}" }
+                  ]
+                }
+                """;
+
+            NuGetPackageSearchStrategy.FindSearchQueryServiceUrl(indexJson)
+                .ShouldBe("https://example.com/search",
+                    customMessage: $"@type='{typeVersion}' MUST be recognized as a search service (NuGet has multiple version suffixes for the same resource type).");
+        }
+    }
+
+    [Fact]
+    public void FindSearchQueryServiceUrl_ShouldReturnNull_WhenNoSearchService()
+    {
+        var indexJson = """
+            {
+              "version": "3.0.0",
+              "resources": [
+                { "@id": "https://example.com/registration", "@type": "RegistrationsBaseUrl/3.6.0" }
+              ]
+            }
+            """;
+
+        NuGetPackageSearchStrategy.FindSearchQueryServiceUrl(indexJson).ShouldBeNull(
+            customMessage: "When index has no SearchQueryService resource, V3 path MUST fall through (return null) so V2 fallback can try.");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{}")]
+    [InlineData("""{ "resources": "not an array" }""")]
+    [InlineData("""{ "no_resources_key": true }""")]
+    public void FindSearchQueryServiceUrl_ShouldReturnNull_ForMalformedOrIncompleteIndex(string indexJson)
+    {
+        NuGetPackageSearchStrategy.FindSearchQueryServiceUrl(indexJson).ShouldBeNull();
+    }
+
+    // ── V3 endpoint construction ──────────────────────────────────────────────
+
+    [Fact]
+    public void BuildV3SearchEndpoint_ShouldAppendQueryParameters()
+    {
+        var endpoint = NuGetPackageSearchStrategy.BuildV3SearchEndpoint("https://example.com/search", "Newtonsoft", 25);
+
+        endpoint.ShouldContain("q=Newtonsoft");
+        endpoint.ShouldContain("take=25");
+        endpoint.ShouldContain("prerelease=true",
+            customMessage: "prerelease=true is REQUIRED — without it, feeds with only prerelease packages silently return zero results.");
+        endpoint.ShouldContain("semVerLevel=2.0.0",
+            customMessage: "semVerLevel=2.0.0 is REQUIRED — without it, SemVer 2.0 packages (e.g. 1.0.0-beta.1+build.2) are silently filtered out.");
+    }
+
+    [Fact]
+    public void BuildV3SearchEndpoint_ShouldUseAmpersand_WhenSearchUrlAlreadyContainsQuery()
+    {
+        // NuGet.org publishes its SearchQueryService URL with a trailing "?q=" baked in.
+        // We must use & not ? as the separator for our extra parameters.
+        var endpoint = NuGetPackageSearchStrategy.BuildV3SearchEndpoint("https://example.com/search?q=", "test", 20);
+
+        // Verify there's exactly one '?' (no double-query-marker like ?q=?...).
+        // Manual count loop — `string.Count(predicate)` resolves to the wrong
+        // MemoryExtensions.Count<T>(Span<T>, T) overload via implicit conversion,
+        // and System.Linq isn't in the test project's GlobalUsings.
+        var questionMarkCount = 0;
+        foreach (var c in endpoint) if (c == '?') questionMarkCount++;
+
+        questionMarkCount.ShouldBe(1,
+            customMessage: $"Endpoint MUST have exactly one '?'. Got: {endpoint}");
+    }
+
+    [Fact]
+    public void BuildV3SearchEndpoint_ShouldUrlEncodeQuery()
+    {
+        var endpoint = NuGetPackageSearchStrategy.BuildV3SearchEndpoint("https://example.com/search", "foo bar+baz/qux", 10);
+
+        endpoint.ShouldContain("q=foo%20bar%2Bbaz%2Fqux",
+            customMessage: "Query MUST be URL-encoded; spaces, +, / would otherwise break the URL.");
+    }
+
+    [Fact]
+    public void BuildV3SearchEndpoint_ShouldHandleEmptyOrNullQuery()
+    {
+        NuGetPackageSearchStrategy.BuildV3SearchEndpoint("https://example.com/search", "", 10)
+            .ShouldContain("q=&");
+        NuGetPackageSearchStrategy.BuildV3SearchEndpoint("https://example.com/search", null, 10)
+            .ShouldContain("q=&");
+    }
+
+    // ── V3 response parsing ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseV3SearchResponse_ShouldReturnPackageIds()
+    {
+        var json = """
+            {
+              "totalHits": 3,
+              "data": [
+                { "id": "Newtonsoft.Json", "version": "13.0.3" },
+                { "id": "AutoMapper", "version": "12.0.1" },
+                { "id": "FluentValidation", "version": "11.7.0" }
+              ]
+            }
+            """;
+
+        var ids = NuGetPackageSearchStrategy.ParseV3SearchResponse(json);
+
+        ids.ShouldBe(new[] { "Newtonsoft.Json", "AutoMapper", "FluentValidation" });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{}")]
+    [InlineData("""{ "data": "not an array" }""")]
+    [InlineData("""{ "no_data_key": true }""")]
+    public void ParseV3SearchResponse_ShouldReturnEmpty_ForMalformedOrIncompleteJson(string json)
+    {
+        NuGetPackageSearchStrategy.ParseV3SearchResponse(json).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseV3SearchResponse_ShouldSkipEntriesWithoutIdField()
+    {
+        var json = """
+            {
+              "data": [
+                { "id": "ValidPackage", "version": "1.0.0" },
+                { "no_id_field": true },
+                { "id": "", "version": "1.0.0" }
+              ]
+            }
+            """;
+
+        var ids = NuGetPackageSearchStrategy.ParseV3SearchResponse(json);
+
+        ids.ShouldBe(new[] { "ValidPackage" });
+    }
+
+    // ── V2 URL construction ───────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildV2SearchUrl_ShouldEscapeSingleQuotesByDoublingThem()
+    {
+        // OData literal-string escape: "Bob's package" → 'Bob''s package'
+        var url = NuGetPackageSearchStrategy.BuildV2SearchUrl("https://example.com/nuget", "Bob's", 10);
+
+        // The escaped query is then URL-encoded; %27 is the encoded single quote
+        url.ShouldContain("Bob%27%27s",
+            customMessage:
+                "Single quote inside OData string literal MUST be doubled. " +
+                $"If a quote isn't escaped, the OData expression breaks. URL: {url}");
+    }
+
+    [Fact]
+    public void BuildV2SearchUrl_ShouldAlwaysIncludeRequiredParameters()
+    {
+        var url = NuGetPackageSearchStrategy.BuildV2SearchUrl("https://example.com/nuget", "test", 20);
+
+        url.ShouldContain("$top=20");
+        url.ShouldContain("includePrerelease=true",
+            customMessage: "V2 includePrerelease=true is required for symmetric coverage with V3 prerelease=true.");
+        url.ShouldContain("semVerLevel=2.0.0",
+            customMessage: "V2 semVerLevel=2.0.0 mirrors V3 — ignored by older servers, honoured by NuGet.Server >= 3.4.");
+        url.ShouldContain("/Search()");
+    }
+
+    [Fact]
+    public void BuildV2SearchUrl_ShouldStripTrailingSlash()
+    {
+        var url = NuGetPackageSearchStrategy.BuildV2SearchUrl("https://example.com/nuget/", "test", 10);
+
+        url.ShouldStartWith("https://example.com/nuget/Search()");
+        url.ShouldNotContain("/nuget//Search()",
+            customMessage: "Trailing slash on feedUri must be stripped to avoid double-slash.");
+    }
+
+    // ── V2 response parsing ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseV2SearchResponse_ShouldExtractIdsFromOdataXml()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry>
+                <title type="text">AuthorizeNet.NetStandard</title>
+                <m:properties>
+                  <d:Id>AuthorizeNet.NetStandard</d:Id>
+                  <d:Version>0.1.0</d:Version>
+                </m:properties>
+              </entry>
+              <entry>
+                <m:properties>
+                  <d:Id>OtherPackage</d:Id>
+                  <d:Version>1.0.0</d:Version>
+                </m:properties>
+              </entry>
+            </feed>
+            """;
+
+        var ids = NuGetPackageSearchStrategy.ParseV2SearchResponse(xml, 20);
+
+        ids.ShouldBe(new[] { "AuthorizeNet.NetStandard", "OtherPackage" });
+    }
+
+    [Fact]
+    public void ParseV2SearchResponse_ShouldDedupeMultipleEntriesForSamePackage()
+    {
+        // V2 /Search() may return one entry per VERSION of each package. The strategy
+        // must dedupe to return each package ID exactly once (the search dropdown shows
+        // package IDs, not (id, version) pairs).
+        var xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry><m:properties><d:Id>PackageA</d:Id><d:Version>1.0.0</d:Version></m:properties></entry>
+              <entry><m:properties><d:Id>PackageA</d:Id><d:Version>2.0.0</d:Version></m:properties></entry>
+              <entry><m:properties><d:Id>PackageB</d:Id><d:Version>1.0.0</d:Version></m:properties></entry>
+              <entry><m:properties><d:Id>packagea</d:Id><d:Version>3.0.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+
+        var ids = NuGetPackageSearchStrategy.ParseV2SearchResponse(xml, 20);
+
+        ids.Count.ShouldBe(2,
+            customMessage:
+                "Three entries for PackageA (one with different casing) MUST dedupe to one. " +
+                "Otherwise the UI shows duplicate options.");
+        ids.ShouldContain("PackageA");
+        ids.ShouldContain("PackageB");
+    }
+
+    [Fact]
+    public void ParseV2SearchResponse_ShouldRespectTakeLimit()
+    {
+        var xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry><m:properties><d:Id>A</d:Id></m:properties></entry>
+              <entry><m:properties><d:Id>B</d:Id></m:properties></entry>
+              <entry><m:properties><d:Id>C</d:Id></m:properties></entry>
+              <entry><m:properties><d:Id>D</d:Id></m:properties></entry>
+            </feed>
+            """;
+
+        var ids = NuGetPackageSearchStrategy.ParseV2SearchResponse(xml, 2);
+
+        ids.Count.ShouldBe(2);
+        ids.ShouldBe(new[] { "A", "B" });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not xml")]
+    [InlineData("<feed></feed>")]
+    public void ParseV2SearchResponse_ShouldReturnEmpty_ForMalformedOrEmptyXml(string xml)
+    {
+        NuGetPackageSearchStrategy.ParseV2SearchResponse(xml, 20).ShouldBeEmpty();
+    }
+
+    // ── Full SearchAsync — V3 happy path ──────────────────────────────────────
+
+    [Fact]
+    public async Task SearchAsync_V3HappyPath_ReturnsParsedIds()
+    {
+        var indexJson = """
+            { "resources": [{ "@id": "https://example.com/search", "@type": "SearchQueryService/3.5.0" }] }
+            """;
+        var searchJson = """
+            { "data": [{ "id": "Newtonsoft.Json" }, { "id": "FluentAssertions" }] }
+            """;
+
+        var client = CreateHttpClient(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.EndsWith("/index.json")) return Ok(indexJson);
+            if (url.StartsWith("https://example.com/search")) return Ok(searchJson);
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/v3" };
+
+        var result = await sut.SearchAsync(feed, "newton", 20, CancellationToken.None);
+
+        result.ShouldBe(new[] { "Newtonsoft.Json", "FluentAssertions" });
+    }
+
+    // ── Full SearchAsync — V2 fallback when V3 service-index is missing ───────
+
+    [Fact]
+    public async Task SearchAsync_V2Fallback_WhenV3IndexReturns404()
+    {
+        var v2Xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry><m:properties><d:Id>LegacyPackage</d:Id></m:properties></entry>
+            </feed>
+            """;
+
+        var client = CreateHttpClient(request =>
+        {
+            var url = request.RequestUri!.ToString();
+
+            // V3 service index returns 404 → V3 attempt aborts, V2 fallback kicks in
+            if (url.EndsWith("/index.json")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+            if (url.Contains("/Search()")) return Ok(v2Xml);
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.SearchAsync(feed, "", 20, CancellationToken.None);
+
+        result.ShouldBe(
+            new[] { "LegacyPackage" },
+            ignoreOrder: false,
+            customMessage:
+                "When V3 /index.json returns 404, the strategy MUST fall back to V2 OData /Search(). " +
+                "This is the only path for legacy NuGet.Server installations.");
+    }
+
+    [Fact]
+    public async Task SearchAsync_BothProtocolsFail_ReturnsEmpty()
+    {
+        var client = CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.SearchAsync(feed, "test", 20, CancellationToken.None);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchAsync_EmptyFeedUri_ReturnsEmptyWithoutHttpCall()
+    {
+        var httpCallMade = false;
+        var client = CreateHttpClient(_ =>
+        {
+            httpCallMade = true;
+            return Ok("[]");
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "" };
+
+        var result = await sut.SearchAsync(feed, "test", 20, CancellationToken.None);
+
+        result.ShouldBeEmpty();
+        httpCallMade.ShouldBeFalse(
+            customMessage: "Empty FeedUri MUST short-circuit before any HTTP call to avoid wasted network round-trips.");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private NuGetPackageSearchStrategy CreateSut() => new(_httpClientFactory.Object);
+
+    private static HttpResponseMessage Ok(string content) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(content) };
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, HttpResponseMessage> handler) =>
+        new(new StubHandler(handler));
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(handler(request));
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageVersionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageVersionStrategyTests.cs
@@ -1,0 +1,424 @@
+using System.Net;
+using System.Net.Http;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
+using Squid.Core.Services.Http;
+
+namespace Squid.UnitTests.Services.Deployments.ExternalFeeds;
+
+public class NuGetPackageVersionStrategyTests
+{
+    private readonly Mock<ISquidHttpClientFactory> _httpClientFactory = new();
+
+    [Theory]
+    [InlineData("NuGet", true)]
+    [InlineData("nuget", true)]
+    [InlineData("NUGET", true)]
+    [InlineData("NuGet Feed", true)]
+    [InlineData("Docker", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void CanHandle_ShouldMatchNuGetFeedTypesCaseInsensitively(string feedType, bool expected)
+    {
+        var sut = CreateSut();
+
+        sut.CanHandle(feedType).ShouldBe(expected);
+    }
+
+    // ── V3 service-index parsing ──────────────────────────────────────────────
+
+    [Fact]
+    public void FindPackageBaseAddressUrl_ShouldReturnUrl_ForValidServiceIndex()
+    {
+        var indexJson = """
+            {
+              "version": "3.0.0",
+              "resources": [
+                { "@id": "https://example.com/search", "@type": "SearchQueryService/3.5.0" },
+                { "@id": "https://example.com/v3-flatcontainer/", "@type": "PackageBaseAddress/3.0.0" }
+              ]
+            }
+            """;
+
+        NuGetPackageVersionStrategy.FindPackageBaseAddressUrl(indexJson)
+            .ShouldBe("https://example.com/v3-flatcontainer/");
+    }
+
+    [Fact]
+    public void FindPackageBaseAddressUrl_ShouldReturnNull_WhenNoFlatContainerResource()
+    {
+        var indexJson = """
+            {
+              "resources": [
+                { "@id": "https://example.com/search", "@type": "SearchQueryService/3.5.0" }
+              ]
+            }
+            """;
+
+        NuGetPackageVersionStrategy.FindPackageBaseAddressUrl(indexJson).ShouldBeNull(
+            customMessage: "When PackageBaseAddress is absent, V3 path MUST return null so V2 fallback can try.");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{}")]
+    public void FindPackageBaseAddressUrl_ShouldReturnNull_ForMalformedJson(string indexJson)
+    {
+        NuGetPackageVersionStrategy.FindPackageBaseAddressUrl(indexJson).ShouldBeNull();
+    }
+
+    // ── V3 versions response parsing ──────────────────────────────────────────
+
+    [Fact]
+    public void ParseV3VersionsResponse_ShouldReturnVersionsArray()
+    {
+        var json = """
+            {
+              "versions": ["1.0.0", "1.1.0", "2.0.0-beta", "2.0.0-rc.1+build.5", "2.0.0"]
+            }
+            """;
+
+        var versions = NuGetPackageVersionStrategy.ParseV3VersionsResponse(json, 100);
+
+        versions.ShouldBe(new[] { "1.0.0", "1.1.0", "2.0.0-beta", "2.0.0-rc.1+build.5", "2.0.0" });
+    }
+
+    [Fact]
+    public void ParseV3VersionsResponse_ShouldRespectEnumerationCap()
+    {
+        var json = """
+            { "versions": ["1.0.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0"] }
+            """;
+
+        var versions = NuGetPackageVersionStrategy.ParseV3VersionsResponse(json, 3);
+
+        versions.Count.ShouldBe(3,
+            customMessage: "Enumeration cap MUST be enforced at the strategy level to prevent OOM on pathological feeds.");
+        versions.ShouldBe(new[] { "1.0.0", "2.0.0", "3.0.0" });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{}")]
+    [InlineData("""{ "versions": "not array" }""")]
+    public void ParseV3VersionsResponse_ShouldReturnEmpty_ForMalformedJson(string json)
+    {
+        NuGetPackageVersionStrategy.ParseV3VersionsResponse(json, 100).ShouldBeEmpty();
+    }
+
+    // ── V2 URL construction ───────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildV2VersionsUrl_ShouldEscapeSingleQuotesByDoublingThem()
+    {
+        var url = NuGetPackageVersionStrategy.BuildV2VersionsUrl("https://example.com/nuget", "Bob's.Package");
+
+        url.ShouldContain("Bob%27%27s.Package",
+            customMessage:
+                "Single quote inside OData literal MUST be doubled and URL-encoded. " +
+                $"Otherwise the OData expression breaks. URL: {url}");
+    }
+
+    [Fact]
+    public void BuildV2VersionsUrl_ShouldIncludeSemVerLevel2()
+    {
+        var url = NuGetPackageVersionStrategy.BuildV2VersionsUrl("https://example.com/nuget", "Newtonsoft.Json");
+
+        url.ShouldContain("semVerLevel=2.0.0",
+            customMessage: "semVerLevel=2.0.0 ensures SemVer 2 versions (e.g. 1.0.0-beta.1+build.2) aren't dropped.");
+        url.ShouldContain("/FindPackagesById()");
+    }
+
+    [Fact]
+    public void BuildV2VersionsUrl_ShouldStripTrailingSlash()
+    {
+        var url = NuGetPackageVersionStrategy.BuildV2VersionsUrl("https://example.com/nuget/", "Newtonsoft.Json");
+
+        url.ShouldStartWith("https://example.com/nuget/FindPackagesById()");
+        url.ShouldNotContain("/nuget//FindPackagesById");
+    }
+
+    // ── V2 response parsing ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseV2VersionsResponse_ShouldExtractVersions_PreferNormalizedVersionWhenPresent()
+    {
+        // Real NuGet.Server response: NormalizedVersion may differ from Version
+        // (e.g. "1.0" vs "1.0.0"). Tests verify we prefer NormalizedVersion.
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry>
+                <m:properties>
+                  <d:Id>AuthorizeNet.NetStandard</d:Id>
+                  <d:Version>0.1.0</d:Version>
+                  <d:NormalizedVersion>0.1.0</d:NormalizedVersion>
+                </m:properties>
+              </entry>
+              <entry>
+                <m:properties>
+                  <d:Id>AuthorizeNet.NetStandard</d:Id>
+                  <d:Version>0.2</d:Version>
+                  <d:NormalizedVersion>0.2.0</d:NormalizedVersion>
+                </m:properties>
+              </entry>
+            </feed>
+            """;
+
+        var (versions, nextLink) = NuGetPackageVersionStrategy.ParseV2VersionsResponse(xml);
+
+        versions.ShouldBe(
+            new[] { "0.1.0", "0.2.0" },
+            ignoreOrder: false,
+            customMessage:
+                "Strategy MUST prefer NormalizedVersion over Version. The unnormalized '0.2' would round-trip " +
+                "inconsistently with .NET's NuGetVersion parser; the normalized '0.2.0' is the canonical form.");
+        nextLink.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseV2VersionsResponse_ShouldFallBackToVersion_WhenNormalizedVersionAbsent()
+    {
+        var xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry>
+                <m:properties>
+                  <d:Version>1.0.0</d:Version>
+                </m:properties>
+              </entry>
+            </feed>
+            """;
+
+        var (versions, _) = NuGetPackageVersionStrategy.ParseV2VersionsResponse(xml);
+
+        versions.ShouldBe(new[] { "1.0.0" });
+    }
+
+    [Fact]
+    public void ParseV2VersionsResponse_ShouldExtractInlineNextLink()
+    {
+        var xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <link rel="self" href="https://example.com/nuget/FindPackagesById()?id='X'" />
+              <link rel="next" href="https://example.com/nuget/FindPackagesById()?id='X'&amp;skip=40" />
+              <entry>
+                <m:properties>
+                  <d:Version>1.0.0</d:Version>
+                </m:properties>
+              </entry>
+            </feed>
+            """;
+
+        var (versions, nextLink) = NuGetPackageVersionStrategy.ParseV2VersionsResponse(xml);
+
+        versions.ShouldBe(new[] { "1.0.0" });
+        nextLink.ShouldBe("https://example.com/nuget/FindPackagesById()?id='X'&skip=40",
+            customMessage: "Next-link from OData inline pagination MUST be extracted so we can iterate large version histories.");
+    }
+
+    [Fact]
+    public void ParseV2VersionsResponse_ShouldReturnNullNextLink_WhenAbsent()
+    {
+        var xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <link rel="self" href="https://example.com/nuget/FindPackagesById()?id='X'" />
+              <entry><m:properties><d:Version>1.0.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+
+        var (_, nextLink) = NuGetPackageVersionStrategy.ParseV2VersionsResponse(xml);
+
+        nextLink.ShouldBeNull(
+            customMessage: "When there's no <link rel='next'>, the pagination loop MUST stop. Else infinite-loop risk.");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not xml")]
+    [InlineData("<feed></feed>")]
+    public void ParseV2VersionsResponse_ShouldReturnEmpty_ForMalformedXml(string xml)
+    {
+        var (versions, nextLink) = NuGetPackageVersionStrategy.ParseV2VersionsResponse(xml);
+
+        versions.ShouldBeEmpty();
+        nextLink.ShouldBeNull();
+    }
+
+    // ── Full ListVersionsAsync — V3 happy path ────────────────────────────────
+
+    [Fact]
+    public async Task ListVersionsAsync_V3HappyPath_ReturnsParsedVersions()
+    {
+        var indexJson = """
+            { "resources": [{ "@id": "https://example.com/v3-flatcontainer/", "@type": "PackageBaseAddress/3.0.0" }] }
+            """;
+        var versionsJson = """
+            { "versions": ["1.0.0", "1.1.0", "2.0.0"] }
+            """;
+
+        var v3PathLowercased = false;
+
+        var client = CreateHttpClient(request =>
+        {
+            var url = request.RequestUri!.ToString();
+
+            // The per-package versions URL ALSO ends in /index.json (it's
+            // `{base}/{id-lower}/index.json`), so the order of these checks
+            // matters: match the longer-suffix path FIRST.
+            if (url.Contains("/v3-flatcontainer/newtonsoft.json/index.json", StringComparison.Ordinal))
+            {
+                v3PathLowercased = true;
+                return Ok(versionsJson);
+            }
+
+            if (url.EndsWith("https://example.com/v3/index.json", StringComparison.Ordinal))
+                return Ok(indexJson);
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/v3" };
+
+        // Operator types mixed-case package ID; the V3 path MUST lowercase before lookup.
+        var result = await sut.ListVersionsAsync(feed, "Newtonsoft.Json", CancellationToken.None);
+
+        result.ShouldBe(new[] { "1.0.0", "1.1.0", "2.0.0" });
+        v3PathLowercased.ShouldBeTrue(
+            customMessage: "V3 PackageBaseAddress URL MUST use the lowercased package ID. The flat-container endpoint is case-sensitive on the path segment.");
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_V2Fallback_WhenV3IndexReturns404()
+    {
+        var v2Xml = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry><m:properties><d:Version>0.1.0</d:Version></m:properties></entry>
+              <entry><m:properties><d:Version>0.2.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+
+        var client = CreateHttpClient(request =>
+        {
+            var url = request.RequestUri!.ToString();
+
+            if (url.EndsWith("/index.json")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+            if (url.Contains("/FindPackagesById()")) return Ok(v2Xml);
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.ListVersionsAsync(feed, "AuthorizeNet.NetStandard", CancellationToken.None);
+
+        result.ShouldBe(new[] { "0.1.0", "0.2.0" });
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_V2FollowsInlinePagination_AndDedupes()
+    {
+        var page1 = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <link rel="next" href="https://example.com/nuget/FindPackagesById()?id='Pkg'&amp;skip=2" />
+              <entry><m:properties><d:Version>1.0.0</d:Version></m:properties></entry>
+              <entry><m:properties><d:Version>2.0.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+        var page2 = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry><m:properties><d:Version>3.0.0</d:Version></m:properties></entry>
+              <entry><m:properties><d:Version>1.0.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+
+        var client = CreateHttpClient(request =>
+        {
+            var url = request.RequestUri!.ToString();
+
+            if (url.EndsWith("/index.json")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+            if (url.Contains("skip=2")) return Ok(page2);
+            if (url.Contains("/FindPackagesById()")) return Ok(page1);
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.ListVersionsAsync(feed, "Pkg", CancellationToken.None);
+
+        result.ShouldBe(
+            new[] { "1.0.0", "2.0.0", "3.0.0" },
+            ignoreOrder: false,
+            customMessage:
+                "Pagination MUST follow inline <link rel='next'> and dedupe (1.0.0 appears on both pages). " +
+                "Without dedupe, the version dropdown shows duplicates.");
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_EmptyPackageId_ReturnsEmptyWithoutHttpCall()
+    {
+        var httpCallMade = false;
+        var client = CreateHttpClient(_ =>
+        {
+            httpCallMade = true;
+            return Ok("{}");
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.ListVersionsAsync(feed, "", CancellationToken.None);
+
+        result.ShouldBeEmpty();
+        httpCallMade.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_BothProtocolsFail_ReturnsEmpty()
+    {
+        var client = CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.ListVersionsAsync(feed, "AnyPackage", CancellationToken.None);
+
+        result.ShouldBeEmpty();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private NuGetPackageVersionStrategy CreateSut() => new(_httpClientFactory.Object);
+
+    private static HttpResponseMessage Ok(string content) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(content) };
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, HttpResponseMessage> handler) =>
+        new(new StubHandler(handler));
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(handler(request));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `NuGetPackageSearchStrategy` and `NuGetPackageVersionStrategy` — the registry's `IPackageSearchStrategy.CanHandle("NuGet")` and `IPackageVersionStrategy.CanHandle("NuGet")` previously returned `false` for every registered strategy, so the resolver fell through and `ExternalFeedPackageSearchService.SearchAsync` + the version service silently returned `[]` for any NuGet feed. Operators selecting a NuGet feed in the IIS-deploy step package picker saw "no results" regardless of feed contents.
- Each strategy tries V3 first (service index → `SearchQueryService` / `PackageBaseAddress`), falls back to V2 OData (`/Search()` / `/FindPackagesById()`) when V3 is unreachable or undeclared. Tested live against a V2-only NuGet.Server.
- Both send `prerelease=true` + `semVerLevel=2.0.0` unconditionally so feeds with prerelease-only / SemVer 2.0 packages aren't silently filtered out. Auth via Basic header from `feed.Username` / `feed.Password`, matching the existing `NuGetPackageNotesStrategy`.
- 74 unit tests pin JSON/XML parser shapes, URL construction (encoding, escaping, dedup, take, semVerLevel), and the V3-fail → V2-success integration path. 5 live integration tests against `https://nuget.sjfood.us/nuget` (operator's V2-only production feed) prove end-to-end correctness with feed-reachability skip on outage.

## Test plan

- [x] `dotnet build Squid.sln` — 0 errors
- [x] `dotnet test --filter NuGetPackageSearchStrategyTests|NuGetPackageVersionStrategyTests` — 74/74 pass, 220ms
- [x] `dotnet test --filter NuGetFeedLiveIntegrationTests` — 5/5 pass against the live operator feed, 46s
- [x] `dotnet test --filter ExternalFeeds` regression — 329/329 pass (Docker/GitHub/Helm strategies unaffected)
- [ ] CI: unit + integration tests on the workflow
- [ ] Manual smoke (post-merge): bind the NuGet feed in SquidWeb, type query in the IIS-deploy step package picker, verify results appear; pick a package, verify versions populate

## Why this matters

- **Affects every operator using NuGet feeds** — not "some packages search-blank", every package on every NuGet feed. The bug effectively made NuGet feeds unusable for IIS deploy.
- **Two halves of the same gap** — search was the symptom; version listing was the hidden second symptom. Even if an operator typed the exact package ID manually as a workaround, the version dropdown would still be empty.
- **V2 fallback isn't theoretical** — `https://nuget.sjfood.us/nuget` is a real production V2-only NuGet.Server instance bound in SquidWeb. Live integration tests prove the V2 path actually works against this exact server.