### PR TITLE
Fix NuGet V2 release-notes fetch — remove rejected $format=json, parse Atom XML

### DIFF
--- a/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageNotes/NuGetPackageNotesStrategy.cs
+++ b/src/Squid.Core/Services/Deployments/ExternalFeeds/PackageNotes/NuGetPackageNotesStrategy.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Xml.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Http;
 
@@ -64,7 +65,21 @@ public class NuGetPackageNotesStrategy(ISquidHttpClientFactory httpClientFactory
 
     private async Task<PackageNotesResult> GetNotesV2Async(string feedUri, string packageId, string version, Dictionary<string, string> headers, CancellationToken ct)
     {
-        var url = $"{feedUri.TrimEnd('/')}/Packages(Id='{packageId}',Version='{version}')?$format=json";
+        // Use Atom XML — the OData V2 default response format. We do NOT request
+        // ?$format=json because the default NuGet.Server (and many derivative
+        // private feeds) reject Format as a disallowed query option, returning
+        // 400/404 with the OData error:
+        //   "URI or query string invalid. Query option 'Format' is not allowed.
+        //    To allow it, set the 'AllowedQueryOptions' property on
+        //    EnableQueryAttribute or QueryValidationSettings."
+        // Asking for Atom XML works on every conformant V2 server (Atom is the
+        // default content negotiation) and matches what the sibling V2 strategies
+        // (search, version) already do. URL-encode the single quotes inside the
+        // OData string literals so feed servers don't reject the raw quotes.
+        var encodedId = Uri.EscapeDataString(packageId);
+        var encodedVersion = Uri.EscapeDataString(version);
+        var url = $"{feedUri.TrimEnd('/')}/Packages(Id=%27{encodedId}%27,Version=%27{encodedVersion}%27)";
+
         var client = httpClientFactory.CreateClient(timeout: Timeout, headers: headers);
 
         try
@@ -74,9 +89,9 @@ public class NuGetPackageNotesStrategy(ISquidHttpClientFactory httpClientFactory
             if (!response.IsSuccessStatusCode)
                 return PackageNotesResult.Failure($"NuGet feed returned {(int)response.StatusCode}");
 
-            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var xml = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
 
-            return ParseNuGetV2Entry(json);
+            return ParseNuGetV2AtomEntry(xml);
         }
         catch (Exception ex)
         {
@@ -144,32 +159,39 @@ public class NuGetPackageNotesStrategy(ISquidHttpClientFactory httpClientFactory
         }
     }
 
-    internal static PackageNotesResult ParseNuGetV2Entry(string json)
+    /// <summary>
+    /// Parses an OData V2 Atom <c>&lt;entry&gt;</c> response body and extracts
+    /// release-notes-relevant fields from <c>&lt;m:properties&gt;</c>:
+    /// <c>&lt;d:ReleaseNotes&gt;</c>, <c>&lt;d:Description&gt;</c>,
+    /// <c>&lt;d:Published&gt;</c>. Falls back to Description when ReleaseNotes
+    /// is blank, matching the V3 catalog leaf parser.
+    /// </summary>
+    internal static PackageNotesResult ParseNuGetV2AtomEntry(string xml)
     {
         try
         {
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
+            XNamespace d = "http://schemas.microsoft.com/ado/2007/08/dataservices";
 
-            var data = root.TryGetProperty("d", out var dProp) ? dProp : root;
+            var doc = XDocument.Parse(xml);
 
-            var releaseNotes = data.TryGetProperty("ReleaseNotes", out var rnProp) && rnProp.ValueKind == JsonValueKind.String ? rnProp.GetString() : null;
-            var description = data.TryGetProperty("Description", out var descProp) && descProp.ValueKind == JsonValueKind.String ? descProp.GetString() : null;
+            var releaseNotes = doc.Descendants(d + "ReleaseNotes").FirstOrDefault()?.Value;
+            var description = doc.Descendants(d + "Description").FirstOrDefault()?.Value;
 
             DateTimeOffset? published = null;
 
-            if (data.TryGetProperty("Published", out var pubProp) && pubProp.ValueKind == JsonValueKind.String && DateTimeOffset.TryParse(pubProp.GetString(), out var pubDate))
+            var publishedRaw = doc.Descendants(d + "Published").FirstOrDefault()?.Value;
+            if (!string.IsNullOrWhiteSpace(publishedRaw) && DateTimeOffset.TryParse(publishedRaw, out var pubDate))
                 published = pubDate;
 
             var notes = !string.IsNullOrWhiteSpace(releaseNotes) ? releaseNotes : description;
 
-            if (notes == null && published == null) return PackageNotesResult.Empty();
+            if (string.IsNullOrWhiteSpace(notes) && published == null) return PackageNotesResult.Empty();
 
             return PackageNotesResult.Success(notes, published);
         }
-        catch (JsonException)
+        catch
         {
-            return PackageNotesResult.Failure("Failed to parse NuGet V2 JSON");
+            return PackageNotesResult.Failure("Failed to parse NuGet V2 Atom entry");
         }
     }
 

--- a/tests/Squid.E2ETests/Deployments/ExternalFeeds/NuGetFeedLiveE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/ExternalFeeds/NuGetFeedLiveE2ETests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using Shouldly;
 using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.ExternalFeeds.PackageNotes;
 using Squid.Core.Services.Deployments.ExternalFeeds.PackageSearch;
 using Squid.Core.Services.Deployments.ExternalFeeds.PackageVersion;
 using Squid.Core.Services.Http;
@@ -210,6 +211,50 @@ public class NuGetFeedLiveE2ETests
                 $"Bogus-query search MUST be filtered by the server. Got {packages.Count} results — " +
                 $"if 20 (the take limit), the searchTerm parameter isn't being honoured. Either the " +
                 $"OData URL is malformed (missing quoting / escaping) or the server is ignoring the param.");
+    }
+
+    [Fact]
+    public async Task GetNotesAsync_FetchesV2AtomEntry_WithoutFormatJsonQueryParam_AgainstLiveV2Feed()
+    {
+        // Regression pin for "Nuget feed returned 400" during release creation.
+        // Root cause was the V2 fallback in NuGetPackageNotesStrategy requesting
+        // ?$format=json — which the default NuGet.Server configuration REJECTS
+        // (returns 400/404 with OData error "Query option 'Format' is not
+        // allowed"). The fix removes the format param so the server returns the
+        // default Atom XML; the parser then extracts <d:ReleaseNotes> /
+        // <d:Description> / <d:Published> via XDocument.
+        //
+        // This test runs against the operator's actual NuGet.Server installation
+        // — if the strategy ever regresses to ?$format=json, sjfood's response
+        // changes from 200+Atom to 400+OData-error and this test fails loudly.
+        if (!await IsFeedReachableAsync().ConfigureAwait(false)) return;
+
+        var notesStrategy = new NuGetPackageNotesStrategy(new LiveHttpClientFactory());
+        var searchStrategy = new NuGetPackageSearchStrategy(new LiveHttpClientFactory());
+        var versionStrategy = new NuGetPackageVersionStrategy(new LiveHttpClientFactory());
+        var feed = new ExternalFeed { FeedType = "NuGet", FeedUri = LiveFeedUri };
+
+        // Discover a real package + version pair from the live feed — resilient
+        // to feed contents drift (don't hardcode "AuthorizeNet.NetStandard").
+        var packages = await searchStrategy.SearchAsync(feed, "", 1, CancellationToken.None).ConfigureAwait(false);
+        if (packages.Count == 0) return;
+
+        var firstPackageId = packages[0];
+        var versions = await versionStrategy.ListVersionsAsync(feed, firstPackageId, CancellationToken.None).ConfigureAwait(false);
+        if (versions.Count == 0) return;
+
+        var firstVersion = versions[0];
+
+        var result = await notesStrategy.GetNotesAsync(feed, firstPackageId, firstVersion, CancellationToken.None).ConfigureAwait(false);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue(
+            customMessage:
+                $"GetNotesAsync against the live V2 feed MUST succeed (not Failure). " +
+                $"If FailureReason starts with 'NuGet feed returned 400', the strategy regressed to using " +
+                $"?$format=json which NuGet.Server's EnableQueryAttribute rejects. " +
+                $"Tested package: '{firstPackageId}' v{firstVersion}. " +
+                $"FailureReason: '{result.FailureReason}'.");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/PackageNotes/NuGetPackageNotesStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ExternalFeeds/PackageNotes/NuGetPackageNotesStrategyTests.cs
@@ -83,57 +83,143 @@ public class NuGetPackageNotesStrategyTests
     }
 
     // ========================================================================
