### PR TITLE
H1: UpgradeEligibilityReason + cold-cache short-circuit + OS-aware messages

### DIFF
--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -4,6 +4,7 @@ using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.Jobs;
 using Squid.Core.Services.Machines.Exceptions;
 using Squid.Message.Commands.Machine;
+using Squid.Message.Enums;
 using Squid.Message.Requests.Machines;
 
 namespace Squid.Core.Services.Machines.Upgrade;
@@ -226,13 +227,14 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
 
         // capabilities thread through info path so OS-aware
         // resolver can pick the right strategy (Linux vs Windows tentacle).
-        // Empty fallback for cold cache; LinuxTentacleUpgradeStrategy claims
-        // the empty case as the historical default.
+        // H1: Empty/cold cache no longer silently routes to Linux historical
+        // default — EvaluateUpgradeEligibility short-circuits with NoOsDetected
+        // for tentacle styles before strategy resolution.
         var capabilities = _runtimeCache.TryGet(machine.Id) ?? MachineRuntimeCapabilities.Empty;
 
         var latestVersion = await ResolveLatestForInfoAsync(style, capabilities, ct).ConfigureAwait(false);
 
-        var (canUpgrade, reason) = EvaluateUpgradeEligibility(style, capabilities, currentVersion, latestVersion);
+        var (canUpgrade, reasonCode, reasonMessage) = EvaluateUpgradeEligibility(style, capabilities, currentVersion, latestVersion);
 
         return new GetUpgradeInfoResponseData
         {
@@ -240,7 +242,8 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
             CurrentVersion = currentVersion ?? string.Empty,
             LatestAvailableVersion = latestVersion ?? string.Empty,
             CanUpgrade = canUpgrade,
-            Reason = reason
+            Reason = reasonMessage,
+            ReasonCode = reasonCode
         };
     }
 
@@ -259,32 +262,126 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
 
     /// <summary>
     /// Pure decision: given what we know, is it worth showing the operator
-    /// an upgrade affordance? Each branch returns a reason the FE can
-    /// render verbatim in a tooltip.
+    /// an upgrade affordance? Returns a tuple of <c>(canUpgrade, reasonCode,
+    /// reasonMessage)</c>:
+    /// <list type="bullet">
+    ///   <item><b>canUpgrade</b> — boolean the FE uses to show/hide the upgrade button</item>
+    ///   <item><b>reasonCode</b> — structured <see cref="UpgradeEligibilityReason"/> the FE can branch on (e.g. show a "Run health check" deep-link for <see cref="UpgradeEligibilityReason.NoOsDetected"/>)</item>
+    ///   <item><b>reasonMessage</b> — operator-facing one-liner, safe to render verbatim in a tooltip</item>
+    /// </list>
+    ///
+    /// <para><b>H1 — Cold-cache short-circuit (avoids misleading "Docker Hub" UX)</b>:
+    /// Before H1, when the capability cache was cold (empty <c>Os</c>) for a
+    /// tentacle-style machine, <see cref="LinuxTentacleUpgradeStrategy"/> claimed
+    /// the request as historical default → version registry queried Docker Hub
+    /// → Windows machines saw "Docker Hub unreachable, set
+    /// <c>SQUID_TARGET_LINUX_TENTACLE_VERSION</c>" messages. Operators followed
+    /// the wrong remediation. Now we short-circuit BEFORE strategy resolution
+    /// with <see cref="UpgradeEligibilityReason.NoOsDetected"/> and a message
+    /// that directs the operator to the health-check endpoint instead.</para>
+    ///
+    /// <para><b>H1 — OS-aware <see cref="UpgradeEligibilityReason.RegistryUnreachable"/>
+    /// messages</b>: <see cref="BuildRegistryUnreachableMessage"/> picks the
+    /// right registry endpoint and override env var per OS, so Windows
+    /// machines see "GitHub Releases" + <c>SQUID_TARGET_WINDOWS_TENTACLE_VERSION</c>
+    /// and Linux machines see "Docker Hub" + <c>SQUID_TARGET_LINUX_TENTACLE_VERSION</c>.</para>
     /// </summary>
