### PR TITLE
Skip Calamari for PowerShell scripts (was crashing with FileNotFoundException)

### DIFF
--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -1178,14 +1178,39 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         var variablesPath = Path.Combine(workDir, "variables.json");
         var sensitiveVariablesPath = Path.Combine(workDir, "sensitiveVariables.json");
 
-        // Calamari only knows how to bootstrap Bash and PowerShell scripts (it
-        // generates `export VAR=...` / `$VAR=...` preambles). For Python /
-        // CSharp / FSharp we bypass Calamari and exec the interpreter directly
-        // — variable injection still happens through process env vars set by
-        // the caller (or the script can read variables.json itself).
-        var canUseCalamari = command.ScriptSyntax == ScriptType.Bash || command.ScriptSyntax == ScriptType.PowerShell;
-
-        if (File.Exists(variablesPath) && canUseCalamari)
+        // Calamari can today only bootstrap BASH scripts — its pipeline contains
+        // exactly one writer step (<see cref="Squid.Calamari.Commands.WriteBootstrappedBashScriptStep"/>)
+        // that does <c>File.ReadAllText("script.sh")</c> + prepends a Bash
+        // <c>export VAR=...</c> preamble. There is NO <c>WriteBootstrappedPowerShellScriptStep</c>
+        // and the Calamari CLI is hardcoded to <c>--script=script.sh</c> at the
+        // call site below — so routing PowerShell through Calamari ALWAYS crashes
+        // with <c>FileNotFoundException</c> (Tentacle wrote <c>script.ps1</c>,
+        // Calamari reads <c>script.sh</c>). The agent's parent process dies, the
+        // server polls GetStatus, the in-memory ticket entry is gone but the
+        // state file still says <c>Progress=Running</c> — orphan detection at
+        // <see cref="GetStatus"/> line 497 then returns <c>Complete + UnknownResult (-1)</c>
+        // which the operator sees as <c>"Unknown result (ticket or process not found)
+        // (exit code -1)"</c>.
+        //
+        // <para><b>Why this is safe for PowerShell flows</b>: every server-side
+        // PowerShell-emitting code path (e.g. <c>IISDeployScriptBuilder</c>,
+        // <c>WindowsTentacleUpgradeStrategy</c>) already inlines all required
+        // variables into the rendered script body via <c>$SquidParameters</c> /
+        // <c>$SquidVariables</c> hashtables. Calamari's bootstrap preamble adds
+        // zero value on top of that — the script is fully self-contained from
+        // the moment the server emits it. Bypassing Calamari for PowerShell
+        // therefore changes nothing about variable visibility; it just routes
+        // through <see cref="StartViaLauncher"/> instead, which in turn picks
+        // <c>PwshCoreProcessLauncher</c> or <c>WindowsPowerShellProcessLauncher</c>
+        // (auto-fallback when pwsh.exe isn't installed — see PR #352).
+        //
+        // <para><b>Future</b>: when Calamari gains a <c>WriteBootstrappedPowerShellScriptStep</c>
+        // AND the Tentacle CLI invocation switches to a per-syntax script path
+        // (<c>--script=script.ps1</c> for PowerShell, <c>--script=script.sh</c>
+        // for Bash), <see cref="IsCalamariCompatible"/> can be widened back to
+        // include PowerShell. Pinned by <c>IsCalamariCompatible_*</c> tests so
+        // a future regression surfaces immediately.
+        if (File.Exists(variablesPath) && IsCalamariCompatible(command.ScriptSyntax))
         {
             // P0-B.2: password no longer on disk — pull it from the in-memory ScriptFile
             // instance. Writing the `.key` sidecar defeated at-rest encryption; passing
@@ -1209,6 +1234,31 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
             _ => StartViaLauncher(workDir, ScriptType.Bash, command.Arguments)
         };
     }
