### PR TITLE
Fall back to Windows PowerShell when pwsh-Core not installed

### DIFF
--- a/src/Squid.Tentacle/Platform/ProcessLauncherFactory.cs
+++ b/src/Squid.Tentacle/Platform/ProcessLauncherFactory.cs
@@ -14,22 +14,43 @@ namespace Squid.Tentacle.Platform;
 /// <item><c>ScriptType.Bash</c> → <see cref="BashProcessLauncher"/> on every OS.</item>
 /// <item><c>ScriptType.PowerShell</c> on Linux / macOS → <see cref="PwshCoreProcessLauncher"/>
 /// (pwsh on PATH + UTF-8 stdout).</item>
-/// <item><c>ScriptType.PowerShell</c> on Windows → <see cref="PwshCoreProcessLauncher"/>
-/// (default — preserves behaviour and UTF-8 Unicode round-trip).
-/// Operators who specifically want the OS-bundled <c>PowerShell.exe</c>
-/// (Windows PowerShell 5.1) opt in via env var <see cref="UseWindowsPowerShellEnvVar"/>
-/// — covered by <see cref="WindowsPowerShellProcessLauncher"/>.</item>
+/// <item><c>ScriptType.PowerShell</c> on Windows with operator opt-in
+/// (<see cref="UseWindowsPowerShellEnvVar"/> truthy) → <see cref="WindowsPowerShellProcessLauncher"/>.</item>
+/// <item><c>ScriptType.PowerShell</c> on Windows with <c>pwsh.exe</c> resolvable
+/// on the host (PS7 / Core installed at the canonical MSI path or anywhere on
+/// PATH) → <see cref="PwshCoreProcessLauncher"/> (default — UTF-8 Unicode
+/// round-trip).</item>
+/// <item><c>ScriptType.PowerShell</c> on Windows when <c>pwsh.exe</c> is NOT
+/// resolvable → automatic fallback to <see cref="WindowsPowerShellProcessLauncher"/>
+/// (OS-bundled PS 5.1, always present on every supported Windows release).
+/// See "<b>Why auto-fallback</b>" below.</item>
 /// </list>
 ///
-/// <para><b>Why default to pwsh-Core on Windows</b>: Windows PowerShell 5.1
-/// writes stdout in the host's OEM codepage (cp437 on en-US, cp936 on zh-CN
-/// etc). Capturing OEM bytes via the redirect pipe with a matched
-/// StandardOutputEncoding works for ASCII + locale-matching characters but
-/// silently mangles cross-locale Unicode (e.g. 中文 on en-US runners produces
-/// <c>"??"</c>).  keeps the modern, UTF-8-by-default pwsh-Core path
-/// as the safe default; a future phase can address the encoding strategy
-/// (e.g. <c>chcp 65001</c> bootstrap or <c>$OutputEncoding=[Text.Encoding]::UTF8</c>
-/// prepend) before promoting Windows PowerShell to the default.</para>
+/// <para><b>Why prefer pwsh-Core on Windows when available</b>: Windows
+/// PowerShell 5.1 writes stdout in the host's OEM codepage (cp437 on en-US,
+/// cp936 on zh-CN etc). Capturing OEM bytes via the redirect pipe with a
+/// matched StandardOutputEncoding works for ASCII + locale-matching characters
+/// but silently mangles cross-locale Unicode (e.g. 中文 on en-US runners
+/// produces <c>"??"</c>). When pwsh-Core is installed, the factory prefers it
+/// for the UTF-8-by-default stdout path.</para>
+///
+/// <para><b>Why auto-fallback to Windows PowerShell when pwsh is missing</b>:
+/// pwsh-Core (PowerShell 7) is an OPTIONAL install on Windows — Microsoft does
+/// not ship it with the OS. Without this fallback, every Windows tentacle that
+/// hasn't installed PS7 crashed with <c>Win32Exception (2) "system cannot find
+/// the file specified"</c> the moment any PowerShell script dispatched
+/// (deployment, upgrade, health probe). The fix: probe <c>pwsh.exe</c>
+/// availability and, when absent, route to the OS-bundled
+/// <c>PowerShell.exe</c> 5.1 (always present on Windows Server 2016+ and
+/// Win10 1607+). Stock Windows hosts work out of the box; operators who
+/// install PS7 transparently get the better UTF-8 path on the next dispatch
+/// (no service restart needed — probe runs per-Resolve).</para>
+///
+/// <para><b>Operator opt-in still wins</b>: Setting
+/// <see cref="UseWindowsPowerShellEnvVar"/>=true forces Windows PowerShell
+/// regardless of whether pwsh is installed — supports operators with legacy
+/// modules that ONLY work on 5.1 (older WMI cmdlets, certain Active Directory
+/// modules etc.).</para>
 ///
 /// <para><b>Out of scope</b>: <c>ScriptType.Python</c> / <c>CSharp</c> / <c>FSharp</c>
 /// stay on the inline <c>StartPythonProcess</c> / <c>StartCSharpProcess</c> /