-    private (bool canUpgrade, string reason) EvaluateUpgradeEligibility(string style, MachineRuntimeCapabilities capabilities, string currentVersion, string latestVersion)
+    private (bool canUpgrade, UpgradeEligibilityReason code, string message) EvaluateUpgradeEligibility(
+        string style, MachineRuntimeCapabilities capabilities, string currentVersion, string latestVersion)
     {
         if (string.IsNullOrWhiteSpace(style))
-            return (false, "Machine endpoint JSON is malformed or missing CommunicationStyle — re-run machine registration.");
+            return (false, UpgradeEligibilityReason.NoCommunicationStyle,
+                "Machine endpoint JSON is malformed or missing CommunicationStyle — re-run machine registration.");
+
+        // H1: cold-cache short-circuit. For tentacle styles we cannot
+        // reliably route to the right strategy / version registry without
+        // OS data; rather than fall through to the Linux historical default,
+        // tell the operator to run an active health check first. Non-tentacle
+        // styles (Ssh, etc.) fall through to ResolveStrategy below, which
+        // correctly returns null → StyleNotSupported regardless of OS.
+        if (IsTentacleStyle(style) && string.IsNullOrWhiteSpace(capabilities?.Os))
+            return (false, UpgradeEligibilityReason.NoOsDetected,
+                "OS not yet detected for this machine — the capability cache is cold (likely a recent " +
+                "server pod restart) or the agent's CapabilitiesResponse is missing the 'os' metadata field. " +
+                "Trigger an active health check (POST /api/machines/{id}/health-check or click 'Health Check' " +
+                "in the UI) to populate the OS metadata. If the cache stays empty AFTER a health check, " +
+                "the agent is too old to report 'os' metadata — upgrade it via the manual install path " +
+                "(see deploy/scripts/install-tentacle.sh / install-tentacle.ps1).");
 
         if (ResolveStrategy(style, capabilities) == null)
-            return (false, $"CommunicationStyle '{style}' is not supported for in-UI upgrades — use the style's manual upgrade path.");
+            return (false, UpgradeEligibilityReason.StyleNotSupported,
+                $"CommunicationStyle '{style}' is not supported for in-UI upgrades — use the style's manual upgrade path.");
 
         if (string.IsNullOrEmpty(latestVersion))
-            return (false, "Could not resolve the latest available version (Docker Hub unreachable and no env override). Set SQUID_TARGET_LINUX_TENTACLE_VERSION on the server pod to pin a version.");
+            return (false, UpgradeEligibilityReason.RegistryUnreachable,
+                BuildRegistryUnreachableMessage(capabilities));
 
         if (string.IsNullOrWhiteSpace(currentVersion))
-            return (true, "Current agent version is unknown (machine has not been health-checked yet). Upgrade will dispatch; AlreadyUpToDate will catch it if the agent is already on the target.");
+            return (true, UpgradeEligibilityReason.EligibleCurrentVersionUnknown,
+                "Current agent version is unknown (machine has not been health-checked yet). " +
+                "Upgrade will dispatch; AlreadyUpToDate will catch it if the agent is already on the target.");
 
         if (!SemVer.TryParse(currentVersion, out var parsedCurrent) || !SemVer.TryParse(latestVersion, out var parsedLatest))
-            return (true, $"Cannot compare versions strictly (non-semver current='{currentVersion}'). Upgrade is allowed; worst case the agent's per-version idempotency lock no-ops the run.");
+            return (true, UpgradeEligibilityReason.EligibleNonSemverComparison,
+                $"Cannot compare versions strictly (non-semver current='{currentVersion}'). " +
+                $"Upgrade is allowed; worst case the agent's per-version idempotency lock no-ops the run.");
 
         var compare = parsedCurrent.CompareTo(parsedLatest);
 
-        if (compare < 0) return (true, $"Latest published version {latestVersion} is newer than current {currentVersion}.");
-        if (compare == 0) return (false, $"Already on version {latestVersion}; nothing to do.");
+        if (compare < 0)
+            return (true, UpgradeEligibilityReason.Eligible,
+                $"Latest published version {latestVersion} is newer than current {currentVersion}.");
+        if (compare == 0)
+            return (false, UpgradeEligibilityReason.AlreadyUpToDate,
+                $"Already on version {latestVersion}; nothing to do.");
 
-        return (false, $"Current version {currentVersion} is newer than the latest published ({latestVersion}) — likely a pre-release or dev build. Use AllowDowngrade=true on the upgrade endpoint if a downgrade is deliberate.");
+        return (false, UpgradeEligibilityReason.WouldBeDowngrade,
+            $"Current version {currentVersion} is newer than the latest published ({latestVersion}) — " +
+            $"likely a pre-release or dev build. Use AllowDowngrade=true on the upgrade endpoint if a downgrade is deliberate.");
+    }
+
+    /// <summary>
+    /// Whether <paramref name="style"/> is a wire-protocol tentacle style
+    /// (<c>TentaclePolling</c> / <c>TentacleListening</c>). Used by the H1
+    /// cold-cache short-circuit — these styles need OS data to resolve the
+    /// correct upgrade strategy, and short-circuiting before
+    /// <see cref="ResolveStrategy"/> avoids the misleading Linux historical
+    /// default. Other styles (<c>Ssh</c>, <c>KubernetesAgent</c>) are
+    /// classified independently of OS and don't need this guard.
+    /// </summary>
+    private static bool IsTentacleStyle(string style)
+        => string.Equals(style, nameof(CommunicationStyle.TentaclePolling), StringComparison.Ordinal)
+        || string.Equals(style, nameof(CommunicationStyle.TentacleListening), StringComparison.Ordinal);
+
+    /// <summary>
+    /// H1: per-OS registry-unreachable message. Replaces the pre-H1 hardcoded
+    /// "Docker Hub … SQUID_TARGET_LINUX_TENTACLE_VERSION" message that
+    /// misdirected Windows operators. Each branch names the exact registry
+    /// endpoint, the network host they need to verify, and the OS-specific
+    /// override env var.
+    /// </summary>
+    internal static string BuildRegistryUnreachableMessage(MachineRuntimeCapabilities capabilities)
+    {
+        if (capabilities != null && capabilities.IsWindows)
+            return "Could not resolve the latest Windows tentacle version from " +
+                   "github.com/SolarifyDev/Squid/releases — check the server's outbound HTTPS access " +
+                   "(api.github.com:443). To pin a specific version offline, set " +
+                   $"{TentacleVersionRegistry.WindowsOverrideEnvVar} on the server pod.";
+
+        if (capabilities != null && capabilities.IsLinux)
+            return "Could not resolve the latest Linux tentacle version from Docker Hub " +
+                   "(squidcd/squid-tentacle-linux) — check the server's outbound HTTPS access " +
+                   "(registry-1.docker.io:443). To pin a specific version offline, set " +
+                   $"{TentacleVersionRegistry.LinuxOverrideEnvVar} on the server pod.";
+
+        // Defensive fallback: capabilities resolved a strategy but the OS
+        // predicate didn't match Windows OR Linux (e.g. KubernetesAgent style
+        // with Unknown OS, or a future macOS strategy). Don't pretend to know
+        // which registry to suggest — give the generic "registry unreachable"
+        // signal so the operator looks at the strategy-specific docs.
+        return "Could not resolve the latest tentacle version — the registry path for this " +
+               "communication style is unreachable and no env-var override is set. " +
+               "Check server logs for the specific registry endpoint and ops hint.";
     }
 
     // ── Loading + reading ────────────────────────────────────────────────────

