### PR TITLE
H2: Persist runtime capability cache to DB so server restarts don't wipe it

### DIFF
--- a/src/Squid.Core/Persistence/DbUpFiles/20260523_add_machine_runtime_capabilities_persistence.sql
+++ b/src/Squid.Core/Persistence/DbUpFiles/20260523_add_machine_runtime_capabilities_persistence.sql
@@ -1,0 +1,27 @@
+-- H2 — persist runtime capability cache to DB so server pod restarts don't
+-- wipe the cache and force operators into the cold-cache UX trap fixed in H1.
+--
+-- Adds two columns to `machine`:
+--   * runtime_capabilities_json — full MachineRuntimeCapabilities snapshot
+--     as JSON (jsonb for efficient ->> queries from future filters).
+--     NULL means "never health-checked" — cache stays empty until next probe.
+--   * runtime_capabilities_updated_at — when the snapshot was taken. Used by
+--     a future TTL-invalidation step (H2 itself doesn't gate on age; cache
+--     remains valid until next active health-check overwrites or
+--     IMachineRuntimeCapabilitiesPersistence.InvalidateAsync nulls the row).
+--
+-- Backward compatibility: pre-existing machines get NULL columns. The
+-- MachineRuntimeCapabilitiesCacheHydrator IStartable skips NULL rows at
+-- startup, so first-ever upgrade-info call returns NoOsDetected (H1) which
+-- correctly points the operator at the health-check endpoint.
+
+ALTER TABLE machine
+    ADD COLUMN runtime_capabilities_json     jsonb       NULL,
+    ADD COLUMN runtime_capabilities_updated_at timestamptz NULL;
+
+-- Optional partial index for future "which machines were health-checked in
+-- the last hour" admin queries. WHERE clause keeps it small for the common
+-- case where most fleets have a small staleness window.
+CREATE INDEX ix_machine_runtime_capabilities_updated_at
+    ON machine USING btree (runtime_capabilities_updated_at DESC)
+    WHERE runtime_capabilities_updated_at IS NOT NULL;

--- a/src/Squid.Core/Persistence/Entities/Deployments/Machine.cs
+++ b/src/Squid.Core/Persistence/Entities/Deployments/Machine.cs
@@ -20,6 +20,16 @@ public class Machine : IEntity<int>, IAuditable
     public DateTimeOffset? HealthLastChecked { get; set; }
     public string HealthDetail { get; set; }
 
+    // H2 — Persisted runtime capability snapshot (full MachineRuntimeCapabilities
+    // serialised as JSON). NULL when the agent has never been health-checked.
+    // The InMemoryMachineRuntimeCapabilitiesCache hydrates from this column at
+    // startup so server pod restarts no longer wipe operators into the H1
+    // cold-cache UX trap. Updated atomically via
+    // IMachineRuntimeCapabilitiesPersistence after every successful Capabilities
+    // probe in TentacleHealthCheckStrategy.
+    public string RuntimeCapabilitiesJson { get; set; }
+    public DateTimeOffset? RuntimeCapabilitiesUpdatedAt { get; set; }
+
     // IAuditable
     public DateTimeOffset CreatedDate { get; set; }
     public int CreatedBy { get; set; }

--- a/src/Squid.Core/Persistence/EntityConfigurations/MachineConfiguration.cs
+++ b/src/Squid.Core/Persistence/EntityConfigurations/MachineConfiguration.cs
@@ -17,5 +17,11 @@ public class MachineConfiguration: IEntityTypeConfiguration<Machine>
             .HasMaxLength(50)
             .IsRequired();
         builder.Property(p => p.HealthLastChecked);