@@ -49,6 +70,16 @@ public static class ProcessLauncherFactory
     public const string UseWindowsPowerShellEnvVar = "SQUID_TENTACLE_USE_WINDOWS_POWERSHELL";
 
     /// <summary>
+    /// Swappable seam for the <c>pwsh.exe</c> availability probe. Production
+    /// uses <see cref="DefaultPwshAvailable"/> (disk lookups). Tests swap to a
+    /// fixed boolean so the launcher resolution can be exercised cross-platform
+    /// without depending on the test runner's actual PS7 install state.
+    /// Restore via <c>try/finally</c> in tests — this is mutable static state
+    /// serialised by the <c>TentacleEnvVarMutatorsCollection</c> xUnit collection.
+    /// </summary>
+    internal static Func<bool> PwshAvailableProbe = DefaultPwshAvailable;
+
+    /// <summary>
     /// Resolves the launcher for <paramref name="syntax"/>. Throws for syntaxes
     /// not yet routed through this factory — call sites must explicitly opt-in.
     /// </summary>
@@ -56,15 +87,80 @@ public static class ProcessLauncherFactory
     {
         return syntax switch
         {
+            // Operator opt-in to Windows PowerShell 5.1 (env var truthy) — wins
+            // over both the pwsh-Core preference AND the auto-fallback. Supports
+            // operators with legacy modules pinned to 5.1.
             ScriptType.PowerShell when OperatingSystem.IsWindows() && IsWindowsPowerShellPreferred()
                 => new WindowsPowerShellProcessLauncher(),
+
+            // Auto-fallback (operator bug fix): on Windows without pwsh-Core
+            // installed, route to the always-present OS-bundled PowerShell.exe
+            // 5.1 instead of letting the dispatch crash with Win32Exception (2)
+            // "file not found" at process spawn.
+            ScriptType.PowerShell when OperatingSystem.IsWindows() && !PwshAvailableProbe()
+                => new WindowsPowerShellProcessLauncher(),
+
+            // Default: pwsh-Core on every host (Linux/macOS always, Windows when
+            // PS7 is installed). UTF-8 stdout / cross-locale Unicode round-trip.
             ScriptType.PowerShell => new PwshCoreProcessLauncher(),
+
             ScriptType.Bash => new BashProcessLauncher(),
             _ => throw new NotSupportedException(
                 $"ScriptType.{syntax} is not routed through ProcessLauncherFactory yet. " +
                 "Python/CSharp/FSharp stay on LocalScriptService's inline Start*Process path; " +
                 "Calamari uses BuildCalamariProcessStartInfo.")
         };
+    }
+
+    /// <summary>
+    /// Production probe: is <c>pwsh.exe</c> resolvable on this host? Checks
+    /// the canonical PS7 MSI install path (<c>%ProgramFiles%\PowerShell\7\pwsh.exe</c>)
+    /// first, then walks every PATH entry. Pure <see cref="File.Exists"/> —
+    /// no process spawn, no caching, ~milliseconds. Called per <see cref="Resolve"/>
+    /// so an operator installing PS7 mid-deployment gets routed to the new
+    /// binary on the next script dispatch without a tentacle restart.
+    /// </summary>
+    /// <remarks>
+    /// Off-Windows: trivially returns <c>true</c> — the probe only gates the
+    /// Windows auto-fallback branch in <see cref="Resolve"/>, and Linux/macOS
+    /// have no PS 5.1 to fall back to (PowerShell.exe doesn't exist there).
+    /// Returning <c>true</c> off-Windows means the default probe is a no-op on
+    /// cross-platform test runners, with no spurious disk I/O.
+    /// </remarks>
+    internal static bool DefaultPwshAvailable()
+    {
+        if (!OperatingSystem.IsWindows()) return true;
+
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+
+        if (!string.IsNullOrEmpty(programFiles))
+        {
+            var canonical = Path.Combine(programFiles, "PowerShell", "7", "pwsh.exe");
+
+            if (File.Exists(canonical)) return true;
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+
+        if (string.IsNullOrEmpty(pathEnv)) return false;
+
+        foreach (var rawDir in pathEnv.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(rawDir)) continue;
+
+            try
+            {
+                var candidate = Path.Combine(rawDir.Trim(), "pwsh.exe");
+
+                if (File.Exists(candidate)) return true;
+            }
+            catch
+            {
+                // Malformed PATH entry (invalid chars, locked dir, etc.) — skip.
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Squid.Tentacle.Tests/Platform/ProcessLauncherTests.cs
+++ b/tests/Squid.Tentacle.Tests/Platform/ProcessLauncherTests.cs
@@ -420,4 +420,154 @@ public sealed class ProcessLauncherTests
         // compile-time-visible decision rather than an invisible refactor.
         ProcessLauncherFactory.UseWindowsPowerShellEnvVar.ShouldBe("SQUID_TENTACLE_USE_WINDOWS_POWERSHELL");
     }
+
+    // ── pwsh-Core auto-fallback (operator bug fix) ──────────────────────────────
+    //
+    // The operator-reported failure mode: a Windows tentacle WITHOUT PowerShell 7
+    // installed dispatched a PowerShell upgrade script and crashed with
+    // Win32Exception (2) "系统找不到指定的文件" / "system cannot find the file
+    // specified". pwsh-Core is OPTIONAL on Windows (Microsoft does not bundle it
+    // with the OS); the factory's prior unconditional `pwsh` default stranded
+    // every stock Windows host.
+    //
+    // Fix: probe pwsh.exe availability; when absent, fall back to the always-
+    // present OS-bundled PowerShell.exe 5.1. Tests below pin each cell of the
+    // truth table:
+    //   (isWindows, optInToWindowsPowerShell, pwshAvailable) → expected launcher
+
+    [Fact]
+    public void Factory_PowerShell_OnWindows_PwshMissing_AutoFallsBackToWindowsPowerShell()
+    {
+        // The operator's specific scenario: Windows host, no PS7 installed,
+        // no env-var opt-in set. Without auto-fallback, the dispatch hits
+        // Win32Exception (2) at process spawn. With auto-fallback, the agent
+        // transparently uses Windows PowerShell 5.1 (always present on every
+        // supported Windows release since 2016) and the upgrade succeeds.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var priorEnv = Environment.GetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar);
+        var priorProbe = ProcessLauncherFactory.PwshAvailableProbe;
+
+        try
+        {
+            Environment.SetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar, null);
+            ProcessLauncherFactory.PwshAvailableProbe = () => false;    // simulate "no pwsh.exe on host"
+
+            ProcessLauncherFactory.Resolve(ScriptType.PowerShell)
+                .ShouldBeOfType<WindowsPowerShellProcessLauncher>(
+                    customMessage: "Windows host without pwsh-Core MUST auto-fall-back to PowerShell.exe 5.1 — " +
+                                   "without this branch, every stock Windows tentacle crashed with Win32Exception (2) " +
+                                   "on the first PowerShell dispatch (upgrade, deployment, health check).");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar, priorEnv);
+            ProcessLauncherFactory.PwshAvailableProbe = priorProbe;
+        }
+    }
+
+    [Fact]
+    public void Factory_PowerShell_OnWindows_PwshAvailable_PrefersPwshCore()
+    {
+        // Inverse of the auto-fallback case: when pwsh-Core IS resolvable on
+        // the host, the factory MUST keep preferring it (UTF-8 stdout,
+        // cross-locale Unicode round-trip). Pinning this row ensures a future
+        // refactor that accidentally widens the fallback branch to "always use
+        // Windows PowerShell on Windows" would fail this test.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var priorEnv = Environment.GetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar);
+        var priorProbe = ProcessLauncherFactory.PwshAvailableProbe;
+
+        try
+        {
+            Environment.SetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar, null);
+            ProcessLauncherFactory.PwshAvailableProbe = () => true;
+
+            ProcessLauncherFactory.Resolve(ScriptType.PowerShell)
+                .ShouldBeOfType<PwshCoreProcessLauncher>(
+                    customMessage: "When pwsh-Core IS available on the Windows host, the factory MUST prefer it. " +
+                                   "The auto-fallback branch only fires when the probe returns false.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar, priorEnv);
+            ProcessLauncherFactory.PwshAvailableProbe = priorProbe;
+        }
+    }
+
+    [Fact]
+    public void Factory_PowerShell_OnWindows_EnvVarOptIn_BeatsAutoFallback_EvenWhenPwshAvailable()
+    {
+        // Operator opt-in is the explicit user signal "I want Windows PowerShell
+        // 5.1 specifically" (e.g. legacy WMI modules, OEM stdout pinning, or
+        // forcing test reproducibility). It MUST take precedence over the
+        // pwsh-availability probe — otherwise an operator who installs PS7
+        // would silently lose their 5.1 routing without any visible warning.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var priorEnv = Environment.GetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar);
+        var priorProbe = ProcessLauncherFactory.PwshAvailableProbe;
+
+        try
+        {
+            Environment.SetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar, "true");
+            ProcessLauncherFactory.PwshAvailableProbe = () => true;    // pwsh IS available but opt-in must still win
+
+            ProcessLauncherFactory.Resolve(ScriptType.PowerShell)
+                .ShouldBeOfType<WindowsPowerShellProcessLauncher>(
+                    customMessage: "Env var opt-in (UseWindowsPowerShellEnvVar=true) MUST beat the pwsh-availability probe. " +
+                                   "Operators who explicitly request PS 5.1 get it deterministically, regardless of PS7 install state.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ProcessLauncherFactory.UseWindowsPowerShellEnvVar, priorEnv);
+            ProcessLauncherFactory.PwshAvailableProbe = priorProbe;
+        }
+    }
+
+    [Fact]
+    public void Factory_PowerShell_OnNonWindows_PwshProbe_DoesNotGate()
+    {
+        // Off-Windows drift detector: even if the probe somehow returns false
+        // on a Linux/macOS host, the factory MUST keep routing to pwsh-Core.
+        // Windows PowerShell 5.1 doesn't exist outside Windows; activating the
+        // fallback off-Windows would route to a launcher whose binary can never
+        // be found. This guard means a future refactor that drops the
+        // `OperatingSystem.IsWindows()` gate would fail loudly here.
+        if (OperatingSystem.IsWindows()) return;
+
+        var priorProbe = ProcessLauncherFactory.PwshAvailableProbe;
+
+        try
+        {
+            ProcessLauncherFactory.PwshAvailableProbe = () => false;
+
+            ProcessLauncherFactory.Resolve(ScriptType.PowerShell)
+                .ShouldBeOfType<PwshCoreProcessLauncher>(
+                    customMessage: "Off-Windows: pwsh-availability probe MUST NOT gate launcher choice — " +
+                                   "Linux/macOS always route to pwsh-Core (PowerShell.exe 5.1 doesn't exist there).");
+        }
+        finally
+        {
+            ProcessLauncherFactory.PwshAvailableProbe = priorProbe;
+        }
+    }
+
+    [Fact]
+    public void DefaultPwshAvailable_ReturnsBoolean_DoesNotThrow_OnAnyPlatform()
+    {
+        // Sanity: the default probe must be safe on every supported runner —
+        // malformed PATH entries, locked directories, empty %ProgramFiles%,
+        // non-Windows hosts all must be handled without throwing. Cold-call
+        // the probe and verify it returns one of {true, false} cleanly.
+        var result = ProcessLauncherFactory.DefaultPwshAvailable();
+
+        // Result must be a real bool (not throw). On non-Windows runners the
+        // probe trivially returns true (it doesn't gate off-Windows anyway —
+        // see the Factory_PowerShell_OnNonWindows_PwshProbe_DoesNotGate test).
+        if (!OperatingSystem.IsWindows())
+            result.ShouldBeTrue(
+                customMessage: "DefaultPwshAvailable() MUST return true off-Windows so the auto-fallback branch never accidentally activates on Linux/macOS where Windows PowerShell doesn't exist.");
+    }
 }


