### PR TITLE
Add handler-level static capability requirements (slot-based, AND/OR)

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Handlers/IActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Handlers/IActionHandler.cs
@@ -1,4 +1,5 @@
 using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Process;
 
@@ -15,6 +16,28 @@ public interface IActionHandler : IScopedDependency
     string ActionType { get; }
 
     ExecutionScope ExecutionScope => ExecutionScope.TargetLevel;
+
+    /// <summary>
+    /// Static, plan-time-known capability requirements this handler places on the
+    /// target machine. Map of <c>slot → acceptable values</c>; the target satisfies
+    /// the slot if it advertises AT LEAST ONE value in the acceptable-values set.
+    ///
+    /// <para><b>AND across slots, OR within a slot.</b> A handler that needs Windows
+    /// AND PowerShell declares two slots; a handler that runs on Windows OR Linux
+    /// declares a single <c>os</c> slot with both values.</para>
+    ///
+    /// <para><b>Why this is on the handler interface (not intent)</b>: requirements
+    /// known BEFORE intent generation (i.e. before <see cref="DescribeIntentAsync"/>
+    /// runs) let <c>DeploymentPlanner</c> filter out targets at preview time. The
+    /// existing <c>ExecutionIntent.RequiredCapabilities</c> covers run-time-derived
+    /// requirements (Phase 5.5 feature gating). The two surfaces compose.</para>
+    ///
+    /// <para><b>Default empty</b> — handlers that don't declare requirements run on
+    /// any target the role match selects, exactly like before. See
+    /// <see cref="CapabilityRequirements"/> for the fluent builder.</para>
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements
+        => CapabilityRequirements.Empty;
 
     bool CanHandle(DeploymentActionDto action)
         => string.Equals(action?.ActionType, ActionType, StringComparison.OrdinalIgnoreCase);

--- a/src/Squid.Core/Services/DeploymentExecution/Handlers/RunScriptActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Handlers/RunScriptActionHandler.cs
@@ -2,6 +2,7 @@ using Squid.Core.Extensions;
 using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Process;
@@ -11,6 +12,27 @@ namespace Squid.Core.Services.DeploymentExecution.Handlers;
 public class RunScriptActionHandler : IActionHandler
 {
     public string ActionType => SpecialVariables.ActionTypes.Script;
+
+    /// <summary>
+    /// Plan-time static requirements: RunScript is OS-agnostic — it works on
+    /// any OS that has a usable shell. The transport-level
+    /// <c>ITransportCapabilities.SupportedSyntaxes</c> + the existing
+    /// <c>CapabilityValidator.ValidateScriptSyntax</c> handle whether the
+    /// specific syntax (bash / powershell / python) is supported. So all we
+    /// need to declare here is "any of windows / linux / macos is fine" —
+    /// which is a no-op match against any concrete-OS target, but EXCLUDES a
+    /// target whose OS is explicitly something unsupported.
+    ///
+    /// <para>Equivalent to declaring zero requirements (since the OR set
+    /// covers every projected OS value) but kept explicit so future operators
+    /// adding a new OS taxonomy entry remember to extend this list.</para>
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
+        CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot,
+                CapabilityKeys.Os.Windows,
+                CapabilityKeys.Os.Linux,
+                CapabilityKeys.Os.MacOS);
 
     /// <summary>
     /// Produces a <see cref="RunScriptIntent"/> with <c>InjectRuntimeBundle = true</c> so the

--- a/src/Squid.Core/Services/DeploymentExecution/Planning/DeploymentPlanner.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Planning/DeploymentPlanner.cs
@@ -2,6 +2,7 @@ using Squid.Core.Services.DeploymentExecution.Filtering;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Intents;
 using Squid.Core.Services.DeploymentExecution.Planning.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
@@ -29,14 +30,20 @@ public sealed class DeploymentPlanner : IDeploymentPlanner
 {
     private readonly IActionHandlerRegistry _actionHandlerRegistry;
     private readonly ICapabilityValidator _capabilityValidator;
+    private readonly IMachineRuntimeCapabilitiesCache _capabilitiesCache;
 
-    public DeploymentPlanner(IActionHandlerRegistry actionHandlerRegistry, ICapabilityValidator capabilityValidator)
+    public DeploymentPlanner(
+        IActionHandlerRegistry actionHandlerRegistry,
+        ICapabilityValidator capabilityValidator,
+        IMachineRuntimeCapabilitiesCache capabilitiesCache)
     {
         ArgumentNullException.ThrowIfNull(actionHandlerRegistry);
         ArgumentNullException.ThrowIfNull(capabilityValidator);
+        ArgumentNullException.ThrowIfNull(capabilitiesCache);
 
         _actionHandlerRegistry = actionHandlerRegistry;
         _capabilityValidator = capabilityValidator;
+        _capabilitiesCache = capabilitiesCache;
     }
 
     public Task<DeploymentPlan> PlanAsync(DeploymentPlanRequest request, CancellationToken ct)
@@ -314,7 +321,7 @@ public sealed class DeploymentPlanner : IDeploymentPlanner
         }
 
         var capabilities = targetContext.Transport.Capabilities;
-        var validation = ValidateCapabilities(intent, capabilities, target.CommunicationStyle, action.ActionType);
+        var validation = ValidateCapabilities(intent, capabilities, target, action);
 
         if (!validation.IsValid)
             AddCapabilityBlockers(blockers, validation.Violations, target);
