### PR TITLE
H5: Remove Linux upgrade strategy's cold-cache historical default

### DIFF
--- a/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
@@ -173,25 +173,30 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
 
         if (!matchesStyle) return false;
 
-        // explicit-claim semantic (was "non-Windows"
-        // before): the Linux strategy claims agents whose reported OS is
-        // Linux OR whose capabilities are unknown (cold cache / agent
-        // hasn't health-checked yet / explicit "Unknown" fallback). It
-        // does NOT claim macOS, FreeBSD, or any other future OS — those
-        // get a clear "no strategy registered" error from the resolver
-        // until a dedicated strategy is added, and a future
-        // MacOSTentacleUpgradeStrategy plugs in WITHOUT MODIFYING THIS
-        // METHOD (the prior `!IsWindows` shape would have force-claimed
-        // macOS and required modifying Linux to add a `&& !IsMacOS` skip
-        // — open-closed violation).
+        // H5 — strict-Linux-only: the historical "claim Unknown for cold-cache
+        // backward-compat" behaviour produced the 1.7.x operator bug where a
+        // cold-cache Windows machine got routed to LinuxTentacleUpgradeStrategy,
+        // which then tried Docker Hub for a Linux tarball that doesn't exist
+        // for win-x64. H1 already short-circuits cold cache before reaching
+        // ResolveStrategy via the NoOsDetected reason code, and H5 mirrors
+        // that guard inside <see cref="MachineUpgradeService.UpgradeAsync"/>
+        // so direct API callers can't bypass it either. So this strategy can
+        // now safely refuse anything that's not explicitly Linux.
         //
-        // Cold-cache historical default:  there was no OS
-        // axis, Linux was the only strategy, so a tentacle with
-        // capabilities.Os = empty (never health-checked) MUST still route
-        // to Linux to preserve operator backward compatibility.
-        if (capabilities == null) return true;
+        // <para>Side benefits of the strict refusal:
+        // <list type="bullet">
+        ///   <item>macOS / FreeBSD / future OSes get a clean "no strategy
+        ///         registered" error instead of silent Linux misrouting.</item>
+        ///   <item>Adding a MacOSTentacleUpgradeStrategy plugs in via DI
+        ///         without modifying this method (open-closed).</item>
+        ///   <item>A regression that re-introduces the cold-cache Linux
+        ///         fallback would fail
+        ///         <c>CanHandle_RoutesByOs_ClaimsLinuxOnly_NotUnknown</c>
+        ///         instead of silently misrouting Windows agents.</item>
+        /// </list></para>
+        if (capabilities == null) return false;
 
-        return capabilities.IsLinux || capabilities.IsUnknown;
+        return capabilities.IsLinux;
     }
 
     public async Task<MachineUpgradeOutcome> UpgradeAsync(Machine machine, string targetVersion, CancellationToken ct)

--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -188,6 +188,24 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         // CommunicationStyle values; the OS reported by the agent's last
         // health check is what differentiates them).
         var capabilities = _runtimeCache.TryGet(machine.Id) ?? MachineRuntimeCapabilities.Empty;