### PR DESCRIPTION
## Summary

- Fix operator-visible crash on Windows tentacles without PowerShell 7 installed: every PowerShell dispatch (upgrade, deployment, health check) hit `Win32Exception (2): system cannot find the file specified` at process spawn because `ProcessLauncherFactory.Resolve(ScriptType.PowerShell)` unconditionally returned `PwshCoreProcessLauncher` (which spawns `pwsh.exe`). PS7 is OPTIONAL on Windows — Microsoft does NOT ship it with the OS — so this stranded every stock Windows host.
- Add `PwshAvailableProbe` (swappable seam) + `DefaultPwshAvailable()` (production probe: canonical MSI install path at `%ProgramFiles%\PowerShell\7\pwsh.exe` then PATH walk, all `File.Exists` — no process spawn, ~ms). New routing branch falls back to `WindowsPowerShellProcessLauncher` (OS-bundled PS 5.1, always present on Windows Server 2016+ / Win10 1607+) when the probe returns false.
- Operator opt-in via `SQUID_TENTACLE_USE_WINDOWS_POWERSHELL=true` still wins over the probe (operators with legacy WMI / older AD modules get deterministic 5.1 routing regardless of PS7 install state).

## Routing precedence (Windows)

| # | Condition | Launcher |
|---|---|---|
| 1 | Opt-in env var truthy | `WindowsPowerShellProcessLauncher` (5.1) |
| 2 | pwsh.exe resolvable | `PwshCoreProcessLauncher` (7+, UTF-8 stdout) |
| 3 | pwsh.exe NOT resolvable | `WindowsPowerShellProcessLauncher` (5.1, **the fix**) |

