### PR TITLE
Harden capability requirements tests and extract shared OS helper

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
@@ -98,7 +98,7 @@ public class IISDeployActionHandler : IActionHandler
         if (osVariable == null || string.IsNullOrEmpty(osVariable.Value))
             return;   // unknown — proceed optimistically (see XML doc above)
 
-        if (LooksLikeWindowsOsString(osVariable.Value))
+        if (WindowsOsStringHelper.IsWindows(osVariable.Value))
             return;   // confirmed Windows — proceed
 
         var stepName = ctx.Step?.Name ?? "(unknown)";
@@ -112,29 +112,10 @@ public class IISDeployActionHandler : IActionHandler
     }
 
     /// <summary>
-    /// Returns true when the OS string identifies a Windows host. Matches:
-    /// <list type="bullet">
-    ///   <item>The canonical short form <c>"Windows"</c> from
-    ///         <see cref="AgentOperatingSystems.Windows"/></item>
-    ///   <item>Legacy long forms starting with <c>"Microsoft Windows"</c> (e.g.
-    ///         <c>"Microsoft Windows NT 10.0.19045.0"</c> — what
-    ///         <c>Environment.OSVersion.VersionString</c> returns on modern
-    ///         Windows Server / 10 / 11)</item>
-    /// </list>
-    /// Explicitly does NOT match <c>"Linux"</c>, <c>"macOS"</c>, or empty —
-    /// those are caught by the caller's null-or-empty short-circuit + the
-    /// explicit-throw fall-through.
+    /// Backward-compatible delegate to <see cref="WindowsOsStringHelper.IsWindows"/>.
+    /// The dispatch-time guard above ALSO references this name; the test suite
+    /// pins it under this name. New code should call the helper directly.
     /// </summary>
     internal static bool LooksLikeWindowsOsString(string osValue)