--- a/src/Squid.Message/Enums/UpgradeEligibilityReason.cs
+++ b/src/Squid.Message/Enums/UpgradeEligibilityReason.cs
@@ -1,0 +1,92 @@
+namespace Squid.Message.Enums;
+
+/// <summary>
+/// Structured reason code returned by the upgrade-info endpoint alongside the
+/// human-readable <c>Reason</c> string. The frontend uses the code to drive UI
+/// behaviour (hide button vs. show actionable hint with deep-link to health
+/// check); the human string is the operator-facing tooltip.
+///
+/// <para><b>Wire stability (Rule 8 — operator-facing surface)</b>: this enum's
+/// names AND numeric values are wire contract. Renaming a member breaks every
+/// FE / SDK consumer parsing the response; re-ordering breaks anything that
+/// serialises by ordinal. Pinned by
+/// <c>UpgradeEligibilityReasonIntegrityTests</c>. <b>Add new members at the
+/// END only.</b></para>
+/// </summary>
+public enum UpgradeEligibilityReason
+{
+    /// <summary>
+    /// Machine endpoint JSON is malformed or missing <c>CommunicationStyle</c>.
+    /// Operator action: re-register the machine.
+    /// </summary>
+    NoCommunicationStyle = 0,
+
+    /// <summary>
+    /// OS not yet detected for this machine — the capability cache is cold
+    /// (server pod restarted recently and cache hasn't been re-populated) OR
+    /// the agent's <c>CapabilitiesResponse</c> didn't include the <c>os</c>
+    /// metadata field. The Linux upgrade strategy historically claimed the
+    /// Unknown case as a default, producing misleading "Docker Hub unreachable"
+    /// messages for Windows machines that hadn't had a health check yet. Under
+    /// H1 we short-circuit BEFORE strategy resolution and return this code.
+    ///
+    /// <para>Operator action: trigger an active health check
+    /// (<c>POST /api/machines/{id}/health-check</c> or click "Health Check" in
+    /// the UI). If the cache stays empty after a health check, the agent is
+    /// likely old enough to predate <c>os</c> metadata — upgrade the agent via
+    /// the manual install path.</para>
+    /// </summary>
+    NoOsDetected = 1,
+
+    /// <summary>
+    /// The <c>CommunicationStyle</c> has no in-UI upgrade strategy registered.
+    /// E.g. <c>Ssh</c> targets — they're managed by the host's package
+    /// manager, not by Squid. Operator action: follow the style's manual
+    /// upgrade procedure.
+    /// </summary>
+    StyleNotSupported = 2,
+
+    /// <summary>
+    /// Version registry unreachable AND no env-var override pinned. The human
+    /// message mentions the correct registry endpoint and override env var for
+    /// this OS (GitHub Releases + <c>SQUID_TARGET_WINDOWS_TENTACLE_VERSION</c>
+    /// for Windows; Docker Hub + <c>SQUID_TARGET_LINUX_TENTACLE_VERSION</c>
+    /// for Linux). Before H1 this message hardcoded the Linux variant
+    /// regardless of OS.
+    /// </summary>
+    RegistryUnreachable = 3,
+
+    /// <summary>
+    /// Eligible: current agent version is unknown (machine has not reported a
+    /// version yet, but OS IS known so we know which registry to query). The
+    /// agent's per-version idempotency lock will no-op the dispatch if the
+    /// agent is already on the target.
+    /// </summary>
+    EligibleCurrentVersionUnknown = 4,
+
+    /// <summary>
+    /// Eligible: one side of the version comparison is non-semver (typically a
+    /// dev build like <c>"custom-build-20260419"</c>). Strict comparison isn't
+    /// possible, so we conservatively allow the upgrade — worst case the
+    /// agent-side idempotency lock no-ops the run.
+    /// </summary>
+    EligibleNonSemverComparison = 5,
+
+    /// <summary>
+    /// Eligible (happy path): latest published version is strictly newer than
+    /// current. FE renders the upgrade button.
+    /// </summary>
+    Eligible = 6,
+
+    /// <summary>
+    /// Current version equals latest. Nothing to do; FE hides the button.
+    /// </summary>
+    AlreadyUpToDate = 7,
+
+    /// <summary>
+    /// Current version is newer than latest published — would be a downgrade.
+    /// FE hides the button. Operator can explicitly opt in via
+    /// <c>AllowDowngrade=true</c> on the upgrade dispatch endpoint.
+    /// </summary>
+    WouldBeDowngrade = 8
+}

