### PR TITLE
Fix IIS handler Windows detection — accept legacy long-form OS strings

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
@@ -56,8 +56,21 @@ public class IISDeployActionHandler : IActionHandler
     /// <summary>
     /// Rejects dispatch when the target machine is known to NOT be a Windows Tentacle.
     /// "Known non-Windows" = the runtime-capabilities cache has a value for
-    /// <c>Squid.Tentacle.OS</c> and that value isn't <c>Windows</c>. "Unknown" (no value
-    /// in the cache yet) is permitted — the script will fail loudly on the agent if so.
+    /// <c>Squid.Tentacle.OS</c> and the value doesn't look like a Windows identifier.
+    /// "Unknown" (no value in the cache yet) is permitted — the script will fail
+    /// loudly on the agent if so.
+    ///
+    /// <para><b>Tolerant match rationale</b>: this handler accepts BOTH the
+    /// canonical short form <c>"Windows"</c> (current <see cref="AgentOperatingSystems.Windows"/>
+    /// constant emitted by modern <c>RuntimeCapabilitiesInspector.DetectOs()</c>)
+    /// AND legacy long forms like <c>"Microsoft Windows NT 10.0.19045.0"</c>
+    /// (from older Tentacle binaries that wrote <c>Environment.OSVersion.VersionString</c>
+    /// into the "os" metadata field, or from cache entries seeded before the
+    /// canonical-constant refactor). A strict equality check rejected the legacy
+    /// form and blocked operators with not-yet-upgraded Tentacles from deploying
+    /// IIS — the failure mode the original release pinned. Symmetric tolerance
+    /// for the explicit Linux / macOS markers keeps the rejection path correct
+    /// (we still throw on <c>"Linux"</c> / <c>"macOS"</c> / anything else).</para>
     /// </summary>
     private static void EnsureWindowsTentacleTarget(ActionExecutionContext ctx)
     {
@@ -67,7 +80,7 @@ public class IISDeployActionHandler : IActionHandler
         if (osVariable == null || string.IsNullOrEmpty(osVariable.Value))
             return;   // unknown — proceed optimistically (see XML doc above)
 
-        if (string.Equals(osVariable.Value, "Windows", StringComparison.OrdinalIgnoreCase))
+        if (LooksLikeWindowsOsString(osVariable.Value))
             return;   // confirmed Windows — proceed
 
         var stepName = ctx.Step?.Name ?? "(unknown)";
@@ -78,5 +91,32 @@ public class IISDeployActionHandler : IActionHandler
             $"requires a Windows Tentacle target. The configured target reports '{IISDeployProperties.TentacleOS}'='{osVariable.Value}'. " +
             $"To deploy to IIS, configure a Windows Tentacle (Polling or Listening) and assign it the role this step targets. " +
             $"If you believe the target IS Windows, run a health check against it so the runtime-capabilities cache refreshes.");