+
+    /// <summary>
+    /// Whether the given script <paramref name="syntax"/> can be bootstrapped by
+    /// the bundled <c>squid-calamari</c> CLI.
+    ///
+    /// <para>Today only <see cref="ScriptType.Bash"/> qualifies — Calamari's
+    /// <c>RunScriptCommand</c> pipeline contains a single bootstrap step
+    /// (<c>WriteBootstrappedBashScriptStep</c>) that reads <c>script.sh</c> and
+    /// prepends a Bash <c>export VAR=...</c> preamble. There is intentionally
+    /// NO <c>WriteBootstrappedPowerShellScriptStep</c>: every server-side
+    /// PowerShell-emitting code path (<c>IISDeployScriptBuilder</c>,
+    /// <c>WindowsTentacleUpgradeStrategy</c>, etc.) already inlines all
+    /// variables into the rendered script body via <c>$SquidParameters</c> /
+    /// <c>$SquidVariables</c> hashtables, so Calamari's bootstrap preamble adds
+    /// zero value on top of that.</para>
+    ///
+    /// <para>Routing PowerShell through Calamari ALWAYS crashed with
+    /// <c>FileNotFoundException</c> (Tentacle wrote <c>script.ps1</c>, Calamari
+    /// read <c>script.sh</c>). Operator-visible symptom: <c>"Unknown result
+    /// (ticket or process not found) (exit code -1)"</c> from the
+    /// <see cref="GetStatus"/> orphan-detection path (state file said
+    /// <c>Progress=Running</c> but the Calamari child had already crashed).
+    /// Pinned by <c>IsCalamariCompatible_*</c> tests.</para>
+    /// </summary>
+    internal static bool IsCalamariCompatible(ScriptType syntax) => syntax == ScriptType.Bash;
 
     /// <summary>
     /// dispatches to the platform-resolved

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
@@ -1,0 +1,99 @@
+using Shouldly;
+using Squid.Message.Contracts.Tentacle;
+using Squid.Tentacle.ScriptExecution;
+
+namespace Squid.Tentacle.Tests.ScriptExecution;
+
+/// <summary>
+/// Pin the <see cref="LocalScriptService.IsCalamariCompatible"/> decision and the
+/// <see cref="LocalScriptService.BuildCalamariProcessStartInfo"/> argv shape so that
+/// PowerShell scripts NEVER route through the Calamari child process — the bug
+/// fix for the operator-reported failure:
+///
+/// <code>
+///   Unhandled exception. System.IO.FileNotFoundException:
+///     Could not find file 'C:\Windows\TEMP\squid-tentacle-{ticket}\script.sh'.
+///       at Squid.Calamari.Commands.WriteBootstrappedBashScriptStep.ExecuteAsync(...)
+/// </code>
+///
+/// <para><b>Root cause</b>: Calamari's <c>RunScriptCommand</c> pipeline contains
+/// a SINGLE bootstrap step — <c>WriteBootstrappedBashScriptStep</c> — which does
+/// <c>File.ReadAllText("script.sh")</c>. The Tentacle CLI invocation hardcodes
+/// <c>--script=script.sh</c>. When the dispatched script is PowerShell, Tentacle
+/// writes <c>script.ps1</c> (right extension) but Calamari reads <c>script.sh</c>
+/// (wrong path) and crashes immediately with FileNotFoundException. The Calamari
+/// child process dies; the agent's state file is stuck at <c>Progress=Running</c>;
+/// the server's next <c>GetStatus</c> hits the orphan-detection path in
+/// <see cref="LocalScriptService.GetStatus"/> and returns
+/// <c>Complete + UnknownResult (-1)</c>. Operator sees:
+/// "Unknown result (ticket or process not found) (exit code -1)".</para>
+///
+/// <para><b>Fix</b>: <see cref="LocalScriptService.IsCalamariCompatible"/> only
+/// returns true for Bash. PowerShell scripts route through
+/// <see cref="LocalScriptService.StartViaLauncher"/> instead, which picks the
+/// right launcher (pwsh-Core if installed, else Windows PowerShell 5.1 — PR #352).
+/// Variables are NOT lost: every PowerShell-emitting server-side builder
+/// (<c>IISDeployScriptBuilder</c>, <c>WindowsTentacleUpgradeStrategy</c>, etc.)
+/// already inlines <c>$SquidParameters</c> / <c>$SquidVariables</c> into the
+/// rendered script body, so Calamari's bootstrap preamble adds zero value.</para>
+/// </summary>
+public sealed class CalamariRoutingTests
+{
+    // ── IsCalamariCompatible — exhaustive truth table ───────────────────────────
+
+    [Theory]
+    [InlineData(ScriptType.Bash, true)]                // ONLY syntax Calamari handles today
+    [InlineData(ScriptType.PowerShell, false)]         // PR #353 bug fix — must NOT route to Calamari
+    [InlineData(ScriptType.Python, false)]             // Calamari has no Python pipeline
+    [InlineData(ScriptType.CSharp, false)]             // Calamari has no C# pipeline
+    [InlineData(ScriptType.FSharp, false)]             // Calamari has no F# pipeline
+    public void IsCalamariCompatible_ReturnsTrueOnlyForBash(ScriptType syntax, bool expected)
+    {
+        LocalScriptService.IsCalamariCompatible(syntax).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void IsCalamariCompatible_PowerShell_ExplicitlyFalse_RegressionPin()
+    {
+        // The operator-reported failure mode was caused by this returning TRUE.
+        // A future refactor that flips it back without ALSO adding
+        // WriteBootstrappedPowerShellScriptStep to Calamari AND a per-syntax
+        // --script=... path in BuildCalamariProcessStartInfo would re-introduce
+        // the FileNotFoundException + UnknownResult crash. This standalone Fact
+        // exists so the failure message names the operator-visible symptom
+        // (not just "expected false but was true") if anyone widens the rule
+        // without checking the downstream prerequisites.
+        LocalScriptService.IsCalamariCompatible(ScriptType.PowerShell)
+            .ShouldBeFalse(
+                customMessage: "Routing PowerShell through Calamari crashes the child process " +
+                               "with FileNotFoundException ('script.sh' vs 'script.ps1' mismatch) " +
+                               "and surfaces as 'Unknown result (ticket or process not found) (exit code -1)' " +
+                               "to the operator. See LocalScriptService.IsCalamariCompatible docstring for " +
+                               "the full prerequisite list before flipping this back.");
+    }
+
+    // ── BuildCalamariProcessStartInfo — Bash-only argv contract ────────────────
+
+    [Fact]
+    public void BuildCalamariProcessStartInfo_HardcodesScriptSh_DocumentsBashOnlyContract()
+    {
+        // Drift detector for the prerequisite call out in IsCalamariCompatible's
+        // docstring: Calamari's argv is hardcoded to --script=script.sh. If this
+        // EVER changes (e.g. someone adds per-syntax script paths), they MUST
+        // also widen IsCalamariCompatible — the two are co-dependent. Pinning the
+        // literal here makes any breaking refactor a test-time-visible decision.
+        var psi = LocalScriptService.BuildCalamariProcessStartInfo(
+            workDir: "/tmp/work",
+            variablesPath: "/tmp/work/variables.json",
+            sensitiveVariablesPath: "/tmp/work/sensitiveVariables.json",
+            sensitivePassword: null,
+            sensitiveCiphertextExists: false,
+            arguments: System.Array.Empty<string>());
+
+        psi.ArgumentList.ShouldContain("--script=script.sh",
+            customMessage: "Calamari's --script= path is hardcoded to script.sh, which is why " +
+                           "IsCalamariCompatible must only return true for Bash. If you change this " +
+                           "to a per-syntax path (e.g. --script=<computed>), update IsCalamariCompatible " +
+                           "and the Calamari pipeline in the SAME PR — both halves are co-dependent.");
+    }
+}


### PR DESCRIPTION
## Summary

- Fix operator-visible failure on Windows IIS deploy (and any other Windows + PowerShell + variables.json path): the dispatch crashed with `Unknown result (ticket or process not found) (exit code -1)` because the agent invoked Calamari with a Bash-only contract on a PowerShell script.
- Extract `IsCalamariCompatible(ScriptType)` returning `true` only for `Bash`. PowerShell scripts route through `StartViaLauncher` instead, which picks `PwshCoreProcessLauncher` or `WindowsPowerShellProcessLauncher` (auto-fallback per #352).

## Root cause (from the operator's work dir dump)

`C:\Windows\TEMP\squid-tentacle-{ticket}\output.log`:
```
Unhandled exception. System.IO.FileNotFoundException:
  Could not find file 'C:\Windows\TEMP\squid-tentacle-{ticket}\script.sh'.
    at Squid.Calamari.Commands.WriteBootstrappedBashScriptStep.ExecuteAsync(...)
    at Squid.Calamari.Pipeline.ExecutionPipeline...
```

Same dir contains `script.ps1` (96 KB — the rendered IIS deploy PowerShell with all `$SquidParameters` / `$SquidVariables` inlined). Tentacle wrote `.ps1`, Calamari read `.sh`. Two layered bugs:

| File:Line | Bug |
|---|---|
| `LocalScriptService.cs:1275` | `psi.ArgumentList.Add("--script=script.sh")` — hardcoded Bash filename |
| `Squid.Calamari/Commands/RunScriptCommand.cs:26` | Pipeline only contains `WriteBootstrappedBashScriptStep` — no `WriteBootstrappedPowerShellScriptStep` exists |

The agent's routing decision `File.Exists(variablesPath) && canUseCalamari` (where `canUseCalamari` was `Bash || PowerShell`) sent PowerShell into a Bash-only child. Calamari crashed → state file stuck at `Progress=Running, ProcessId=<dead>` → server's `GetStatus` hit orphan detection at line 497 → returned `Complete + UnknownResult (-1)`.

## Why bypassing Calamari for PowerShell is safe

Every server-side PowerShell-emitting builder (`IISDeployScriptBuilder`, `WindowsTentacleUpgradeStrategy`, etc.) already inlines variables into the rendered script body via `$SquidParameters` / `$SquidVariables` hashtables. From the operator's failed dispatch:

```powershell
$SquidParameters = @{}
$SquidParameters['Squid.Action.IISWebSite.WebSiteName'] = 'SquidWeb'
$SquidParameters['Squid.Action.IISWebSite.ApplicationPoolName'] = 'SquidPool'
# … 50+ more
$SquidVariables = @{}
$SquidVariables['Squid.Deployment.Id'] = 'Deployments-67'
$SquidVariables['Squid.Tentacle.OS'] = 'Microsoft Windows NT 10.0.19045.0'
# … all variables baked in
```

The script is self-contained from the moment the server emits it. Calamari's Bash-style `export VAR=...` preamble adds zero value on top of that.

## Test plan

- [x] Truth-table pin: `IsCalamariCompatible` returns true only for `Bash` (5 syntaxes covered: Bash / PowerShell / Python / CSharp / FSharp)
- [x] Standalone regression Fact: `IsCalamariCompatible(PowerShell) == false` with operator-visible failure description in the assert message
- [x] Drift detector: `BuildCalamariProcessStartInfo_HardcodesScriptSh_DocumentsBashOnlyContract` pins the `--script=script.sh` literal so a future PR that introduces a per-syntax path is forced to update `IsCalamariCompatible` in the same change
- [x] 5517/5517 `Squid.UnitTests` green (no adjacent regressions)
- [ ] Operator-side: re-trigger the IIS deploy on 1.7.9 — expect process spawn via `WindowsPowerShellProcessLauncher` (since pwsh not installed on host); expect IIS deploy to succeed

## Operator's failure mode chain (now fixed)

```
1.7.0 — pwsh not installed              → Win32Exception (2) at process spawn                      [fixed by #352, shipped in 1.7.8]
1.7.8 — Windows IIS deploy              → FileNotFoundException 'script.sh' (Calamari bash-only)   [fixed by THIS PR, shipping in 1.7.9]
1.7.9+ — Windows IIS deploy             → succeeds via WindowsPowerShellProcessLauncher (or pwsh if installed)
```

## Future work (not in this PR)

When Calamari grows a `WriteBootstrappedPowerShellScriptStep` AND switches its CLI invocation to a per-syntax script path (`--script=script.ps1` for PowerShell), `IsCalamariCompatible` can be widened back. The co-dependency is documented in the helper's xmldoc + the drift-detector test.