### PR TITLE
Move NuGetFeedLiveIntegrationTests to Squid.E2ETests

### DIFF
--- a/tests/Squid.E2ETests/Deployments/ExternalFeeds/NuGetFeedLiveE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/ExternalFeeds/NuGetFeedLiveE2ETests.cs
@@ -1,13 +1,15 @@
 using System.Net.Http;
+using Shouldly;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Deployments.ExternalFeeds.PackageSearch;
 using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
 using Squid.Core.Services.Http;
+using Xunit;
 
-namespace Squid.IntegrationTests.Services.Deployments.ExternalFeeds;
+namespace Squid.E2ETests.Deployments.ExternalFeeds;
 
 /// <summary>
-/// Live integration tests driving <see cref="NuGetPackageSearchStrategy"/> and
+/// Live E2E tests driving <see cref="NuGetPackageSearchStrategy"/> and
 /// <see cref="NuGetPackageVersionStrategy"/> against a real operator NuGet feed
 /// (<c>https://nuget.sjfood.us/nuget</c>) — the same feed bound in the SquidWeb
 /// frontend during the IIS-deploy smoke validation that surfaced the original
@@ -48,7 +50,7 @@ namespace Squid.IntegrationTests.Services.Deployments.ExternalFeeds;
 /// (any → any), proving the protocol contract end-to-end.</para>
 /// </summary>
 [Trait("Category", "LiveNuGetFeed")]
-public class NuGetFeedLiveIntegrationTests
+public class NuGetFeedLiveE2ETests
 {
     private const string LiveFeedUri = "https://nuget.sjfood.us/nuget";
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
## Summary

- Test landed in the wrong project (`Squid.IntegrationTests`) in PR #344. Per Rule 12 fidelity tiers, tests that drive real network calls to external resources are E2E, not Integration. The Integration tier is reserved for tests that touch real-but-isolated infrastructure the project owns (real Postgres + EF, in-process Halibut, etc.). A live HTTP call to a remote operator NuGet feed is high-fidelity E2E.
- Rename: `NuGetFeedLiveIntegrationTests` → `NuGetFeedLiveE2ETests`; namespace updated to `Squid.E2ETests.Deployments.ExternalFeeds`
- File contents otherwise unchanged

## Test plan

- [x] `dotnet build Squid.E2ETests.csproj` → 0 errors
- [x] `dotnet build Squid.IntegrationTests.csproj` → 0 errors (file removed cleanly)
- [x] `dotnet test --filter NuGetFeedLiveE2ETests` → 5/5 pass against https://nuget.sjfood.us/nuget in 53s