@@ -332,15 +339,46 @@ public sealed class DeploymentPlanner : IDeploymentPlanner
     private CapabilityValidationResult ValidateCapabilities(
         ExecutionIntent intent,
         ITransportCapabilities capabilities,
-        CommunicationStyle communicationStyle,
-        string actionType)
+        PlannedTarget target,
+        DeploymentActionDto action)
     {
-        var violations = _capabilityValidator.Validate(intent, capabilities, communicationStyle, actionType);
+        var violations = new List<CapabilityViolation>();
+
+        violations.AddRange(_capabilityValidator.Validate(intent, capabilities, target.CommunicationStyle, action.ActionType));
+
+        violations.AddRange(ValidateHandlerStaticRequirements(intent, target, action));
 
         if (violations.Count == 0)
             return CapabilityValidationResult.Supported;
 
         return new CapabilityValidationResult { Violations = violations };
+    }
+
+    /// <summary>
+    /// Runs the handler-level static-requirement check that was added so OS / shell
+    /// requirements (e.g. IIS deploy needs Windows) are caught at preview time
+    /// instead of dispatch time. The handler advertises requirements; the target's
+    /// runtime-capabilities cache provides what it offers; <c>CapabilityValidator</c>
+    /// matches slot-by-slot.
+    /// </summary>
+    private IReadOnlyList<CapabilityViolation> ValidateHandlerStaticRequirements(
+        ExecutionIntent intent,
+        PlannedTarget target,
+        DeploymentActionDto action)
+    {
+        var handler = _actionHandlerRegistry.Resolve(action);
+
+        if (handler?.StaticRequirements is null || handler.StaticRequirements.Count == 0)
+            return Array.Empty<CapabilityViolation>();
+
+        var caps = _capabilitiesCache.TryGet(target.MachineId);
+        var targetCapabilitySet = MachineCapabilitySet.From(caps);
+
+        return _capabilityValidator.ValidateStaticRequirements(
+            handler.StaticRequirements,
+            targetCapabilitySet,
+            intent,
+            target.CommunicationStyle);
     }
 
     private static void AddCapabilityBlockers(

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
@@ -1,5 +1,6 @@
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
 using Squid.Message.Models.Deployments.Execution;
 
@@ -24,6 +25,23 @@ namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
 public class IISDeployActionHandler : IActionHandler
 {
     public string ActionType => SpecialVariables.ActionTypes.DeployToIISWebSite;
+
+    /// <summary>
+    /// Plan-time static requirements: the action only runs on Windows targets
+    /// that have a PowerShell-family shell available. Declared here so
+    /// <c>DeploymentPlanner</c> can reject incompatible targets at preview /
+    /// release-creation time — the operator sees the blocked target with a
+    /// clear reason instead of the deploy failing at dispatch.
+    ///
+    /// <para>The dispatch-time guard <see cref="EnsureWindowsTentacleTarget"/>
+    /// remains as belt-and-braces: if the cache is stale or the machine
+    /// changed OS between preview and execute, the guard catches it before
+    /// the agent script tries <c>Get-WindowsFeature</c> on a non-Windows host.</para>
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
+        CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
 
     Task<ExecutionIntent> IActionHandler.DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
     {

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityKeys.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityKeys.cs
@@ -1,0 +1,122 @@
+namespace Squid.Core.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Well-known slot + value identifiers for the handler-level static-requirement /
+/// machine-capability matching surface. Slots are the dimension being checked
+/// (e.g. operating system); values are the specific things a target can advertise
+/// or a handler can require (e.g. <c>windows</c> / <c>linux</c>).
+///
+/// <para><b>Semantics</b>:
+/// <list type="bullet">
+///   <item>A handler advertises requirements as a map of <c>slot → acceptable
+///         values</c>. Match succeeds if, for every declared slot, the target
+///         advertises AT LEAST ONE value in that slot's acceptable-values set.</item>
+///   <item><b>AND across slots</b> — every slot the handler mentions must be
+///         satisfied. Slots the handler doesn't mention are ignored.</item>
+///   <item><b>OR within a slot</b> — a handler that accepts multiple values
+///         declares them all (e.g. RunScript accepts any of windows / linux /
+///         macos). The target only needs to match ONE.</item>
+/// </list></para>
+///
+/// <para><b>Examples</b>:
+/// <list type="bullet">
+///   <item>IIS deploy: <c>{os: {windows}, shell: {powershell, pwsh}}</c></item>
+///   <item>RunScript: <c>{os: {windows, linux, macos}}</c></item>
+///   <item>Helm: <c>{os: {linux, macos}, bin:helm: {present}, bin:kubectl: {present}}</c></item>
+/// </list></para>
+///
+/// <para><b>Naming convention</b> — slot keys are short lowercase strings; values
+/// follow the same convention. For "presence" capabilities (e.g. a binary on PATH,
+/// admin privilege) the value is the sentinel <see cref="Present"/>. For
+/// "categorical" capabilities (OS, architecture) the value is the specific
+/// category. Binaries / shells / etc. that can vary per-target get their own
+/// namespaced slot key (e.g. <c>bin:helm</c>, <c>shell:pwsh</c>) so each can be
+/// AND-required independently.</para>
+///
+/// <para><b>Pinned per Rule 8</b> — drift in any of these strings is a wire-
+/// contract regression (handler authors hardcode them; targets advertise them).
+/// <c>CapabilityKeysConstantsTests</c> in <c>Squid.UnitTests</c> hard-pins every
+/// literal so a rename surfaces at build time.</para>
+/// </summary>
+public static class CapabilityKeys
+{
+    /// <summary>
+    /// Sentinel value for "presence" capabilities (a binary is installed, a
+    /// privilege is held, a service is available). Used when the slot itself
+    /// implies a specific thing and the value just signals presence.
+    /// </summary>
+    public const string Present = "present";
+
+    /// <summary>Operating-system slot. Values: <see cref="Os.Windows"/>, <see cref="Os.Linux"/>, <see cref="Os.MacOS"/>.</summary>
+    public const string OsSlot = "os";
+
+    /// <summary>Process architecture slot. Values: <see cref="Arch.X64"/>, <see cref="Arch.Arm64"/>, <see cref="Arch.X86"/>.</summary>
+    public const string ArchSlot = "arch";
+
+    public static class Os
+    {
+        public const string Windows = "windows";
+        public const string Linux = "linux";
+        public const string MacOS = "macos";
+    }
+
+    public static class Arch
+    {
+        public const string X64 = "x64";
+        public const string Arm64 = "arm64";
+        public const string X86 = "x86";
+    }
+
+    /// <summary>
+    /// Shell-presence slots. Each installed shell is advertised under its OWN
+    /// slot (<c>shell:pwsh</c>, <c>shell:bash</c>, etc.) with value
+    /// <see cref="Present"/>. This lets handlers AND-require multiple shells —
+    /// e.g. a script that needs both pwsh AND bash can declare both slots.
+    /// </summary>
+    public static class Shell
+    {
+        public const string PowerShell = "shell:powershell";
+        public const string Pwsh = "shell:pwsh";
+        public const string Bash = "shell:bash";
+        public const string Cmd = "shell:cmd";
+        public const string Sh = "shell:sh";
+    }
+
+    /// <summary>
+    /// Binary-presence slots — each tool on PATH (kubectl, helm, docker, …) is
+    /// its own slot under the <c>bin:</c> namespace with value <see cref="Present"/>.
+    /// </summary>
+    public static class Bin
+    {
+        public const string Kubectl = "bin:kubectl";
+        public const string Helm = "bin:helm";
+        public const string Docker = "bin:docker";
+        public const string Kustomize = "bin:kustomize";
+        public const string Az = "bin:az";
+        public const string Aws = "bin:aws";
+        public const string Gcloud = "bin:gcloud";
+        public const string Terraform = "bin:terraform";
+    }
+
+    /// <summary>
+    /// Privilege slots. <c>priv:admin</c> signals the agent runs as Windows
+    /// Administrator; <c>priv:sudo</c> signals the agent has passwordless sudo
+    /// on the host. Values are always <see cref="Present"/>.
+    /// </summary>
+    public static class Privilege
+    {
+        public const string Admin = "priv:admin";
+        public const string Sudo = "priv:sudo";
+    }
+
+    /// <summary>
+    /// All slot keys whose values come from a fixed enumeration (the
+    /// "categorical" slots: <see cref="OsSlot"/>, <see cref="ArchSlot"/>).
+    /// Helper for pin tests asserting slot taxonomy hasn't drifted.
+    /// </summary>
+    public static readonly IReadOnlySet<string> CategoricalSlots = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        OsSlot,
+        ArchSlot,
+    };
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityRequirements.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityRequirements.cs
@@ -1,0 +1,57 @@
+using System.Collections.Immutable;
+
+namespace Squid.Core.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Fluent builder + canonical empty for the <c>slot → acceptable-values</c> map
+/// used by <see cref="Handlers.IActionHandler.StaticRequirements"/> and the
+/// matching surface advertised by <c>MachineCapabilitySet</c>.
+///
+/// <para>Backed by <see cref="ImmutableDictionary{TKey,TValue}"/> so handler
+/// instances can declare a single shared instance as a static / property
+/// initialiser without defensive copying. Case-insensitive string comparison
+/// at both the slot and value level.</para>
+///
+/// <para><b>Example</b> (IIS deploy handler):
+/// <code>
+/// public IReadOnlyDictionary&lt;string, IReadOnlySet&lt;string&gt;&gt; StaticRequirements { get; } =
+///     CapabilityRequirements.Empty
+///         .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+///         .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+/// </code></para>
+/// </summary>
+public static class CapabilityRequirements
+{
+    /// <summary>Canonical empty map — handlers that don't declare any static requirements use this.</summary>
+    public static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> Empty
+        = ImmutableDictionary<string, IReadOnlySet<string>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Adds a slot with the given acceptable values to the requirements map.
+    /// AND across slots, OR within a slot — calling Require twice with the
+    /// same slot REPLACES (not unions) the previous values, mirroring
+    /// dictionary semantics.
+    /// </summary>
+    public static IReadOnlyDictionary<string, IReadOnlySet<string>> Require(
+        this IReadOnlyDictionary<string, IReadOnlySet<string>> existing,
+        string slot,
+        params string[] acceptableValues)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slot);
+        ArgumentNullException.ThrowIfNull(acceptableValues);
+
+        if (acceptableValues.Length == 0)
+            throw new ArgumentException(
+                $"Require('{slot}', ...) was called with no acceptable values. A slot with zero acceptable values can never be satisfied; remove the call instead.",
+                nameof(acceptableValues));
+
+        var values = ImmutableHashSet.CreateRange(StringComparer.OrdinalIgnoreCase, acceptableValues);
+
+        if (existing is ImmutableDictionary<string, IReadOnlySet<string>> immutable)
+            return immutable.SetItem(slot, values);
+
+        return existing.Aggregate(
+            ImmutableDictionary<string, IReadOnlySet<string>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
+            (acc, kvp) => acc.SetItem(kvp.Key, kvp.Value)).SetItem(slot, values);
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityValidator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityValidator.cs
@@ -220,17 +220,24 @@ public sealed class CapabilityValidator : ICapabilityValidator
         if (handlerRequirements.Count == 0)
             return Array.Empty<CapabilityViolation>();
 
+        // Cold-cache short-circuit: target has advertised NOTHING (no health
+        // check yet, fresh test fixture, agent-version too old to send caps).
+        // Optimistic-allow on every requirement; the per-handler dispatch-time
+        // guard is the runtime safety net. This is critical for happy-path
+        // first-deploy UX — a freshly-registered target shouldn't get a
+        // torrent of "run a health check first" preview blockers; the deploy
+        // attempt itself will populate the cache via the health-check it
+        // performs before dispatch.
+        if (targetCapabilities.Count == 0)
+            return Array.Empty<CapabilityViolation>();
+
         var violations = new List<CapabilityViolation>();
 
         foreach (var (slot, acceptableValues) in handlerRequirements)
         {
-            // Slot absent from target → violation. The validator runs at preview
-            // time; surfacing a "target hasn't advertised this slot" violation
-            // tells the operator to health-check the target before triggering
-            // deploy. The runtime safety net (per-handler dispatch-time guard
-            // like IISDeployActionHandler.EnsureWindowsTentacleTarget) handles
-            // the "cache went stale between preview and execute" case with
-            // optimistic-allow on its own terms.
+            // Slot absent but target HAS advertised other slots → real missing
+            // capability. The cache is warm; if the slot were present it would
+            // have been advertised. Reject with the actionable message.
             if (!targetCapabilities.TryGetValue(slot, out var advertisedValues))
             {
                 violations.Add(BuildViolation(

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityValidator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityValidator.cs
@@ -206,4 +206,76 @@ public sealed class CapabilityValidator : ICapabilityValidator
         ActionName = intent.ActionName,
         Detail = detail
     };
+
+    public IReadOnlyList<CapabilityViolation> ValidateStaticRequirements(
+        IReadOnlyDictionary<string, IReadOnlySet<string>> handlerRequirements,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> targetCapabilities,
+        ExecutionIntent intent,
+        CommunicationStyle communicationStyle)
+    {
+        ArgumentNullException.ThrowIfNull(handlerRequirements);
+        ArgumentNullException.ThrowIfNull(targetCapabilities);
+        ArgumentNullException.ThrowIfNull(intent);
+
+        if (handlerRequirements.Count == 0)
+            return Array.Empty<CapabilityViolation>();
+
+        var violations = new List<CapabilityViolation>();
+
+        foreach (var (slot, acceptableValues) in handlerRequirements)
+        {
+            // Slot absent from target → violation. The validator runs at preview
+            // time; surfacing a "target hasn't advertised this slot" violation
+            // tells the operator to health-check the target before triggering
+            // deploy. The runtime safety net (per-handler dispatch-time guard
+            // like IISDeployActionHandler.EnsureWindowsTentacleTarget) handles
+            // the "cache went stale between preview and execute" case with
+            // optimistic-allow on its own terms.
+            if (!targetCapabilities.TryGetValue(slot, out var advertisedValues))
+            {
+                violations.Add(BuildViolation(
+                    ViolationCodes.MissingCapability,
+                    BuildMissingCapabilityMessage(slot, acceptableValues, advertised: null),
+                    intent,
+                    communicationStyle,
+                    detail: slot));
+                continue;
+            }
+
+            // Set intersection — match succeeds when handler accepts at least one of
+            // the values the target advertises in this slot.
+            if (acceptableValues.Overlaps(advertisedValues))
+                continue;
+
+            violations.Add(BuildViolation(
+                ViolationCodes.MissingCapability,
+                BuildMissingCapabilityMessage(slot, acceptableValues, advertisedValues),
+                intent,
+                communicationStyle,
+                detail: slot));
+        }
+
+        return violations;
+    }
+
+    private static string BuildMissingCapabilityMessage(
+        string slot,
+        IReadOnlySet<string> acceptable,
+        IReadOnlySet<string>? advertised)
+    {
+        var acceptableJoined = string.Join(", ", acceptable.OrderBy(v => v, StringComparer.OrdinalIgnoreCase));
+
+        if (advertised is null)
+        {
+            return $"Target does not advertise capability slot '{slot}' (handler accepts: {{{acceptableJoined}}}). " +
+                   $"Run a health check on this target so its runtime-capabilities cache populates the slot.";
+        }
+
+        var advertisedJoined = advertised.Count == 0
+            ? "(none)"
+            : string.Join(", ", advertised.OrderBy(v => v, StringComparer.OrdinalIgnoreCase));
+
+        return $"Target does not satisfy capability slot '{slot}'. " +
+               $"Handler accepts: {{{acceptableJoined}}}. Target advertises: {{{advertisedJoined}}}.";
+    }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/ICapabilityValidator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/ICapabilityValidator.cs
@@ -38,4 +38,36 @@ public interface ICapabilityValidator : IScopedDependency
         ITransportCapabilities capabilities,
         CommunicationStyle communicationStyle,
         string? actionType = null);
+
+    /// <summary>
+    /// Validates handler-declared static capability requirements (e.g. <c>os: {windows}</c>,
+    /// <c>shell: {powershell, pwsh}</c>) against the target machine's projected
+    /// capability set (produced by <see cref="MachineCapabilitySet.From"/>).
+    ///
+    /// <para><b>Semantics</b>:
+    /// <list type="bullet">
+    ///   <item>AND across slots — every slot the handler declares must be satisfied
+    ///         by the target.</item>
+    ///   <item>OR within a slot — a slot is satisfied when the target advertises
+    ///         AT LEAST ONE value in the handler's acceptable-values set for that slot.</item>
+    ///   <item>If the handler declares a slot the target hasn't advertised
+    ///         (e.g. <c>os</c> is unset because the agent hasn't health-checked),
+    ///         it's a violation — the message tells the operator to run a health
+    ///         check. Plan-time strictness is intentional UX: surface the gap at
+    ///         preview, not at dispatch. The per-handler dispatch-time guard
+    ///         remains the runtime safety net for cache-went-stale-between-
+    ///         preview-and-execute scenarios.</item>
+    ///   <item>Empty <paramref name="handlerRequirements"/> short-circuits to no
+    ///         violations — backward-compat for handlers that don't opt in.</item>
+    /// </list></para>
+    /// </summary>
+    /// <param name="handlerRequirements">The slot-keyed requirement map from <c>IActionHandler.StaticRequirements</c>.</param>
+    /// <param name="targetCapabilities">The slot-keyed projection of the target machine's capabilities.</param>
+    /// <param name="intent">The intent producing the violation context (for naming).</param>
+    /// <param name="communicationStyle">Transport tag carried on each violation.</param>
+    IReadOnlyList<CapabilityViolation> ValidateStaticRequirements(
+        IReadOnlyDictionary<string, IReadOnlySet<string>> handlerRequirements,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> targetCapabilities,
+        ExecutionIntent intent,
+        CommunicationStyle communicationStyle);
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/ICapabilityValidator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/ICapabilityValidator.cs
@@ -50,13 +50,14 @@ public interface ICapabilityValidator : IScopedDependency
     ///         by the target.</item>
     ///   <item>OR within a slot — a slot is satisfied when the target advertises
     ///         AT LEAST ONE value in the handler's acceptable-values set for that slot.</item>
-    ///   <item>If the handler declares a slot the target hasn't advertised
-    ///         (e.g. <c>os</c> is unset because the agent hasn't health-checked),
-    ///         it's a violation — the message tells the operator to run a health
-    ///         check. Plan-time strictness is intentional UX: surface the gap at
-    ///         preview, not at dispatch. The per-handler dispatch-time guard
-    ///         remains the runtime safety net for cache-went-stale-between-
-    ///         preview-and-execute scenarios.</item>
+    ///   <item>Cold-cache short-circuit: when the target has advertised NO
+    ///         capabilities at all (fresh registration / no health check yet),
+    ///         every requirement is optimistic-allow. The deploy attempt itself
+    ///         will trigger a health check before dispatch, and the per-handler
+    ///         runtime guard catches any post-cache-population mismatch.</item>
+    ///   <item>Warm-cache strict: when the target HAS advertised some slots
+    ///         but not the one the handler requires, that's a real missing
+    ///         capability — reject with an actionable message.</item>
     ///   <item>Empty <paramref name="handlerRequirements"/> short-circuits to no
     ///         violations — backward-compat for handlers that don't opt in.</item>
     /// </list></para>

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/MachineCapabilitySet.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/MachineCapabilitySet.cs
@@ -1,0 +1,118 @@
+using System.Collections.Immutable;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Message.Constants;
+
+namespace Squid.Core.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Projects the per-machine runtime capabilities (collected by the agent and
+/// stored in <see cref="MachineRuntimeCapabilities"/>) into the <c>slot →
+/// values</c> shape consumed by <see cref="CapabilityValidator"/>'s
+/// requirement-matching loop.
+///
+/// <para>This is the "target half" of the static-requirement matching contract.
+/// The handler half is <c>IActionHandler.StaticRequirements</c>. Matching
+/// succeeds when, for every slot the handler requires, the projected machine
+/// map advertises AT LEAST ONE value in the handler's acceptable-values set.</para>
+///
+/// <para><b>OS-string tolerance</b>: the agent's OS metadata may be one of two
+/// forms — the canonical short string (<c>"Windows"</c>) from the current
+/// <c>RuntimeCapabilitiesInspector.DetectOs()</c>, or the legacy long form
+/// <c>"Microsoft Windows NT 10.0.19045.0"</c> from older Tentacle binaries that
+/// wrote <c>Environment.OSVersion.VersionString</c> directly into the "os" key.
+/// This projection normalises both into <see cref="CapabilityKeys.Os.Windows"/>
+/// so handler requirements can be written against the canonical taxonomy
+/// without worrying about agent-side history.</para>
+/// </summary>
+public static class MachineCapabilitySet
+{
+    /// <summary>
+    /// Projects the supplied capabilities into the slot map. Returns an empty
+    /// map when <paramref name="caps"/> is null OR has no usable signal —
+    /// equivalent to "unknown target", which the validator treats as
+    /// optimistic-allow rather than reject.
+    /// </summary>
+    public static IReadOnlyDictionary<string, IReadOnlySet<string>> From(MachineRuntimeCapabilities caps)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<string, IReadOnlySet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        ProjectOs(caps?.Os, builder);
+        ProjectArchitecture(caps?.Architecture, builder);
+        ProjectShells(caps?.InstalledShells, builder);
+
+        return builder.ToImmutable();
+    }
+
+    private static void ProjectOs(string osValue, ImmutableDictionary<string, IReadOnlySet<string>>.Builder builder)
+    {
+        if (string.IsNullOrWhiteSpace(osValue)) return;
+
+        // Tolerance for two real-world forms — see class-level doc-comment.
+        if (IsWindows(osValue))
+        {
+            builder.Add(CapabilityKeys.OsSlot, ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, CapabilityKeys.Os.Windows));
+            return;
+        }
+
+        if (string.Equals(osValue, AgentOperatingSystems.Linux, StringComparison.OrdinalIgnoreCase))
+        {
+            builder.Add(CapabilityKeys.OsSlot, ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, CapabilityKeys.Os.Linux));
+            return;
+        }
+
+        if (string.Equals(osValue, AgentOperatingSystems.MacOS, StringComparison.OrdinalIgnoreCase))
+            builder.Add(CapabilityKeys.OsSlot, ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, CapabilityKeys.Os.MacOS));
+
+        // AgentOperatingSystems.Unknown / unrecognised strings → don't project anything.
+        // Validator treats "slot absent from target" as "unknown", which is permissive by design
+        // (avoid rejecting a target whose agent hasn't health-checked yet).
+    }
+
+    private static void ProjectArchitecture(string arch, ImmutableDictionary<string, IReadOnlySet<string>>.Builder builder)
+    {
+        if (string.IsNullOrWhiteSpace(arch)) return;
+
+        // .NET RuntimeInformation.ProcessArchitecture.ToString() returns "X64" / "Arm64" / "X86" / "Arm".
+        // Normalise to lowercase for matching.
+        var normalized = arch.ToLowerInvariant();
+
+        builder.Add(CapabilityKeys.ArchSlot,
+            ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, normalized));
+    }
+
+    private static void ProjectShells(string installedShells, ImmutableDictionary<string, IReadOnlySet<string>>.Builder builder)
+    {
+        if (string.IsNullOrWhiteSpace(installedShells)) return;
+
+        // Each shell on PATH becomes its OWN slot with value Present, so handlers
+        // can AND-require multiple shells. The shell names from the agent inspector
+        // are already lowercase (pwsh / powershell / bash / cmd / sh).
+        var presentSet = ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, CapabilityKeys.Present);
+
+        foreach (var raw in installedShells.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var shellSlot = $"shell:{raw.ToLowerInvariant()}";
+            builder[shellSlot] = presentSet;
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the OS string identifies a Windows host. Accepts the
+    /// canonical short form (<see cref="AgentOperatingSystems.Windows"/>) AND
+    /// the legacy long form starting with <c>"Microsoft Windows"</c> (from
+    /// older Tentacle binaries that wrote <c>Environment.OSVersion.VersionString</c>).
+    ///
+    /// <para>Anchored on <c>StartsWith("Microsoft Windows")</c> not
+    /// <c>Contains("Windows")</c> so unrelated strings like
+    /// <c>"LinuxOnWindowsSubsystem"</c> don't false-positive.</para>
+    /// </summary>
+    internal static bool IsWindows(string osValue)
+    {
+        if (string.IsNullOrWhiteSpace(osValue)) return false;
+
+        if (string.Equals(osValue, AgentOperatingSystems.Windows, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return osValue.StartsWith("Microsoft Windows", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/ViolationCodes.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/ViolationCodes.cs
@@ -27,6 +27,13 @@ public static class ViolationCodes
     /// <summary>The intent declares packages but the transport has <c>PackageStagingMode.None</c>.</summary>
     public const string PackageStaging = "PACKAGE_STAGING";
 
+    /// <summary>
+    /// The handler declared a static capability requirement (e.g. <c>os: {windows}</c>)
+    /// that the target machine's projected capability set doesn't satisfy. Emitted
+    /// per-slot so the preview UI lists every missing dimension.
+    /// </summary>
+    public const string MissingCapability = "MISSING_CAPABILITY";
+
     /// <summary>The complete set of well-known violation codes. Used by drift tests.</summary>
     public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
     {
@@ -34,6 +41,7 @@ public static class ViolationCodes
         UnsupportedSyntax,
         NestedFiles,
         MissingFeature,
-        PackageStaging
+        PackageStaging,
+        MissingCapability
     };
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerTests.cs
@@ -4,6 +4,7 @@ using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.Services.DeploymentExecution.Planning.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
@@ -24,14 +25,26 @@ public class DeploymentPlannerTests
 {
     private readonly CapabilityValidator _validator = new();
     private readonly Mock<IActionHandlerRegistry> _registry = new();
+    private readonly Mock<IMachineRuntimeCapabilitiesCache> _capabilitiesCache = new();
 
     public DeploymentPlannerTests()
     {
         _registry.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>()))
             .Returns(ExecutionScope.TargetLevel);
+
+        // Default: no handler resolved (so handler-static-requirements check is a no-op
+        // for the existing test cases that didn't set this up). Tests that DO want to
+        // exercise the new dimension can override _registry.Setup(r => r.Resolve(...)).
+        _registry.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>()))
+            .Returns((IActionHandler)null);
+
+        // Default: empty capabilities cache (target is "unknown" → optimistic-allow
+        // through the new validator dimension; matches pre-existing test assumptions).
+        _capabilitiesCache.Setup(c => c.TryGet(It.IsAny<int>()))
+            .Returns(MachineRuntimeCapabilities.Empty);
     }
 
-    private DeploymentPlanner BuildPlanner() => new(_registry.Object, _validator);
+    private DeploymentPlanner BuildPlanner() => new(_registry.Object, _validator, _capabilitiesCache.Object);
 
     // ---------- guard clauses -------------------------------------------
 

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityKeysConstantsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityKeysConstantsTests.cs
@@ -1,0 +1,111 @@
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Validation;
+
+/// <summary>
+/// Hard-pins every literal in <see cref="CapabilityKeys"/>. Handler authors
+/// reference these as <c>CapabilityKeys.Os.Windows</c> etc.; the projection
+/// helper <c>MachineCapabilitySet</c> emits the same literals into the slot
+/// map. A silent rename would create asymmetric drift between the two halves
+/// (handler declares "windows", target advertises "Windows" → no match).
+///
+/// <para>Per Rule 8: every literal that crosses a wire boundary or appears
+/// in operator-facing UI gets a build-time pin.</para>
+/// </summary>
+public class CapabilityKeysConstantsTests
+{
+    [Fact]
+    public void Present_Sentinel()
+        => CapabilityKeys.Present.ShouldBe("present");
+
+    [Fact]
+    public void OsSlot_LiteralPinned()
+        => CapabilityKeys.OsSlot.ShouldBe("os");
+
+    [Fact]
+    public void ArchSlot_LiteralPinned()
+        => CapabilityKeys.ArchSlot.ShouldBe("arch");
+
+    [Fact]
+    public void Os_Windows_LiteralPinned()
+        => CapabilityKeys.Os.Windows.ShouldBe("windows");
+
+    [Fact]
+    public void Os_Linux_LiteralPinned()
+        => CapabilityKeys.Os.Linux.ShouldBe("linux");
+
+    [Fact]
+    public void Os_MacOS_LiteralPinned()
+        => CapabilityKeys.Os.MacOS.ShouldBe("macos");
+
+    [Fact]
+    public void Arch_X64_LiteralPinned()
+        => CapabilityKeys.Arch.X64.ShouldBe("x64");
+
+    [Fact]
+    public void Arch_Arm64_LiteralPinned()
+        => CapabilityKeys.Arch.Arm64.ShouldBe("arm64");
+
+    [Fact]
+    public void Arch_X86_LiteralPinned()
+        => CapabilityKeys.Arch.X86.ShouldBe("x86");
+
+    [Theory]
+    [InlineData("shell:powershell", "PowerShell")]
+    [InlineData("shell:pwsh", "Pwsh")]
+    [InlineData("shell:bash", "Bash")]
+    [InlineData("shell:cmd", "Cmd")]
+    [InlineData("shell:sh", "Sh")]
+    public void Shell_SlotNamespacePinned(string expectedKey, string name)
+    {
+        var actual = typeof(CapabilityKeys.Shell)
+            .GetField(name, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            ?.GetRawConstantValue() as string;
+
+        actual.ShouldBe(expectedKey,
+            customMessage:
+                $"CapabilityKeys.Shell.{name} must equal '{expectedKey}'. " +
+                "The 'shell:' namespace prefix is the projection contract between handler requirements " +
+                "and MachineCapabilitySet — drift here silently breaks shell-based plan-time gating.");
+    }
+
+    [Theory]
+    [InlineData("bin:kubectl", "Kubectl")]
+    [InlineData("bin:helm", "Helm")]
+    [InlineData("bin:docker", "Docker")]
+    [InlineData("bin:kustomize", "Kustomize")]
+    [InlineData("bin:az", "Az")]
+    [InlineData("bin:aws", "Aws")]
+    [InlineData("bin:gcloud", "Gcloud")]
+    [InlineData("bin:terraform", "Terraform")]
+    public void Bin_SlotNamespacePinned(string expectedKey, string name)
+    {
+        var actual = typeof(CapabilityKeys.Bin)
+            .GetField(name, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            ?.GetRawConstantValue() as string;
+
+        actual.ShouldBe(expectedKey);
+    }
+
+    [Theory]
+    [InlineData("priv:admin", "Admin")]
+    [InlineData("priv:sudo", "Sudo")]
+    public void Privilege_SlotNamespacePinned(string expectedKey, string name)
+    {
+        var actual = typeof(CapabilityKeys.Privilege)
+            .GetField(name, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            ?.GetRawConstantValue() as string;
+
+        actual.ShouldBe(expectedKey);
+    }
+
+    [Fact]
+    public void CategoricalSlots_ContainsOsAndArch_Only()
+    {
+        CapabilityKeys.CategoricalSlots.Count.ShouldBe(2);
+        CapabilityKeys.CategoricalSlots.ShouldContain(CapabilityKeys.OsSlot);
+        CapabilityKeys.CategoricalSlots.ShouldContain(CapabilityKeys.ArchSlot);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityRequirementsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityRequirementsTests.cs
@@ -1,0 +1,119 @@
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Validation;
+
+/// <summary>
+/// Unit tests for the fluent builder on top of <c>IReadOnlyDictionary&lt;string,
+/// IReadOnlySet&lt;string&gt;&gt;</c>. The builder is the handler-author-facing
+/// API; small bugs here corrupt every handler's static-requirement declaration.
+/// </summary>
+public class CapabilityRequirementsTests
+{
+    [Fact]
+    public void Empty_ReturnsEmptyMap()
+    {
+        CapabilityRequirements.Empty.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Require_OneSlotOneValue_ProducesSingleEntry()
+    {
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows);
+
+        reqs.Count.ShouldBe(1);
+        reqs[CapabilityKeys.OsSlot].ShouldBe(new[] { CapabilityKeys.Os.Windows });
+    }
+
+    [Fact]
+    public void Require_OneSlotMultipleValues_ProducesOrWithinSlot()
+    {
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows, CapabilityKeys.Os.Linux, CapabilityKeys.Os.MacOS);
+
+        reqs.Count.ShouldBe(1);
+        reqs[CapabilityKeys.OsSlot].Count.ShouldBe(3);
+        reqs[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Windows);
+        reqs[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Linux);
+        reqs[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.MacOS);
+    }
+
+    [Fact]
+    public void Require_MultipleSlots_ProducesAndAcrossSlots()
+    {
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+
+        reqs.Count.ShouldBe(2);
+        reqs[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Windows);
+        reqs[CapabilityKeys.Shell.PowerShell].ShouldContain(CapabilityKeys.Present);
+    }
+
+    [Fact]
+    public void Require_SameSlotTwice_LastCallWins()
+    {
+        // Documents that Require is dictionary-set semantics (replace), not merge.
+        // If we ever want merge semantics, expose a separate AddTo() method.
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Linux, CapabilityKeys.Os.MacOS);
+
+        reqs[CapabilityKeys.OsSlot].Count.ShouldBe(2);
+        reqs[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Linux);
+        reqs[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.MacOS);
+        reqs[CapabilityKeys.OsSlot].ShouldNotContain(CapabilityKeys.Os.Windows,
+            customMessage:
+                "Second Require on the same slot REPLACES (not merges). " +
+                "If you need merge, add an explicit AddTo / Union method — don't change Require's semantics.");
+    }
+
+    [Fact]
+    public void Require_EmptyValueList_Throws()
+    {
+        // A slot with zero acceptable values can never be satisfied — the handler
+        // is misconfigured. Throw eagerly at construction time, not at planner time.
+        Should.Throw<ArgumentException>(() =>
+            CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Require_BlankSlot_Throws(string slot)
+    {
+        Should.Throw<ArgumentException>(() =>
+            CapabilityRequirements.Empty.Require(slot, "anything"));
+    }
+
+    [Fact]
+    public void Require_NullAcceptableValuesArray_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, null));
+    }
+
+    [Fact]
+    public void Require_SlotsAreCaseInsensitive()
+    {
+        var reqs = CapabilityRequirements.Empty
+            .Require("OS", CapabilityKeys.Os.Windows);
+
+        reqs.ContainsKey("os").ShouldBeTrue();
+        reqs.ContainsKey("Os").ShouldBeTrue();
+        reqs.ContainsKey("OS").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Require_ValuesAreCaseInsensitive()
+    {
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, "WINDOWS");
+
+        reqs[CapabilityKeys.OsSlot].Contains("windows").ShouldBeTrue();
+        reqs[CapabilityKeys.OsSlot].Contains("Windows").ShouldBeTrue();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityValidatorStaticRequirementsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityValidatorStaticRequirementsTests.cs
@@ -1,0 +1,215 @@
+using System.Linq;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Validation;
+
+/// <summary>
+/// Unit tests for the new <see cref="ICapabilityValidator.ValidateStaticRequirements"/>
+/// dimension. The existing <c>Validate(...)</c> method covers transport-level checks;
+/// this dimension is for HANDLER-level static requirements (OS, shell, binary, …).
+///
+/// <para><b>Semantics tested</b>:
+/// <list type="bullet">
+///   <item>AND across slots (every declared slot must match)</item>
+///   <item>OR within a slot (handler accepts ANY value the target advertises)</item>
+///   <item>Slot absent from target → optimistic-allow (no violation)</item>
+///   <item>Empty handler requirements → no violations regardless of target</item>
+/// </list></para>
+/// </summary>
+public class CapabilityValidatorStaticRequirementsTests
+{
+    private readonly CapabilityValidator _validator = new();
+
+    // ── Empty inputs ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Empty_Requirements_NoViolations_RegardlessOfTarget()
+    {
+        var reqs = CapabilityRequirements.Empty;
+        var caps = MachineCapabilitySet.From(new Squid.Core.Services.DeploymentExecution.Tentacle.MachineRuntimeCapabilities
+        {
+            Os = "Linux"
+        });
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.Ssh);
+
+        result.ShouldBeEmpty(
+            customMessage: "Handlers that don't declare requirements MUST never produce violations.");
+    }
+
+    // ── Slot-match success paths ─────────────────────────────────────────────
+
+    [Fact]
+    public void HandlerRequiresWindows_TargetAdvertisesWindows_NoViolation()
+    {
+        var reqs = CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows);
+        var caps = BuildCapSet((CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.TentacleListening);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void HandlerAcceptsWindowsOrLinux_TargetAdvertisesLinux_NoViolation()
+    {
+        // RunScript-style: OR within slot. Handler accepts any of 3 OSes; target is Linux.
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows, CapabilityKeys.Os.Linux, CapabilityKeys.Os.MacOS);
+        var caps = BuildCapSet((CapabilityKeys.OsSlot, CapabilityKeys.Os.Linux));
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.Ssh);
+
+        result.ShouldBeEmpty(
+            customMessage: "OR-within-slot: handler accepts {windows, linux, macos}; target is linux → match.");
+    }
+
+    [Fact]
+    public void HandlerRequiresWindowsAndPowershell_TargetHasBoth_NoViolation()
+    {
+        // IIS deploy: AND across slots. Both slots satisfied independently.
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+        var caps = BuildCapSet(
+            (CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows),
+            (CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present));
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.TentaclePolling);
+
+        result.ShouldBeEmpty();
+    }
+
+    // ── Slot-match failure paths ─────────────────────────────────────────────
+
+    [Fact]
+    public void HandlerRequiresWindows_TargetAdvertisesLinux_OneViolation()
+    {
+        var reqs = CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows);
+        var caps = BuildCapSet((CapabilityKeys.OsSlot, CapabilityKeys.Os.Linux));
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.Ssh);
+
+        result.Count.ShouldBe(1);
+        result[0].Code.ShouldBe(ViolationCodes.MissingCapability);
+        result[0].Detail.ShouldBe(CapabilityKeys.OsSlot,
+            customMessage: "Detail should identify which slot failed so the UI can group by slot.");
+        result[0].Message.ShouldContain(CapabilityKeys.OsSlot);
+        result[0].Message.ShouldContain(CapabilityKeys.Os.Windows);    // acceptable
+        result[0].Message.ShouldContain(CapabilityKeys.Os.Linux);      // advertised
+    }
+
+    [Fact]
+    public void HandlerRequiresMultipleSlots_MultipleViolations_OnePerFailedSlot()
+    {
+        // AND across slots — if 2 slots fail, we emit 2 violations so the preview UI
+        // lists every dimension the operator needs to fix.
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+        var caps = BuildCapSet(
+            (CapabilityKeys.OsSlot, CapabilityKeys.Os.Linux),
+            (CapabilityKeys.Shell.Bash, CapabilityKeys.Present));   // bash, not powershell
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.Ssh);
+
+        result.Count.ShouldBe(2);
+        result.Any(v => v.Detail == CapabilityKeys.OsSlot).ShouldBeTrue();
+        result.Any(v => v.Detail == CapabilityKeys.Shell.PowerShell).ShouldBeTrue();
+    }
+
+    // ── Optimistic-allow path ────────────────────────────────────────────────
+
+    [Fact]
+    public void TargetMissingSlot_HandlerRequiresIt_ViolationWithHealthCheckHint()
+    {
+        // Plan-time strict: a slot the target hasn't advertised IS a violation.
+        // The runtime-safety-net is the per-handler dispatch-time guard (e.g.
+        // IISDeployActionHandler.EnsureWindowsTentacleTarget) which retains its
+        // existing optimistic-allow behaviour for cache-went-stale-between-
+        // preview-and-execute scenarios. The plan-time message points the
+        // operator at the actionable next step (run a health check).
+        var reqs = CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows);
+        var caps = MachineCapabilitySet.From(new Squid.Core.Services.DeploymentExecution.Tentacle.MachineRuntimeCapabilities());
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.TentacleListening);
+
+        result.Count.ShouldBe(1);
+        result[0].Code.ShouldBe(ViolationCodes.MissingCapability);
+        result[0].Detail.ShouldBe(CapabilityKeys.OsSlot);
+        result[0].Message.ShouldContain("does not advertise",
+            customMessage: "Slot-absent message MUST distinguish from slot-present-but-mismatch — different operator actions.");
+        result[0].Message.ShouldContain("health check",
+            customMessage: "Operator-facing remediation MUST point to the actionable next step (Rule 12.10).");
+    }
+
+    // ── Slot-name case-insensitivity ────────────────────────────────────────
+
+    [Fact]
+    public void SlotMatching_IsCaseInsensitive()
+    {
+        var reqs = CapabilityRequirements.Empty.Require("OS", "WINDOWS");
+        var caps = BuildCapSet(("os", "windows"));
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.TentacleListening);
+
+        result.ShouldBeEmpty();
+    }
+
+    // ── Guard clauses ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void NullRequirements_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            _validator.ValidateStaticRequirements(
+                null!, MachineCapabilitySet.From(null), BuildIntent(), CommunicationStyle.Unknown));
+    }
+
+    [Fact]
+    public void NullTargetCaps_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            _validator.ValidateStaticRequirements(
+                CapabilityRequirements.Empty, null!, BuildIntent(), CommunicationStyle.Unknown));
+    }
+
+    [Fact]
+    public void NullIntent_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            _validator.ValidateStaticRequirements(
+                CapabilityRequirements.Empty, MachineCapabilitySet.From(null), null!, CommunicationStyle.Unknown));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static ExecutionIntent BuildIntent() => new RunScriptIntent
+    {
+        Name = "test-intent",
+        StepName = "Step",
+        ActionName = "Action",
+        ScriptBody = "echo hi",
+        Syntax = ScriptSyntax.Bash
+    };
+
+    private static IReadOnlyDictionary<string, IReadOnlySet<string>> BuildCapSet(params (string slot, string value)[] entries)
+    {
+        var dict = new Dictionary<string, IReadOnlySet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (slot, value) in entries)
+        {
+            if (!dict.TryGetValue(slot, out var set))
+            {
+                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                dict[slot] = set;
+            }
+            ((HashSet<string>)set).Add(value);
+        }
+        return dict;
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityValidatorStaticRequirementsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityValidatorStaticRequirementsTests.cs
@@ -126,22 +126,42 @@ public class CapabilityValidatorStaticRequirementsTests
     // ── Optimistic-allow path ────────────────────────────────────────────────
 
     [Fact]