--- a/src/Squid.Message/Requests/Machines/GetUpgradeInfoRequest.cs
+++ b/src/Squid.Message/Requests/Machines/GetUpgradeInfoRequest.cs
@@ -60,4 +60,13 @@ public class GetUpgradeInfoResponseData
     /// decision. Safe to render directly in a tooltip without sanitisation.
     /// </summary>
     public string Reason { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Structured reason code paired with <see cref="Reason"/>. Frontend can
+    /// branch on the code to drive UI behaviour (e.g. show a "Run health
+    /// check" deep-link for <see cref="UpgradeEligibilityReason.NoOsDetected"/>
+    /// instead of just rendering the text). Added in H1 — existing clients
+    /// that read only <see cref="Reason"/> are unaffected.
+    /// </summary>
+    public UpgradeEligibilityReason ReasonCode { get; set; }
 }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
@@ -1234,8 +1234,10 @@ public sealed class MachineUpgradeServiceTests
     public async Task GetUpgradeInfoAsync_CurrentOlderThanLatest_CanUpgradeTrue()
     {
         // The primary UI signal: "new version N available". FE renders badge.
+        // H1: must seed OS in cache; cold cache now short-circuits to NoOsDetected
+        // for tentacle styles (which is precisely the bug operators hit in 1.7.x).
         ArrangeMachine(id: 1, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(1, new Dictionary<string, string>(), agentVersion: "1.3.9");
+        _runtimeCache.Store(1, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 1 }, CancellationToken.None);
 
@@ -1244,18 +1246,20 @@ public sealed class MachineUpgradeServiceTests
         info.LatestAvailableVersion.ShouldBe("1.4.0");
         info.Reason.ShouldContain("1.4.0");
         info.Reason.ShouldContain("newer than current");
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.Eligible);
     }
 
     [Fact]
     public async Task GetUpgradeInfoAsync_SameVersion_CanUpgradeFalse_WithClearReason()
     {
         ArrangeMachine(id: 2, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(2, new Dictionary<string, string>(), agentVersion: "1.4.0");
+        _runtimeCache.Store(2, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.4.0");
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 2 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeFalse();
         info.Reason.ShouldContain("Already on");
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.AlreadyUpToDate);
     }
 
     [Fact]
@@ -1265,59 +1269,171 @@ public sealed class MachineUpgradeServiceTests
         // FE should NOT show upgrade badge even though versions differ —
         // surfacing the badge would tempt a downgrade via one-click UX.
         ArrangeMachine(id: 3, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(3, new Dictionary<string, string>(), agentVersion: "2.0.0-rc.1");
+        _runtimeCache.Store(3, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "2.0.0-rc.1");
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 3 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeFalse();
         info.Reason.ShouldContain("newer than", Case.Insensitive);
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.WouldBeDowngrade);
     }
 
     [Fact]