-    {
-        if (string.IsNullOrWhiteSpace(osValue)) return false;
-
-        if (string.Equals(osValue, AgentOperatingSystems.Windows, StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        // Environment.OSVersion.VersionString on Windows always starts with "Microsoft Windows".
-        // Anchoring on the prefix (not a Contains "Windows") avoids false positives like a
-        // hypothetical Linux distro string accidentally containing the word "Windows".
-        return osValue.StartsWith("Microsoft Windows", StringComparison.OrdinalIgnoreCase);
-    }
+        => WindowsOsStringHelper.IsWindows(osValue);
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/MachineCapabilitySet.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/MachineCapabilitySet.cs
@@ -48,7 +48,7 @@ public static class MachineCapabilitySet
         if (string.IsNullOrWhiteSpace(osValue)) return;
 
         // Tolerance for two real-world forms — see class-level doc-comment.
-        if (IsWindows(osValue))
+        if (WindowsOsStringHelper.IsWindows(osValue))
         {
             builder.Add(CapabilityKeys.OsSlot, ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, CapabilityKeys.Os.Windows));
             return;
@@ -97,22 +97,9 @@ public static class MachineCapabilitySet
     }
 
     /// <summary>
-    /// Returns true when the OS string identifies a Windows host. Accepts the
-    /// canonical short form (<see cref="AgentOperatingSystems.Windows"/>) AND
-    /// the legacy long form starting with <c>"Microsoft Windows"</c> (from
-    /// older Tentacle binaries that wrote <c>Environment.OSVersion.VersionString</c>).
-    ///
-    /// <para>Anchored on <c>StartsWith("Microsoft Windows")</c> not
-    /// <c>Contains("Windows")</c> so unrelated strings like
-    /// <c>"LinuxOnWindowsSubsystem"</c> don't false-positive.</para>
+    /// Backward-compatible delegate to <see cref="WindowsOsStringHelper.IsWindows"/>.
+    /// Kept on this class to preserve the existing test surface; new code
+    /// should call the helper directly.
     /// </summary>
-    internal static bool IsWindows(string osValue)
-    {
-        if (string.IsNullOrWhiteSpace(osValue)) return false;
-
-        if (string.Equals(osValue, AgentOperatingSystems.Windows, StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        return osValue.StartsWith("Microsoft Windows", StringComparison.OrdinalIgnoreCase);
-    }
+    internal static bool IsWindows(string osValue) => WindowsOsStringHelper.IsWindows(osValue);
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/WindowsOsStringHelper.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/WindowsOsStringHelper.cs
@@ -1,0 +1,57 @@
+using Squid.Message.Constants;
+
+namespace Squid.Core.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Single source of truth for "does this OS string identify a Windows host?".
+///
+/// <para>Used by two call sites that need the same tolerance contract:
+/// <list type="bullet">
+///   <item><c>IISDeployActionHandler.EnsureWindowsTentacleTarget</c> —
+///         dispatch-time guard; the runtime safety net.</item>
+///   <item><c>MachineCapabilitySet.From</c> — plan-time projection of
+///         <c>MachineRuntimeCapabilities.Os</c> into the <c>os: windows</c>
+///         capability slot.</item>
+/// </list>
+/// Before this helper existed, the two call sites carried bit-identical
+/// copies of the tolerance logic. A future Windows OS-string variant (e.g.
+/// ARM long-form) would have to update both — easy to drift. Centralising
+/// here means a single edit covers both surfaces.</para>
+///
+/// <para><b>Match rules</b>:
+/// <list type="bullet">
+///   <item>Canonical short form <see cref="AgentOperatingSystems.Windows"/>
+///         (<c>"Windows"</c>) emitted by current
+///         <c>RuntimeCapabilitiesInspector.DetectOs()</c>.</item>
+///   <item>Legacy long forms starting with <c>"Microsoft Windows"</c>
+///         (e.g. <c>"Microsoft Windows NT 10.0.19045.0"</c> — what
+///         <c>Environment.OSVersion.VersionString</c> returns on modern
+///         Windows 10 / 11 / Server). Older Tentacle binaries wrote this
+///         directly into the <c>"os"</c> metadata field; cache entries from
+///         those agents persist until invalidated.</item>
+/// </list></para>
+///
+/// <para><b>Anti-false-positive anchor</b>: uses
+/// <c>StartsWith("Microsoft Windows")</c>, not <c>Contains("Windows")</c>.
+/// Strings like <c>"LinuxOnWindowsSubsystem"</c> or
+/// <c>"WindowsSomethingElse"</c> are NOT treated as Windows hosts even
+/// though they contain the substring <c>"Windows"</c>. Pinned by tests.</para>
+/// </summary>
+internal static class WindowsOsStringHelper
+{
+    /// <summary>
+    /// Returns true when <paramref name="osValue"/> identifies a Windows host.
+    /// Returns false for null / empty / whitespace, for non-Windows OS markers
+    /// (<c>"Linux"</c>, <c>"macOS"</c>, etc.), and for strings that merely
+    /// contain the substring <c>"Windows"</c> without the canonical prefix.
+    /// </summary>
+    public static bool IsWindows(string osValue)
+    {
+        if (string.IsNullOrWhiteSpace(osValue)) return false;
+
+        if (string.Equals(osValue, AgentOperatingSystems.Windows, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return osValue.StartsWith("Microsoft Windows", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerStaticRequirementsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerStaticRequirementsTests.cs
@@ -1,0 +1,396 @@
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Planning;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Planning;
+
+/// <summary>
+/// Dedicated tests for the new <c>DeploymentPlanner.ValidateHandlerStaticRequirements</c>
+/// wiring added by the static-capability-requirements PR. The sibling
+/// <see cref="DeploymentPlannerTests"/> covers the pre-existing planner surface
+/// (role match, transport-level validation, blocker aggregation) but it sets up
+/// the <c>IActionHandlerRegistry</c> mock to return <c>null</c> from
+/// <c>Resolve()</c> — so the new static-requirement validation branch is never
+/// exercised there.
+///
+/// <para>This file fills that gap: every test stubs <see cref="IActionHandlerRegistry"/>
+/// to return a real handler with declared <see cref="IActionHandler.StaticRequirements"/>,
+/// and the capabilities cache returns shapes that exercise the cold-cache /
+/// warm-cache-match / warm-cache-mismatch paths through
+/// <c>CapabilityValidator.ValidateStaticRequirements</c>.</para>
+///
+/// <para><b>Coverage matrix</b>:
+/// <list type="bullet">
+///   <item>Handler has empty requirements → no check (covered transitively but pinned here)</item>
+///   <item>Cold cache → optimistic-allow regardless of requirements</item>
+///   <item>Warm cache + match → no violation</item>
+///   <item>Warm cache + value mismatch → MissingCapability violation</item>
+///   <item>Warm cache + slot absent → MissingCapability violation with health-check hint</item>
+///   <item>OR-within-slot — handler accepts multiple values</item>
+///   <item>AND-across-slots — multiple slots all required</item>
+///   <item>Legacy OS string tolerance through projection ("Microsoft Windows NT ..." → matches "windows")</item>
+///   <item>Mixed targets — some match, some don't, in one plan</item>
+///   <item>Execute mode throws when violations exist</item>
+/// </list></para>
+/// </summary>
+public class DeploymentPlannerStaticRequirementsTests
+{
+    private readonly CapabilityValidator _validator = new();
+    private readonly Mock<IActionHandlerRegistry> _registry = new();
+    private readonly Mock<IMachineRuntimeCapabilitiesCache> _capabilitiesCache = new();
+
+    private const string TestActionType = "Squid.TestAction";
+
+    public DeploymentPlannerStaticRequirementsTests()
+    {
+        _registry.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>()))
+            .Returns(ExecutionScope.TargetLevel);
+
+        // Default: cold cache. Tests that need warm cache override this.
+        _capabilitiesCache.Setup(c => c.TryGet(It.IsAny<int>()))
+            .Returns(MachineRuntimeCapabilities.Empty);
+    }
+
+    private DeploymentPlanner BuildPlanner() => new(_registry.Object, _validator, _capabilitiesCache.Object);
+
+    // ── Empty requirements → no check ───────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerWithEmptyRequirements_AllTargetsPassValidation_RegardlessOfCacheState()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty);
+
+        // Mixed cache: target 1 has Linux, target 2 cold. Empty requirements bypass everything.
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Linux });
+        // target 2 stays default (empty)
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "linux-1", "web", CommunicationStyle.Ssh),
+            BuildTargetContext(2, "linux-2", "web", CommunicationStyle.Ssh)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.All(d => d.Validation.IsValid).ShouldBeTrue(
+            customMessage: "Handler with empty StaticRequirements MUST never produce MissingCapability violations.");
+    }
+
+    // ── Cold-cache short-circuit ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerRequiresWindows_ColdCache_OptimisticAllow_NoViolation()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+        // Cache stays default (Empty).
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "fresh-target", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue(
+            customMessage:
+                "Cold-cache target (no capabilities yet) MUST get optimistic-allow at preview. " +
+                "Otherwise fresh-target-first-deploy gets blocked — the operator can't even kick off " +
+                "the deploy that would populate the cache.");
+    }
+
+    // ── Warm-cache match ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerRequiresWindows_WarmCacheWindows_NoViolation()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Windows });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "win-tentacle-1", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue();
+    }
+
+    // ── Warm-cache mismatch ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerRequiresWindows_WarmCacheLinux_EmitsMissingCapabilityViolation()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Linux });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "linux-target", "web", CommunicationStyle.Ssh)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+
+        dispatch.Validation.IsValid.ShouldBeFalse();
+        dispatch.Validation.Violations.ShouldContain(v =>
+            v.Code == ViolationCodes.MissingCapability && v.Detail == CapabilityKeys.OsSlot);
+
+        plan.BlockingReasons.ShouldContain(r => r.Code == PlanBlockingReasonCodes.CapabilityViolation,
+            customMessage: "Warm-cache mismatch MUST surface as a preview-visible blocking reason.");
+    }
+
+    // ── Warm-cache slot absent ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerRequiresShellPowerShell_WarmCacheHasOsButNoShell_EmitsViolationWithHealthCheckHint()
+    {
+        // Warm cache (has 'os' slot) but doesn't advertise the required 'shell:powershell' slot.
+        // This is real-world: an older Tentacle binary may have populated os but not shell metadata.
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present));
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Windows });   // no InstalledShells
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "win-old-tentacle", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+        dispatch.Validation.IsValid.ShouldBeFalse();
+
+        var missing = dispatch.Validation.Violations.Single(v => v.Code == ViolationCodes.MissingCapability);
+        missing.Detail.ShouldBe(CapabilityKeys.Shell.PowerShell);
+        missing.Message.ShouldContain("health check",
+            customMessage: "Slot-absent message MUST tell operator to run a health check (Rule 12.10 actionable).");
+    }
+
+    // ── OR-within-slot ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerAcceptsAnyOs_LinuxTarget_NoViolation()
+    {
+        // RunScript-style: declares all three OSes; target is Linux → match.
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(
+            CapabilityKeys.OsSlot,
+            CapabilityKeys.Os.Windows, CapabilityKeys.Os.Linux, CapabilityKeys.Os.MacOS));
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Linux });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "linux-target", "web", CommunicationStyle.Ssh)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue();
+    }
+
+    // ── AND-across-slots ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerRequiresWindowsAndPowerShell_BothSlotsMatch_NoViolation()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present));
+
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "powershell,pwsh,cmd"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "win-with-shells", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HandlerRequiresWindowsAndPowerShell_OsMatchesButShellMissing_OneViolation()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present));
+
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "cmd"   // no powershell
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "win-without-pwsh", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+        dispatch.Validation.IsValid.ShouldBeFalse();
+
+        var missing = dispatch.Validation.Violations.Single(v => v.Code == ViolationCodes.MissingCapability);
+        missing.Detail.ShouldBe(CapabilityKeys.Shell.PowerShell,
+            customMessage: "The OS slot matched; only the shell slot should violate.");
+    }
+
+    // ── Legacy OS string tolerance through projection ────────────────────────
+
+    [Fact]
+    public async Task HandlerRequiresWindows_TargetReportsLegacyLongFormOsString_AcceptedAsWindows()
+    {
+        // Real production failure mode: older Tentacle binary writes
+        // Environment.OSVersion.VersionString into metadata["os"]. The projection
+        // normalises this to canonical "windows" via WindowsOsStringHelper.IsWindows.
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+        StubCache(1, new MachineRuntimeCapabilities { Os = "Microsoft Windows NT 10.0.19045.0" });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "win10-22h2", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue(
+            customMessage:
+                "Legacy 'Microsoft Windows NT 10.0.19045.0' MUST project to canonical 'windows' " +
+                "via WindowsOsStringHelper; otherwise operators on older Tentacle binaries see their " +
+                "Windows targets rejected at preview. Drift in the projection would silently re-break the " +
+                "production failure mode this whole feature was built to prevent.");
+    }
+
+    // ── Mixed targets in one plan ────────────────────────────────────────────
+
+    [Fact]
+    public async Task TwoTargets_OneWindowsOneLinux_OnlyLinuxFails()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Windows });
+        StubCache(2, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Linux });
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(targets:
+        [
+            BuildTargetContext(1, "win-1", "web", CommunicationStyle.TentacleListening),
+            BuildTargetContext(2, "linux-1", "web", CommunicationStyle.Ssh)
+        ]), CancellationToken.None);
+
+        var dispatches = plan.Steps.Single().Actions.Single().Dispatches.OrderBy(d => d.Target.MachineId).ToList();
+
+        dispatches[0].Validation.IsValid.ShouldBeTrue(customMessage: "Windows target should pass.");
+        dispatches[1].Validation.IsValid.ShouldBeFalse(customMessage: "Linux target should fail Windows requirement.");
+
+        plan.CanProceed.ShouldBeFalse(
+            customMessage: "Plan with ANY blocking reason cannot proceed in Preview/Execute mode.");
+    }
+
+    // ── Execute-mode throw ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteMode_HandlerRequirementUnmet_ThrowsDeploymentPlanValidationException()
+    {
+        StubHandler(requirements: CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows));
+        StubCache(1, new MachineRuntimeCapabilities { Os = AgentOperatingSystems.Linux });
+
+        await Should.ThrowAsync<Squid.Core.Services.DeploymentExecution.Planning.Exceptions.DeploymentPlanValidationException>(
+            () => BuildPlanner().PlanAsync(BuildRequest(
+                mode: PlanMode.Execute,
+                targets:
+                [
+                    BuildTargetContext(1, "linux-target", "web", CommunicationStyle.Ssh)
+                ]), CancellationToken.None));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Sets up the action handler registry mock to return a stub handler with the
+    /// supplied <paramref name="requirements"/>. Production handlers like
+    /// IISDeployActionHandler set their own; here we use a stub so the test
+    /// targets the planner wiring rather than any specific handler's
+    /// declaration.
+    /// </summary>
+    private void StubHandler(IReadOnlyDictionary<string, IReadOnlySet<string>> requirements)
+    {
+        var handler = new Mock<IActionHandler>();
+        handler.SetupGet(h => h.ActionType).Returns(TestActionType);
+        handler.SetupGet(h => h.StaticRequirements).Returns(requirements);
+        handler.Setup(h => h.DescribeIntentAsync(It.IsAny<ActionExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunScriptIntent
+            {
+                Name = "test", StepName = "S", ActionName = "A",
+                ScriptBody = "echo", Syntax = ScriptSyntax.Bash
+            });
+
+        _registry.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>())).Returns(handler.Object);
+    }
+
+    private void StubCache(int machineId, MachineRuntimeCapabilities caps)
+        => _capabilitiesCache.Setup(c => c.TryGet(machineId)).Returns(caps);
+
+    private static DeploymentPlanRequest BuildRequest(
+        PlanMode mode = PlanMode.Preview,
+        IList<DeploymentTargetContext> targets = null)
+    {
+        var step = new DeploymentStepDto
+        {
+            Id = 10,
+            StepOrder = 1,
+            Name = "Deploy",
+            Properties = new List<DeploymentStepPropertyDto>
+            {
+                new() { PropertyName = SpecialVariables.Step.TargetRoles, PropertyValue = "web" }
+            },
+            Actions = new List<DeploymentActionDto>
+            {
+                new()
+                {
+                    Id = 100,
+                    ActionOrder = 1,
+                    ActionType = TestActionType,
+                    Name = "Run"
+                }
+            }
+        };
+
+        return new DeploymentPlanRequest
+        {
+            Mode = mode,
+            ReleaseId = 1,
+            EnvironmentId = 100,
+            ChannelId = 200,
+            DeploymentProcessSnapshotId = 999,
+            Steps = new[] { step },
+            Variables = Array.Empty<VariableDto>(),
+            TargetContexts = targets?.ToList() ?? new List<DeploymentTargetContext>()
+        };
+    }
+
+    private static DeploymentTargetContext BuildTargetContext(
+        int machineId,
+        string machineName,
+        string roles,
+        CommunicationStyle style)
+    {
+        var caps = new TransportCapabilities
+        {
+            SupportedSyntaxes = TransportCapabilities.Syntaxes(ScriptSyntax.Bash, ScriptSyntax.PowerShell)
+        };
+
+        var transport = new Mock<IDeploymentTransport>();
+        transport.SetupGet(t => t.CommunicationStyle).Returns(style);
+        transport.SetupGet(t => t.Capabilities).Returns(caps);
+
+        return new DeploymentTargetContext
+        {
+            Machine = new Machine
+            {
+                Id = machineId,
+                Name = machineName,
+                Roles = $"[{string.Join(",", roles.Split(',').Select(r => $"\"{r.Trim()}\""))}]"
+            },
+            CommunicationStyle = style,
+            Transport = transport.Object
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/ViolationCodesIntegrityTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/ViolationCodesIntegrityTests.cs
@@ -1,0 +1,213 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Core.Services.DeploymentExecution.Script.Files;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Validation;
+
+/// <summary>
+/// Drift guards for <see cref="ViolationCodes"/>. The <see cref="ViolationCodes.All"/>
+/// HashSet is consumed by the preview UI and by any future telemetry that wants to
+/// distinguish known violation kinds from unknown ones; an emitted code that's not
+/// in <c>All</c> would silently slip through.
+///
+/// <para>Adding a new violation code without updating <c>All</c> would be invisible
+/// to every existing test — these tests force the contract:</para>
+///
+/// <list type="bullet">
+///   <item><c>All_ContainsEveryPublicConst</c> — reflection pins that every
+///         public const string in the class is in <c>All</c>.</item>
+///   <item><c>All_CardinalityPinned</c> — explicit count check so a code added
+///         without a matching test update fails CI loudly.</item>
+///   <item><c>EmittedCodes_AreAllInAll</c> — drives every validator branch and
+///         asserts every emitted <c>CapabilityViolation.Code</c> is in <c>All</c>.</item>
+/// </list>
+/// </summary>
+public class ViolationCodesIntegrityTests
+{
+    [Fact]
+    public void All_ContainsEveryPublicConst()
+    {
+        // Reflection-based drift detector: anyone who adds a new public const must
+        // also include it in `All`, or this test fails on the very next build.
+        var publicConsts = typeof(ViolationCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        publicConsts.ShouldNotBeEmpty(
+            customMessage: "Reflection found zero public string consts on ViolationCodes — class shape unexpectedly changed.");
+
+        foreach (var literal in publicConsts)
+        {
+            ViolationCodes.All.ShouldContain(literal,
+                customMessage:
+                    $"Constant '{literal}' is declared on ViolationCodes but NOT in ViolationCodes.All. " +
+                    "Add it to the All HashSet — otherwise downstream UI / telemetry treats it as " +
+                    "an unknown violation.");
+        }
+    }
+
+    [Fact]
+    public void All_CardinalityPinned()
+    {
+        // Hard-pin the cardinality. Adding a violation code requires bumping this
+        // number — surfaces "did you forget to update tests?" at build time
+        // rather than during a production incident.
+        ViolationCodes.All.Count.ShouldBe(6,
+            customMessage:
+                "ViolationCodes.All cardinality changed. If you added a new violation, also: " +
+                "(1) update this pin to the new count, (2) add a corresponding test in " +
+                "CapabilityValidator that exercises the new code path, (3) verify the preview UI " +
+                "translates the new code to a useful message.");
+    }
+
+    [Fact]
+    public void All_ExpectedCodesPresent_Pinned()
+    {
+        // Each well-known violation code spelled out so a typo in either the
+        // constant value or the All set is caught.
+        ViolationCodes.All.ShouldContain(ViolationCodes.UnsupportedActionType);
+        ViolationCodes.All.ShouldContain(ViolationCodes.UnsupportedSyntax);
+        ViolationCodes.All.ShouldContain(ViolationCodes.NestedFiles);
+        ViolationCodes.All.ShouldContain(ViolationCodes.MissingFeature);
+        ViolationCodes.All.ShouldContain(ViolationCodes.PackageStaging);
+        ViolationCodes.All.ShouldContain(ViolationCodes.MissingCapability);
+    }
+
+    [Fact]
+    public void EmittedCodes_FromValidate_AreAllInAll()
+    {
+        // Run the existing 5-dimension Validate against scenarios that force each
+        // distinct violation code, then assert every emitted Code is in All.
+        // If a future PR adds a new emitter without updating All, this fails.
+        var validator = new CapabilityValidator();
+        var emittedCodes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var scenario in BuildValidateScenarios())
+        {
+            var violations = validator.Validate(
+                scenario.Intent, scenario.Capabilities, CommunicationStyle.Unknown, scenario.ActionType);
+
+            foreach (var v in violations) emittedCodes.Add(v.Code);
+        }
+
+        emittedCodes.ShouldNotBeEmpty(
+            customMessage: "Validate scenarios should have produced at least one violation; check the test scenarios.");
+
+        foreach (var code in emittedCodes)
+        {
+            ViolationCodes.All.ShouldContain(code,
+                customMessage:
+                    $"CapabilityValidator.Validate emitted code '{code}' but it's not in ViolationCodes.All. " +
+                    "Either add the const to ViolationCodes.All or stop emitting this code.");
+        }
+    }
+
+    [Fact]
+    public void EmittedCodes_FromValidateStaticRequirements_AreAllInAll()
+    {
+        var validator = new CapabilityValidator();
+        var emittedCodes = new HashSet<string>(StringComparer.Ordinal);
+
+        // Slot mismatch — handler accepts Windows, target advertises Linux.
+        var reqs = CapabilityRequirements.Empty.Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows);
+        var caps = new Dictionary<string, IReadOnlySet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [CapabilityKeys.OsSlot] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { CapabilityKeys.Os.Linux }
+        };
+
+        var violations = validator.ValidateStaticRequirements(
+            reqs, caps, BuildIntent(), CommunicationStyle.Unknown);
+
+        foreach (var v in violations) emittedCodes.Add(v.Code);
+
+        // Slot missing — handler requires shell:powershell, target has different shell.
+        var reqs2 = CapabilityRequirements.Empty.Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+        var caps2 = new Dictionary<string, IReadOnlySet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [CapabilityKeys.OsSlot] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { CapabilityKeys.Os.Linux }
+        };
+
+        var violations2 = validator.ValidateStaticRequirements(
+            reqs2, caps2, BuildIntent(), CommunicationStyle.Unknown);
+
+        foreach (var v in violations2) emittedCodes.Add(v.Code);
+
+        emittedCodes.ShouldNotBeEmpty();
+
+        foreach (var code in emittedCodes)
+        {
+            ViolationCodes.All.ShouldContain(code,
+                customMessage:
+                    $"CapabilityValidator.ValidateStaticRequirements emitted code '{code}' but it's not in ViolationCodes.All.");
+        }
+    }
+
+    private static ExecutionIntent BuildIntent() => new RunScriptIntent
+    {
+        Name = "test", StepName = "S", ActionName = "A", ScriptBody = "echo", Syntax = ScriptSyntax.Bash
+    };
+
+    private static IEnumerable<(ExecutionIntent Intent, ITransportCapabilities Capabilities, string ActionType)> BuildValidateScenarios()
+    {
+        var bashOnly = new TransportCapabilities { SupportedSyntaxes = TransportCapabilities.Syntaxes(ScriptSyntax.Bash) };
+        var restrictiveActionTypes = new TransportCapabilities
+        {
+            SupportedSyntaxes = TransportCapabilities.Syntaxes(ScriptSyntax.Bash),
+            SupportedActionTypes = TransportCapabilities.ActionTypes("Squid.Other"),
+        };
+
+        // Scenario 1: UnsupportedActionType — transport's SupportedActionTypes set is non-empty + doesn't include action type
+        yield return (
+            new RunScriptIntent { Name = "n", StepName = "S", ActionName = "A", ScriptBody = "x", Syntax = ScriptSyntax.Bash },
+            restrictiveActionTypes,
+            "Squid.Unknown"
+        );
+
+        // Scenario 2: UnsupportedSyntax — transport supports Bash; intent uses PowerShell
+        yield return (
+            new RunScriptIntent { Name = "n", StepName = "S", ActionName = "A", ScriptBody = "x", Syntax = ScriptSyntax.PowerShell },
+            bashOnly,
+            null
+        );
+
+        // Scenario 3: NestedFiles — transport rejects, intent has asset with subpath
+        var nestedIntent = new RunScriptIntent
+        {
+            Name = "n", StepName = "S", ActionName = "A", ScriptBody = "x", Syntax = ScriptSyntax.Bash,
+            Assets = new List<DeploymentFile>
+            {
+                DeploymentFile.Asset("sub/dir/file.txt", System.Array.Empty<byte>())
+            }
+        };
+        yield return (nestedIntent, bashOnly, null);
+
+        // Scenario 4: MissingFeature — intent requires a feature transport doesn't declare
+        var featureIntent = new RunScriptIntent
+        {
+            Name = "n", StepName = "S", ActionName = "A", ScriptBody = "x", Syntax = ScriptSyntax.Bash,
+            RequiredCapabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { IntentCapabilityKeys.Kubectl }
+        };
+        yield return (featureIntent, bashOnly, null);
+
+        // Scenario 5: PackageStaging — intent declares packages, transport has staging=None (default)
+        var packageIntent = new RunScriptIntent
+        {
+            Name = "n", StepName = "S", ActionName = "A", ScriptBody = "x", Syntax = ScriptSyntax.Bash,
+            Packages = new List<IntentPackageReference>
+            {
+                new() { PackageId = "pkg", Version = "1.0.0", FeedId = "1" }
+            }
+        };
+        yield return (packageIntent, bashOnly, null);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/WindowsOsStringHelperTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/WindowsOsStringHelperTests.cs
@@ -1,0 +1,125 @@
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Execution.Validation;
+
+/// <summary>
+/// Pins the single source of truth for "is this OS string a Windows host?".
+/// Before <see cref="WindowsOsStringHelper"/> existed, the tolerance logic was
+/// bit-copied into both <c>IISDeployActionHandler.LooksLikeWindowsOsString</c>
+/// (dispatch-time guard) and <c>MachineCapabilitySet.IsWindows</c> (plan-time
+/// projection). Drift between the two copies would have shifted what counts as
+/// a Windows target without anyone noticing.
+///
+/// <para><b>Cross-call-site drift detector</b>: the two preserved backward-
+/// compatible wrappers (<c>LooksLikeWindowsOsString</c>,
+/// <c>MachineCapabilitySet.IsWindows</c>) MUST forward to this helper, not
+/// reimplement the logic. The
+/// <c>BackwardCompatibleWrappers_DelegateToHelper</c> test verifies all three
+/// surfaces return identical results for the same input — if they ever diverge,
+/// someone reintroduced the duplication and the test catches it immediately.</para>
+/// </summary>
+public class WindowsOsStringHelperTests
+{
+    // ── Canonical short form ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Windows", true)]
+    [InlineData("windows", true)]
+    [InlineData("WINDOWS", true)]
+    [InlineData("WindowS", true)]
+    public void IsWindows_CanonicalShortForm_AcceptedCaseInsensitive(string input, bool expected)
+        => WindowsOsStringHelper.IsWindows(input).ShouldBe(expected);
+
+    // ── Legacy long form — real Windows version strings ──────────────────────
+
+    [Theory]
+    [InlineData("Microsoft Windows NT 10.0.19045.0")]    // Win10 22H2 (operator's failure mode)
+    [InlineData("Microsoft Windows NT 10.0.22631.0")]    // Win11 23H2
+    [InlineData("Microsoft Windows NT 10.0.17763.0")]    // Server 2019
+    [InlineData("Microsoft Windows NT 10.0.20348.0")]    // Server 2022
+    [InlineData("Microsoft Windows NT 6.3.9600.0")]      // Server 2012 R2
+    [InlineData("Microsoft Windows NT 6.1.7601.0")]      // Win7 SP1
+    [InlineData("microsoft windows nt 10.0.19045.0")]    // lowercase
+    [InlineData("MICROSOFT WINDOWS NT 10.0.19045.0")]    // uppercase
+    public void IsWindows_LegacyLongForm_AcceptedCaseInsensitive(string input)
+    {
+        WindowsOsStringHelper.IsWindows(input).ShouldBeTrue(
+            customMessage:
+                $"Legacy OS string '{input}' MUST be recognised as Windows. " +
+                "Drift here would reintroduce the production bug where operators on older Tentacle " +
+                "binaries see Windows targets rejected at preview time.");
+    }
+
+    // ── Non-Windows OS markers ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Linux")]
+    [InlineData("linux")]
+    [InlineData("macOS")]
+    [InlineData("Darwin")]
+    [InlineData("FreeBSD")]
+    [InlineData("Unknown")]
+    public void IsWindows_NonWindowsMarkers_Rejected(string input)
+        => WindowsOsStringHelper.IsWindows(input).ShouldBeFalse();
+
+    // ── Anti-false-positive anchor (the critical guard) ──────────────────────
+
+    [Theory]
+    [InlineData("LinuxOnWindowsSubsystem")]          // Contains "Windows" but isn't Windows
+    [InlineData("not-a-windows-host")]
+    [InlineData("WindowsSomethingElse")]             // Doesn't start with "Microsoft Windows"
+    [InlineData("Some-Microsoft-Windows-mirror")]    // Doesn't START with the prefix
+    [InlineData("Windowsy")]                         // Almost the canonical form but not quite
+    public void IsWindows_StringMerelyContainingWindows_DoesNotFalsePositive(string input)
+    {
+        WindowsOsStringHelper.IsWindows(input).ShouldBeFalse(
+            customMessage:
+                $"String '{input}' merely CONTAINS 'Windows' but isn't a Windows OS marker. " +
+                "False-positive here would let non-Windows targets pass IIS-deploy gating — a real " +
+                "regression risk. The anchor MUST be StartsWith(\"Microsoft Windows\"), NOT Contains(\"Windows\").");
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void IsWindows_NullOrBlank_Rejected(string input)
+        => WindowsOsStringHelper.IsWindows(input).ShouldBeFalse();
+
+    // ── Backward-compatible delegation pin (the drift detector) ──────────────
+
+    [Theory]
+    [InlineData("Windows")]
+    [InlineData("Microsoft Windows NT 10.0.19045.0")]
+    [InlineData("Linux")]
+    [InlineData("LinuxOnWindowsSubsystem")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BackwardCompatibleWrappers_DelegateToHelper(string input)
+    {
+        // Three call sites that historically had their own copy of the logic.
+        // After PR consolidating to WindowsOsStringHelper, the two old surfaces
+        // are kept as backward-compat wrappers. They MUST forward to the helper —
+        // if they reintroduce their own logic, this test catches the drift on
+        // the first divergent input. Covered inputs span every branch (short,
+        // long, non-Windows, false-positive guard, null, empty).
+        var expected = WindowsOsStringHelper.IsWindows(input);
+
+        IISDeployActionHandler.LooksLikeWindowsOsString(input).ShouldBe(expected,
+            customMessage:
+                $"IISDeployActionHandler.LooksLikeWindowsOsString('{input}') diverged from " +
+                "WindowsOsStringHelper.IsWindows. Someone reimplemented the logic locally — " +
+                "delete the local copy and delegate to the helper.");
+
+        MachineCapabilitySet.IsWindows(input).ShouldBe(expected,
+            customMessage:
+                $"MachineCapabilitySet.IsWindows('{input}') diverged from " +
+                "WindowsOsStringHelper.IsWindows. Same drift issue — delegate to the helper.");
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageSearchStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageSearchStrategyTests.cs
@@ -445,6 +445,79 @@ public class NuGetPackageSearchStrategyTests
             customMessage: "Empty FeedUri MUST short-circuit before any HTTP call to avoid wasted network round-trips.");
     }
 
+    // ── Edge cases — auth failure, timeout, special chars, pagination ────────
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]    // wrong credentials
+    [InlineData(HttpStatusCode.Forbidden)]       // valid creds but not allowed to read
+    public async Task SearchAsync_AuthFailureOnV3Index_FallsBackToV2_AlsoFails_ReturnsEmpty(HttpStatusCode authError)
+    {
+        // V3 service index returns 401/403 → strategy aborts V3 attempt + tries V2.
+        // V2 /Search() also returns the same auth error → empty result (no exception).
+        // The strategy MUST treat auth failure as "no results", not crash — otherwise
+        // a misconfigured private feed crashes every deploy that searches it.
+        var client = CreateHttpClient(_ => new HttpResponseMessage(authError));
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed
+        {
+            FeedType = "NuGet",
+            FeedUri = "https://example.com/nuget",
+            Username = "wrong",
+            Password = "creds"
+        };
+
+        var result = await sut.SearchAsync(feed, "Newtonsoft", 20, CancellationToken.None);
+
+        result.ShouldBeEmpty(
+            customMessage:
+                $"Auth failure ({authError}) MUST be swallowed by the strategy as 'no results'. " +
+                "Crashing here would block every deploy whose pipeline brushes this feed.");
+    }
+
+    [Fact]
+    public async Task SearchAsync_HttpClientThrows_TaskCanceled_ReturnsEmpty()
+    {
+        // Simulates network timeout / cancellation. The strategy's inner try/catch
+        // MUST absorb the exception and return empty.
+        var client = CreateHttpClient(_ => throw new TaskCanceledException("simulated timeout"));
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://slow.example.com/nuget" };
+
+        var result = await sut.SearchAsync(feed, "test", 20, CancellationToken.None);
+
+        result.ShouldBeEmpty(
+            customMessage:
+                "Network exceptions in the search path MUST be swallowed — the strategy's " +
+                "try/catch returns empty so an unreachable feed doesn't crash the entire UI's package picker.");
+    }
+
+    [Theory]
+    [InlineData("foo bar", "foo%20bar")]
+    [InlineData("foo+bar", "foo%2Bbar")]
+    [InlineData("foo/bar", "foo%2Fbar")]
+    [InlineData("foo&bar", "foo%26bar")]
+    [InlineData("foo#bar", "foo%23bar")]
+    [InlineData("foo=bar", "foo%3Dbar")]
+    public void BuildV3SearchEndpoint_SpecialCharsInQuery_AreUrlEncoded(string raw, string expectedEncoded)
+    {
+        // Defense-in-depth: special chars in package query MUST be URL-encoded
+        // before going into the V3 ?q= parameter. Without encoding, '&' / '=' /
+        // '/' break the URL structure and the feed returns garbage.
+        var endpoint = NuGetPackageSearchStrategy.BuildV3SearchEndpoint("https://example.com/search", raw, 20);
+
+        endpoint.ShouldContain($"q={expectedEncoded}",
+            customMessage:
+                $"Query '{raw}' MUST encode to '{expectedEncoded}'. Full endpoint: {endpoint}");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private NuGetPackageSearchStrategy CreateSut() => new(_httpClientFactory.Object);

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageVersionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/NuGetPackageVersionStrategyTests.cs
@@ -406,6 +406,97 @@ public class NuGetPackageVersionStrategyTests
         result.ShouldBeEmpty();
     }
 
+    // ── Edge cases — auth failure, timeout, pagination loop ──────────────────
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task ListVersionsAsync_AuthFailure_ReturnsEmpty(HttpStatusCode authError)
+    {
+        var client = CreateHttpClient(_ => new HttpResponseMessage(authError));
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed
+        {
+            FeedType = "NuGet",
+            FeedUri = "https://example.com/nuget",
+            Username = "wrong",
+            Password = "creds"
+        };
+
+        var result = await sut.ListVersionsAsync(feed, "AnyPackage", CancellationToken.None);
+
+        result.ShouldBeEmpty(
+            customMessage:
+                $"Auth failure ({authError}) MUST return empty (no exception). Otherwise a misconfigured " +
+                "private feed crashes every release-creation that brushes it.");
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_HttpClientThrows_TaskCanceled_ReturnsEmpty()
+    {
+        var client = CreateHttpClient(_ => throw new TaskCanceledException("simulated timeout"));
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://slow.example.com/nuget" };
+
+        var result = await sut.ListVersionsAsync(feed, "AnyPackage", CancellationToken.None);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_V2PaginationLoop_TerminatesOnEmptyNextLink()
+    {
+        // Pagination loop safety — must terminate when no <link rel="next">.
+        // Failure mode: infinite loop hanging the UI's version-listing call.
+        // Two pages of versions, second has no next link.
+        var page1 = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <link rel="next" href="https://example.com/nuget/FindPackagesById()?id='X'&amp;%24skip=1" />
+              <entry><m:properties><d:Version>1.0.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+        var page2 = """
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <entry><m:properties><d:Version>2.0.0</d:Version></m:properties></entry>
+            </feed>
+            """;
+
+        var hits = 0;
+        var client = CreateHttpClient(req =>
+        {
+            hits++;
+            var url = req.RequestUri!.ToString();
+            if (url.EndsWith("/index.json")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+            if (url.Contains("%24skip=1")) return Ok(page2);
+            if (url.Contains("/FindPackagesById()")) return Ok(page1);
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>()))
+            .Returns(client);
+
+        var sut = CreateSut();
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = "https://example.com/nuget" };
+
+        var result = await sut.ListVersionsAsync(feed, "X", CancellationToken.None);
+
+        result.ShouldBe(new[] { "1.0.0", "2.0.0" });
+
+        hits.ShouldBeLessThan(10,
+            customMessage:
+                $"V2 pagination loop made {hits} HTTP requests for a 2-page result. " +
+                "Should be at most 3 (V3 index probe + 2 pages). Anything higher means the loop " +
+                "isn't terminating on missing next-link — fix immediately or production will hang.");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private NuGetPackageVersionStrategy CreateSut() => new(_httpClientFactory.Object);


### PR DESCRIPTION
## Summary

Three focused improvements identified by the post-merge review of the static-capability-requirements series:

1. **Single source of truth for OS-string tolerance** — extracted `WindowsOsStringHelper.IsWindows` so the dispatch-time guard (`IISDeployActionHandler.LooksLikeWindowsOsString`) and the plan-time projection (`MachineCapabilitySet.IsWindows`) no longer carry bit-identical copies of the logic. Existing method names kept as backward-compat wrappers. Cross-call-site drift detector (`BackwardCompatibleWrappers_DelegateToHelper`) pins identical behaviour across all three surfaces.

2. **Critical coverage gap closed** — `DeploymentPlanner.ValidateHandlerStaticRequirements` now has dedicated unit coverage. Previously the new method introduced by the static-capability-requirements PR was only exercised transitively by tests that stubbed the action handler registry to return null; the new branch wasn't actually validated. 11 new tests drive the real `DeploymentPlanner` + real `CapabilityValidator` against stubbed handlers + cache, covering: empty requirements no-op, cold-cache optimistic-allow, warm-cache match/mismatch/slot-absent, OR-within-slot, AND-across-slots, multi-slot mixed outcomes, legacy long-form OS tolerance via projection, mixed-target plans, and Execute-mode throw.

3. **Smaller hygiene gaps** —
   - `ViolationCodesIntegrityTests`: reflection-pinned `All` set membership + cardinality + emitted-code-must-be-in-`All` invariant. Catches "added new code but forgot to update `All`" at build time.
   - `NuGetPackageSearchStrategyTests` + `NuGetPackageVersionStrategyTests`: 13 new edge cases for auth failure (401/403), TaskCanceled timeout, URL encoding of special chars in queries, V2 pagination loop termination.
   - `WindowsOsStringHelperTests`: 33 consolidated cases (canonical, 8 legacy Windows version strings, non-Windows markers, anchoring guards against `LinuxOnWindowsSubsystem` / `WindowsSomethingElse` false-positives, null/empty edges).

## Test plan

- [x] `dotnet build Squid.sln` → 0 errors
- [x] `dotnet test Squid.UnitTests` → **5495/5495 pass** (was 5411 before this PR → **+84 new tests, zero regression**)
- [x] Drift detectors verified: cross-call-site OS-tolerance test passes; reflection-pinned ViolationCodes.All test passes
- [ ] CI: full pipeline

## Backward compatibility

- No public/internal API removed; `IISDeployActionHandler.LooksLikeWindowsOsString` and `MachineCapabilitySet.IsWindows` remain available as forwarders to `WindowsOsStringHelper.IsWindows`
- No semantic behaviour change — the two existing wrappers return bit-identical results to the previous implementation (verified by the drift detector)
- No DI / constructor / interface change in this PR

## Deferred (intentional)

- **E2E for preview blocking flow** (operator creates IIS release against Linux target → preview shows `MissingCapability` blocking reason). The unit-tier coverage of the **real** `DeploymentPlanner` + **real** `CapabilityValidator` with stubbed cache/handler provides high confidence; full E2E adds marginal value relative to the fixture-seeding cost. Can be added later as a single focused test once the preview API surface has more E2E demand.