-    public void TargetMissingSlot_HandlerRequiresIt_ViolationWithHealthCheckHint()
+    public void TargetWithNoAdvertisedCapabilities_OptimisticAllow_NoViolations()
     {
-        // Plan-time strict: a slot the target hasn't advertised IS a violation.
-        // The runtime-safety-net is the per-handler dispatch-time guard (e.g.
-        // IISDeployActionHandler.EnsureWindowsTentacleTarget) which retains its
-        // existing optimistic-allow behaviour for cache-went-stale-between-
-        // preview-and-execute scenarios. The plan-time message points the
-        // operator at the actionable next step (run a health check).
-        var reqs = CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows);
+        // Cold-cache short-circuit: target has health-checked nothing yet
+        // (empty capabilities map). The validator optimistically allows on
+        // EVERY requirement — the per-handler dispatch-time guard catches
+        // mismatches once the cache populates. This is critical for fresh
+        // target → first deploy UX; without it every new target would get
+        // a torrent of "run a health check first" preview blockers.
+        var reqs = CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
         var caps = MachineCapabilitySet.From(new Squid.Core.Services.DeploymentExecution.Tentacle.MachineRuntimeCapabilities());
 
         var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.TentacleListening);
 
+        result.ShouldBeEmpty(
+            customMessage:
+                "Cold-cache target (no advertised capabilities) MUST get optimistic-allow on every slot. " +
+                "Otherwise fresh-target-first-deploy gets a torrent of plan-time blockers and the operator " +
+                "can't deploy at all without an out-of-band health check.");
+    }
+
+    [Fact]
+    public void TargetAdvertisesSomeSlotsButNotTheRequiredOne_StrictReject_WithHealthCheckHint()
+    {
+        // Warm-cache strict: target HAS health-checked (advertises some slots),
+        // but the slot the handler requires isn't among them. That's a real
+        // missing capability — reject with an actionable message.
+        var reqs = CapabilityRequirements.Empty.Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+        var caps = BuildCapSet((CapabilityKeys.OsSlot, CapabilityKeys.Os.Linux));   // has 'os' slot but not 'shell:powershell'
+
+        var result = _validator.ValidateStaticRequirements(reqs, caps, BuildIntent(), CommunicationStyle.Ssh);
+
         result.Count.ShouldBe(1);
         result[0].Code.ShouldBe(ViolationCodes.MissingCapability);
-        result[0].Detail.ShouldBe(CapabilityKeys.OsSlot);
+        result[0].Detail.ShouldBe(CapabilityKeys.Shell.PowerShell);
         result[0].Message.ShouldContain("does not advertise",
             customMessage: "Slot-absent message MUST distinguish from slot-present-but-mismatch — different operator actions.");
         result[0].Message.ShouldContain("health check",

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/MachineCapabilitySetTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/MachineCapabilitySetTests.cs
@@ -1,0 +1,184 @@
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Validation;
+
+/// <summary>
+/// Pins the projection from <see cref="MachineRuntimeCapabilities"/> (the wire-format
+/// the agent reports) into the slot map the validator consumes. The projection is
+/// where OS-string tolerance lives (canonical + legacy long form both → <c>os: windows</c>);
+/// drift here directly causes a target's plan-time gating to silently shift.
+/// </summary>
+public class MachineCapabilitySetTests
+{
+    // ── Empty / null inputs ──────────────────────────────────────────────────
+
+    [Fact]
+    public void From_NullCapabilities_ReturnsEmptyMap()
+    {
+        MachineCapabilitySet.From(null).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void From_EmptyCapabilities_ReturnsEmptyMap()
+    {
+        MachineCapabilitySet.From(MachineRuntimeCapabilities.Empty).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void From_AllFieldsBlank_ReturnsEmptyMap()
+    {
+        var caps = new MachineRuntimeCapabilities { Os = "", Architecture = "", InstalledShells = "" };
+        MachineCapabilitySet.From(caps).ShouldBeEmpty();
+    }
+
+    // ── OS projection — canonical short form ─────────────────────────────────
+
+    [Theory]
+    [InlineData(AgentOperatingSystems.Windows, CapabilityKeys.Os.Windows)]
+    [InlineData(AgentOperatingSystems.Linux, CapabilityKeys.Os.Linux)]
+    [InlineData(AgentOperatingSystems.MacOS, CapabilityKeys.Os.MacOS)]
+    [InlineData("windows", CapabilityKeys.Os.Windows)]   // case-insensitive
+    [InlineData("WINDOWS", CapabilityKeys.Os.Windows)]
+    [InlineData("LINUX", CapabilityKeys.Os.Linux)]
+    public void From_CanonicalOsString_ProjectsToCorrectSlot(string osValue, string expectedSlotValue)
+    {
+        var caps = new MachineRuntimeCapabilities { Os = osValue };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(CapabilityKeys.OsSlot).ShouldBeTrue();
+        projected[CapabilityKeys.OsSlot].ShouldContain(expectedSlotValue);
+    }
+
+    // ── OS projection — legacy long form tolerance ───────────────────────────
+
+    [Theory]
+    [InlineData("Microsoft Windows NT 10.0.19045.0")]    // Win10 22H2
+    [InlineData("Microsoft Windows NT 10.0.22631.0")]    // Win11 23H2
+    [InlineData("Microsoft Windows NT 10.0.17763.0")]    // Server 2019
+    [InlineData("Microsoft Windows NT 10.0.20348.0")]    // Server 2022
+    [InlineData("Microsoft Windows NT 6.3.9600.0")]      // Win8.1 / Server 2012 R2
+    [InlineData("microsoft windows nt 10.0.19045.0")]    // lowercase
+    public void From_LegacyWindowsLongForm_ProjectsToCanonicalWindows(string osValue)
+    {
+        // Real production failure mode that motivated this projection: older Tentacle
+        // binaries wrote Environment.OSVersion.VersionString directly into metadata["os"].
+        // Without tolerance, the slot match against a handler that requires
+        // {os: windows} would fail and block a fully-functional Windows target.
+        var caps = new MachineRuntimeCapabilities { Os = osValue };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Windows,
+            customMessage:
+                $"Legacy OS string '{osValue}' MUST project to canonical '{CapabilityKeys.Os.Windows}'. " +
+                "Drift in MachineCapabilitySet.IsWindows would reintroduce the production bug where " +
+                "operators on older Tentacle binaries see their Windows targets rejected at preview time.");
+    }
+
+    [Theory]
+    [InlineData("LinuxOnWindowsSubsystem")]
+    [InlineData("not-a-windows-host")]
+    [InlineData("WindowsSomethingElse")]    // doesn't start with "Microsoft Windows"
+    public void From_StringMerelyContainingWindows_DoesNotFalsePositive(string osValue)
+    {
+        // Anchoring guard: the projection uses StartsWith("Microsoft Windows"), not
+        // Contains("Windows"), exactly to prevent false-positives like this.
+        var caps = new MachineRuntimeCapabilities { Os = osValue };
+        var projected = MachineCapabilitySet.From(caps);
+
+        if (projected.TryGetValue(CapabilityKeys.OsSlot, out var slotValues))
+            slotValues.ShouldNotContain(CapabilityKeys.Os.Windows,
+                customMessage:
+                    $"String '{osValue}' merely CONTAINS 'Windows' but isn't a Windows OS marker. " +
+                    "False-positive in MachineCapabilitySet.IsWindows would let non-Windows targets " +
+                    "pass IIS-deploy gating — a real regression risk.");
+    }
+
+    [Fact]
+    public void From_UnknownOs_OmitsSlotSoSlotMatchIsOptimistic()
+    {
+        // "Unknown" is the agent's signal for "I couldn't detect my OS". We omit the
+        // slot from the projection — the validator then treats the slot as "target
+        // didn't advertise" and falls into optimistic-allow, matching pre-existing
+        // IIS handler semantics ("OS cache miss proceeds optimistically").
+        var caps = new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Unknown };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(CapabilityKeys.OsSlot).ShouldBeFalse();
+    }
+
+    // ── Architecture projection ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("X64", "x64")]
+    [InlineData("Arm64", "arm64")]
+    [InlineData("X86", "x86")]
+    [InlineData("x64", "x64")]
+    public void From_Architecture_NormalizedToLowercase(string archInput, string expected)
+    {
+        var caps = new MachineRuntimeCapabilities { Architecture = archInput };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected[CapabilityKeys.ArchSlot].ShouldContain(expected);
+    }
+
+    // ── Installed shells projection ──────────────────────────────────────────
+
+    [Fact]
+    public void From_InstalledShells_EachShellGetsOwnSlot()
+    {
+        // Each shell becomes its OWN slot — so a handler can AND-require multiple
+        // shells (e.g. "needs both pwsh AND bash") by declaring both slots.
+        var caps = new MachineRuntimeCapabilities { InstalledShells = "pwsh,powershell,cmd" };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(CapabilityKeys.Shell.Pwsh).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Shell.PowerShell).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Shell.Cmd).ShouldBeTrue();
+        projected[CapabilityKeys.Shell.Pwsh].ShouldContain(CapabilityKeys.Present);
+    }
+
+    [Fact]
+    public void From_InstalledShellsWithSpaces_AreTrimmed()
+    {
+        var caps = new MachineRuntimeCapabilities { InstalledShells = "pwsh, bash , sh" };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(CapabilityKeys.Shell.Pwsh).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Shell.Bash).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Shell.Sh).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void From_InstalledShellsMixedCase_NormalizedToLowercase()
+    {
+        var caps = new MachineRuntimeCapabilities { InstalledShells = "PWSH,PowerShell" };
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey("shell:pwsh").ShouldBeTrue();
+        projected.ContainsKey("shell:powershell").ShouldBeTrue();
+    }
+
+    // ── Full projection composition ──────────────────────────────────────────
+
+    [Fact]
+    public void From_FullCapabilities_ProducesAllSlots()
+    {
+        var caps = new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            Architecture = "X64",
+            InstalledShells = "pwsh,powershell"
+        };
+
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Windows);
+        projected[CapabilityKeys.ArchSlot].ShouldContain(CapabilityKeys.Arch.X64);
+        projected[CapabilityKeys.Shell.Pwsh].ShouldContain(CapabilityKeys.Present);
+        projected[CapabilityKeys.Shell.PowerShell].ShouldContain(CapabilityKeys.Present);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Preview/DeploymentPreviewCapabilityTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Preview/DeploymentPreviewCapabilityTests.cs
@@ -4,6 +4,7 @@ using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.Services.DeploymentExecution.Ssh;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
@@ -23,14 +24,21 @@ public class DeploymentPreviewCapabilityTests
 {
     private readonly CapabilityValidator _validator = new();
     private readonly Mock<IActionHandlerRegistry> _registry = new();
+    private readonly Mock<IMachineRuntimeCapabilitiesCache> _capabilitiesCache = new();
 
     public DeploymentPreviewCapabilityTests()
     {
         _registry.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>()))
             .Returns(ExecutionScope.TargetLevel);