+    }
+
+    /// <summary>
+    /// Returns true when the OS string identifies a Windows host. Matches:
+    /// <list type="bullet">
+    ///   <item>The canonical short form <c>"Windows"</c> from
+    ///         <see cref="AgentOperatingSystems.Windows"/></item>
+    ///   <item>Legacy long forms starting with <c>"Microsoft Windows"</c> (e.g.
+    ///         <c>"Microsoft Windows NT 10.0.19045.0"</c> — what
+    ///         <c>Environment.OSVersion.VersionString</c> returns on modern
+    ///         Windows Server / 10 / 11)</item>
+    /// </list>
+    /// Explicitly does NOT match <c>"Linux"</c>, <c>"macOS"</c>, or empty —
+    /// those are caught by the caller's null-or-empty short-circuit + the
+    /// explicit-throw fall-through.
+    /// </summary>
+    internal static bool LooksLikeWindowsOsString(string osValue)
+    {
+        if (string.IsNullOrWhiteSpace(osValue)) return false;
+
+        if (string.Equals(osValue, AgentOperatingSystems.Windows, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Environment.OSVersion.VersionString on Windows always starts with "Microsoft Windows".
+        // Anchoring on the prefix (not a Contains "Windows") avoids false positives like a
+        // hypothetical Linux distro string accidentally containing the word "Windows".
+        return osValue.StartsWith("Microsoft Windows", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployActionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/IISDeployActionHandlerTests.cs
@@ -106,9 +106,20 @@ public class IISDeployActionHandlerTests
     }
 
     [Theory]
+    // Canonical short form — current AgentOperatingSystems.Windows
     [InlineData("Windows")]
     [InlineData("windows")]   // case-insensitive — Windows reports vary
     [InlineData("WINDOWS")]
+    // Legacy long form — older Tentacle binaries / cache entries seeded before the
+    // canonical-constant refactor wrote Environment.OSVersion.VersionString into
+    // the "os" metadata field. Real-world examples reported by operators below.
+    // Without these the production-blocking failure mode lands: a fully-functional
+    // Windows Tentacle gets rejected at dispatch with a misleading "not Windows" error.
+    [InlineData("Microsoft Windows NT 10.0.19045.0")]    // Windows 10 22H2 (user's failure mode)
+    [InlineData("Microsoft Windows NT 10.0.22631.0")]    // Windows 11 23H2
+    [InlineData("Microsoft Windows NT 10.0.17763.0")]    // Windows Server 2019
+    [InlineData("Microsoft Windows NT 10.0.20348.0")]    // Windows Server 2022
+    [InlineData("microsoft windows nt 10.0.19045.0")]    // lowercased — defensive
     public async Task DescribeIntentAsync_WindowsTentacle_ProceedsSuccessfully(string os)
     {
         var handler = (IActionHandler)new IISDeployActionHandler();
@@ -119,6 +130,46 @@ public class IISDeployActionHandlerTests
         // Should not throw.
         var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
         intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Theory]
+    // Canonical short form
+    [InlineData("Windows", true)]
+    [InlineData("windows", true)]
+    [InlineData("WINDOWS", true)]
+    // Legacy long forms — Environment.OSVersion.VersionString on Windows
+    [InlineData("Microsoft Windows NT 10.0.19045.0", true)]
+    [InlineData("Microsoft Windows NT 6.3.9600.0", true)]    // legacy Windows 8.1 / Server 2012 R2
+    [InlineData("microsoft windows nt 6.1.7601.0", true)]    // case-insensitive prefix
+    // Non-Windows — must reject
+    [InlineData("Linux", false)]
+    [InlineData("linux", false)]
+    [InlineData("macOS", false)]
+    [InlineData("Darwin", false)]
+    [InlineData("FreeBSD", false)]
+    [InlineData("Unknown", false)]
+    // Edge cases
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData(null, false)]
+    // Anchoring guard: must NOT false-positive on a string that merely CONTAINS
+    // "Windows" but isn't a Windows OS marker (the helper anchors on prefix,
+    // not Contains, exactly to prevent this).
+    [InlineData("LinuxOnWindowsSubsystem", false)]
+    [InlineData("not-a-windows-host", false)]
+    public void LooksLikeWindowsOsString_PinnedBehaviour(string osValue, bool expected)
+    {
+        // Pin both halves of the tolerance contract:
+        //   1. canonical "Windows" → true
+        //   2. legacy "Microsoft Windows ..." → true (the operator-blocking bug fix)
+        //   3. explicit Linux/macOS/Unknown → false (we still reject these)
+        //   4. unrelated strings that contain the word "Windows" → false
+        //      (prevents accidental positives — the helper uses StartsWith, not Contains)
+        IISDeployActionHandler.LooksLikeWindowsOsString(osValue).ShouldBe(expected,
+            customMessage:
+                $"LooksLikeWindowsOsString('{osValue}') expected {expected} but got {!expected}. " +
+                $"If a legitimate Windows OS string is being rejected, extend the helper's prefix list. " +
+                $"If a non-Windows string is being accepted, the prefix anchor has been weakened.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `IISDeployActionHandler.EnsureWindowsTentacleTarget` used strict equality with the canonical short form `"Windows"` emitted by modern Tentacle agents via `AgentOperatingSystems.Windows`. Older Tentacle binaries (or cache entries seeded before the canonical-constant refactor) write the value of `Environment.OSVersion.VersionString` (e.g. `"Microsoft Windows NT 10.0.19045.0"`) into the same `"os"` metadata field. The validator rejected those agents as "not Windows" and surfaced a misleading error
- New `LooksLikeWindowsOsString` helper accepts both forms: the canonical `"Windows"` AND any string starting with `"Microsoft Windows"`. Anchored on `StartsWith`, not `Contains` — explicitly tested to NOT false-positive on strings like `"LinuxOnWindowsSubsystem"` or `"not-a-windows-host"`
- 21 new theory cases covering: canonical short form, four legacy long forms across Win10 22H2 / Win11 23H2 / Server 2019 / Server 2022, case sensitivity, non-Windows markers (Linux/macOS/Darwin/FreeBSD/Unknown), null/empty edges, anchoring false-positive prevention. Total IIS handler tests: 13 → 34

## Real-world failure mode

A user with a fully-functional Windows 10 Tentacle (build 19045 = Win10 22H2) hit this exact error at deploy dispatch:

```
Action 'Deploy to IIS' (type 'Squid.DeployToIISWebSite') in step 'Deploy to IIS'
requires a Windows Tentacle target. The configured target reports
'Squid.Tentacle.OS'='Microsoft Windows NT 10.0.19045.0'.
```

The remediation guidance ("run a health check to refresh the cache") didn't help because the cache was already populated; the validator was too narrow.

## Test plan

- [x] `dotnet build Squid.sln` → 0 errors
- [x] `dotnet test --filter IISDeployActionHandlerTests` → 34/34 pass, 293ms
- [ ] CI: unit + integration tests
- [ ] Manual smoke (post-merge): retry the user's deploy against the same Win10 19045 Tentacle, confirm action passes the gate