-    public async Task GetUpgradeInfoAsync_CurrentVersionUnknown_CanUpgradeTrue_DispatchDecidesActualOutcome()
+    public async Task GetUpgradeInfoAsync_OsKnownButVersionUnknown_CanUpgradeTrue_DispatchDecidesActualOutcome()
     {
-        // Cold cache — machine never health-checked. FE shows the upgrade
-        // button (conservative default: let the user dispatch; the
-        // AlreadyUpToDate path on actual upgrade will catch no-ops).
+        // H1 — narrower contract than pre-H1: cold cache no longer counts as
+        // "version unknown / allow upgrade". To hit this branch the agent
+        // must have reported OS (so we know which registry to query) but NOT
+        // have reported its AgentVersion yet. Then optimistic-allow is safe —
+        // the agent's per-version idempotency lock will no-op the run if it's
+        // already on the target.
         ArrangeMachine(id: 4, style: nameof(CommunicationStyle.TentaclePolling));
-        // intentionally not storing in runtimeCache → cold cache
+        _runtimeCache.Store(4, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: string.Empty);
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 4 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeTrue();
         info.CurrentVersion.ShouldBe(string.Empty);
         info.Reason.ShouldContain("unknown", Case.Insensitive);
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.EligibleCurrentVersionUnknown);
+    }
+
+    [Fact]
+    public async Task GetUpgradeInfoAsync_ColdCacheTentacleStyle_NoOsDetected_PointsAtHealthCheck()
+    {
+        // H1 — the operator's 1.7.x failure mode. Cold cache (no runtime cache
+        // entry at all) on a TentaclePolling machine previously routed through
+        // LinuxTentacleUpgradeStrategy's historical default, producing the
+        // misleading "Docker Hub unreachable, set SQUID_TARGET_LINUX_TENTACLE_VERSION"
+        // message even for Windows machines. Now we short-circuit BEFORE
+        // strategy resolution and tell the operator to run a health check.
+        ArrangeMachine(id: 14, style: nameof(CommunicationStyle.TentaclePolling));
+        // intentionally not storing in runtimeCache → cold cache
+
+        var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 14 }, CancellationToken.None);
+
+        info.CanUpgrade.ShouldBeFalse(
+            customMessage: "Cold-cache tentacle style MUST NOT dispatch optimistically — we can't tell which OS / registry to use, so a wrong dispatch would either crash the agent or trigger the misleading Linux Docker Hub error path.");
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.NoOsDetected);
+        info.Reason.ShouldContain("health check", Case.Insensitive,
+            customMessage: "Operator MUST be pointed at the health-check endpoint as the actionable next step — the whole point of NoOsDetected is to avoid the 1.7.x 'Docker Hub' misdirection.");
+        // No "Docker Hub" / "SQUID_TARGET_LINUX_TENTACLE_VERSION" leakage when
+        // OS is unknown (those messages belong to RegistryUnreachable + Linux).
+        info.Reason.ShouldNotContain("Docker Hub");
+        info.Reason.ShouldNotContain("SQUID_TARGET_LINUX_TENTACLE_VERSION");
+    }
+
+    [Fact]
+    public async Task GetUpgradeInfoAsync_ColdCacheSshStyle_StillReportsStyleNotSupported_NotNoOsDetected()
+    {
+        // Drift detector for the IsTentacleStyle guard: non-tentacle styles
+        // (Ssh, future SshAgent) MUST NOT route through the NoOsDetected
+        // short-circuit. Their "not supported for in-UI upgrade" answer is
+        // independent of OS, so falling through to ResolveStrategy (which
+        // returns null for Ssh regardless of capabilities) gives the more
+        // actionable message.
+        ArrangeMachine(id: 15, style: "Ssh");
+        // intentionally cold cache
+
+        var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 15 }, CancellationToken.None);
+
+        info.CanUpgrade.ShouldBeFalse();
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.StyleNotSupported,
+            customMessage: "Ssh has no upgrade strategy in any case — operator gets 'manual upgrade required' regardless of whether OS is known.");
+        info.Reason.ShouldContain("Ssh");
+        info.Reason.ShouldContain("not supported", Case.Insensitive);
     }
 
     [Fact]
     public async Task GetUpgradeInfoAsync_NoStrategyForStyle_CanUpgradeFalse()
     {
         // SSH target or any future style without a strategy.
+        // H1: seed cache with OS so we test StyleNotSupported (NOT NoOsDetected).
+        // The drift detector GetUpgradeInfoAsync_ColdCacheSshStyle_* covers
+        // the cold-cache + Ssh path explicitly.
         ArrangeMachine(id: 5, style: "Ssh");
+        _runtimeCache.Store(5, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 5 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeFalse();
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.StyleNotSupported);
         info.Reason.ShouldContain("Ssh");
         info.Reason.ShouldContain("not supported", Case.Insensitive);
     }
 
     [Fact]
