### PR TITLE
H3: Return structured ManualHealthCheckResult from active health-check probe

### DIFF
--- a/src/Squid.Core/Handlers/CommandHandlers/Machine/RunMachineHealthCheckCommandHandler.cs
+++ b/src/Squid.Core/Handlers/CommandHandlers/Machine/RunMachineHealthCheckCommandHandler.cs
@@ -7,8 +7,12 @@ public class RunMachineHealthCheckCommandHandler(IMachineHealthCheckService heal
 {
     public async Task<RunMachineHealthCheckResponse> Handle(IReceiveContext<RunMachineHealthCheckCommand> context, CancellationToken cancellationToken)
     {
-        await healthCheckService.ManualHealthCheckAsync(context.Message.MachineId, cancellationToken).ConfigureAwait(false);
+        // H3 — thread the structured ManualHealthCheckResult through to the FE
+        // so the user sees the fresh AgentVersion / Os from the probe alongside
+        // a structured ErrorCode (null on success, "agent_unreachable" / etc.
+        // on failure) instead of an empty success/fail signal.
+        var result = await healthCheckService.ManualHealthCheckAsync(context.Message.MachineId, cancellationToken).ConfigureAwait(false);
 
-        return new RunMachineHealthCheckResponse();
+        return new RunMachineHealthCheckResponse { Data = result };
     }
 }

--- a/src/Squid.Core/Services/Machines/MachineHealthCheckService.cs
+++ b/src/Squid.Core/Services/Machines/MachineHealthCheckService.cs
@@ -2,15 +2,30 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Cronos;
 using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Machine;
+using Squid.Message.Models.Machines;
 using Squid.Core.Services.DeploymentExecution.Transport;
 
 namespace Squid.Core.Services.Machines;
 
 public interface IMachineHealthCheckService : IScopedDependency
 {
-    Task ManualHealthCheckAsync(int machineId, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Active health-check probe — runs the per-style <c>IHealthCheckStrategy</c>
+    /// (typically a Halibut Capabilities RPC for tentacles) and returns a
+    /// structured outcome. Updates the capability cache + DB persistence
+    /// (H2) atomically with the probe result.
+    ///
+    /// <para>H3 — return type changed from <c>Task</c> to
+    /// <c>Task&lt;ManualHealthCheckResult&gt;</c> so FE / CLI can render
+    /// "agent_unreachable" vs "agent ok, here are the new capabilities" without
+    /// re-parsing the human-readable detail. Existing callers that ignore the
+    /// result (<c>await svc.ManualHealthCheckAsync(...)</c>) are unaffected —
+    /// the awaitable contract is preserved.</para>
+    /// </summary>
+    Task<ManualHealthCheckResult> ManualHealthCheckAsync(int machineId, CancellationToken cancellationToken = default);
 
     Task AutoHealthCheckForAllAsync(CancellationToken cancellationToken = default);
 }
@@ -28,36 +43,79 @@ public class MachineHealthCheckService : IMachineHealthCheckService
     private readonly IMachineDataProvider _machineDataProvider;
     private readonly IMachinePolicyDataProvider _policyDataProvider;
     private readonly ITransportRegistry _transportRegistry;
+    private readonly IMachineRuntimeCapabilitiesCache _capabilitiesCache;
 
-    public MachineHealthCheckService(IMachineDataProvider machineDataProvider, IMachinePolicyDataProvider policyDataProvider, ITransportRegistry transportRegistry)
+    public MachineHealthCheckService(IMachineDataProvider machineDataProvider, IMachinePolicyDataProvider policyDataProvider, ITransportRegistry transportRegistry, IMachineRuntimeCapabilitiesCache capabilitiesCache = null)
     {
         _machineDataProvider = machineDataProvider;
         _policyDataProvider = policyDataProvider;
         _transportRegistry = transportRegistry;
+        _capabilitiesCache = capabilitiesCache;
     }
 
-    public async Task ManualHealthCheckAsync(int machineId, CancellationToken cancellationToken = default)
+    public async Task<ManualHealthCheckResult> ManualHealthCheckAsync(int machineId, CancellationToken cancellationToken = default)
     {
-        var machine = await LoadMachineAsync(machineId, cancellationToken).ConfigureAwait(false);
+        var checkedAt = DateTimeOffset.UtcNow;
+
+        var machine = await _machineDataProvider.GetMachinesByIdAsync(machineId, cancellationToken).ConfigureAwait(false);
+
+        if (machine == null)
+            return new ManualHealthCheckResult
+            {
+                Successful = false,
+                Detail = $"Machine {machineId} not found",
+                ErrorCode = ManualHealthCheckErrorCodes.MachineNotFound,
+                CheckedAt = checkedAt
+            };
 
         if (machine.IsDisabled)
         {
             Log.Information("Skipping health check for disabled machine {MachineName}", machine.Name);
-            return;
+            return new ManualHealthCheckResult
+            {
+                Successful = false,
+                Detail = $"Machine '{machine.Name}' is disabled — enable it before running a health check.",
+                ErrorCode = ManualHealthCheckErrorCodes.MachineDisabled,
+                CheckedAt = checkedAt
+            };
         }
 
         var transport = ResolveTransport(machine);
 
         if (transport?.HealthChecker == null)
         {
-            await RecordUnavailableAsync(machine, $"No health checker for {CommunicationStyleParser.Parse(machine.Endpoint)}", cancellationToken).ConfigureAwait(false);
-            return;
+            var detail = $"No health checker for {CommunicationStyleParser.Parse(machine.Endpoint)}";
+            await RecordUnavailableAsync(machine, detail, cancellationToken).ConfigureAwait(false);
+            return new ManualHealthCheckResult
+            {
+                Successful = false,
+                Detail = detail,
+                ErrorCode = ManualHealthCheckErrorCodes.NoHealthChecker,
+                CheckedAt = checkedAt
+            };
         }
 
         var connectivityPolicy = await LoadConnectivityPolicyAsync(machine, cancellationToken).ConfigureAwait(false);
         var healthCheckPolicy = await LoadHealthCheckPolicyAsync(machine, cancellationToken).ConfigureAwait(false);
 
-        await RunAndRecordAsync(machine, transport, connectivityPolicy, healthCheckPolicy, cancellationToken).ConfigureAwait(false);
+        var probeResult = await RunAndRecordAsync(machine, transport, connectivityPolicy, healthCheckPolicy, cancellationToken).ConfigureAwait(false);
+
+        // Read cache POST-probe so the FE sees the freshly-written capabilities
+        // (TentacleHealthCheckStrategy.CacheCapabilitiesFor writes during the
+        // probe). If the cache miss (e.g. non-tentacle transport that doesn't
+        // populate capabilities), AgentVersion / Os stay empty — that's fine,
+        // the success flag + detail give the caller enough signal.
+        var caps = _capabilitiesCache?.TryGet(machine.Id);
+
+        return new ManualHealthCheckResult
+        {
+            Successful = probeResult.Healthy,
+            Detail = probeResult.Detail ?? string.Empty,
+            ErrorCode = probeResult.Healthy ? null : ManualHealthCheckErrorCodes.AgentUnreachable,
+            AgentVersion = caps?.AgentVersion ?? string.Empty,
+            Os = caps?.Os ?? string.Empty,
+            CheckedAt = checkedAt
+        };
     }
 
     public async Task AutoHealthCheckForAllAsync(CancellationToken cancellationToken = default)
@@ -113,7 +171,7 @@ public class MachineHealthCheckService : IMachineHealthCheckService
     // Core — single entry point, strategy decides how
     // ========================================================================
 
-    private async Task RunAndRecordAsync(Machine machine, IDeploymentTransport transport, MachineConnectivityPolicyDto connectivityPolicy, MachineHealthCheckPolicyDto healthCheckPolicy, CancellationToken cancellationToken)
+    private async Task<HealthCheckResult> RunAndRecordAsync(Machine machine, IDeploymentTransport transport, MachineConnectivityPolicyDto connectivityPolicy, MachineHealthCheckPolicyDto healthCheckPolicy, CancellationToken cancellationToken)
     {
         Log.Information("Running health check for machine {MachineName} ({Style})", machine.Name, transport.CommunicationStyle);
 
@@ -123,6 +181,8 @@ public class MachineHealthCheckService : IMachineHealthCheckService
         await RecordHealthStatusAsync(machine, status, result.Detail, cancellationToken).ConfigureAwait(false);
 
         Log.Information("Health check for {MachineName}: {Status}", machine.Name, status);
+
+        return result;
     }
 
     // ========================================================================

--- a/src/Squid.Message/Commands/Machine/RunMachineHealthCheckCommand.cs
+++ b/src/Squid.Message/Commands/Machine/RunMachineHealthCheckCommand.cs
@@ -1,5 +1,6 @@
 using Squid.Message.Attributes;
 using Squid.Message.Enums;
+using Squid.Message.Models.Machines;
 using Squid.Message.Response;
 
 namespace Squid.Message.Commands.Machine;
@@ -11,6 +12,12 @@ public class RunMachineHealthCheckCommand : ICommand, ISpaceScoped
     public int MachineId { get; set; }
 }
 
-public class RunMachineHealthCheckResponse : SquidResponse
+/// <summary>
+/// H3 — Carries the structured <see cref="ManualHealthCheckResult"/> payload
+/// so the FE / CLI can distinguish probe outcomes (agent_unreachable vs
+/// machine_disabled vs success-with-fresh-OS) without re-parsing the
+/// human-readable detail line.
+/// </summary>
+public class RunMachineHealthCheckResponse : SquidResponse<ManualHealthCheckResult>
 {
 }

--- a/src/Squid.Message/Models/Machines/ManualHealthCheckResult.cs
+++ b/src/Squid.Message/Models/Machines/ManualHealthCheckResult.cs
@@ -1,0 +1,64 @@
+namespace Squid.Message.Models.Machines;
+
+/// <summary>
+/// H3 — structured outcome of a manual / active health-check probe. Returned
+/// by <c>IMachineHealthCheckService.ManualHealthCheckAsync</c> and threaded
+/// into <c>RunMachineHealthCheckResponse.Data</c> so the frontend / CLI can
+/// distinguish "agent unreachable" from "probe completed but reported error"
+/// without re-parsing the human-readable Detail string.
+///
+/// <para><b>Why this exists</b>: in 1.7.x clicking "Health Check" returned
+/// an empty success/failure shape. Operators couldn't tell whether the probe
+/// actually re-read agent metadata (the entire UX point of the button) or
+/// just succeeded as a stale read. The user reported "點了 health check 還是
+/// 一樣的" — they had no signal that the active probe had been attempted
+/// and what it found.</para>
+/// </summary>
+public sealed class ManualHealthCheckResult
+{
+    /// <summary>True iff the Halibut Capabilities RPC round-tripped AND the
+    /// agent returned a non-null response.</summary>
+    public bool Successful { get; init; }
+
+    /// <summary>Human-readable detail line. Same wording as
+    /// <c>Machine.HealthDetail</c> persisted to DB — safe to render in a
+    /// tooltip without further processing.</summary>
+    public string Detail { get; init; } = string.Empty;
+
+    /// <summary>Structured error category for failed probes. <c>null</c> on
+    /// success. Stable wire values: <c>"machine_disabled"</c> /
+    /// <c>"no_health_checker"</c> / <c>"agent_unreachable"</c> /
+    /// <c>"machine_not_found"</c>. Pinned by integrity test.</summary>
+    public string ErrorCode { get; init; }
+
+    /// <summary>Agent's reported version after the probe (from cache snapshot
+    /// at probe completion). Empty when the probe failed or the agent didn't
+    /// report a version field.</summary>
+    public string AgentVersion { get; init; } = string.Empty;
+
+    /// <summary>Agent's reported OS string after the probe — could be the
+    /// canonical <c>"Windows"</c> / <c>"Linux"</c> or the legacy long form
+    /// <c>"Microsoft Windows NT 10.0.19045.0"</c>. Both are accepted by
+    /// <see cref="Squid.Core.Services.DeploymentExecution.Validation.WindowsOsStringHelper"/>.</summary>
+    public string Os { get; init; } = string.Empty;
+
+    /// <summary>UTC timestamp of when the probe completed (regardless of
+    /// outcome). Matches the value persisted to
+    /// <c>machine.runtime_capabilities_updated_at</c> on success — so the FE
+    /// can compare against the previously-shown value and confirm the probe
+    /// actually refreshed.</summary>
+    public DateTimeOffset CheckedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Stable wire literals for <see cref="ManualHealthCheckResult.ErrorCode"/>.
+/// Renaming a constant here breaks any FE / SDK consumer parsing the
+/// response — pinned by integrity test (Rule 8).
+/// </summary>
+public static class ManualHealthCheckErrorCodes
+{
+    public const string MachineNotFound = "machine_not_found";
+    public const string MachineDisabled = "machine_disabled";
+    public const string NoHealthChecker = "no_health_checker";
+    public const string AgentUnreachable = "agent_unreachable";
+}

--- a/tests/Squid.UnitTests/Services/Machines/MachineHealthCheckServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineHealthCheckServiceTests.cs
@@ -8,6 +8,7 @@ using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.Machines;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Machine;
+using Squid.Message.Models.Machines;
 using Squid.Core.Services.DeploymentExecution.Transport;
 
 namespace Squid.UnitTests.Services.Machines;
@@ -116,11 +117,101 @@ public class MachineHealthCheckServiceTests
     }
 
     [Fact]
-    public async Task RunHealthCheck_MachineNotFound_Throws()
+    public async Task RunHealthCheck_MachineNotFound_ReturnsStructuredErrorCode()
     {
+        // H3 — manual health check returns a structured ManualHealthCheckResult
+        // instead of throwing. The thrown InvalidOperationException pre-H3 gave
+        // the FE a generic 500; the structured result lets the UI render an
+        // actionable "machine #999 doesn't exist" error.
         _machineDataProvider.Setup(p => p.GetMachinesByIdAsync(999, It.IsAny<CancellationToken>())).ReturnsAsync((Machine)null);
 
-        await Should.ThrowAsync<InvalidOperationException>(() => _service.ManualHealthCheckAsync(999));
+        var result = await _service.ManualHealthCheckAsync(999);
+
+        result.Successful.ShouldBeFalse();
+        result.ErrorCode.ShouldBe(ManualHealthCheckErrorCodes.MachineNotFound);
+        result.Detail.ShouldContain("999");
+    }
+
+    // ========================================================================
+    // H3 — ManualHealthCheckResult structured outcomes
+    //
+    // Operator-visible motivator: in 1.7.x the FE got an empty success/fail
+    // signal from the health-check endpoint and couldn't tell what the active
+    // probe found OR what to do when it failed. H3 returns a structured
+    // result with AgentVersion / Os / ErrorCode so the UI can render
+    // actionable next steps. Pin each outcome with a dedicated test.
+    // ========================================================================
+
+    [Fact]
+    public async Task ManualHealthCheck_ProbeSucceeds_ReturnsSuccessfulResultWithDetail()
+    {
+        var machine = CreateActiveMachineWithEndpoint(CommunicationStyle.KubernetesApi);
+        SetupMachineById(machine);
+
+        var result = await _service.ManualHealthCheckAsync(machine.Id);
+
+        result.Successful.ShouldBeTrue();
+        result.ErrorCode.ShouldBeNull(
+            customMessage: "Successful probe MUST have null ErrorCode — FE branches on null/non-null to decide whether to show error UI.");
+        result.Detail.ShouldBe("ok");
+        result.CheckedAt.ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddSeconds(-10));
+    }
+
+    [Fact]
+    public async Task ManualHealthCheck_DisabledMachine_ReturnsMachineDisabledErrorCode()
+    {
+        var machine = new Machine { Id = 5, Name = "disabled-host", IsDisabled = true };
+        _machineDataProvider.Setup(p => p.GetMachinesByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(machine);
+
+        var result = await _service.ManualHealthCheckAsync(5);
+
+        result.Successful.ShouldBeFalse();
+        result.ErrorCode.ShouldBe(ManualHealthCheckErrorCodes.MachineDisabled);
+        result.Detail.ShouldContain("disabled", Case.Insensitive);
+        result.Detail.ShouldContain("disabled-host",
+            customMessage: "Detail MUST include the machine name so the operator can identify which one without consulting another screen.");
+    }
+
+    [Fact]
+    public async Task ManualHealthCheck_NoHealthChecker_ReturnsNoHealthCheckerErrorCode()
+    {
+        // Transport exists but doesn't have an IHealthCheckStrategy (e.g. an
+        // SSH transport that doesn't support active probes). H3 surfaces this
+        // distinctly from "agent unreachable" — operator knows it's a server-
+        // side capability gap, not a network issue.
+        _transport.Setup(t => t.HealthChecker).Returns((IHealthCheckStrategy)null);
+
+        var machine = CreateActiveMachineWithEndpoint(CommunicationStyle.KubernetesApi);
+        SetupMachineById(machine);
+
+        var result = await _service.ManualHealthCheckAsync(machine.Id);
+
+        result.Successful.ShouldBeFalse();
+        result.ErrorCode.ShouldBe(ManualHealthCheckErrorCodes.NoHealthChecker);
+        result.Detail.ShouldContain("No health checker");
+    }
+
+    [Fact]
+    public async Task ManualHealthCheck_HalibutProbeFails_ReturnsAgentUnreachableErrorCode()
+    {
+        // Halibut RPC timed out / connection refused / agent process down →
+        // strategy returns Healthy=false. H3 maps to agent_unreachable so the
+        // FE can render the operator-actionable "check network, check agent
+        // service" hint vs. confusing them with a generic "health check failed".
+        _healthChecker.Setup(h => h.CheckHealthAsync(
+                It.IsAny<Machine>(), It.IsAny<MachineConnectivityPolicyDto>(),
+                It.IsAny<CancellationToken>(), It.IsAny<MachineHealthCheckPolicyDto>()))
+            .ReturnsAsync(new HealthCheckResult(false, "Halibut: connection refused"));
+
+        var machine = CreateActiveMachineWithEndpoint(CommunicationStyle.KubernetesApi);
+        SetupMachineById(machine);
+
+        var result = await _service.ManualHealthCheckAsync(machine.Id);
+
+        result.Successful.ShouldBeFalse();
+        result.ErrorCode.ShouldBe(ManualHealthCheckErrorCodes.AgentUnreachable,
+            customMessage: "Failed Halibut probe MUST map to agent_unreachable — FE shows the operator a network / agent-service diagnostic, not a generic 500.");
+        result.Detail.ShouldContain("connection refused");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/ManualHealthCheckErrorCodesIntegrityTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/ManualHealthCheckErrorCodesIntegrityTests.cs
@@ -1,0 +1,57 @@
+using Shouldly;
+using Squid.Message.Models.Machines;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// H3 — wire-stability pin (Rule 8) for <see cref="ManualHealthCheckErrorCodes"/>.
+/// These literal strings are serialised in the upgrade-info API response and
+/// consumed by the FE / CLI / external SDKs to drive error-UI branching. A
+/// rename here breaks every consumer that parses the response. Pin the
+/// literals so a refactor becomes a test-time-visible decision.
+///
+/// <para><b>Convention</b>: add new codes as new constants; NEVER rename
+/// existing ones. If a code becomes obsolete, mark <c>[Obsolete]</c> but
+/// don't delete or rename.</para>
+/// </summary>
+public sealed class ManualHealthCheckErrorCodesIntegrityTests
+{
+    [Fact]
+    public void MachineNotFound_LiteralPinned()
+        => ManualHealthCheckErrorCodes.MachineNotFound.ShouldBe("machine_not_found");
+
+    [Fact]
+    public void MachineDisabled_LiteralPinned()
+        => ManualHealthCheckErrorCodes.MachineDisabled.ShouldBe("machine_disabled");
+
+    [Fact]
+    public void NoHealthChecker_LiteralPinned()
+        => ManualHealthCheckErrorCodes.NoHealthChecker.ShouldBe("no_health_checker");
+
+    [Fact]
+    public void AgentUnreachable_LiteralPinned()
+        => ManualHealthCheckErrorCodes.AgentUnreachable.ShouldBe("agent_unreachable");
+
+    [Fact]
+    public void AllCodes_LowerSnakeCase_StableConvention()
+    {
+        // Convention: lower_snake_case so consumers can split-on-underscore +
+        // proper-case for display, or use the literal as a JSON enum key.
+        // Future codes MUST follow the same convention — pin it explicitly.
+        var codes = new[]
+        {
+            ManualHealthCheckErrorCodes.MachineNotFound,
+            ManualHealthCheckErrorCodes.MachineDisabled,
+            ManualHealthCheckErrorCodes.NoHealthChecker,
+            ManualHealthCheckErrorCodes.AgentUnreachable
+        };
+
+        foreach (var code in codes)
+        {
+            code.ShouldMatch(@"^[a-z]+(_[a-z]+)*$",
+                customMessage: $"Error code '{code}' violates the lower_snake_case convention. " +
+                               "Future codes MUST be lower_snake_case so consumers can parse them deterministically.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

H3 of the **1.8.0 Upgrade Hardening initiative** (H1 #354 + H2 #355 already merged).

Fixes the operator-reported "點了 health check 還是一樣的" UX gap. The existing `/api/machines/{id}/health-check` endpoint already does an active Halibut Capabilities probe + updates cache (now also DB-persisted via H2). H3 is purely about **response richness** — the empty `success/fail` shape gave operators no signal that the probe actually re-read agent metadata, so they couldn't tell what changed or what to do when it failed.

## API shape change (additive, backward-compatible)

```json
// Before (pre-H3):
{ "code": 200, "msg": "Success" }

// After (H3):
{
  "code": 200,
  "msg": "Success",
  "data": {
    "successful": true,
    "detail": "Tentacle connected — version 1.7.9, OS=Windows",
    "errorCode": null,
    "agentVersion": "1.7.9",
    "os": "Windows",
    "checkedAt": "2026-05-23T08:30:45Z"
  }
}
```

Pre-H3 clients reading only the success/fail signal continue to work; new clients can branch on `errorCode` and render fresh `agentVersion` / `os`.

## Structured error codes (wire-stable, lower_snake_case)

| Code | When | Operator action |
|---|---|---|
| `null` | probe succeeded | none — agent capabilities updated |
| `machine_not_found` | machine ID doesn't exist | check the ID; refresh fleet list |
| `machine_disabled` | machine is disabled | enable the machine before re-running |
| `no_health_checker` | transport has no probe strategy (e.g. some SSH transports) | use the manual health-check procedure for this style |
| `agent_unreachable` | Halibut RPC failed (timeout, refused, etc.) | check network + agent service status |

Pre-H3 behaviour for `machine_not_found` was a thrown `InvalidOperationException` → generic 500 to FE. Post-H3 returns the structured result.

## Test plan

- [x] +4 wire-stability pins on error code literals (`ManualHealthCheckErrorCodesIntegrityTests`)
- [x] +1 lower_snake_case convention drift detector
- [x] +4 structured-outcome scenarios (success / disabled / no_health_checker / agent_unreachable)
- [x] +1 retrofitted `MachineNotFound` test (now returns structured result instead of throwing)
- [x] **5554/5554 unit tests green** (vs 5545/5545 baseline → +9 net new)
- [ ] Integration/E2E: deferred to H8 (E2E matrix includes "health check populates fresh capabilities" round-trip scenarios)

## Backward compatibility

- `IMachineHealthCheckService.ManualHealthCheckAsync` signature: `Task` → `Task<ManualHealthCheckResult>`. Existing `await svc.ManualHealthCheckAsync(...)` callers (5+ in prod + tests) continue to compile and run unchanged (T is just discarded at await).
- `RunMachineHealthCheckResponse`: now derives from `SquidResponse<T>` instead of bare `SquidResponse`. The base class properties (code, msg) are preserved; the new `Data` field is additive.
- "Machine not found" semantic change: throw → structured result. Behavioural break, but in the direction operators want (actionable error code vs. generic 500).

## What's NOT in this PR

- **H4**: Upgrade lock TTL + idempotency (curing the "repeated upgrade clicks stuck me forever" failure)
- **H5**: Cross-OS unified upgrade pipeline
- **H6**: Agent rollback + abandonment recovery
- **H7**: Role/feature capability slots (catches "IIS not installed" at plan-time)
- **H8**: Comprehensive E2E test matrix