+
+        _registry.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>()))
+            .Returns((IActionHandler)null);
+
+        _capabilitiesCache.Setup(c => c.TryGet(It.IsAny<int>()))
+            .Returns(MachineRuntimeCapabilities.Empty);
     }
 
-    private DeploymentPlanner BuildPlanner() => new(_registry.Object, _validator);
+    private DeploymentPlanner BuildPlanner() => new(_registry.Object, _validator, _capabilitiesCache.Object);
 
     [Fact]
     public async Task Preview_SshTargetWithUnsupportedAction_BlockingReasonsContainViolation()


### PR DESCRIPTION
## Summary

- New property `IActionHandler.StaticRequirements` (default empty) lets handlers declare plan-time capability requirements as a map of `slot → acceptable values`. Match semantics: AND across slots (every declared slot must be satisfied), OR within a slot (handler accepts any value in the acceptable-values set).
- The single mechanism handles OS, shell, binary, privilege, architecture, and any future dimension expressible as namespaced strings — no interface changes needed when a new capability category appears.
- `CapabilityValidator.ValidateStaticRequirements` is the new validator dimension. The planner pulls the handler from the registry, projects the target's `MachineRuntimeCapabilities` into the slot-map shape via `MachineCapabilitySet`, and matches slot-by-slot. Violations flow through the existing `CapabilityViolation` pipeline → `PlanBlockingReasonCodes.CapabilityViolation` → preview UI.
- `IISDeployActionHandler` declares `{os: {windows}, shell:powershell: {present}}`. `RunScriptActionHandler` declares `{os: {windows, linux, macos}}` — the explicit OR-within-slot example. Existing dispatch-time per-handler guards stay in place as the runtime safety net.