-    public async Task GetUpgradeInfoAsync_RegistryReturnsEmpty_CanUpgradeFalse_WithOpsHint()
+    public async Task GetUpgradeInfoAsync_RegistryReturnsEmptyForLinux_MessageMentionsDockerHub()
     {
-        // Docker Hub unreachable + no env override; registry returns empty.
-        // FE should show "version info unavailable" instead of "update button".
+        // Linux machine + Docker Hub unreachable AND no env override → registry
+        // returns empty. H1 makes the message OS-aware: Linux gets the Docker
+        // Hub + SQUID_TARGET_LINUX_TENTACLE_VERSION hint (the historical text).
         ArrangeMachine(id: 6, style: nameof(CommunicationStyle.TentaclePolling));
         _versionRegistry
             .Setup(x => x.GetLatestVersionAsync(nameof(CommunicationStyle.TentaclePolling), It.IsAny<MachineRuntimeCapabilities>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(string.Empty);
-        _runtimeCache.Store(6, new Dictionary<string, string>(), agentVersion: "1.3.9");
+        _runtimeCache.Store(6, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 6 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeFalse();
         info.LatestAvailableVersion.ShouldBe(string.Empty);
-        info.Reason.ShouldContain("Could not resolve", Case.Insensitive);
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.RegistryUnreachable);
+        info.Reason.ShouldContain("Docker Hub");
+        info.Reason.ShouldContain("SQUID_TARGET_LINUX_TENTACLE_VERSION");
+        // Defensive: Linux machines must NOT see the Windows env var hint.
+        info.Reason.ShouldNotContain("SQUID_TARGET_WINDOWS_TENTACLE_VERSION");
+        info.Reason.ShouldNotContain("github.com");
+    }
+
+    [Fact]
+    public async Task GetUpgradeInfoAsync_RegistryReturnsEmptyForWindows_MessageMentionsGitHub_NotDockerHub()
+    {
+        // H1 — the operator's specific 1.7.x bug. Windows machine + registry
+        // returns empty (GitHub Releases unreachable) → message MUST mention
+        // GitHub + SQUID_TARGET_WINDOWS_TENTACLE_VERSION, NOT Docker Hub +
+        // Linux env var. Pre-H1 the Windows case showed Linux hints, sending
+        // operators down the wrong remediation path.
+        ArrangeMachine(id: 16, style: nameof(CommunicationStyle.TentaclePolling));
+        _versionRegistry
+            .Setup(x => x.GetLatestVersionAsync(nameof(CommunicationStyle.TentaclePolling), It.IsAny<MachineRuntimeCapabilities>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+        _runtimeCache.Store(16, new Dictionary<string, string> { ["os"] = "Windows" }, agentVersion: "1.7.8");
+
+        var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 16 }, CancellationToken.None);
+
+        info.CanUpgrade.ShouldBeFalse();
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.RegistryUnreachable);
+        info.Reason.ShouldContain("github.com",
+            customMessage: "Windows machine MUST be pointed at GitHub Releases — the operator-blocking 1.7.x bug was sending Windows operators to Docker Hub.");
+        info.Reason.ShouldContain("SQUID_TARGET_WINDOWS_TENTACLE_VERSION");
+        // The 1.7.x bug class: Windows operator seeing Linux hints. Pin this.
+        info.Reason.ShouldNotContain("Docker Hub",
+            customMessage: "Windows registry-unreachable message MUST NOT mention Docker Hub — that misdirection is exactly the operator bug H1 fixes.");
+        info.Reason.ShouldNotContain("SQUID_TARGET_LINUX_TENTACLE_VERSION");
+    }
+
+    [Fact]
+    public async Task GetUpgradeInfoAsync_RegistryReturnsEmptyForWindowsLongFormOs_StillMessageMentionsGitHub()
+    {
+        // Drift detector: the operator's actual cache state in 1.7.x had
+        // `Os = "Microsoft Windows NT 10.0.19045.0"` (the long form). Make
+        // sure MachineRuntimeCapabilities.IsWindows still recognizes it
+        // (already fixed in PR #351 via WindowsOsStringHelper) AND that the
+        // registry-unreachable message picks the Windows branch accordingly.
+        ArrangeMachine(id: 17, style: nameof(CommunicationStyle.TentaclePolling));
+        _versionRegistry
+            .Setup(x => x.GetLatestVersionAsync(nameof(CommunicationStyle.TentaclePolling), It.IsAny<MachineRuntimeCapabilities>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+        _runtimeCache.Store(17,
+            new Dictionary<string, string> { ["os"] = "Microsoft Windows NT 10.0.19045.0" },
+            agentVersion: "1.7.8");
+
+        var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 17 }, CancellationToken.None);
+
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.RegistryUnreachable);
+        info.Reason.ShouldContain("github.com");
+        info.Reason.ShouldNotContain("Docker Hub");
     }
 
     [Fact]
