### PR TITLE
H4: Enrich upgrade-lock contention message with dispatch metadata

### DIFF
--- a/src/Squid.Core/Services/Machines/Upgrade/IUpgradeDispatchMetadataStore.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/IUpgradeDispatchMetadataStore.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using Squid.Core.Services.Caching.Redis;
+
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// H4 — companion store for the Redis upgrade-dispatch lock. Holds a small
+/// JSON metadata blob (when the dispatch started, what version was targeted)
+/// at <c>squid:upgrade:machine:{id}:meta</c>, written when the lock is
+/// acquired and deleted when it's released.
+///
+/// <para><b>Why this exists</b>: pre-H4, when an operator double-clicked
+/// "Upgrade", the second click hit the lock-contention path and got
+/// <c>"Machine 'X' is currently being upgraded by another request. Wait for
+/// it to complete (typically under 2 minutes) and retry."</c>. The "typically
+/// under 2 minutes" was a hardcoded guess — the operator had no idea when
+/// the original dispatch actually started or what version it was targeting.
+/// H4 attaches metadata so the contention message can say <c>"In progress
+/// since 12:34:56 (started ~45s ago), targeting 1.8.0. Expected completion
+/// within 7 minutes from start."</c>.</para>
+///
+/// <para><b>Lifecycle</b>: same TTL as the RedLockNet lock so the metadata
+/// is automatically cleaned up if the dispatcher crashes — no separate
+/// expiry tracking needed. Best-effort writes: a failed metadata write logs
+/// + does NOT fail the dispatch (the lock is still held and the upgrade
+/// proceeds; the contention UX just falls back to the old hardcoded
+/// message).</para>
+/// </summary>
+public interface IUpgradeDispatchMetadataStore : IScopedDependency
+{
+    /// <summary>Write metadata for the given machine's in-flight dispatch.
+    /// TTL matches the lock's expiry — best-effort: errors are logged but
+    /// do not propagate (the dispatch should not fail because of a
+    /// metadata-write hiccup).</summary>
+    Task WriteAsync(int machineId, UpgradeDispatchMetadata metadata, TimeSpan ttl, CancellationToken ct);
+
+    /// <summary>Read the metadata for a machine if a dispatch is in flight.
+    /// Returns <c>null</c> when nothing is recorded (or on Redis error).</summary>
+    Task<UpgradeDispatchMetadata> ReadAsync(int machineId, CancellationToken ct);
+
+    /// <summary>Best-effort delete on successful dispatch release. If the
+    /// delete fails, the TTL catches it.</summary>
+    Task DeleteAsync(int machineId, CancellationToken ct);
+}
+
+/// <summary>
+/// Wire-stable JSON shape — pin by unit test. Property names are
+/// camelCase to match the rest of the upgrade API. New fields stay
+/// nullable to preserve backward-compat with older blobs.
+/// </summary>
+public sealed class UpgradeDispatchMetadata
+{
+    public DateTimeOffset DispatchedAt { get; init; }
+    public string TargetVersion { get; init; }
+    public string CurrentVersion { get; init; }
+}
+
+public sealed class UpgradeDispatchMetadataStore : IUpgradeDispatchMetadataStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly IRedisSafeRunner _redis;
+
+    public UpgradeDispatchMetadataStore(IRedisSafeRunner redis)
+    {
+        _redis = redis;
+    }
+
+    /// <summary>Companion key — co-located with the lock at
+    /// <c>squid:upgrade:machine:{id}</c>. Suffix keeps them grouped under the
+    /// same key-space prefix for easier ops queries
+    /// (<c>SCAN squid:upgrade:machine:*</c>).</summary>
+    internal static string BuildMetadataKey(int machineId)
+        => $"{UpgradeDispatchLockReconciler.BuildLockKey(machineId)}:meta";
+
+    public async Task WriteAsync(int machineId, UpgradeDispatchMetadata metadata, TimeSpan ttl, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var key = BuildMetadataKey(machineId);
+        var json = JsonSerializer.Serialize(metadata, SerializerOptions);
+
+        await _redis.ExecuteAsync(async multiplexer =>
+        {
+            await multiplexer.GetDatabase()
+                .StringSetAsync(key, json, expiry: ttl)
+                .ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+
+    public async Task<UpgradeDispatchMetadata> ReadAsync(int machineId, CancellationToken ct)
+    {
+        var key = BuildMetadataKey(machineId);
+
+        var json = await _redis.ExecuteAsync<string>(async multiplexer =>
+        {
+            var value = await multiplexer.GetDatabase().StringGetAsync(key).ConfigureAwait(false);
+            return value.HasValue ? value.ToString() : null;
+        }).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<UpgradeDispatchMetadata>(json, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            // Corrupted JSON shouldn't crash the contention path. Log + return
+            // null so the caller falls back to the old hardcoded message.
+            Log.Warning(ex,
+                "Failed to deserialise upgrade dispatch metadata for machine {MachineId} (key {Key}). " +
+                "Contention message falls back to the generic 'in progress' shape.",
+                machineId, key);
+            return null;
+        }
+    }
+
+    public async Task DeleteAsync(int machineId, CancellationToken ct)
+    {
+        var key = BuildMetadataKey(machineId);
+
+        await _redis.ExecuteAsync(async multiplexer =>
+        {
+            await multiplexer.GetDatabase().KeyDeleteAsync(key).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+}

--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -95,8 +95,9 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
     private readonly IEnumerable<IMachineUpgradeStrategy> _strategies;
     private readonly IRedisSafeRunner _redisLock;
     private readonly ISquidBackgroundJobClient _backgroundJobClient;
+    private readonly IUpgradeDispatchMetadataStore _dispatchMetadata;
 
-    public MachineUpgradeService(IMachineDataProvider machineDataProvider, IMachineRuntimeCapabilitiesCache runtimeCache, ITentacleVersionRegistry versionRegistry, IEnumerable<IMachineUpgradeStrategy> strategies, IRedisSafeRunner redisLock, ISquidBackgroundJobClient backgroundJobClient, IMachineRuntimeCapabilitiesPersistence runtimePersistence = null)
+    public MachineUpgradeService(IMachineDataProvider machineDataProvider, IMachineRuntimeCapabilitiesCache runtimeCache, ITentacleVersionRegistry versionRegistry, IEnumerable<IMachineUpgradeStrategy> strategies, IRedisSafeRunner redisLock, ISquidBackgroundJobClient backgroundJobClient, IMachineRuntimeCapabilitiesPersistence runtimePersistence = null, IUpgradeDispatchMetadataStore dispatchMetadata = null)
     {
         _machineDataProvider = machineDataProvider;
         _runtimeCache = runtimeCache;
@@ -105,6 +106,7 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         _strategies = strategies;
         _redisLock = redisLock;
         _backgroundJobClient = backgroundJobClient;
+        _dispatchMetadata = dispatchMetadata;
     }
 
     public async Task<UpgradeMachineResponseData> UpgradeAsync(UpgradeMachineCommand command, CancellationToken ct)
@@ -487,7 +489,7 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         {
             result = await _redisLock.ExecuteWithLockAsync<UpgradeMachineResponseData>(
                 lockKey,
-                () => RunStrategyAsync(machine, strategy, targetVersion, currentVersion, ct),
+                () => RunStrategyWithMetadataAsync(machine, strategy, targetVersion, currentVersion, ct),
                 expiry: LockExpiry, wait: LockWait, retry: LockRetry).ConfigureAwait(false);
         }
         catch (LockAcquireFailedException ex)
@@ -505,9 +507,115 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
                 "infrastructure recovers, or contact your operator if it persists.");
         }
 
-        return result ?? BuildResponse(machine, currentVersion, targetVersion, MachineUpgradeStatus.Failed,
-            $"Machine '{machine.Name}' is currently being upgraded by another request. " +
-            "Wait for it to complete (typically under 2 minutes) and retry.");
+        if (result != null) return result;
+
+        // H4 — contention path. Pre-H4 we returned a hardcoded "wait 2 min and
+        // retry" message; operator had no idea WHEN the original dispatch
+        // started or what version was targeted (and "2 min" was wrong — the
+        // worst-case wait is LockExpiry = 7 min). Now we read the companion
+        // metadata key and tell the operator exactly when the in-flight
+        // dispatch began + when to expect completion.
+        return BuildResponse(machine, currentVersion, targetVersion, MachineUpgradeStatus.Failed,
+            await BuildContentionMessageAsync(machine, ct).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// H4 — wrap <see cref="RunStrategyAsync"/> with metadata write-before /
+    /// delete-after-success. The metadata key lives at
+    /// <c>{lockKey}:meta</c> and shares the lock's TTL, so a crashed
+    /// dispatcher's metadata is auto-cleaned by Redis (no leak). On lock
+    /// release path the explicit DeleteAsync is best-effort — if it fails
+    /// the TTL catches it.
+    /// </summary>
+    private async Task<UpgradeMachineResponseData> RunStrategyWithMetadataAsync(Persistence.Entities.Deployments.Machine machine, IMachineUpgradeStrategy strategy, string targetVersion, string currentVersion, CancellationToken ct)
+    {
+        if (_dispatchMetadata != null)
+        {
+            try
+            {
+                await _dispatchMetadata.WriteAsync(machine.Id, new UpgradeDispatchMetadata
+                {
+                    DispatchedAt = DateTimeOffset.UtcNow,
+                    TargetVersion = targetVersion,
+                    CurrentVersion = currentVersion ?? string.Empty
+                }, LockExpiry, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Metadata is best-effort — log + continue. The lock is still
+                // held and the upgrade proceeds; the contention UX just falls
+                // back to the old generic message.
+                Log.Warning(ex,
+                    "Failed to write upgrade dispatch metadata for machine {MachineId}. " +
+                    "Upgrade proceeds; contention UX falls back to generic message.",
+                    machine.Id);
+            }
+        }
+
+        try
+        {
+            return await RunStrategyAsync(machine, strategy, targetVersion, currentVersion, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_dispatchMetadata != null)
+            {
+                try
+                {
+                    await _dispatchMetadata.DeleteAsync(machine.Id, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Best-effort delete; TTL catches stragglers.
+                    Log.Debug(ex,
+                        "Failed to delete upgrade dispatch metadata for machine {MachineId} after dispatch release. " +
+                        "Redis TTL will clean it up within {Ttl}.",
+                        machine.Id, LockExpiry);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// H4 — build the contention error message. If H4's metadata store has a
+    /// record of when the in-flight dispatch started, embed it so the operator
+    /// can wait an INFORMED amount of time. Falls back to the pre-H4 generic
+    /// message when metadata is unavailable (Redis hiccup, race, etc.).
+    /// </summary>
+    private async Task<string> BuildContentionMessageAsync(Persistence.Entities.Deployments.Machine machine, CancellationToken ct)
+    {
+        if (_dispatchMetadata == null)
+            return $"Machine '{machine.Name}' is currently being upgraded by another request. " +
+                   "Wait for it to complete (typically under 2 minutes) and retry.";
+
+        UpgradeDispatchMetadata metadata;
+        try
+        {
+            metadata = await _dispatchMetadata.ReadAsync(machine.Id, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex,
+                "Failed to read upgrade dispatch metadata for machine {MachineId}. " +
+                "Contention message falls back to generic shape.",
+                machine.Id);
+            metadata = null;
+        }
+
+        if (metadata == null)
+            return $"Machine '{machine.Name}' is currently being upgraded by another request. " +
+                   $"Wait for it to complete (at most {LockExpiry.TotalMinutes:F0} minutes from start) and retry.";
+
+        var elapsed = DateTimeOffset.UtcNow - metadata.DispatchedAt;
+        var deadline = metadata.DispatchedAt + LockExpiry;
+        var remaining = deadline - DateTimeOffset.UtcNow;
+
+        return $"Machine '{machine.Name}' is currently being upgraded by another request " +
+               $"(dispatched at {metadata.DispatchedAt:HH:mm:ss} UTC, ~{elapsed.TotalSeconds:F0}s ago, " +
+               $"targeting {metadata.TargetVersion ?? "unknown"}). " +
+               $"Expected to complete by {deadline:HH:mm:ss} UTC " +
+               $"(~{Math.Max(0, remaining.TotalSeconds):F0}s remaining). " +
+               "Retry after that, or contact your operator if it appears genuinely stuck.";
     }
 
     private async Task<UpgradeMachineResponseData> RunStrategyAsync(Persistence.Entities.Deployments.Machine machine, IMachineUpgradeStrategy strategy, string targetVersion, string currentVersion, CancellationToken ct)

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
@@ -704,6 +704,98 @@ public sealed class MachineUpgradeServiceTests
     }
 
     [Fact]
+    public async Task UpgradeAsync_Contention_WithDispatchMetadata_EnrichesMessageWithDispatchedAt()
+    {
+        // H4 — when the lock is contended AND we have metadata about the
+        // in-flight dispatch, surface dispatchedAt + targetVersion + expected
+        // deadline to the operator. Pre-H4 message ("wait under 2 minutes")
+        // was both wrong (worst case is LockExpiry=7 min) and unhelpful (no
+        // start time, no target version).
+        ArrangeMachine(id: 62, style: nameof(CommunicationStyle.TentaclePolling));
+        _runtimeCache.Store(62, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
+
+        var dispatchedAt = new DateTimeOffset(2026, 5, 23, 12, 34, 56, TimeSpan.Zero);
+        var metadataStore = new Mock<IUpgradeDispatchMetadataStore>();
+        metadataStore
+            .Setup(s => s.ReadAsync(62, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpgradeDispatchMetadata
+            {
+                DispatchedAt = dispatchedAt,
+                TargetVersion = "1.8.0",
+                CurrentVersion = "1.7.0"
+            });
+
+        // Lock returns null = contention.
+        _redisLock
+            .Setup(x => x.ExecuteWithLockAsync<UpgradeMachineResponseData>(
+                It.IsAny<string>(),
+                It.IsAny<Func<Task<UpgradeMachineResponseData>>>(),
+                It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<RedisServer>()))
+            .ReturnsAsync((UpgradeMachineResponseData)null);
+
+        var service = new MachineUpgradeService(
+            _machineDataProvider.Object,
+            _runtimeCache,
+            _versionRegistry.Object,
+            new[] { _linuxStrategy.Object, _k8sStrategy.Object },
+            _redisLock.Object,
+            _backgroundJobClient.Object,
+            runtimePersistence: null,
+            dispatchMetadata: metadataStore.Object);
+
+        var resp = await service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 62 }, CancellationToken.None);
+
+        resp.Status.ShouldBe(MachineUpgradeStatus.Failed);
+        resp.Detail.ShouldContain("12:34:56 UTC",
+            customMessage: "H4 contention message MUST include the dispatchedAt timestamp so the operator knows when the in-flight dispatch started.");
+        resp.Detail.ShouldContain("1.8.0",
+            customMessage: "H4 contention message MUST name the targetVersion so the operator can decide whether to wait or interrupt.");
+        resp.Detail.ShouldContain("remaining",
+            customMessage: "H4 contention message MUST include the expected-remaining time so the operator can wait an informed amount.");
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_Contention_NoDispatchMetadata_FallsBackToGenericMessage()
+    {
+        // H4 fallback path: when the metadata store is unavailable (e.g. Redis
+        // hiccup), the contention message gracefully degrades to the
+        // pre-H4-style generic guidance with a corrected wait time (LockExpiry
+        // = 7 min, not "2 minutes" which was the pre-H4 hardcoded fib).
+        ArrangeMachine(id: 63, style: nameof(CommunicationStyle.TentaclePolling));
+        _runtimeCache.Store(63, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
+
+        var metadataStore = new Mock<IUpgradeDispatchMetadataStore>();
+        metadataStore
+            .Setup(s => s.ReadAsync(63, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UpgradeDispatchMetadata)null);
+
+        _redisLock
+            .Setup(x => x.ExecuteWithLockAsync<UpgradeMachineResponseData>(
+                It.IsAny<string>(),
+                It.IsAny<Func<Task<UpgradeMachineResponseData>>>(),
+                It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<RedisServer>()))
+            .ReturnsAsync((UpgradeMachineResponseData)null);
+
+        var service = new MachineUpgradeService(
+            _machineDataProvider.Object,
+            _runtimeCache,
+            _versionRegistry.Object,
+            new[] { _linuxStrategy.Object, _k8sStrategy.Object },
+            _redisLock.Object,
+            _backgroundJobClient.Object,
+            runtimePersistence: null,
+            dispatchMetadata: metadataStore.Object);
+
+        var resp = await service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 63 }, CancellationToken.None);
+
+        resp.Detail.ShouldContain("currently being upgraded");
+        resp.Detail.ShouldContain("7 minutes",
+            customMessage: "Fallback message MUST surface the actual LockExpiry (7 min) so the operator's wait expectation matches reality.");
+    }
+
+    [Fact]
     public async Task UpgradeAsync_RedisInfrastructureDown_ReturnsDistinctFailure_NotContention()
     {
         // P0-F3 regression guard (2026-04-24 audit).

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeDispatchMetadataTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeDispatchMetadataTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Shouldly;
+using Squid.Core.Services.Machines.Upgrade;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// H4 — pin the on-disk JSON shape + Redis key naming of
+/// <see cref="UpgradeDispatchMetadata"/>. The metadata blob is operator-facing
+/// indirectly: its content powers the H4-enriched contention message
+/// ("dispatched at X, targeting Y, expected to complete by Z"). If the JSON
+/// shape or key naming drifts, the contention UX silently regresses to the
+/// pre-H4 hardcoded message.
+/// </summary>
+public sealed class UpgradeDispatchMetadataTests
+{
+    [Fact]
+    public void BuildMetadataKey_FormatPinned_SuffixUnderLockKey()
+    {
+        // H4 invariant: metadata key MUST be derived from the lock key by
+        // appending ":meta". This keeps both keys grouped under the same
+        // squid:upgrade:machine:{id}* prefix so ops can SCAN them together.
+        UpgradeDispatchMetadataStore.BuildMetadataKey(23)
+            .ShouldBe("squid:upgrade:machine:23:meta");
+    }
+
+    [Fact]
+    public void BuildMetadataKey_DerivedFromLockKey_NotIndependentlyDefined()
+    {
+        // Drift detector: any future refactor that introduces an independent
+        // string literal here (vs. building from BuildLockKey + suffix) would
+        // create a chance to drift apart from the lock key naming. Pin the
+        // derivation pattern by comparing to the constructed expectation.
+        var lockKey = UpgradeDispatchLockReconciler.BuildLockKey(42);
+        var metadataKey = UpgradeDispatchMetadataStore.BuildMetadataKey(42);
+
+        metadataKey.ShouldBe($"{lockKey}:meta",
+            customMessage: "Metadata key MUST be {lock-key}:meta — pre-H4 ops scripts SCAN squid:upgrade:machine:* expecting BOTH to appear; an independent prefix would break those.");
+    }
+
+    [Fact]
+    public void SerialisedJson_ShapeStable_CamelCase()
+    {
+        var metadata = new UpgradeDispatchMetadata
+        {
+            DispatchedAt = new DateTimeOffset(2026, 5, 23, 12, 34, 56, TimeSpan.Zero),
+            TargetVersion = "1.8.0",
+            CurrentVersion = "1.7.9"
+        };
+
+        var json = JsonSerializer.Serialize(metadata, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        });
+
+        // camelCase per convention; same naming as H2 PersistedCapabilities
+        // and H3 ManualHealthCheckResult — keeps the API consistent.
+        json.ShouldContain("\"dispatchedAt\":\"2026-05-23T12:34:56+00:00\"");
+        json.ShouldContain("\"targetVersion\":\"1.8.0\"");
+        json.ShouldContain("\"currentVersion\":\"1.7.9\"");
+    }
+
+    [Fact]
+    public void Deserialise_RoundTrip_PreservesAllFields()
+    {
+        var json = """
+            {
+              "dispatchedAt": "2026-05-23T12:34:56Z",
+              "targetVersion": "1.8.0",
+              "currentVersion": "1.7.9"
+            }
+            """;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+
+        var metadata = JsonSerializer.Deserialize<UpgradeDispatchMetadata>(json, options);
+
+        metadata.ShouldNotBeNull();
+        metadata!.DispatchedAt.ShouldBe(new DateTimeOffset(2026, 5, 23, 12, 34, 56, TimeSpan.Zero));
+        metadata.TargetVersion.ShouldBe("1.8.0");
+        metadata.CurrentVersion.ShouldBe("1.7.9");
+    }
+
+    [Fact]
+    public void Deserialise_MissingOptionalFields_DoesNotThrow_ProducesNulls()
+    {
+        // Older blobs (or future ones with renamed fields) MUST not crash the
+        // contention path — readers null-coalesce per H4 service code.
+        var json = """{"dispatchedAt":"2026-05-23T12:34:56Z"}""";
+
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var metadata = JsonSerializer.Deserialize<UpgradeDispatchMetadata>(json, options);
+
+        metadata.ShouldNotBeNull();
+        metadata!.DispatchedAt.ShouldNotBe(default);
+        metadata.TargetVersion.ShouldBeNull();
+        metadata.CurrentVersion.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

H4 of the **1.8.0 Upgrade Hardening initiative** (H1 #354 + H2 #355 + H3 #356 already merged).

Fixes the misleading contention UX from the operator-reported "之前點過幾次 upgrade 後就這樣了" symptom. When two dispatch attempts race, the second got a hardcoded "wait under 2 minutes" message — which was both wrong (worst case is `LockExpiry=7min`) and uninformative (no start time, no target version).

## Behaviour change

| Click sequence | Pre-H4 message | Post-H4 message |
|---|---|---|
| Operator double-clicks Upgrade, second click hits lock contention | `"Machine 'X' is currently being upgraded by another request. Wait for it to complete (typically under 2 minutes) and retry."` | `"Machine 'X' is currently being upgraded by another request (dispatched at 12:34:56 UTC, ~45s ago, targeting 1.8.0). Expected to complete by 12:41:56 UTC (~415s remaining). Retry after that, or contact your operator if it appears genuinely stuck."` |
| Same, but metadata read fails (Redis hiccup) | Same wrong "2 minutes" message | Falls back to generic message with **correct** `LockExpiry` (7 min, not the pre-H4 fib) |

## Components

- **`IUpgradeDispatchMetadataStore`** (new) — companion Redis key `squid:upgrade:machine:{id}:meta` (derived from `UpgradeDispatchLockReconciler.BuildLockKey` + `:meta` suffix; drift detector pinned). Same TTL as the lock so crashed dispatcher's metadata is auto-cleaned by Redis — no separate expiry bookkeeping needed.
- **`UpgradeDispatchMetadata`** DTO — stable camelCase JSON shape (matches H2/H3 convention)
- **`MachineUpgradeService.DispatchUnderLockAsync`** — wraps `RunStrategyAsync` in `try/finally` that writes metadata before strategy + deletes after release
- **`BuildContentionMessageAsync`** — reads metadata on contention path; falls back gracefully when unavailable

## Why not a periodic Redis sweep job?

Considered but rejected — over-engineering for marginal value:
- RedLockNet already auto-expires the lock at `LockExpiry=7min`
- The existing `UpgradeDispatchLockReconciler` already clears stale locks reactively on health check (10-min staleness threshold per `ShouldClearLockForStatus`)
- A periodic SCAN would add Redis load + a new failure surface (Hangfire job crash) for at-most a 7-min wait improvement
- Genuinely-stuck locks are extremely rare given existing TTL + reactive reconciler

If H8's E2E matrix surfaces a real recurring stuck-lock case, a follow-up PR can add the sweep.

## Test plan

- [x] +5 UpgradeDispatchMetadataTests (key format, derivation pattern, JSON shape, round-trip, backward-compat)
- [x] +2 enriched contention scenarios (with metadata; fallback when null)
- [x] Existing 64 MachineUpgradeService tests continue to pass
- [x] **5561/5561 unit tests green** (vs 5554 baseline → +7 net new)
- [ ] Integration with real Redis: deferred to H8 (E2E matrix exercises full dispatch round-trip)

## Backward compatibility

- `MachineUpgradeService` constructor adds optional `IUpgradeDispatchMetadataStore` parameter (defaults to null). Existing test fixtures + DI configs without the store continue to work — service degrades to the pre-H4 generic fallback message.
- Existing contention test (`UpgradeAsync_LockAcquisitionFails_ReturnsFailedWithRetryHint`) continues to pass — it uses the constructor that doesn't pass `dispatchMetadata`, exercising the fallback path.

## What's NOT in this PR

- **H5**: Cross-OS unified upgrade pipeline (next)
- **H6**: Agent rollback + abandonment recovery
- **H7**: Role/feature capability slots
- **H8**: Comprehensive E2E test matrix