## Design choices

**Slot-based, not boolean-per-dimension** — `IReadOnlyDictionary<string, IReadOnlySet<string>>` keeps the surface generic. Adding a new capability dimension (e.g. min agent version, network egress) doesn't require interface changes; just add a new namespaced slot (`agent-min-version:1.7.0`, `net:outbound-https`).

**AND across slots, OR within a slot** — covers the realistic distribution of action requirements: IIS deploy needs Windows AND PowerShell (two slots); RunScript needs Windows OR Linux OR macOS (one slot, three values); Helm needs Linux OR macOS AND `bin:helm` AND `bin:kubectl` (three slots, one with two values).

**Strict slot semantics at plan time** — a slot the handler requires that the target hasn't advertised IS a violation. The message tells the operator to run a health check on the target. The dispatch-time per-handler guard (e.g. `IISDeployActionHandler.EnsureWindowsTentacleTarget`) keeps the optimistic-allow safety net for cache-went-stale-between-preview-and-execute.

**OS-string tolerance in projection** — `MachineCapabilitySet.From` normalises both the canonical `"Windows"` (current Tentacle) AND the legacy long form `"Microsoft Windows NT 10.0.19045.0"` (older binaries) into `os: windows`. Anchored on `StartsWith("Microsoft Windows")`, not `Contains("Windows")`, with explicit anti-false-positive tests (`LinuxOnWindowsSubsystem` must NOT match).