@@ -1330,6 +1446,7 @@ public sealed class MachineUpgradeServiceTests
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 7 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeFalse();
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.NoCommunicationStyle);
         info.Reason.ShouldContain("endpoint", Case.Insensitive);
     }
 
@@ -1340,11 +1457,12 @@ public sealed class MachineUpgradeServiceTests
         // compare, so the SAFE default is allow (dispatch is idempotent on
         // the agent side anyway). Reason makes the fuzziness explicit.
         ArrangeMachine(id: 8, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(8, new Dictionary<string, string>(), agentVersion: "custom-build-20260419");
+        _runtimeCache.Store(8, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "custom-build-20260419");
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 8 }, CancellationToken.None);
 
         info.CanUpgrade.ShouldBeTrue();
+        info.ReasonCode.ShouldBe(UpgradeEligibilityReason.EligibleNonSemverComparison);
         info.Reason.ShouldContain("cannot compare", Case.Insensitive);
     }
 

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeEligibilityReasonIntegrityTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeEligibilityReasonIntegrityTests.cs
@@ -1,0 +1,69 @@
+using Shouldly;
+using Squid.Message.Enums;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Wire-stability pin (Rule 8 — operator-facing surface) for
+/// <see cref="UpgradeEligibilityReason"/>. The enum's <b>names</b> AND
+/// <b>numeric values</b> are serialised over the upgrade-info API and consumed
+/// by the FE + any external SDK. Renaming a member breaks string-based
+/// parsing; re-ordering breaks anything that serialises by ordinal. Pin both
+/// here so a refactor becomes a test-time-visible decision.
+///
+/// <para><b>Convention</b>: add new members at the END only; never re-number
+/// existing members. If a member becomes obsolete, mark it <c>[Obsolete]</c>
+/// but DO NOT delete or renumber.</para>
+/// </summary>
+public sealed class UpgradeEligibilityReasonIntegrityTests
+{
+    [Theory]
+    [InlineData(UpgradeEligibilityReason.NoCommunicationStyle, 0)]
+    [InlineData(UpgradeEligibilityReason.NoOsDetected, 1)]
+    [InlineData(UpgradeEligibilityReason.StyleNotSupported, 2)]
+    [InlineData(UpgradeEligibilityReason.RegistryUnreachable, 3)]
+    [InlineData(UpgradeEligibilityReason.EligibleCurrentVersionUnknown, 4)]
+    [InlineData(UpgradeEligibilityReason.EligibleNonSemverComparison, 5)]
+    [InlineData(UpgradeEligibilityReason.Eligible, 6)]
+    [InlineData(UpgradeEligibilityReason.AlreadyUpToDate, 7)]
+    [InlineData(UpgradeEligibilityReason.WouldBeDowngrade, 8)]
+    public void NumericValue_PinnedToOrdinal(UpgradeEligibilityReason reason, int expected)
+    {
+        // Pinning numeric values defends against accidental re-ordering. Any
+        // change to this table is an API break — the test forces the author
+        // to think about backward compat (vs. silently shipping the break).
+        ((int)reason).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(UpgradeEligibilityReason.NoCommunicationStyle, "NoCommunicationStyle")]
+    [InlineData(UpgradeEligibilityReason.NoOsDetected, "NoOsDetected")]
+    [InlineData(UpgradeEligibilityReason.StyleNotSupported, "StyleNotSupported")]
+    [InlineData(UpgradeEligibilityReason.RegistryUnreachable, "RegistryUnreachable")]
+    [InlineData(UpgradeEligibilityReason.EligibleCurrentVersionUnknown, "EligibleCurrentVersionUnknown")]
+    [InlineData(UpgradeEligibilityReason.EligibleNonSemverComparison, "EligibleNonSemverComparison")]
+    [InlineData(UpgradeEligibilityReason.Eligible, "Eligible")]
+    [InlineData(UpgradeEligibilityReason.AlreadyUpToDate, "AlreadyUpToDate")]
+    [InlineData(UpgradeEligibilityReason.WouldBeDowngrade, "WouldBeDowngrade")]
+    public void NameLiteral_Pinned(UpgradeEligibilityReason reason, string expected)
+    {
+        // Pinning the literal string defends against rename refactors that
+        // would silently break clients parsing the response. JSON serialisation
+        // uses the member name, so a rename here is a wire-protocol break.
+        reason.ToString().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TotalCount_PinnedToCurrentSize()
+    {
+        // Any new member added to the enum must come with a test row above
+        // AND bump this count. The mismatch forces the author to consciously
+        // update the integrity tests rather than skip them.
+        System.Enum.GetValues<UpgradeEligibilityReason>().Length.ShouldBe(9,
+            customMessage: "If you're adding a new UpgradeEligibilityReason, also: " +
+                           "(1) append at the END (never re-number), " +
+                           "(2) add [InlineData] rows to NumericValue_PinnedToOrdinal and NameLiteral_Pinned, " +
+                           "(3) bump this expected count. See class docstring.");
+    }
+}


### PR DESCRIPTION
## Summary

H1 of the **1.8.0 Upgrade Hardening initiative** (8 PRs total, sequential H1-H8).

Fixes the operator-facing 1.7.x bug where clicking Upgrade on a Windows tentacle without a recent health check showed `"Docker Hub unreachable, set SQUID_TARGET_LINUX_TENTACLE_VERSION"` — sending Windows operators down the wrong remediation path.

## Behaviour changes

| Scenario | Pre-H1 | Post-H1 |
|---|---|---|
| Cold cache + TentaclePolling | LinuxStrategy historical-default → Docker Hub queried → misleading Linux env-var hint | Short-circuit before strategy resolution → `NoOsDetected` reason code + message pointing to health-check endpoint |
| Windows machine + registry empty | `"Docker Hub unreachable, set SQUID_TARGET_LINUX_TENTACLE_VERSION"` | `"github.com unreachable, set SQUID_TARGET_WINDOWS_TENTACLE_VERSION"` |
| Linux machine + registry empty | Same as before | Same as before (preserved) |
| Cold cache + Ssh | "Ssh not supported" | "Ssh not supported" (preserved — non-tentacle styles bypass H1) |
| API response shape | `{canUpgrade, currentVersion, latestAvailableVersion, reason}` | Adds `reasonCode` field (additive, backward-compat) |

## API additions

- New enum `UpgradeEligibilityReason` (9 codes, ordinals + name strings pinned by integrity tests per Rule 8)
- New `ReasonCode` field on `GetUpgradeInfoResponseData`
- FE can branch on `reasonCode === "NoOsDetected"` to render a "Run Health Check" deep-link button

## Test plan

- [x] +9 integrity-test rows pinning every enum name + ordinal
- [x] +5 new GetUpgradeInfoAsync scenario tests covering the H1 behaviour changes
- [x] +1 drift detector pinning long-form Windows OS still routes correctly (regression guard for PR #351)
- [x] Updated 6 existing tests that relied on the cold-cache Linux historical default
- [x] **5540/5540 unit tests green** (vs 5517 before H1 → +23 net new tests)
- [ ] Integration / E2E coverage: deferred to H8 (comprehensive E2E matrix)

## Backward compatibility

- API response shape: additive (existing clients reading only `reason` are unaffected)
- Enum stability: values + names pinned via `UpgradeEligibilityReasonIntegrityTests` — re-ordering or renaming is now a test-time-visible decision
- Cold-cache + tentacle style behaviour: **intentional break** — old behaviour (allow optimistic upgrade) was the root cause of the operator's 1.7.x failure chain. New behaviour rejects with actionable guidance. Operators who were depending on the old behaviour will see `canUpgrade=false` with `reasonCode=NoOsDetected` — they should run a health check first

## What's NOT in this PR (later phases)

- **H2**: Capability cache persistence to DB (so server pod restart doesn't wipe cache)
- **H3**: Active health-check probe API (currently the UI button doesn't actively probe agent)
- **H4**: Upgrade lock TTL + idempotency
- **H5**: Cross-OS unified upgrade pipeline
- **H6**: Agent rollback + abandonment recovery
- **H7**: Role/feature capability slots
- **H8**: Comprehensive E2E test matrix