### PR TITLE
Fix Windows Tentacle deploy crashing on AV-locked Halibut temp files

### DIFF
--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -975,9 +975,12 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
                 // completion regardless of CancelScript. Now mid-stream
                 // cancel aborts the SaveToAsync via the underlying
                 // CopyToAsync's CT plumbing.
-                file.Contents.Receiver()
-                    .SaveToAsync(tempPath, cancellationToken)
-                    .GetAwaiter().GetResult();
+                //
+                // Wrapped in SaveDataStreamWithRetry to absorb the transient
+                // IOException from Windows Defender / AV holding the source
+                // temp file open during real-time scan. See helper doc-comment
+                // for the failure mode this addresses.
+                SaveDataStreamWithRetry(file, tempPath, cancellationToken);
 
                 File.Move(tempPath, filePath, overwrite: true);
 
@@ -1008,6 +1011,144 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         => fileName.EndsWith(".sh", StringComparison.OrdinalIgnoreCase)
         || fileName.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase)
         || fileName.EndsWith(".py", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Maximum SaveDataStreamWithRetry attempts. Five attempts × exponential
+    /// backoff (100 / 200 / 400 / 800 ms, max 1000 ms) tops out at ~2.5s total
+    /// wait. Real Windows Defender scan windows are typically &lt;300 ms; five
+    /// attempts is generous headroom.
+    /// </summary>
+    internal const int SaveDataStreamMaxAttempts = 5;
+
+    /// <summary>
+    /// Initial inter-attempt delay (ms) for SaveDataStreamWithRetry. Doubles
+    /// per attempt up to <see cref="SaveDataStreamMaxDelayMs"/>.
+    /// </summary>
+    internal const int SaveDataStreamInitialDelayMs = 100;
+
+    /// <summary>Cap on the per-attempt delay (ms). Above this point we hold steady.</summary>
+    internal const int SaveDataStreamMaxDelayMs = 1000;
+
+    /// <summary>
+    /// Env var override for testing / air-gapped operators with aggressive AV.
+    /// When set to a positive integer, replaces <see cref="SaveDataStreamMaxAttempts"/>.
+    /// Pinned name (Rule 8): tests assert the literal string.
+    /// </summary>
+    internal const string SaveDataStreamMaxAttemptsEnvVar = "SQUID_TENTACLE_SAVE_DATASTREAM_MAX_ATTEMPTS";
+
+    /// <summary>
+    /// Wraps Halibut <c>SaveToAsync</c> in a retry-with-exponential-backoff
+    /// loop. Absorbs transient <see cref="IOException"/> with the "being used
+    /// by another process" pattern — typically Windows Defender / AV real-time
+    /// scan holding the source temp file open briefly after Halibut writes it.
+    ///
+    /// <para><b>Failure mode this fixes</b> (real production report):</para>
+    ///
+    /// <code>
+    ///   IOException: The process cannot access the file 'C:\Windows\TEMP\{guid}_1'
+    ///   because it is being used by another process.
+    ///     at Halibut.Transport.Protocol.TemporaryFileStream.SaveToAsync(string filePath, ...)
+    ///     at Squid.Tentacle.ScriptExecution.LocalScriptService.WriteAdditionalFiles(...)
+    /// </code>
+    ///
+    /// <para>The locked file is Halibut's INTERNAL backing temp where the
+    /// inbound DataStream was buffered. Right after Halibut closes its write
+    /// handle, Windows Defender's real-time protection opens the file
+    /// exclusively to scan it. If we try to read the source during that
+    /// scan window (typically &lt;300 ms but can spike to 1-2 s on slow
+    /// disks / older Defender engines), <see cref="File.Open"/> throws
+    /// IOException — which crashes the entire StartScript RPC.</para>
+    ///
+    /// <para><b>Strategy</b>: 5 attempts × exponential backoff (100 / 200 /
+    /// 400 / 800 / 1000 ms). Only retries on IOException — propagates any
+    /// other exception immediately. Cancellation token observed between
+    /// attempts so an operator-initiated CancelScript doesn't sit through
+    /// the full ~2.5 s budget.</para>
+    /// </summary>
+    internal static void SaveDataStreamWithRetry(ScriptFile file, string tempPath, CancellationToken cancellationToken)
+        => RetryOnTransientIO(
+            operation: () => file.Contents.Receiver()
+                .SaveToAsync(tempPath, cancellationToken)
+                .GetAwaiter().GetResult(),
+            contextName: file?.Name ?? "(unnamed)",
+            cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Generic retry-with-backoff for transient <see cref="IOException"/>.
+    /// Extracted from <see cref="SaveDataStreamWithRetry"/> so the retry +
+    /// timing + cancellation contract is tested directly with a synthetic
+    /// failing operation, without involving Halibut's DataStream wire types.
+    /// </summary>
+    /// <param name="operation">The IO operation to run. Re-invoked on transient IOException.</param>
+    /// <param name="contextName">Human-readable subject for log messages (typically the file name).</param>
+    /// <param name="cancellationToken">Observed before every attempt + during inter-attempt delay.</param>
+    /// <exception cref="IOException">Re-thrown wrapped after every attempt fails.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when cancellation requested between attempts.</exception>
+    internal static void RetryOnTransientIO(Action operation, string contextName, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var maxAttempts = ResolveMaxAttempts();
+        var delayMs = SaveDataStreamInitialDelayMs;
+        IOException lastException = null;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                operation();
+
+                if (attempt > 1)
+                    Log.Warning(
+                        "IO operation for '{Context}' succeeded on attempt {Attempt}/{Max} after transient file-lock IOException. " +
+                        "Suspect: Windows Defender / AV holding the source temp file during real-time scan.",
+                        contextName, attempt, maxAttempts);
+
+                return;
+            }
+            catch (IOException ex)
+            {
+                // Record EVERY IOException — including the final-attempt one — so the
+                // wrapper thrown after the loop carries the most-recent message as
+                // InnerException. Don't use `when (attempt < maxAttempts)` here — that
+                // would skip the catch on the last attempt and propagate the raw
+                // IOException unwrapped, defeating the retry-count + env-var-hint
+                // operator messaging.
+                lastException = ex;
+
+                if (attempt >= maxAttempts) break;    // fall through to wrap-and-throw
+
+                Log.Debug(ex,
+                    "IO operation attempt {Attempt}/{Max} for '{Context}' hit IOException; retrying after {Delay}ms",
+                    attempt, maxAttempts, contextName, delayMs);
+
+                Task.Delay(delayMs, cancellationToken).GetAwaiter().GetResult();
+
+                delayMs = Math.Min(delayMs * 2, SaveDataStreamMaxDelayMs);
+            }
+        }
+
+        // Fell through: every attempt failed. Surface the LAST IOException with
+        // a richer message so operators see the retry count without having to
+        // tail Tentacle logs.
+        throw new IOException(
+            $"IO operation for '{contextName}' failed after {maxAttempts} attempts. " +
+            $"The source temp file remained locked by another process — most likely Windows Defender / AV. " +
+            $"If your AV is known-aggressive, raise {SaveDataStreamMaxAttemptsEnvVar} above the default {SaveDataStreamMaxAttempts} or exclude " +
+            $"the Tentacle workspace from real-time scanning. See last inner exception for the underlying message.",
+            lastException);
+    }
+
+    private static int ResolveMaxAttempts()
+    {
+        var raw = Environment.GetEnvironmentVariable(SaveDataStreamMaxAttemptsEnvVar);
+
+        if (string.IsNullOrWhiteSpace(raw)) return SaveDataStreamMaxAttempts;
+
+        return int.TryParse(raw, out var parsed) && parsed > 0 ? parsed : SaveDataStreamMaxAttempts;
+    }
 
     private static void SetDirectoryPermissions(string dirPath)
     {

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/LocalScriptServiceRetryTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/LocalScriptServiceRetryTests.cs
@@ -1,0 +1,268 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Squid.Tentacle.ScriptExecution;
+using Xunit;
+
+namespace Squid.Tentacle.Tests.ScriptExecution;
+
+/// <summary>
+/// Tests for <see cref="LocalScriptService.RetryOnTransientIO"/> — the retry +
+/// backoff helper that wraps Halibut <c>SaveToAsync</c> calls so transient
+/// Windows Defender / AV file-lock IOExceptions don't crash an entire
+/// StartScript RPC.
+///
+/// <para><b>Real production failure mode pinned by these tests</b>:</para>
+/// <code>
+///   IOException: The process cannot access the file 'C:\Windows\TEMP\{guid}_1'
+///   because it is being used by another process.
+///     at Halibut.Transport.Protocol.TemporaryFileStream.SaveToAsync(string filePath, ...)
+///     at Squid.Tentacle.ScriptExecution.LocalScriptService.WriteAdditionalFiles(...)
+/// </code>
+///
+/// <para>Tests inject a synthetic <see cref="Action"/> that throws IOException
+/// for the first N attempts then succeeds (or never succeeds). The retry
+/// contract — attempt count, backoff timing, IOException-only catch,
+/// cancellation between attempts, env-var override — is fully exercised
+/// without involving Halibut's DataStream wire types.</para>
+/// </summary>
+public sealed class LocalScriptServiceRetryTests
+{
+    // ── Happy / sad paths ────────────────────────────────────────────────────
+
+    [Fact]
+    public void RetryOnTransientIO_SuccessOnFirstAttempt_NoRetry()
+    {
+        var calls = 0;
+
+        LocalScriptService.RetryOnTransientIO(
+            operation: () => calls++,
+            contextName: "test.txt",
+            cancellationToken: CancellationToken.None);
+
+        calls.ShouldBe(1, customMessage: "no exception means no retry");
+    }
+
+    [Theory]
+    [InlineData(1)]    // succeeds on 2nd attempt
+    [InlineData(2)]    // succeeds on 3rd
+    [InlineData(3)]    // succeeds on 4th
+    [InlineData(4)]    // succeeds on 5th (last)
+    public void RetryOnTransientIO_TransientIOException_RetriesUntilSuccess(int failuresBeforeSuccess)
+    {
+        var calls = 0;
+
+        LocalScriptService.RetryOnTransientIO(
+            operation: () =>
+            {
+                calls++;
+                if (calls <= failuresBeforeSuccess)
+                    throw new IOException(
+                        $"The process cannot access the file 'C:\\Windows\\TEMP\\{Guid.NewGuid():N}_1' because it is being used by another process.");
+            },
+            contextName: "package.nupkg",
+            cancellationToken: CancellationToken.None);
+
+        calls.ShouldBe(failuresBeforeSuccess + 1,
+            customMessage: "operation must be retried until success");
+    }
+
+    [Fact]
+    public void RetryOnTransientIO_AllAttemptsFail_ThrowsWrappedIOExceptionWithAttemptCount()
+    {
+        var calls = 0;
+        var originalMessage = "The process cannot access the file 'C:\\Windows\\TEMP\\victim' because it is being used by another process.";
+
+        var ex = Should.Throw<IOException>(() => LocalScriptService.RetryOnTransientIO(
+            operation: () =>
+            {
+                calls++;
+                throw new IOException(originalMessage);
+            },
+            contextName: "stubborn.bin",
+            cancellationToken: CancellationToken.None));
+
+        calls.ShouldBe(LocalScriptService.SaveDataStreamMaxAttempts,
+            customMessage: $"every attempt up to the max ({LocalScriptService.SaveDataStreamMaxAttempts}) must fire");
+
+        ex.Message.ShouldContain("stubborn.bin",
+            customMessage: "wrapper message must include the context name so operators can grep logs by filename");
+
+        ex.Message.ShouldContain($"after {LocalScriptService.SaveDataStreamMaxAttempts} attempts",
+            customMessage: "wrapper message must surface the attempt count");
+
+        ex.Message.ShouldContain(LocalScriptService.SaveDataStreamMaxAttemptsEnvVar,
+            customMessage: "wrapper message must name the env-var escape hatch (Rule 8)");
+
+        ex.InnerException.ShouldNotBeNull(customMessage: "the original IOException must be preserved as InnerException");
+        ex.InnerException!.Message.ShouldBe(originalMessage,
+            customMessage: "InnerException carries the ORIGINAL message so root-cause stays visible");
+    }
+
+    [Fact]
+    public void RetryOnTransientIO_NonIOException_ThrowsImmediatelyWithoutRetry()
+    {
+        // Only IOException is the retry trigger. Any other exception must
+        // propagate immediately so genuine bugs aren't masked by 5 seconds of
+        // retry sleep.
+        var calls = 0;
+
+        Should.Throw<InvalidOperationException>(() => LocalScriptService.RetryOnTransientIO(
+            operation: () =>
+            {
+                calls++;
+                throw new InvalidOperationException("genuine bug, not transient");
+            },
+            contextName: "test.txt",
+            cancellationToken: CancellationToken.None));
+
+        calls.ShouldBe(1,
+            customMessage: "non-IOException MUST propagate without retry — only the transient AV lock case retries");
+    }
+
+    // ── Cancellation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RetryOnTransientIO_CancellationBeforeFirstAttempt_ThrowsImmediately()
+    {
+        var calls = 0;
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Should.Throw<OperationCanceledException>(() => LocalScriptService.RetryOnTransientIO(
+            operation: () => calls++,
+            contextName: "test.txt",
+            cancellationToken: cts.Token));
+
+        calls.ShouldBe(0, customMessage: "pre-cancelled token MUST short-circuit before any operation runs");
+    }
+
+    [Fact]
+    public void RetryOnTransientIO_CancellationDuringBackoff_AbortsRetryLoop()
+    {
+        // Operator hit CancelScript mid-retry. The Task.Delay between attempts
+        // must observe the token and unwind so the cancel response is fast
+        // (not blocked behind the full ~2.5s retry budget).
+        var calls = 0;
+        var cts = new CancellationTokenSource();
+
+        Should.Throw<OperationCanceledException>(() => LocalScriptService.RetryOnTransientIO(
+            operation: () =>
+            {
+                calls++;
+                if (calls == 1) cts.Cancel();    // cancel between attempt 1 and 2
+                throw new IOException("transient");
+            },
+            contextName: "cancelled-mid-retry.bin",
+            cancellationToken: cts.Token));
+
+        calls.ShouldBe(1,
+            customMessage: "cancel between attempts MUST stop the loop before the next operation runs");
+    }
+
+    // ── Env-var override (Rule 8) ────────────────────────────────────────────
+
+    [Fact]
+    public void SaveDataStreamMaxAttemptsEnvVar_LiteralPinned()
+    {
+        // Air-gapped operators with aggressive AV may need to raise the
+        // attempt count. Pin the env var name so a silent rename doesn't
+        // strand their override in production.
+        LocalScriptService.SaveDataStreamMaxAttemptsEnvVar
+            .ShouldBe("SQUID_TENTACLE_SAVE_DATASTREAM_MAX_ATTEMPTS");
+    }
+
+    [Fact]
+    public void RetryOnTransientIO_EnvVarRaisesAttemptCount()
+    {
+        var calls = 0;
+
+        Environment.SetEnvironmentVariable(
+            LocalScriptService.SaveDataStreamMaxAttemptsEnvVar, "8");
+
+        try
+        {
+            Should.Throw<IOException>(() => LocalScriptService.RetryOnTransientIO(
+                operation: () =>
+                {
+                    calls++;
+                    throw new IOException("always");
+                },
+                contextName: "test.txt",
+                cancellationToken: CancellationToken.None));
+
+            calls.ShouldBe(8,
+                customMessage: "env var override MUST replace the default attempt count");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                LocalScriptService.SaveDataStreamMaxAttemptsEnvVar, null);
+        }
+    }
+
+    [Theory]
+    [InlineData("0")]         // zero → fall back to default
+    [InlineData("-1")]        // negative → fall back to default
+    [InlineData("not-int")]   // garbage → fall back to default
+    [InlineData("  ")]        // whitespace → fall back to default
+    public void RetryOnTransientIO_EnvVarInvalidValue_FallsBackToDefault(string envValue)
+    {
+        var calls = 0;
+
+        Environment.SetEnvironmentVariable(
+            LocalScriptService.SaveDataStreamMaxAttemptsEnvVar, envValue);
+
+        try
+        {
+            Should.Throw<IOException>(() => LocalScriptService.RetryOnTransientIO(
+                operation: () =>
+                {
+                    calls++;
+                    throw new IOException("always");
+                },
+                contextName: "test.txt",
+                cancellationToken: CancellationToken.None));
+
+            calls.ShouldBe(LocalScriptService.SaveDataStreamMaxAttempts,
+                customMessage: $"invalid env var '{envValue}' MUST fall back to the default ({LocalScriptService.SaveDataStreamMaxAttempts})");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                LocalScriptService.SaveDataStreamMaxAttemptsEnvVar, null);
+        }
+    }
+
+    // ── Backoff timing (sanity check) ────────────────────────────────────────
+
+    [Fact]
+    public async Task RetryOnTransientIO_AppliesBackoff_BetweenAttempts()
+    {
+        // Don't pin exact timings (CI noise), but verify the retry loop actually
+        // sleeps between attempts. With InitialDelay=100ms and 3 failures+success,
+        // total wait MUST be at least 100+200 = 300ms.
+        var calls = 0;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        await Task.Run(() =>
+            LocalScriptService.RetryOnTransientIO(
+                operation: () =>
+                {
+                    calls++;
+                    if (calls <= 2) throw new IOException("transient");
+                },
+                contextName: "timing.txt",
+                cancellationToken: CancellationToken.None));
+
+        sw.Stop();
+
+        calls.ShouldBe(3, customMessage: "should succeed on 3rd attempt");
+        sw.ElapsedMilliseconds.ShouldBeGreaterThan(250,
+            customMessage: "backoff between attempts MUST insert real sleep — 2 failures + success = at least " +
+                $"{LocalScriptService.SaveDataStreamInitialDelayMs} + {LocalScriptService.SaveDataStreamInitialDelayMs * 2} = " +
+                $"{LocalScriptService.SaveDataStreamInitialDelayMs + LocalScriptService.SaveDataStreamInitialDelayMs * 2}ms");
+    }
+}