-    // ParseNuGetV2Entry
+    // ParseNuGetV2AtomEntry
+    //
+    // V2 OData feeds default to Atom XML; we stopped requesting ?$format=json
+    // because the default NuGet.Server installation REJECTS the Format query
+    // option (returns 400 / 404 with an OData error). The fix request the
+    // default Atom and parse it via XDocument. These tests pin the parser
+    // against real-world XML shapes harvested from a live V2 feed.
     // ========================================================================
 
     [Fact]
-    public void ParseNuGetV2Entry_WithReleaseNotes_ExtractsNotesAndPublished()
+    public void ParseNuGetV2AtomEntry_WithReleaseNotes_ExtractsNotesAndPublished()
     {
-        var json = """
-        {
-            "d": {
-                "Description": "OData library",
-                "ReleaseNotes": "Performance improvements",
-                "Published": "2026-02-20T08:00:00Z"
-            }
-        }
-        """;
+        // Shape mirrors what NuGet.Server actually returns for a single
+        // Packages(Id='X',Version='Y') lookup — verified live against sjfood.
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <entry xml:base="https://example.com/nuget" xmlns="http://www.w3.org/2005/Atom"
+                   xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                   xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <m:properties>
+                <d:Id>OData.Library</d:Id>
+                <d:Version>1.0.0</d:Version>
+                <d:Description>OData library</d:Description>
+                <d:ReleaseNotes>Performance improvements</d:ReleaseNotes>
+                <d:Published m:type="Edm.DateTime">2026-02-20T08:00:00Z</d:Published>
+              </m:properties>
+            </entry>
+            """;
 
-        var result = NuGetPackageNotesStrategy.ParseNuGetV2Entry(json);
+        var result = NuGetPackageNotesStrategy.ParseNuGetV2AtomEntry(xml);
 
         result.Succeeded.ShouldBeTrue();
         result.Notes.ShouldBe("Performance improvements");
         result.Published.ShouldNotBeNull();
+        result.Published.Value.Month.ShouldBe(2);
     }
 
     [Fact]
-    public void ParseNuGetV2Entry_NoReleaseNotes_FallsBackToDescription()
+    public void ParseNuGetV2AtomEntry_NoReleaseNotes_FallsBackToDescription()
     {
-        var json = """{"d":{"Description":"A utility package","Published":"2026-01-01T00:00:00Z"}}""";
+        var xml = """
+            <entry xmlns="http://www.w3.org/2005/Atom"
+                   xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                   xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <m:properties>
+                <d:Description>A utility package</d:Description>
+                <d:Published m:type="Edm.DateTime">2026-01-01T00:00:00Z</d:Published>
+              </m:properties>
+            </entry>
+            """;
 
-        var result = NuGetPackageNotesStrategy.ParseNuGetV2Entry(json);
+        var result = NuGetPackageNotesStrategy.ParseNuGetV2AtomEntry(xml);
 
         result.Succeeded.ShouldBeTrue();
         result.Notes.ShouldBe("A utility package");
     }
 
     [Fact]
-    public void ParseNuGetV2Entry_FlatJsonWithoutD_StillParses()
+    public void ParseNuGetV2AtomEntry_MultilineReleaseNotes_PreservesNewlines()
     {
-        var json = """{"Description":"Flat format","Published":"2026-01-01T00:00:00Z"}""";
+        // Real release notes are often multi-line (changelog entries). Verify
+        // the XML parser preserves the formatting verbatim.
+        var xml = """
+            <entry xmlns="http://www.w3.org/2005/Atom"
+                   xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                   xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <m:properties>
+                <d:ReleaseNotes>0.1.0: Targets v 1.9.3 of official package.
+            Items removed:
+            - AppSettings configuration
+            - AddFraudCheck</d:ReleaseNotes>
+              </m:properties>
+            </entry>
+            """;
 
-        var result = NuGetPackageNotesStrategy.ParseNuGetV2Entry(json);
+        var result = NuGetPackageNotesStrategy.ParseNuGetV2AtomEntry(xml);
 
         result.Succeeded.ShouldBeTrue();
-        result.Notes.ShouldBe("Flat format");
+        result.Notes.ShouldContain("0.1.0:");
+        result.Notes.ShouldContain("Items removed:");
+        result.Notes.ShouldContain("AddFraudCheck");
     }
 
     [Fact]
-    public void ParseNuGetV2Entry_InvalidJson_ReturnsFailure()
+    public void ParseNuGetV2AtomEntry_EmptyProperties_ReturnsEmpty()
     {
-        var result = NuGetPackageNotesStrategy.ParseNuGetV2Entry("{bad}");
+        var xml = """
+            <entry xmlns="http://www.w3.org/2005/Atom"
+                   xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                   xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <m:properties />
+            </entry>
+            """;
+
+        var result = NuGetPackageNotesStrategy.ParseNuGetV2AtomEntry(xml);
+
+        // PackageNotesResult.Empty() is { Succeeded = true, Notes = null }.
+        // Distinct from Failure() which is { Succeeded = false, FailureReason = "..." }.
+        result.Succeeded.ShouldBeTrue();
+        result.Notes.ShouldBeNull(
+            customMessage: "Empty <m:properties> MUST yield Notes=null with Succeeded=true — not a failure, just nothing to display.");
+        result.FailureReason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseNuGetV2AtomEntry_InvalidXml_ReturnsFailure()
+    {
+        var result = NuGetPackageNotesStrategy.ParseNuGetV2AtomEntry("<not valid xml");
 
         result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ParseNuGetV2AtomEntry_OdataErrorResponse_DoesNotCrash()
+    {
+        // Some V2 feeds return an OData error body in <m:error> when a query
+        // option is rejected. The parser MUST NOT crash — the HTTP-level
+        // non-2xx check at the call site catches the protocol failure, but
+        // the parser still needs robustness.
+        var xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+              <m:code />
+              <m:message xml:lang="en-US">Query option 'Format' is not allowed.</m:message>
+            </m:error>
+            """;
+
+        // Should not throw.
+        var result = NuGetPackageNotesStrategy.ParseNuGetV2AtomEntry(xml);
+
+        // OData error body has no <d:ReleaseNotes>/<d:Description>/<d:Published>
+        // → Empty result. (The HTTP-level guard already short-circuited to
+        // Failure before we ever got here in production.)
+        result.Succeeded.ShouldBeTrue(
+            customMessage: "Parser MUST treat unrecognized XML as Empty, not Failure — robustness against any V2 server quirk.");
+        result.Notes.ShouldBeNull();
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Real-world failure reported during release creation:

> Nuget feed returned 400

Source: `NuGetPackageNotesStrategy.GetNotesV2Async` requested release notes via `/Packages(Id='X',Version='Y')?$format=json`. The default NuGet.Server configuration (and many derivative private feeds) **rejects** the `Format` OData query option with:

```
URI or query string invalid. Query option 'Format' is not allowed.
To allow it, set the 'AllowedQueryOptions' property on EnableQueryAttribute
or QueryValidationSettings.
```

The server returns 400 or 404 depending on configuration — either way the operator hits `Nuget feed returned <status>` on the release page and can't see release notes for IIS packages.

## Fix

- **Drop `?$format=json`**. Atom XML is the OData V2 default and every conformant V2 server returns it without opt-in. URL-encode the single quotes (`%27`) in OData string literals defensively.
- **New `ParseNuGetV2AtomEntry`** extracts `<d:ReleaseNotes>`, `<d:Description>`, `<d:Published>` via `XDocument` — same shape `NuGetPackageVersionStrategy` already uses. Mirrors the existing V3 catalog leaf parser contract (prefer ReleaseNotes, fall back to Description; tolerant Empty when neither present).
- **Removed** the obsolete `ParseNuGetV2Entry` JSON-parsing static helper (internal; no external API touched).

## Test plan

- [x] `dotnet build Squid.sln` → 0 errors
- [x] `dotnet test NuGetPackageNotesStrategyTests` → 19/19 pass, 185ms (4 obsolete JSON cases replaced with 6 XML cases: ReleaseNotes extraction, Description fallback, multi-line preservation, Empty-vs-Failure distinction, malformed XML rejection, OData-error-body robustness)
- [x] **Live E2E against sjfood**: new `GetNotesAsync_FetchesV2AtomEntry_*` drives the strategy with a real package/version pair discovered from the feed. Pinned with the exact failure fragment `NuGet feed returned 400` so a regression to `?$format=json` fails loudly. 6/6 live E2E pass against `https://nuget.sjfood.us/nuget` in 62s
- [x] Full Squid.UnitTests suite → 5497/5497 pass (zero regression)
- [ ] CI: full pipeline
- [ ] Manual smoke (post-merge): retry the IIS release creation on the operator's feed; release notes column populates (or shows Empty if package has no notes) instead of the 400 error

## Backward compatibility

- No public API removed; internal `ParseNuGetV2Entry` (JSON) replaced by `ParseNuGetV2AtomEntry` (XML). Same `GetNotesAsync` external contract.
- V2 servers that previously supported `?$format=json` continue to work — they also serve Atom XML by default; we're just no longer requesting the optional JSON variant.
- V3 path untouched.