Linux / macOS always route to `PwshCoreProcessLauncher` — the probe is a no-op off-Windows because PS 5.1 doesn't exist there.

## Test plan

- [x] Truth-table tests covering all four cross-platform routing cells (Windows + pwsh present / Windows + pwsh missing / Windows + opt-in beats probe / non-Windows probe inert)
- [x] `DefaultPwshAvailable()` sanity test: returns a bool without throwing on every platform
- [x] Focused tests: 44/44 in `Squid.Tentacle.Tests.Platform.ProcessLauncherTests`
- [x] Unit suite: 5517/5517 in `Squid.UnitTests`
- [ ] Operator-side: redeploy the agent, retry upgrade — expect Win32Exception (2) gone; `PowerShell.exe -NoProfile -NoLogo -NonInteractive -ExecutionPolicy Unrestricted -File script.ps1` invocation succeeds

## Operator's failure mode this fixes

```
Server exception: Win32Exception (2): An error occurred trying to start process 'pwsh'
with working directory 'C:\Windows\TEMP\squid-tentacle-upgrade-23-...'.
系统找不到指定的文件。
  at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
  at Squid.Tentacle.ScriptExecution.LocalScriptService.StartViaLauncher(...)
  at Squid.Tentacle.ScriptExecution.LocalScriptService.StartProcess(...)
```

After this PR: agent transparently uses `PowerShell.exe` 5.1 → process spawns → upgrade runs.

## Why not change the default?

The comment block on `Resolve` (preserved + extended in this PR) documents the reason pwsh-Core is preferred on Windows: it writes UTF-8 stdout, so cross-locale non-ASCII output (中文 / emoji / accented chars) round-trips correctly through the redirect pipe. Windows PowerShell 5.1 writes OEM bytes which the dedicated `WindowsPowerShellProcessLauncher` decodes correctly via `OEMCodePage`, but that only works for ASCII + locale-matching characters. For operators who install PS7, the better path stays the default. The fallback is a safety net for the OOTB case.