### PR DESCRIPTION
## Summary

Real production failure during IIS deploy on Windows Tentacle:

\`\`\`
IOException: The process cannot access the file 'C:\\Windows\\TEMP\\{guid}_1'
because it is being used by another process.
  at Halibut.Transport.Protocol.TemporaryFileStream.SaveToAsync(string filePath, ...)
  at Squid.Tentacle.ScriptExecution.LocalScriptService.WriteAdditionalFiles(...)
\`\`\`

The locked file is Halibut's INTERNAL backing temp where the inbound DataStream was buffered. Right after Halibut closes its write handle, Windows Defender's real-time protection opens the file exclusively to scan it. If \`WriteAdditionalFiles\` tries to read the source during that scan window (typically <300ms, but can spike to 1-2s on slow disks / older Defender engines), \`File.Open\` throws and the entire StartScript RPC crashes — turning a transient AV-scan timing issue into a hard deploy failure.

## Fix

Wrap the \`SaveToAsync\` call in a retry-with-backoff loop. 5 attempts × 100/200/400/800/1000ms exponential backoff (~2.5s total). IOException-only retry; non-IO exceptions propagate immediately. Cancellation token observed before each attempt AND during inter-attempt delay so operator-initiated CancelScript unwinds in <1s.

After all attempts fail, throws a wrapper \`IOException\` naming the file + attempt count + env-var hint; \`InnerException\` preserves the original raw exception so root-cause stays visible.

Refactored into two methods for testability:
- \`SaveDataStreamWithRetry(ScriptFile, tempPath, ct)\` — production call site
- \`RetryOnTransientIO(Action operation, contextName, ct)\` — generic, unit-testable

Air-gapped escape hatch (Rule 8): \`SQUID_TENTACLE_SAVE_DATASTREAM_MAX_ATTEMPTS\` env var raises the budget for operators with aggressive AV.

## Test plan

- [x] \`dotnet build Squid.sln\` → 0 errors
- [x] \`dotnet test --filter LocalScriptServiceRetryTests\` → **16/16 pass** (15s)
- [x] Defect-detection note: the test suite caught a real bug in my initial implementation — \`catch (IOException ex) when (attempt < maxAttempts)\` skipped the catch on the FINAL attempt, propagating the raw IOException instead of the wrapper. Fixed before commit.
- [ ] CI: full pipeline
- [ ] Manual smoke (post-merge): retry IIS deploy on the Windows Tentacle that hit the original error; should succeed (or fail with the new wrapper message naming the env-var escape hatch)

Local Tentacle Tests sweep shows 37 unrelated environmental failures (\`DiskSpaceChecker\` requires 10% free on the temp drive; my dev mac is below threshold). These are unrelated to this change and won't reproduce on CI runners.

## Backward compatibility

- No public API removed; \`SaveDataStreamWithRetry\` is internal and only called by \`WriteAdditionalFiles\`
- Behaviour is strictly more lenient — calls that previously failed with raw \`IOException\` now either succeed after retry, or fail with a richer wrapper that surfaces remediation steps
- Cancellation semantics preserved (token observed at every step)

## Coverage matrix (LocalScriptServiceRetryTests, 16 cases)

| Case | What it pins |
|---|---|
| \`SuccessOnFirstAttempt_NoRetry\` | No retry overhead when operation succeeds first |
| \`TransientIOException_RetriesUntilSuccess\` (×4) | Recovers from 1, 2, 3, 4 transient failures |
| \`AllAttemptsFail_ThrowsWrappedIOExceptionWithAttemptCount\` | Wrapper message includes filename + attempt count + env var; InnerException preserves original |
| \`NonIOException_ThrowsImmediatelyWithoutRetry\` | Non-IO exceptions aren't masked by retry sleep |
| \`CancellationBeforeFirstAttempt_ThrowsImmediately\` | Pre-cancelled token short-circuits |
| \`CancellationDuringBackoff_AbortsRetryLoop\` | Mid-retry cancel unwinds promptly |
| \`SaveDataStreamMaxAttemptsEnvVar_LiteralPinned\` | Env var name pinned (Rule 8) |
| \`EnvVarRaisesAttemptCount\` | Operator override works |
| \`EnvVarInvalidValue_FallsBackToDefault\` (×4) | Garbage values don't crash, fall back gracefully |
| \`AppliesBackoff_BetweenAttempts\` | Real sleep happens; timing budget exists |