### PR TITLE
Accept legacy "Microsoft Windows ..." OS form for in-UI upgrades

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesCache.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
 
 namespace Squid.Core.Services.DeploymentExecution.Tentacle;
@@ -73,8 +74,25 @@ public sealed class MachineRuntimeCapabilities
     /// <see cref="AgentOperatingSystems"/>. Without these, the agent-side
     /// <c>"Windows"</c> token was duplicated across 4+ consumer sites and
     /// any rename silently broke OS routing.
+    ///
+    /// <para><b>Long-form Windows tolerance</b>: delegates to
+    /// <see cref="WindowsOsStringHelper.IsWindows"/> so that legacy agent
+    /// metadata carrying <c>"Microsoft Windows NT 10.0.19045.0"</c> (the raw
+    /// <c>Environment.OSVersion.VersionString</c> form, written by older
+    /// Tentacle binaries / out-of-band callers) still routes correctly.
+    /// Before this delegation, strict equality with the canonical short form
+    /// <c>"Windows"</c> caused <see cref="WindowsTentacleUpgradeStrategy"/>'s
+    /// <c>CanHandle</c> to reject ALL long-form Windows machines, while the
+    /// Linux strategy's <c>IsLinux || IsUnknown</c> ALSO rejected them
+    /// (because long form is neither empty nor exactly <c>"Unknown"</c>) —
+    /// the operator-visible symptom was <c>"CommunicationStyle
+    /// 'TentaclePolling' is not supported for in-UI upgrades"</c> on a
+    /// perfectly healthy Windows agent. Single source of truth for "is this
+    /// a Windows host?" now lives in <see cref="WindowsOsStringHelper"/>,
+    /// shared with the IIS dispatch guard + <c>MachineCapabilitySet</c>
+    /// projection (PR #348).</para>
     /// </summary>
-    public bool IsWindows => string.Equals(Os, AgentOperatingSystems.Windows, StringComparison.OrdinalIgnoreCase);
+    public bool IsWindows => WindowsOsStringHelper.IsWindows(Os);
 
     /// <summary>True when agent reported Linux OS (any distro) via Capabilities probe.</summary>
     public bool IsLinux => string.Equals(Os, AgentOperatingSystems.Linux, StringComparison.OrdinalIgnoreCase);

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/MachineRuntimeCapabilitiesOsConstantsTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/MachineRuntimeCapabilitiesOsConstantsTests.cs
@@ -47,12 +47,31 @@ public sealed class MachineRuntimeCapabilitiesOsConstantsTests
     [InlineData("windows", true)]   // case-insensitive
     [InlineData("WINDOWS", true)]
     [InlineData("WiNdOwS", true)]
+    // Legacy long-form Windows strings — older Tentacle binaries (and any
+    // out-of-band caller that wrote Environment.OSVersion.VersionString into
+    // the cache directly) emit these. The operator-reported failure mode
+    // ("CommunicationStyle 'TentaclePolling' is not supported for in-UI
+    // upgrades") happened because strict equality treated these as a foreign
+    // OS, so BOTH the Windows AND Linux upgrade strategies rejected. Fix:
+    // delegate to WindowsOsStringHelper.IsWindows() — the same shared helper
+    // that already powers the IIS dispatch guard + MachineCapabilitySet
+    // projection (PR #348). Single source of truth for "is this a Windows
+    // host?" across the entire codebase.
+    [InlineData("Microsoft Windows NT 10.0.19045.0", true)]    // Win10 22H2 — operator's specific failure mode
+    [InlineData("Microsoft Windows NT 10.0.22631.0", true)]    // Win11 23H2
+    [InlineData("Microsoft Windows NT 10.0.17763.0", true)]    // Server 2019
+    [InlineData("Microsoft Windows NT 10.0.20348.0", true)]    // Server 2022
+    [InlineData("Microsoft Windows NT 6.3.9600.0", true)]      // Server 2012 R2 / Win 8.1
+    [InlineData("Microsoft Windows Server 2022 Datacenter", true)]    // friendly long form
+    [InlineData("microsoft windows nt 10.0.19045.0", true)]    // case-insensitive long form
     [InlineData("Linux", false)]
     [InlineData("macOS", false)]
     [InlineData("Unknown", false)]
     [InlineData("", false)]
     [InlineData("FreeBSD", false)]