+
+        // H5 — cold-cache short-circuit for tentacle styles. Mirrors the
+        // identical guard in EvaluateUpgradeEligibility (H1) so direct API
+        // callers (curl, scripted automation that bypassed the UI's
+        // upgrade-info gate) can't dispatch with empty OS — pre-H5 they
+        // would have hit LinuxTentacleUpgradeStrategy's historical-default
+        // "claim Unknown" path and dispatched the Linux upgrade script
+        // against a possibly-Windows machine. H5 removes that historical
+        // default in LinuxTentacleUpgradeStrategy.CanHandle AND blocks
+        // the dispatch entry point here so the failure mode is impossible
+        // from BOTH directions.
+        if (IsTentacleStyle(style) && string.IsNullOrWhiteSpace(capabilities.Os))
+            return BuildResponse(machine, currentVersion: null, targetVersion: null, MachineUpgradeStatus.Failed,
+                $"Machine '{machine.Name}' OS is not yet detected (capability cache is cold). " +
+                "Trigger an active health check (POST /api/machines/{id}/health-check or click 'Health Check' in the UI) " +
+                "BEFORE retrying the upgrade. Pre-H5 this would have routed to the Linux upgrade strategy via a " +
+                "historical-default fallback, which broke when the agent was actually Windows.");
+
         var strategy = ResolveStrategy(style, capabilities);
 
         if (strategy == null)

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -431,35 +431,40 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
     {
         var strategy = new LinuxTentacleUpgradeStrategy(halibutClientFactory: null, observer: null);
 
-        // empty capabilities (cold cache) preserves the
-        //  behaviour where Linux strategy claimed all matching
-        // styles regardless of OS. Linux-OS / Windows-OS routing is covered
-        // by the dedicated OS-routing Theories below.
-        strategy.CanHandle(style, MachineRuntimeCapabilities.Empty).ShouldBe(expected);
+        // H5 — pass explicit Linux capabilities so the style-only matrix tests
+        // the style axis in isolation. Pre-H5 we passed MachineRuntimeCapabilities.Empty
+        // and relied on the historical "claim Unknown" default — that default
+        // is removed in H5 because H1's cold-cache short-circuit + the H5 guard
+        // in UpgradeAsync make it unreachable in practice. OS-axis routing has
+        // its own dedicated Theory below.
+        var linuxCaps = new MachineRuntimeCapabilities { Os = "Linux" };
+        strategy.CanHandle(style, linuxCaps).ShouldBe(expected);
     }
 
     [Theory]
     [InlineData("Linux", true)]    // explicit Linux — claims
     [InlineData("linux", true)]    // case-insensitive
     [InlineData("LINUX", true)]
-    [InlineData("", true)]         // cold cache → IsUnknown=true → historical default (preserves behaviour)
-    [InlineData("Unknown", true)]  // agent's "Unknown" fallback (when IsWindows/IsLinux/IsMacOS all false) routes to Linux historical default
-    [InlineData("Windows", false)] // explicit Windows skip — WindowsTentacleUpgradeStrategy claims
+    // H5 — Linux strategy NO LONGER claims cold-cache / Unknown OS. The
+    // pre-H5 "historical default" routed cold-cache Windows machines through
+    // Linux's Docker Hub path → misleading "Docker Hub unreachable" UX.
+    // H1 + the H5 guard in MachineUpgradeService.UpgradeAsync make cold
+    // cache impossible to reach this point, so strict-Linux is now safe.
+    [InlineData("", false)]
+    [InlineData("Unknown", false)]
+    [InlineData("Windows", false)]
     [InlineData("windows", false)]
     [InlineData("WINDOWS", false)]
     // Drift detector for the long-form Windows fix: legacy "Microsoft Windows
     // NT ..." strings MUST NOT trigger the Linux claim (would route a Windows
-    // agent to a tarball that doesn't exist for win-x64 RIDs). Pairs with
-    // WindowsTentacleUpgradeStrategyTests' matching rows so we pin the
-    // single-owner invariant from BOTH ends — both halves of the resolver
-    // independently agree the long form is Windows-only.
+    // agent to a tarball that doesn't exist for win-x64 RIDs).
     [InlineData("Microsoft Windows NT 10.0.19045.0", false)]
     [InlineData("Microsoft Windows NT 10.0.22631.0", false)]
     [InlineData("Microsoft Windows Server 2022 Datacenter", false)]
-    [InlineData("macOS", false)]   // explicit-claim refactor: Linux NO LONGER claims macOS (was true under "non-Windows" predicate). A future MacOSTentacleUpgradeStrategy plugs in WITHOUT MODIFYING THIS METHOD.
-    [InlineData("MACOS", false)]   // case-insensitive
-    [InlineData("FreeBSD", false)] // any unknown OS string (not in AgentOperatingSystems) → no Linux claim → resolver says "no strategy registered"; clear operator error vs silent install-tarball-on-FreeBSD attempt
-    public void CanHandle_RoutesByOs_ClaimsLinuxOrUnknownOnly(string os, bool expected)
+    [InlineData("macOS", false)]
+    [InlineData("MACOS", false)]
+    [InlineData("FreeBSD", false)]
+    public void CanHandle_RoutesByOs_ClaimsLinuxOnly_NotUnknown(string os, bool expected)
     {
         // explicit-claim semantic (was "non-Windows"
         // before): Linux strategy claims TentaclePolling/Listening for
@@ -482,14 +487,53 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
     }
 
     [Fact]