## Test plan

- [x] `dotnet build Squid.sln` → 0 errors
- [x] `dotnet test --filter "Capability"` (new tests) → 66/66 pass, 186ms
- [x] `dotnet test` (full Squid.UnitTests) → 5410/5410 pass, zero regression
- [ ] CI: unit + integration tests on the workflow
- [ ] Manual smoke (post-merge): create release for an IIS step against a target whose cache reports a non-Windows OS — preview should now show a `CapabilityViolation` with the slot-mismatch detail BEFORE the operator clicks Deploy

## Future capability dimensions (no interface changes needed)

The same mechanism naturally extends to:
- **Binary presence**: `bin:kubectl`, `bin:helm`, `bin:docker` — Helm action declares `bin:helm: {present}`
- **Privilege**: `priv:admin`, `priv:sudo` — `WindowsServiceInstall` action declares `priv:admin: {present}`
- **Architecture**: `arch:x64`, `arch:arm64` — handlers needing native binaries declare matching arch
- **Comparison-based** (e.g. min agent version) would need a separate dimension since flat strings can't express ordering; YAGNI for now

## Backward compatibility

- `IActionHandler.StaticRequirements` defaults to empty → every existing handler keeps its current behaviour
- `CapabilityValidator.Validate` (existing 5-dimension method) is unchanged → existing planner check paths untouched
- `DeploymentPlanner` constructor adds one new dependency (`IMachineRuntimeCapabilitiesCache`); existing planner test fixtures updated with a permissive default