-    [InlineData("Win", false)]      // partial-match must NOT match — guards against future agent rename to abbreviated form
+    [InlineData("Win", false)]                       // partial-match must NOT match — guards against future agent rename to abbreviated form
+    [InlineData("WindowsSomethingElse", false)]      // anti-false-positive anchor — doesn't start with "Microsoft Windows"
+    [InlineData("LinuxOnWindowsSubsystem", false)]   // contains "Windows" but not at start → must reject
     public void IsWindows_MatchesCanonicalString_CaseInsensitive(string os, bool expected)
     {
         var caps = new MachineRuntimeCapabilities { Os = os };
@@ -70,6 +89,14 @@ public sealed class MachineRuntimeCapabilitiesOsConstantsTests
     [InlineData("macOS", false)]
     [InlineData("Unknown", false)]
     [InlineData("", false)]
+    // Drift detector: long-form Windows must NEVER be claimed by IsLinux. Without
+    // this row, a future refactor that accidentally widened IsLinux (e.g.
+    // "if not strictly canonical, fall through to Linux") would silently route
+    // a Windows agent to the Linux upgrade strategy → tarball MD5 mismatch /
+    // /var/lib path missing / cryptic operator error. Single-owner invariant
+    // in MachineUpgradeService.ResolveStrategy depends on this exclusion.
+    [InlineData("Microsoft Windows NT 10.0.19045.0", false)]
+    [InlineData("Microsoft Windows Server 2022 Datacenter", false)]
     public void IsLinux_MatchesCanonicalString_CaseInsensitive(string os, bool expected)
     {
         var caps = new MachineRuntimeCapabilities { Os = os };
@@ -115,6 +142,15 @@ public sealed class MachineRuntimeCapabilitiesOsConstantsTests
     [InlineData("Windows", false)]      // explicit Windows is NOT unknown
     [InlineData("macOS", false)]
     [InlineData("FreeBSD", false)]      // unrecognised but explicit OS is NOT unknown — gives "no strategy registered" instead of falling to Linux
+    // Drift detector: long-form Windows is a RECOGNISED Windows variant, not
+    // Unknown. Without this row, the Linux strategy's `IsLinux || IsUnknown`
+    // claim path would accidentally route long-form Windows agents to the
+    // Linux upgrade strategy (because IsLinux=false, IsUnknown=true historically
+    // when only canonical "Windows" was recognised). The combo of (IsWindows
+    // tolerant) + (IsUnknown strict) is the invariant that keeps single-owner
+    // routing correct.
+    [InlineData("Microsoft Windows NT 10.0.19045.0", false)]
+    [InlineData("Microsoft Windows Server 2022 Datacenter", false)]
     public void IsUnknown_CoversBothColdCacheAndExplicitUnknownFallback(string os, bool expected)
     {
         var caps = new MachineRuntimeCapabilities { Os = os };
@@ -159,5 +195,26 @@ public sealed class MachineRuntimeCapabilitiesOsConstantsTests
         mac.IsLinux.ShouldBeFalse();
         mac.IsMacOS.ShouldBeTrue();
         mac.IsUnknown.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OsPredicates_LegacyMicrosoftWindowsForm_RoutesToWindowsOnly()
+    {
+        // The operator-reported failure mode: agent metadata carries the legacy
+        // "Microsoft Windows NT ..." string from Environment.OSVersion.VersionString.
+        // After the fix, all FOUR predicates must agree with the canonical
+        // "Windows" case — IsWindows=true, IsLinux=false, IsMacOS=false,
+        // IsUnknown=false. Without this, MachineUpgradeService.ResolveStrategy
+        // sees zero claimants and emits "CommunicationStyle 'TentaclePolling'
+        // is not supported for in-UI upgrades" even though the agent IS Windows.
+        var longForm = new MachineRuntimeCapabilities { Os = "Microsoft Windows NT 10.0.19045.0" };
+
+        longForm.IsWindows.ShouldBeTrue(
+            customMessage: "Legacy 'Microsoft Windows NT ...' MUST be recognised as Windows so WindowsTentacleUpgradeStrategy claims it");
+        longForm.IsLinux.ShouldBeFalse(
+            customMessage: "Long-form Windows must NOT trigger IsLinux — would silently route to Linux strategy");
+        longForm.IsMacOS.ShouldBeFalse();
+        longForm.IsUnknown.ShouldBeFalse(
+            customMessage: "Long-form Windows is a recognised Windows variant, not Unknown — Linux's `IsLinux || IsUnknown` claim path must NOT activate");
     }
 }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -447,6 +447,15 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
     [InlineData("Windows", false)] // explicit Windows skip — WindowsTentacleUpgradeStrategy claims
     [InlineData("windows", false)]
     [InlineData("WINDOWS", false)]
+    // Drift detector for the long-form Windows fix: legacy "Microsoft Windows
+    // NT ..." strings MUST NOT trigger the Linux claim (would route a Windows
+    // agent to a tarball that doesn't exist for win-x64 RIDs). Pairs with
+    // WindowsTentacleUpgradeStrategyTests' matching rows so we pin the
+    // single-owner invariant from BOTH ends — both halves of the resolver
+    // independently agree the long form is Windows-only.
+    [InlineData("Microsoft Windows NT 10.0.19045.0", false)]
+    [InlineData("Microsoft Windows NT 10.0.22631.0", false)]
+    [InlineData("Microsoft Windows Server 2022 Datacenter", false)]
     [InlineData("macOS", false)]   // explicit-claim refactor: Linux NO LONGER claims macOS (was true under "non-Windows" predicate). A future MacOSTentacleUpgradeStrategy plugs in WITHOUT MODIFYING THIS METHOD.
     [InlineData("MACOS", false)]   // case-insensitive
     [InlineData("FreeBSD", false)] // any unknown OS string (not in AgentOperatingSystems) → no Linux claim → resolver says "no strategy registered"; clear operator error vs silent install-tarball-on-FreeBSD attempt

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -97,6 +97,16 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
     [InlineData("Windows", true)]
     [InlineData("windows", true)]
     [InlineData("WINDOWS", true)]
+    // Legacy long-form Windows strings — the operator's specific failure mode
+    // (TentaclePolling + Windows agent reporting "Microsoft Windows NT
+    // 10.0.19044.0" via Environment.OSVersion.VersionString). Without these
+    // claims, BOTH Windows AND Linux strategies reject → ResolveStrategy
+    // returns null → UI shows "is not supported for in-UI upgrades" even
+    // though the agent IS Windows. The fix in MachineRuntimeCapabilities.IsWindows
+    // (delegate to WindowsOsStringHelper) is what makes these pass.
+    [InlineData("Microsoft Windows NT 10.0.19045.0", true)]    // Win10 22H2 (operator's scenario)
+    [InlineData("Microsoft Windows NT 10.0.22631.0", true)]    // Win11 23H2
+    [InlineData("Microsoft Windows Server 2022 Datacenter", true)]
     [InlineData("Linux", false)]
     [InlineData("macOS", false)]
     [InlineData("", false)]                // cold cache → falls to Linux historical default, NOT Windows


### PR DESCRIPTION
## Summary

- Fix operator-visible breakage where the UI's upgrade button returns `"CommunicationStyle 'TentaclePolling' is not supported for in-UI upgrades"` for healthy Windows tentacles. Root cause: `MachineRuntimeCapabilities.IsWindows` used strict equality with the canonical short string `"Windows"`, so agents reporting the long form `"Microsoft Windows NT 10.0.19045.0"` (from `Environment.OSVersion.VersionString`) failed every predicate (`IsWindows=false`, `IsLinux=false`, `IsUnknown=false`). Both Windows and Linux upgrade strategies rejected → `ResolveStrategy` returned null → eligibility evaluator emitted the user-facing error.
- Delegate `IsWindows` to the shared `WindowsOsStringHelper.IsWindows()` (introduced in #348 for the IIS dispatch guard + `MachineCapabilitySet` projection). Single source of truth for "is this a Windows host?" across capability projection, dispatch guard, upgrade-strategy resolution, and version-registry Windows-vs-Linux routing.
- Drift detectors pin `IsLinux=false` and `IsUnknown=false` for the long form so the single-owner invariant in `MachineUpgradeService.ResolveStrategy` stays intact — without these rows, a future refactor that widened Linux's `IsLinux || IsUnknown` claim path could accidentally route a Windows agent to the Linux tarball.

## Test plan

- [x] Red: 11 new `[InlineData]` rows on long-form Windows fail before the fix (verified pre-edit run)
- [x] Green: 5517/5517 `Squid.UnitTests` after the fix
- [x] Adjacent sweep: 871/871 across `Upgrade`, `MachineRuntimeCapabilities`, `MachineCapabilitySet`, `TentacleVersionRegistry`, `DeploymentPlannerStaticRequirements`, `IISDeploy`
- [ ] Operator-side: rerun the upgrade-info API on a Windows TentaclePolling machine reporting `Microsoft Windows NT ...` — expect `canUpgrade=true` (or, more accurately, the next branch in `EvaluateUpgradeEligibility` like "could not resolve the latest available version" if GitHub release isn't tagged yet — but no longer the "is not supported" message)

## Why this is non-breaking

- `IsLinux`, `IsMacOS`, `IsUnknown` are unchanged — only `IsWindows` widens. Canonical `"Windows"` agents continue to route to `WindowsTentacleUpgradeStrategy` exactly as before.
- `WindowsOsStringHelper` uses `StartsWith("Microsoft Windows")`, NOT `Contains("Windows")` — `"LinuxOnWindowsSubsystem"` / `"WindowsSomethingElse"` still reject (pinned by test).
- Cold cache (`Os = ""`) still routes through `IsUnknown=true` → Linux historical default. No change to existing operator deployments without a health check.