+
+        // H2 — runtime capability persistence (column added by
+        // 20260523_add_machine_runtime_capabilities_persistence.sql). Nullable —
+        // pre-existing machines have NULL until next health check populates them.
+        builder.Property(p => p.RuntimeCapabilitiesJson).HasColumnType("jsonb");
+        builder.Property(p => p.RuntimeCapabilitiesUpdatedAt);
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesPersistence.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesPersistence.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle;
+
+/// <summary>
+/// H2 — DB-backed persistence for <see cref="MachineRuntimeCapabilities"/>.
+/// Composed with <see cref="InMemoryMachineRuntimeCapabilitiesCache"/> so that
+/// every successful capabilities probe gets written through to the
+/// <c>machine.runtime_capabilities_json</c> column AND the
+/// <see cref="MachineRuntimeCapabilitiesCacheHydrator"/> can re-populate the
+/// in-memory cache at server startup from the DB rows.
+///
+/// <para><b>Why this exists</b>: in 1.7.x the in-memory cache was wiped on
+/// every server pod restart. The first operator action after a deploy
+/// (typically the most stressful moment) hit the H1 NoOsDetected path until
+/// the next scheduled health check repopulated the cache. Now the DB is the
+/// source of truth — cache misses fall through to DB; the in-memory dict is
+/// just a hot-read accelerator.</para>
+///
+/// <para><b>Stability</b>: this interface is internal to the deployment
+/// execution layer. Tests use a fake implementation. Production wires
+/// <see cref="MachineRuntimeCapabilitiesPersistence"/> via
+/// <see cref="IScopedDependency"/>.</para>
+/// </summary>
+public interface IMachineRuntimeCapabilitiesPersistence
+{
+    /// <summary>
+    /// Persist <paramref name="capabilities"/> for <paramref name="machineId"/>
+    /// to <c>machine.runtime_capabilities_json</c> + sets the
+    /// <c>runtime_capabilities_updated_at</c> timestamp. Atomic single-row
+    /// update via <see cref="IRepository.ExecuteUpdateAsync{T}"/> — no entity
+    /// tracking, no concurrent-write race with concurrent <c>UpdateMachineAsync</c>
+    /// calls.
+    /// </summary>
+    Task SaveAsync(int machineId, MachineRuntimeCapabilities capabilities, CancellationToken ct);
+
+    /// <summary>
+    /// Load every machine row with non-NULL <c>runtime_capabilities_json</c> for
+    /// the hydrator. Skips rows where deserialisation fails (logged warning) so
+    /// one corrupt JSON blob can't block startup.
+    /// </summary>
+    Task<IReadOnlyList<(int MachineId, MachineRuntimeCapabilities Capabilities)>> LoadAllAsync(CancellationToken ct);
+
+    /// <summary>
+    /// NULL out both columns for <paramref name="machineId"/>. Called after a
+    /// successful upgrade so the next health check repopulates with the new
+    /// agent version — matches the in-memory cache <c>Invalidate</c> contract.
+    /// </summary>
+    Task InvalidateAsync(int machineId, CancellationToken ct);
+}
+
+public sealed class MachineRuntimeCapabilitiesPersistence : IMachineRuntimeCapabilitiesPersistence, IScopedDependency
+{
+    private readonly IRepository _repository;
+
+    /// <summary>
+    /// Stable JSON serialisation contract — property names are written
+    /// camelCase to match the existing API conventions, no enum-as-string
+    /// magic (the underlying type doesn't have enums anyway). Pinned by
+    /// <c>MachineRuntimeCapabilitiesPersistence_SerialisedJsonShape_Stable</c>
+    /// unit test so a future <see cref="JsonSerializerOptions"/> default change
+    /// (e.g. the .NET 10 PascalCase regression) doesn't silently break the
+    /// hydration round-trip.
+    /// </summary>
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    public MachineRuntimeCapabilitiesPersistence(IRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task SaveAsync(int machineId, MachineRuntimeCapabilities capabilities, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
+
+        var json = JsonSerializer.Serialize(new PersistedCapabilities
+        {
+            Os = capabilities.Os,
+            OsVersion = capabilities.OsVersion,
+            DefaultShell = capabilities.DefaultShell,
+            InstalledShells = capabilities.InstalledShells,
+            Architecture = capabilities.Architecture,
+            AgentVersion = capabilities.AgentVersion,
+            SupportedServices = capabilities.SupportedServices?.ToArray() ?? Array.Empty<string>()
+        }, SerializerOptions);
+
+        var now = DateTimeOffset.UtcNow;
+
+        await _repository.ExecuteUpdateAsync<Machine>(
+            m => m.Id == machineId,
+            s => s.SetProperty(m => m.RuntimeCapabilitiesJson, json)
+                  .SetProperty(m => m.RuntimeCapabilitiesUpdatedAt, (DateTimeOffset?)now),
+            ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<(int MachineId, MachineRuntimeCapabilities Capabilities)>> LoadAllAsync(CancellationToken ct)
+    {
+        // Project to (id, json) tuple — avoid full entity hydration just for
+        // capability data on startup. Skip rows with NULL json (the migration
+        // backward-compat case + machines that never health-checked).
+        var rows = await _repository.QueryNoTracking<Machine>(m => m.RuntimeCapabilitiesJson != null)
+            .Select(m => new { m.Id, m.RuntimeCapabilitiesJson })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var results = new List<(int, MachineRuntimeCapabilities)>(rows.Count);
+
+        foreach (var row in rows)
+        {
+            try
+            {
+                var persisted = JsonSerializer.Deserialize<PersistedCapabilities>(row.RuntimeCapabilitiesJson, SerializerOptions);
+                if (persisted == null) continue;
+
+                results.Add((row.Id, new MachineRuntimeCapabilities
+                {
+                    Os = persisted.Os ?? string.Empty,
+                    OsVersion = persisted.OsVersion ?? string.Empty,
+                    DefaultShell = persisted.DefaultShell ?? string.Empty,
+                    InstalledShells = persisted.InstalledShells ?? string.Empty,
+                    Architecture = persisted.Architecture ?? string.Empty,
+                    AgentVersion = persisted.AgentVersion ?? string.Empty,
+                    SupportedServices = persisted.SupportedServices ?? Array.Empty<string>()
+                }));
+            }
+            catch (JsonException ex)
+            {
+                // One corrupted row can't block startup. Log + skip so the
+                // operator can drop the bad blob (or wait for next health
+                // check to overwrite it) without rebuilding the server image.
+                Log.Warning(ex,
+                    "Failed to deserialise persisted runtime capabilities for machine {MachineId} — skipping. " +
+                    "The cache will repopulate from the next successful health-check probe.",
+                    row.Id);
+            }
+        }
+
+        return results;
+    }
+
+    public Task InvalidateAsync(int machineId, CancellationToken ct)
+    {
+        // NULL both columns atomically. Caller (MachineUpgradeService after
+        // successful upgrade) wants the NEXT health check to be the source
+        // of truth, not the pre-upgrade snapshot.
+        return _repository.ExecuteUpdateAsync<Machine>(
+            m => m.Id == machineId,
+            s => s.SetProperty(m => m.RuntimeCapabilitiesJson, (string)null)
+                  .SetProperty(m => m.RuntimeCapabilitiesUpdatedAt, (DateTimeOffset?)null),
+            ct);
+    }
+
+    /// <summary>
+    /// Internal DTO that pins the on-disk JSON shape so future refactors of
+    /// <see cref="MachineRuntimeCapabilities"/> (adding a property, renaming)
+    /// don't silently break round-trip. New fields here MUST stay nullable for
+    /// backward compat with pre-existing JSON blobs that don't have them.
+    /// </summary>
+    internal sealed class PersistedCapabilities
+    {
+        public string Os { get; set; }
+        public string OsVersion { get; set; }
+        public string DefaultShell { get; set; }
+        public string InstalledShells { get; set; }
+        public string Architecture { get; set; }
+        public string AgentVersion { get; set; }
+        public string[] SupportedServices { get; set; }
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/MachineRuntimeCapabilitiesCacheHydrator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/MachineRuntimeCapabilitiesCacheHydrator.cs
@@ -1,0 +1,104 @@
+using Autofac;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle;
+
+/// <summary>
+/// H2 — hydrates the <see cref="InMemoryMachineRuntimeCapabilitiesCache"/>
+/// from the <c>machine.runtime_capabilities_json</c> column at server
+/// startup, so a freshly-deployed pod doesn't make every operator action
+/// hit the H1 NoOsDetected path until the next scheduled health check.
+///
+/// <para>Autofac calls <see cref="Start"/> once at container build time on
+/// every <see cref="IStartable"/> singleton. We block on the async load
+/// inline — startup is single-threaded and there's no benefit to deferring
+/// the cache warm-up.</para>
+///
+/// <para><b>Failure mode</b>: if the DB read fails (server can't reach
+/// Postgres, etc.), we log + continue with an empty cache. Operators will
+/// see the H1 NoOsDetected message on the first upgrade-info call until
+/// the next health check populates the cache — strictly better than
+/// blocking server startup on a transient DB issue.</para>
+/// </summary>
+public sealed class MachineRuntimeCapabilitiesCacheHydrator : IStartable
+{
+    private readonly IComponentContext _container;
+
+    /// <summary>
+    /// Take the container itself (not the persistence service or the cache
+    /// directly) because <see cref="IMachineRuntimeCapabilitiesPersistence"/>
+    /// is scoped (<see cref="IScopedDependency"/>) — we need to open a
+    /// life-time scope for the one-off startup query, then dispose it. The
+    /// cache itself is a singleton so we resolve it from the root context.
+    /// </summary>
+    public MachineRuntimeCapabilitiesCacheHydrator(IComponentContext container)
+    {
+        _container = container;
+    }
+
+    public void Start()
+    {
+        try
+        {
+            HydrateAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            // Don't block server startup on a transient DB read failure.
+            // Operators will fall through to the H1 NoOsDetected path on
+            // the first upgrade-info call, which already gives them an
+            // actionable next step (run a health check).
+            Log.Warning(ex,
+                "MachineRuntimeCapabilitiesCacheHydrator failed to load persisted runtime capabilities — " +
+                "server will start with an empty in-memory cache and rely on the next health check per machine. " +
+                "Operators may see NoOsDetected on first upgrade-info call until that happens.");
+        }
+    }
+
+    private async Task HydrateAsync(CancellationToken ct)
+    {
+        var cache = _container.Resolve<IMachineRuntimeCapabilitiesCache>();
+
+        // Persistence is scoped (per the IScopedDependency registration) so
+        // we MUST open a lifetime scope to resolve it. ILifetimeScope-aware
+        // services like the EF DbContext need a unit-of-work boundary.
+        // Autofac doesn't expose BeginLifetimeScopeAsync (only the sync
+        // BeginLifetimeScope()); DisposeAsync via `await using` still works
+        // because ILifetimeScope implements IAsyncDisposable.
+        await using var scope = _container.Resolve<ILifetimeScope>().BeginLifetimeScope();
+
+        var persistence = scope.Resolve<IMachineRuntimeCapabilitiesPersistence>();
+
+        var rows = await persistence.LoadAllAsync(ct).ConfigureAwait(false);
+
+        var hydrated = 0;
+        foreach (var (machineId, capabilities) in rows)
+        {
+            cache.Store(machineId, BuildMetadataDictionary(capabilities), capabilities.AgentVersion, capabilities.SupportedServices);
+            hydrated++;
+        }
+
+        Log.Information(
+            "MachineRuntimeCapabilitiesCacheHydrator hydrated {Count} machine(s) from persisted runtime capabilities.",
+            hydrated);
+    }
+
+    /// <summary>
+    /// Rebuild the metadata dictionary that
+    /// <see cref="IMachineRuntimeCapabilitiesCache.Store"/> expects, from the
+    /// canonical <see cref="MachineRuntimeCapabilities"/> shape we loaded out
+    /// of the DB. Keys MUST match those that
+    /// <c>TentacleHealthCheckStrategy</c> passes (the keys are the wire
+    /// contract between agent's CapabilitiesResponse and the cache).
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BuildMetadataDictionary(MachineRuntimeCapabilities capabilities)
+    {
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["os"] = capabilities.Os ?? string.Empty,
+            ["osVersion"] = capabilities.OsVersion ?? string.Empty,
+            ["defaultShell"] = capabilities.DefaultShell ?? string.Empty,
+            ["installedShells"] = capabilities.InstalledShells ?? string.Empty,
+            ["architecture"] = capabilities.Architecture ?? string.Empty
+        };
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
@@ -36,13 +36,15 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
 
     private readonly IHalibutClientFactory _halibutClientFactory;
     private readonly IMachineRuntimeCapabilitiesCache _capabilitiesCache;
+    private readonly IMachineRuntimeCapabilitiesPersistence _capabilitiesPersistence;
     private readonly IUpgradeDispatchLockReconciler _upgradeLockReconciler;
     private readonly IUpgradeEventTimelineStore _upgradeEventStore;
 
-    public TentacleHealthCheckStrategy(IHalibutClientFactory halibutClientFactory, IMachineRuntimeCapabilitiesCache capabilitiesCache = null, IUpgradeDispatchLockReconciler upgradeLockReconciler = null, IUpgradeEventTimelineStore upgradeEventStore = null)
+    public TentacleHealthCheckStrategy(IHalibutClientFactory halibutClientFactory, IMachineRuntimeCapabilitiesCache capabilitiesCache = null, IMachineRuntimeCapabilitiesPersistence capabilitiesPersistence = null, IUpgradeDispatchLockReconciler upgradeLockReconciler = null, IUpgradeEventTimelineStore upgradeEventStore = null)
     {
         _halibutClientFactory = halibutClientFactory;
         _capabilitiesCache = capabilitiesCache;
+        _capabilitiesPersistence = capabilitiesPersistence;
         _upgradeLockReconciler = upgradeLockReconciler;
         _upgradeEventStore = upgradeEventStore;
     }
@@ -73,6 +75,7 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
                 return new HealthCheckResult(false, "Tentacle returned null capabilities response");
 
             CacheCapabilitiesFor(machine, response);
+            await PersistCapabilitiesForAsync(machine, response, ct).ConfigureAwait(false);
 
             await ProcessUpgradeStatusAsync(machine, response, ct).ConfigureAwait(false);
 
@@ -98,6 +101,58 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
         // P0-E.3: also cache the SupportedServices list so the execution strategy
         // can pick the V1/V2 protocol without another capabilities RPC per script.
         _capabilitiesCache.Store(machine.Id, response.Metadata, response.AgentVersion, response.SupportedServices);
+    }
+
+    /// <summary>
+    /// H2 — write-through to the DB-backed persistence so the next server pod
+    /// restart hydrates the cache from this snapshot instead of starting cold.
+    /// Best-effort: a failed DB write logs a warning but does NOT fail the
+    /// health check (the in-memory cache is still updated and the next
+    /// successful health-check probe will retry the persistence write).
+    /// </summary>
+    private async Task PersistCapabilitiesForAsync(Machine machine, CapabilitiesResponse response, CancellationToken ct)
+    {
+        if (_capabilitiesPersistence == null || machine == null) return;
+
+        var capabilities = BuildCapabilitiesFromResponse(response);
+
+        try
+        {
+            await _capabilitiesPersistence.SaveAsync(machine.Id, capabilities, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Don't fail the health check on a DB hiccup — in-memory cache
+            // already has the fresh data so this run completes normally; the
+            // NEXT successful health check will retry the persistence write.
+            Log.Warning(ex,
+                "Failed to persist runtime capabilities for machine {MachineId} to DB. " +
+                "In-memory cache is up to date; next health check will retry the DB write.",
+                machine.Id);
+        }
+    }
+
+    /// <summary>
+    /// Project the agent's <see cref="CapabilitiesResponse"/> into the
+    /// canonical <see cref="MachineRuntimeCapabilities"/> shape the
+    /// persistence layer serialises. Keep this method in lockstep with
+    /// <see cref="InMemoryMachineRuntimeCapabilitiesCache.Store"/>'s field
+    /// reads — both consume the same agent-side <c>metadata</c> dictionary.
+    /// </summary>
+    private static MachineRuntimeCapabilities BuildCapabilitiesFromResponse(CapabilitiesResponse response)
+    {
+        return new MachineRuntimeCapabilities
+        {
+            Os = ReadMetadata(response, "os") ?? string.Empty,
+            OsVersion = ReadMetadata(response, "osVersion") ?? string.Empty,
+            DefaultShell = ReadMetadata(response, "defaultShell") ?? string.Empty,
+            InstalledShells = ReadMetadata(response, "installedShells") ?? string.Empty,
+            Architecture = ReadMetadata(response, "architecture") ?? string.Empty,
+            AgentVersion = response.AgentVersion ?? string.Empty,
+            // CapabilitiesResponse.SupportedServices is a List<string>; cast to
+            // IReadOnlyList<string> for the canonical capabilities shape.
+            SupportedServices = (IReadOnlyList<string>)response.SupportedServices ?? Array.Empty<string>()
+        };
     }
 
     /// <summary>

--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -90,15 +90,17 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
 
     private readonly IMachineDataProvider _machineDataProvider;
     private readonly IMachineRuntimeCapabilitiesCache _runtimeCache;
+    private readonly IMachineRuntimeCapabilitiesPersistence _runtimePersistence;
     private readonly ITentacleVersionRegistry _versionRegistry;
     private readonly IEnumerable<IMachineUpgradeStrategy> _strategies;
     private readonly IRedisSafeRunner _redisLock;
     private readonly ISquidBackgroundJobClient _backgroundJobClient;
 
-    public MachineUpgradeService(IMachineDataProvider machineDataProvider, IMachineRuntimeCapabilitiesCache runtimeCache, ITentacleVersionRegistry versionRegistry, IEnumerable<IMachineUpgradeStrategy> strategies, IRedisSafeRunner redisLock, ISquidBackgroundJobClient backgroundJobClient)
+    public MachineUpgradeService(IMachineDataProvider machineDataProvider, IMachineRuntimeCapabilitiesCache runtimeCache, ITentacleVersionRegistry versionRegistry, IEnumerable<IMachineUpgradeStrategy> strategies, IRedisSafeRunner redisLock, ISquidBackgroundJobClient backgroundJobClient, IMachineRuntimeCapabilitiesPersistence runtimePersistence = null)
     {
         _machineDataProvider = machineDataProvider;
         _runtimeCache = runtimeCache;
+        _runtimePersistence = runtimePersistence;
         _versionRegistry = versionRegistry;
         _strategies = strategies;
         _redisLock = redisLock;
@@ -557,6 +559,28 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         if (!outcome.AgentVersionMayHaveChanged) return;
 
         _runtimeCache.Invalidate(machineId);
+
+        // H2 — also NULL out the persisted snapshot so the next server pod
+        // restart doesn't hydrate the stale pre-upgrade version. Fire-and-forget
+        // with logging — if the DB write fails, the in-memory invalidation is
+        // already done and the next successful health check will overwrite the
+        // stale row with current data.
+        if (_runtimePersistence == null) return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _runtimePersistence.InvalidateAsync(machineId, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex,
+                    "Failed to invalidate persisted runtime capabilities for machine {MachineId} after upgrade. " +
+                    "In-memory cache is cleared; next health check will overwrite the stale DB row.",
+                    machineId);
+            }
+        });
     }
 
     /// <summary>

--- a/src/Squid.Core/SquidModule.cs
+++ b/src/Squid.Core/SquidModule.cs
@@ -160,6 +160,13 @@ public class SquidModule : Module
             .ToArray();
 
         builder.RegisterTypes(seederTypes).As<IDataSeeder>().SingleInstance();
+
+        // H2 — hydrate the runtime capability cache from the DB at startup so
+        // a freshly-deployed pod doesn't make every operator action hit the
+        // H1 NoOsDetected path until the next scheduled health check.
+        builder.RegisterType<Squid.Core.Services.DeploymentExecution.Tentacle.MachineRuntimeCapabilitiesCacheHydrator>()
+            .As<IStartable>()
+            .SingleInstance();
     }
 
     private void RegisterDependency(ContainerBuilder builder)

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/MachineRuntimeCapabilitiesPersistenceTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/MachineRuntimeCapabilitiesPersistenceTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+/// <summary>
+/// H2 — pin the persisted JSON shape so future refactors of
+/// <see cref="MachineRuntimeCapabilities"/> (adding properties, renaming) don't
+/// silently break the hydrate round-trip on operator's existing data. The DB
+/// rows persist across server upgrades; a schema change here without a
+/// migration would mean H2's hydrator can no longer parse rows written by an
+/// older server.
+/// </summary>
+public sealed class MachineRuntimeCapabilitiesPersistenceTests
+{
+    [Fact]
+    public void SerialisedJsonShape_Stable_AcrossKnownProperties()
+    {
+        // The exact JSON shape consumed by hydrator. If property names change
+        // (case, spelling), pre-existing rows from older servers will fail to
+        // deserialise → the H1 cold-cache UX returns until the next health
+        // check overwrites each row. Pin the shape.
+        var persisted = new MachineRuntimeCapabilitiesPersistence.PersistedCapabilities
+        {
+            Os = "Windows",
+            OsVersion = "10.0.19045.0",
+            DefaultShell = "powershell",
+            InstalledShells = "powershell,cmd",
+            Architecture = "X64",
+            AgentVersion = "1.7.9",
+            SupportedServices = new[] { "IScriptService/v1" }
+        };
+
+        var json = JsonSerializer.Serialize(persisted, MachineRuntimeCapabilitiesPersistence.SerializerOptions);
+
+        // CamelCase per the convention set in SerializerOptions.
+        json.ShouldContain("\"os\":\"Windows\"");
+        json.ShouldContain("\"osVersion\":\"10.0.19045.0\"");
+        json.ShouldContain("\"defaultShell\":\"powershell\"");
+        json.ShouldContain("\"installedShells\":\"powershell,cmd\"");
+        json.ShouldContain("\"architecture\":\"X64\"");
+        json.ShouldContain("\"agentVersion\":\"1.7.9\"");
+        json.ShouldContain("\"supportedServices\":[\"IScriptService/v1\"]");
+    }
+
+    [Fact]
+    public void Deserialise_FromCanonicalJsonShape_RoundTripsCorrectly()
+    {
+        // Inverse of the serialisation pin: an operator's existing row
+        // (written by 1.8.0 server) MUST deserialise correctly even after the
+        // SerializerOptions defaults change. Hard-coding the JSON literal here
+        // means a .NET 10 PascalCase regression or a JsonNamingPolicy refactor
+        // is a test-time-visible decision.
+        var json = """
+            {
+              "os": "Linux",
+              "osVersion": "6.5.0",
+              "defaultShell": "bash",
+              "installedShells": "bash,zsh",
+              "architecture": "Arm64",
+              "agentVersion": "1.8.0",
+              "supportedServices": ["IScriptService/v1", "IScriptService/v2"]
+            }
+            """;
+
+        var persisted = JsonSerializer.Deserialize<MachineRuntimeCapabilitiesPersistence.PersistedCapabilities>(
+            json, MachineRuntimeCapabilitiesPersistence.SerializerOptions);
+
+        persisted.ShouldNotBeNull();
+        persisted!.Os.ShouldBe("Linux");
+        persisted.OsVersion.ShouldBe("6.5.0");
+        persisted.DefaultShell.ShouldBe("bash");
+        persisted.InstalledShells.ShouldBe("bash,zsh");
+        persisted.Architecture.ShouldBe("Arm64");
+        persisted.AgentVersion.ShouldBe("1.8.0");
+        persisted.SupportedServices.ShouldBe(new[] { "IScriptService/v1", "IScriptService/v2" });
+    }
+
+    [Fact]
+    public void Deserialise_MissingOptionalFields_DoesNotThrow_ProducesNulls()
+    {
+        // Older rows (or partial fixtures) may not have every field. The DTO
+        // marks all properties nullable specifically for this — deserialising
+        // a row with only `os` must succeed, and the hydrator's coalesce-to-
+        // empty-string logic handles the rest.
+        var json = """{"os":"Windows","agentVersion":"1.6.5"}""";
+
+        var persisted = JsonSerializer.Deserialize<MachineRuntimeCapabilitiesPersistence.PersistedCapabilities>(
+            json, MachineRuntimeCapabilitiesPersistence.SerializerOptions);
+
+        persisted.ShouldNotBeNull();
+        persisted!.Os.ShouldBe("Windows");
+        persisted.AgentVersion.ShouldBe("1.6.5");
+        persisted.OsVersion.ShouldBeNull();
+        persisted.DefaultShell.ShouldBeNull();
+        persisted.SupportedServices.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SerializerOptions_NamingPolicy_PinnedToCamelCase()
+    {
+        // Drift detector: future PRs MUST NOT flip this to PascalCase or
+        // SnakeCase — every existing row in production would become un-readable
+        // for the hydrator. The choice is wire contract; pin it.
+        MachineRuntimeCapabilitiesPersistence.SerializerOptions.PropertyNamingPolicy
+            .ShouldBe(JsonNamingPolicy.CamelCase);
+    }
+
+    [Fact]
+    public void SerializerOptions_WriteIndented_PinnedToFalse()
+    {
+        // Tiny optimisation: jsonb storage is more efficient without leading
+        // whitespace, and the operator's diff tools handle it fine. Pin so a
+        // "make logs prettier" PR doesn't accidentally bloat DB rows.
+        MachineRuntimeCapabilitiesPersistence.SerializerOptions.WriteIndented.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

H2 of the **1.8.0 Upgrade Hardening initiative** (8 PRs total — H1 already merged in #354).

Fixes the operator-facing 1.7.x bug where every server pod restart wiped the in-memory `MachineRuntimeCapabilities` cache, causing operators to hit the H1 `NoOsDetected` path on first action until the next scheduled health check populated the cache.

## Behaviour changes

| Lifecycle event | Pre-H2 | Post-H2 |
|---|---|---|
| Successful Capabilities probe | Update in-memory cache | Update in-memory cache **+ persist to `machine.runtime_capabilities_json`** |
| Server pod restart | Cache empty until first health check per machine | **Hydrator (IStartable) reads all DB rows + populates cache at boot** |
| Successful upgrade | In-memory invalidate | In-memory invalidate **+ NULL out DB column** (next health check overwrites) |
| Pre-existing machine row (NULL column) | n/a | Treated as cold — falls to H1's `NoOsDetected` with health-check hint |
| DB write failure | n/a | Logged warning; in-memory cache still fresh; next probe retries |

## Schema migration

```sql
ALTER TABLE machine
    ADD COLUMN runtime_capabilities_json     jsonb       NULL,
    ADD COLUMN runtime_capabilities_updated_at timestamptz NULL;
CREATE INDEX ix_machine_runtime_capabilities_updated_at
    ON machine USING btree (runtime_capabilities_updated_at DESC)
    WHERE runtime_capabilities_updated_at IS NOT NULL;
```

`runtime_capabilities_updated_at` is unused in H2 — sets the foundation for a future TTL-invalidation step.

## JSON shape (wire contract — pinned by unit test)

```json
{
  "os": "Microsoft Windows NT 10.0.19045.0",
  "osVersion": "10.0.19045.0",
  "defaultShell": "powershell",
  "installedShells": "powershell,cmd",
  "architecture": "X64",
  "agentVersion": "1.8.0",
  "supportedServices": ["IScriptService/v1"]
}
```

camelCase per existing API convention. New optional fields can be appended; renaming/case-changing breaks the hydrate round-trip on operator's existing rows.

## Failure isolation

- **DB write fails on health check** → in-memory cache still fresh; warning logged; next successful probe retries
- **Hydrator fails at startup** → server starts with empty cache; H1 `NoOsDetected` path correctly directs operators to health check; doesn't block boot
- **One corrupt JSON row** → log + skip during hydration; remaining rows hydrate normally
- **`IMachineRuntimeCapabilitiesPersistence == null`** in constructor (test fixtures, etc.) → write-through is a no-op; in-memory cache works as before

## Test plan

- [x] Pin canonical JSON shape (5 unit tests in `MachineRuntimeCapabilitiesPersistenceTests`)
- [x] Round-trip → deserialise from canonical literal → property values match
- [x] Backward-compat: missing optional fields deserialise to null
- [x] `SerializerOptions.PropertyNamingPolicy = CamelCase` literal pin
- [x] `5545/5545` unit tests green (vs `5540/5540` baseline → `+5` net new)
- [ ] Integration test for full Postgres roundtrip — **deferred to H8** (avoid duplicating DB roundtrip coverage; H8's E2E matrix includes "server pod restart between dispatch + status poll" which exercises this end-to-end)

## What's NOT in this PR

- **H3**: Active health-check probe API (UI button currently passive)
- **H4**: Upgrade lock TTL + idempotency (cures the "repeated clicks compound" failure)
- **H5**: Cross-OS unified upgrade pipeline
- **H6**: Agent rollback + abandonment recovery
- **H7**: Role/feature capability slots
- **H8**: Comprehensive E2E test matrix (includes the integration coverage referenced above)