-    public void CanHandle_NullCapabilities_TreatedAsEmpty()
+    public void CanHandle_NullCapabilities_StrictlyRejects_NoHistoricalDefault()
     {
-        // Defensive: a future caller passing null capabilities (instead of
-        // MachineRuntimeCapabilities.Empty) should not NPE. Same fallback
-        // as the empty-OS case — Linux strategy claims.
+        // H5 — Defensive: a future caller passing null capabilities (instead
+        // of MachineRuntimeCapabilities.Empty) MUST get strict rejection. The
+        // pre-H5 "claim null for backward compat" was the source of the
+        // operator's cold-cache misdirection — H1 + H5's UpgradeAsync guard
+        // make this code path unreachable in production, but the test pins
+        // strict rejection so any future regression that re-introduces a
+        // "default claim" gets caught.
         var strategy = new LinuxTentacleUpgradeStrategy(halibutClientFactory: null, observer: null);
 
-        strategy.CanHandle(nameof(CommunicationStyle.TentaclePolling), capabilities: null).ShouldBeTrue();
+        strategy.CanHandle(nameof(CommunicationStyle.TentaclePolling), capabilities: null).ShouldBeFalse(
+            customMessage: "H5 — null capabilities MUST NOT trigger a Linux strategy claim. " +
+                           "Cold cache is intercepted at H1's NoOsDetected check or H5's UpgradeAsync guard; " +
+                           "this strategy contract is strict-Linux-only.");
+    }
+
+    [Fact]
+    public void CanHandle_EmptyOsCapabilities_StrictlyRejects_NoHistoricalDefault()
+    {
+        // H5 invariant — symmetric with the Windows strategy. Both are now
+        // strict OS-only claimants; cold cache must NEVER reach the strategy
+        // resolution layer (H1 + H5's UpgradeAsync guard handle it earlier).
+        // Pin both halves: this test + the Windows test pinning IsWindows
+        // strict-equality are the two ends of the single-owner invariant.
+        var strategy = new LinuxTentacleUpgradeStrategy(halibutClientFactory: null, observer: null);
+        var coldCache = new MachineRuntimeCapabilities { Os = string.Empty };
+
+        strategy.CanHandle(nameof(CommunicationStyle.TentaclePolling), coldCache).ShouldBeFalse(
+            customMessage: "H5 — empty Os (cold cache) MUST NOT trigger Linux strategy claim. " +
+                           "Pre-H5 the IsUnknown predicate allowed this, producing the operator-facing " +
+                           "'Docker Hub unreachable' bug for Windows machines.");
+    }
+
+    [Fact]
+    public void CanHandle_UnknownOsCapabilities_StrictlyRejects_NoHistoricalDefault()
+    {
+        // H5 — explicit "Unknown" sentinel (when agent reports OS but it's
+        // neither Windows/Linux/macOS) must also be rejected by Linux strategy.
+        // Pre-H5, Linux claimed this case via IsUnknown; H5 removes the claim.
+        var strategy = new LinuxTentacleUpgradeStrategy(halibutClientFactory: null, observer: null);
+        var unknownOs = new MachineRuntimeCapabilities { Os = "Unknown" };
+
+        strategy.CanHandle(nameof(CommunicationStyle.TentaclePolling), unknownOs).ShouldBeFalse(
+            customMessage: "H5 — explicit 'Unknown' OS sentinel MUST NOT trigger Linux strategy claim. " +
+                           "Future MacOSTentacleUpgradeStrategy / BSDTentacleUpgradeStrategy plug in via DI " +
+                           "without modifying Linux; the strict-Linux-only contract is the enabler.");
     }
 
     // ========================================================================

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
@@ -101,7 +101,7 @@ public sealed class MachineUpgradeServiceTests
     public async Task UpgradeAsync_AlreadyOnTargetVersion_ShortCircuitsWithoutDispatchingStrategy()
     {
         ArrangeMachine(id: 7, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(7, new Dictionary<string, string>(), agentVersion: "1.4.0");
+        _runtimeCache.Store(7, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.4.0");
 
         var resp = await _service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 7 }, CancellationToken.None);
 
@@ -115,7 +115,7 @@ public sealed class MachineUpgradeServiceTests
     public async Task UpgradeAsync_CurrentVersionNewerThanTarget_DefaultBehavior_RejectsAsDowngradeWithHint()
     {
         ArrangeMachine(id: 8, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(8, new Dictionary<string, string>(), agentVersion: "2.0.0");
+        _runtimeCache.Store(8, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "2.0.0");
 
         var resp = await _service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 8 }, CancellationToken.None);
 
@@ -132,7 +132,7 @@ public sealed class MachineUpgradeServiceTests
         // Emergency downgrade scenario (1.4.2 has a nasty regression, want to
         // revert to 1.4.0). Default-safe: blocked. With explicit opt-in: goes.
         ArrangeMachine(id: 81, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(81, new Dictionary<string, string>(), agentVersion: "2.0.0");
+        _runtimeCache.Store(81, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "2.0.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "forced downgrade applied", AgentVersionMayHaveChanged = true });
@@ -156,7 +156,7 @@ public sealed class MachineUpgradeServiceTests
         // already up-to-date and shouldn't incur a no-op dispatch even with
         // the flag on (would be wasteful filesystem churn).
         ArrangeMachine(id: 82, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(82, new Dictionary<string, string>(), agentVersion: "1.4.0");
+        _runtimeCache.Store(82, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.4.0");
 
         var resp = await _service.UpgradeAsync(
             new UpgradeMachineCommand { MachineId = 82, TargetVersion = "1.4.0", AllowDowngrade = true },
@@ -176,7 +176,7 @@ public sealed class MachineUpgradeServiceTests
         // Safety: setting AllowDowngrade=true on a genuine upgrade must not
         // change the happy path.
         ArrangeMachine(id: 83, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(83, new Dictionary<string, string>(), agentVersion: "1.3.0");
+        _runtimeCache.Store(83, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "up", AgentVersionMayHaveChanged = true });
@@ -192,7 +192,7 @@ public sealed class MachineUpgradeServiceTests
     public async Task UpgradeAsync_OperatorOverridesTargetVersion_PreferredOverBundle()
     {
         ArrangeMachine(id: 11, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(11, new Dictionary<string, string>(), agentVersion: "1.0.0");
+        _runtimeCache.Store(11, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.0.0");
 
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "9.9.9", It.IsAny<CancellationToken>()))
@@ -365,44 +365,35 @@ public sealed class MachineUpgradeServiceTests
     }
 
     [Fact]
-    public async Task UpgradeAsync_ColdCacheNoOs_RoutesToLinuxAsHistoricalDefault()
+    public async Task UpgradeAsync_ColdCacheNoOs_RejectedAtEntry_PointsToHealthCheck()
     {
-        // Cold cache (machine never health-checked) → capabilities.Os = "" →
-        // Linux strategy claims as the historical default; Windows strategy
-        // skips. Preserves behaviour for the operator base, which
-        // is overwhelmingly Linux. Without this, a freshly-registered tentacle
-        // would surface as "no strategy registered" until its first health
-        // check — confusing, since health checks are async.
-        var windowsStrategy = new Mock<IMachineUpgradeStrategy>();
-        windowsStrategy
-            .Setup(s => s.CanHandle(nameof(CommunicationStyle.TentaclePolling), It.Is<MachineRuntimeCapabilities>(c => c.Os == "Windows")))
-            .Returns(true);
-
-        _linuxStrategy.Reset();
-        _linuxStrategy
-            .Setup(s => s.CanHandle(nameof(CommunicationStyle.TentaclePolling), It.Is<MachineRuntimeCapabilities>(c => c.Os != "Windows")))
-            .Returns(true);
-        _linuxStrategy
-            .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "cold-cache default", AgentVersionMayHaveChanged = true });
-
-        var service = new MachineUpgradeService(
-            _machineDataProvider.Object,
-            _runtimeCache,
-            _versionRegistry.Object,
-            new[] { _linuxStrategy.Object, windowsStrategy.Object, _k8sStrategy.Object },
-            _redisLock.Object,
-            _backgroundJobClient.Object);
-
+        // H5 — INVERTS the pre-H5 "cold cache routes to Linux as historical
+        // default" behaviour. That default was the source of the operator-
+        // facing 1.7.x bug where a cold-cache Windows machine dispatched the
+        // Linux upgrade script (which then 404'd on Docker Hub looking for a
+        // tarball that doesn't exist for win-x64).
+        //
+        // Post-H5: cold-cache tentacle styles fail BEFORE strategy resolution,
+        // with an actionable hint pointing the operator at the health-check
+        // endpoint. Mirrors H1's identical guard in GetUpgradeInfoAsync so
+        // direct API callers (curl, scripted automation) can't bypass the
+        // FE's upgrade-info gate.
         ArrangeMachine(id: 303, style: nameof(CommunicationStyle.TentaclePolling));
-        // INTENTIONAL: no _runtimeCache.Store(303, ...) — cold cache scenario.
+        // Override the ArrangeMachine default Linux-OS seed with an explicit
+        // cold-cache state — clear the entry so capabilities.Os == "".
+        _runtimeCache.Invalidate(303);
 
-        var resp = await service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 303 }, CancellationToken.None);
+        var resp = await _service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 303 }, CancellationToken.None);
 
-        resp.Status.ShouldBe(MachineUpgradeStatus.Upgraded);
-        _linuxStrategy.Verify(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()), Times.Once,
-            "cold-cache (empty Os) must route to Linux strategy as historical default — preserves behaviour");
-        windowsStrategy.Verify(s => s.UpgradeAsync(It.IsAny<Machine>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        resp.Status.ShouldBe(MachineUpgradeStatus.Failed,
+            customMessage: "H5 — cold-cache tentacle styles MUST fail at the upgrade entry point, not silently dispatch via the pre-H5 Linux historical default.");
+        resp.Detail.ShouldContain("OS is not yet detected", Case.Insensitive);
+        resp.Detail.ShouldContain("health check", Case.Insensitive,
+            customMessage: "Operator MUST be pointed at the health-check endpoint as the actionable next step.");
+        _linuxStrategy.Verify(
+            s => s.UpgradeAsync(It.IsAny<Machine>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "H5 — Linux strategy MUST NOT be invoked for cold-cache machines. This is the security/correctness property — pre-H5 dispatch could send a Linux script to a Windows machine.");
     }
 
     [Theory]
@@ -525,7 +516,7 @@ public sealed class MachineUpgradeServiceTests
         // (the agent already runs a NEWER beta but the server thinks not).
         // Per semver, 1.4.0 > 1.4.0-beta.1, so this is correctly NOT up-to-date.
         ArrangeMachine(id: 93, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(93, new Dictionary<string, string>(), agentVersion: "1.4.0-beta.1");
+        _runtimeCache.Store(93, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.4.0-beta.1");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "promoted from beta", AgentVersionMayHaveChanged = true });
@@ -545,7 +536,7 @@ public sealed class MachineUpgradeServiceTests
         // service used to silently allow it; with proper compare, "current
         // already higher than target" → AlreadyUpToDate is the safe answer.
         ArrangeMachine(id: 94, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(94, new Dictionary<string, string>(), agentVersion: "1.4.0");
+        _runtimeCache.Store(94, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.4.0");
 
         var resp = await _service.UpgradeAsync(
             new UpgradeMachineCommand { MachineId = 94, TargetVersion = "1.4.0-beta.1" },
@@ -606,7 +597,7 @@ public sealed class MachineUpgradeServiceTests
         // orchestrator. This test no longer cares which Status was returned —
         // only that the flag means "drop the cache".
         ArrangeMachine(id: 51, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(51, new Dictionary<string, string>(), agentVersion: "1.0.0");
+        _runtimeCache.Store(51, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.0.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "ok", AgentVersionMayHaveChanged = true });
@@ -621,7 +612,7 @@ public sealed class MachineUpgradeServiceTests
     public async Task UpgradeAsync_StrategyReportsAgentUnchanged_LeavesRuntimeCacheIntact()
     {
         ArrangeMachine(id: 52, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(52, new Dictionary<string, string>(), agentVersion: "1.0.0");
+        _runtimeCache.Store(52, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.0.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Failed, Detail = "rolled back", AgentVersionMayHaveChanged = false });
@@ -641,7 +632,7 @@ public sealed class MachineUpgradeServiceTests
         // change actually happened" (a hypothetical no-op success), cache
         // is preserved. This pins the orchestrator's flag-only decision.
         ArrangeMachine(id: 53, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(53, new Dictionary<string, string>(), agentVersion: "1.0.0");
+        _runtimeCache.Store(53, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.0.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "no-op success", AgentVersionMayHaveChanged = false });
@@ -659,7 +650,7 @@ public sealed class MachineUpgradeServiceTests
         // change (e.g. partial-write detected, agent in unknown state).
         // Flag wins — invalidate.
         ArrangeMachine(id: 54, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(54, new Dictionary<string, string>(), agentVersion: "1.0.0");
+        _runtimeCache.Store(54, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.0.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Failed, Detail = "partial swap, unknown state", AgentVersionMayHaveChanged = true });
@@ -1037,7 +1028,7 @@ public sealed class MachineUpgradeServiceTests
         // LinuxTentacleUpgradeStrategy — script never reached the agent,
         // so the binary is unchanged, cache is still accurate.
         ArrangeMachine(id: 302, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(302, new Dictionary<string, string>(), agentVersion: "1.3.0");
+        _runtimeCache.Store(302, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.0");
         _linuxStrategy
             .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachineUpgradeOutcome
@@ -1400,7 +1391,9 @@ public sealed class MachineUpgradeServiceTests
         // message even for Windows machines. Now we short-circuit BEFORE
         // strategy resolution and tell the operator to run a health check.
         ArrangeMachine(id: 14, style: nameof(CommunicationStyle.TentaclePolling));
-        // intentionally not storing in runtimeCache → cold cache
+        // H5 — ArrangeMachine now auto-seeds Linux OS for convenience tests;
+        // explicitly invalidate to preserve the cold-cache intent of this test.
+        _runtimeCache.Invalidate(14);
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 14 }, CancellationToken.None);
 
@@ -1425,7 +1418,8 @@ public sealed class MachineUpgradeServiceTests
         // returns null for Ssh regardless of capabilities) gives the more
         // actionable message.
         ArrangeMachine(id: 15, style: "Ssh");
-        // intentionally cold cache
+        // H5 — explicit cold cache (ArrangeMachine auto-seeds Linux OS).
+        _runtimeCache.Invalidate(15);
 
         var info = await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 15 }, CancellationToken.None);
 
@@ -1565,7 +1559,7 @@ public sealed class MachineUpgradeServiceTests
         // (would serialise readers), must NOT call strategy.UpgradeAsync
         // (would actually upgrade!). Pin both negative contracts.
         ArrangeMachine(id: 9, style: nameof(CommunicationStyle.TentaclePolling));
-        _runtimeCache.Store(9, new Dictionary<string, string>(), agentVersion: "1.3.9");
+        _runtimeCache.Store(9, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
 
         await _service.GetUpgradeInfoAsync(new GetUpgradeInfoRequest { MachineId = 9 }, CancellationToken.None);
 
@@ -1595,5 +1589,22 @@ public sealed class MachineUpgradeServiceTests
                 Endpoint = endpoint,
                 SpaceId = 1
             });
+
+        // H5 — seed default Linux capabilities for the convenience overload so
+        // existing tests that don't explicitly care about OS routing continue
+        // to exercise the lock + strategy + dispatch happy path. Tests that
+        // specifically exercise cold-cache OR Windows routing override via
+        // _runtimeCache.Store(...) AFTER calling ArrangeMachine, which the
+        // InMemoryMachineRuntimeCapabilitiesCache merges atomically.
+        //
+        // Pre-H5 the LinuxTentacleUpgradeStrategy.CanHandle "claim Unknown"
+        // historical default meant a cold-cache machine still got Linux
+        // routing for free. H5 removes that default AND the equivalent guard
+        // at MachineUpgradeService.UpgradeAsync entry, so cold-cache tests
+        // explicitly fail with "OS not yet detected" now. To keep the
+        // pre-H5 default-OK behaviour for tests that aren't about OS routing,
+        // pre-seed Linux here.
+        if (_runtimeCache.TryGet(id)?.Os is null or "")
+            _runtimeCache.Store(id, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: string.Empty);
     }
 }


### PR DESCRIPTION
## Summary

H5 of the **1.8.0 Upgrade Hardening initiative** (H1-H4 already merged).

Closes the last gap in the 1.7.x operator failure chain by making `LinuxTentacleUpgradeStrategy.CanHandle` strict-Linux-only AND adding a symmetric cold-cache guard to `MachineUpgradeService.UpgradeAsync` so direct API callers can't bypass the FE's H1 upgrade-info gate.

## The bug class H5 closes

Pre-H5 `LinuxTentacleUpgradeStrategy.CanHandle` had two backward-compat "historical default" branches:

```csharp
if (capabilities == null) return true;                        // ← null = claim
return capabilities.IsLinux || capabilities.IsUnknown;        // ← Unknown = claim
```

The `IsUnknown` claim was the root cause of the operator's 1.7.x failure chain:
1. Cold-cache Windows machine triggers `GetUpgradeInfoAsync`
2. `ResolveStrategy` ran with `capabilities.Os = ""` (cold cache)
3. Linux strategy claimed it via `IsUnknown=true` historical default
4. Version registry queried Docker Hub for a Linux tarball that **doesn't exist** for win-x64
5. Operator saw `"Docker Hub unreachable, set SQUID_TARGET_LINUX_TENTACLE_VERSION"` — and went down the wrong remediation path because they were on Windows

H1 already short-circuits cold-cache tentacle styles at the eligibility evaluator with `NoOsDetected`, so the FE's GetUpgradeInfo call no longer reaches strategy resolution in the cold case. H5 closes the remaining gap (direct API callers / `curl`) AND removes the now-dead historical-default code path.

## Behaviour changes

| Scenario | Pre-H5 | Post-H5 |
|---|---|---|
| `LinuxTentacleUpgradeStrategy.CanHandle("TentaclePolling", null)` | `true` | `false` |
| `LinuxTentacleUpgradeStrategy.CanHandle("TentaclePolling", {Os=""})` | `true` | `false` |
| `LinuxTentacleUpgradeStrategy.CanHandle("TentaclePolling", {Os="Unknown"})` | `true` | `false` |
| `LinuxTentacleUpgradeStrategy.CanHandle("TentaclePolling", {Os="Linux"})` | `true` | `true` (unchanged) |
| Direct `POST /upgrade` with cold-cache tentacle machine | Dispatched via Linux historical default | Rejected with `OS not yet detected, run health check` (mirrors H1) |

## Cross-OS uniformity

The Windows and Linux strategies are now **structurally symmetric**:

```csharp
// Windows:
if (capabilities == null) return false;
return capabilities.IsWindows;

// Linux (post-H5):
if (capabilities == null) return false;
return capabilities.IsLinux;
```

A future `MacOSTentacleUpgradeStrategy` / `BSDTentacleUpgradeStrategy` plugs in via Autofac DI **without modifying** either existing strategy. Open-closed property.

## Test plan

- [x] +2 invariant pins on Linux strategy (empty Os rejected, explicit "Unknown" rejected)
- [x] +1 invariant on `UpgradeAsync` cold-cache guard (rejected at entry with health-check guidance)
- [x] Repurposed `UpgradeAsync_ColdCacheNoOs_RoutesToLinuxAsHistoricalDefault` → `*_RejectedAtEntry_PointsToHealthCheck` with inverted expectations
- [x] `ArrangeMachine` helper auto-seeds `os=Linux` so tests that don't care about OS routing continue to exercise the happy path
- [x] **5563/5563 unit tests green** (+2 net new)

## Backward compatibility

- **Operator-facing break**: cold-cache + direct `POST /upgrade` previously succeeded (via Linux historical default). It now fails with `OS not yet detected`. This is the intentional security/correctness improvement — operators running `curl -X POST` against a freshly-registered machine should hit the same guidance the UI gives.
- All existing tests adjusted to reflect the new strict-OS contract.

## What's NOT in this PR

- **H6**: Agent rollback + abandonment recovery (next)
- **H7**: Role/feature capability slots
- **H8**: Comprehensive E2E test matrix