### PR TITLE
H6: Distinguish 'RolledBack' from 'Failed' in upgrade outcome

### DIFF
--- a/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
@@ -273,6 +273,15 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
         }
     }
 
+    /// <summary>
+    /// Exit codes emitted by <c>upgrade-linux-tentacle.sh</c>. Wire contract
+    /// between the agent-side install script and this interpreter — a change
+    /// here MUST be mirrored in the script (pinned by
+    /// <c>LinuxUpgradeExitCodes_PinnedToScriptContract</c>) or rollback
+    /// outcomes get misinterpreted as straight failures.
+    /// </summary>
+    internal const int LinuxExitRolledBack = 4;
+
     private static MachineUpgradeOutcome InterpretScriptResult(Squid.Core.Services.DeploymentExecution.Script.ScriptExecutionResult result, string targetVersion)
     {
         if (result.Success)
@@ -284,6 +293,21 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
             };
 
         var lastLog = result.LogLines is { Count: > 0 } ll ? ll[^1] : "(no log lines)";
+
+        // H6 — distinguish "successfully rolled back to previous version" from
+        // straight failure. Pre-H6 both mapped to MachineUpgradeStatus.Failed,
+        // confusing operators who couldn't tell whether their machine was now
+        // broken (red) or safely restored to baseline (yellow/amber). The
+        // Linux install script's exit code 4 means "post-swap health check
+        // failed; .bak directory or apt/yum snapshot successfully restored
+        // the previous binary; agent is healthy on that baseline".
+        if (result.ExitCode == LinuxExitRolledBack)
+            return new MachineUpgradeOutcome
+            {
+                Status = MachineUpgradeStatus.RolledBack,
+                Detail = $"Upgrade to {targetVersion} failed post-install health check; rolled back to the previous binary. Agent is healthy on the baseline version — safe to retry once root cause is understood. Last log: {lastLog}",
+                AgentVersionMayHaveChanged = false   // back to baseline → cache stays valid
+            };
 
         return new MachineUpgradeOutcome
         {

--- a/src/Squid.Message/Commands/Machine/UpgradeMachineCommand.cs
+++ b/src/Squid.Message/Commands/Machine/UpgradeMachineCommand.cs
@@ -117,5 +117,26 @@ public enum MachineUpgradeStatus
     Failed = 3,
 
     /// <summary>Server couldn't determine the current version (cache miss) but proceeded; outcome unknown until the next health check.</summary>
-    Initiated = 4
+    Initiated = 4,
+
+    /// <summary>
+    /// H6 — upgrade attempted, new binary failed post-install health check,
+    /// agent-side install script SUCCESSFULLY rolled back to the previous
+    /// version. The agent is healthy on the OLD binary (machine is safe
+    /// to retry / use). Distinct from <see cref="Failed"/> (binary may
+    /// be broken on either side) and <see cref="Upgraded"/> (binary
+    /// changed).
+    ///
+    /// <para>Operator UX: surface this as a yellow/amber "Upgrade rolled
+    /// back" badge — distinct from green ("Upgraded") and red ("Failed").
+    /// The machine is operational on the previous version; operator can
+    /// retry once they understand why the new version failed health check
+    /// (logs in last-upgrade.json + upgrade.log).</para>
+    ///
+    /// <para>Agent-side detection: Linux install script exit code 4
+    /// (ROLLED_BACK), Windows install script exit code 8 (Invoke-Rollback
+    /// fired). Both scripts already implement comprehensive backup +
+    /// restore; H6 just exposes the outcome to the server-facing API.</para>
+    /// </summary>
+    RolledBack = 5
 }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -806,6 +806,53 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
     }
 
     [Fact]
+    public async Task UpgradeAsync_ScriptExitCode4_ReturnsRolledBack_NotFailed()
+    {
+        // H6 — the install script's exit code 4 means "post-swap health check
+        // failed; .bak / apt-snapshot restore succeeded; agent is healthy on
+        // the previous binary". Pre-H6 this collapsed into MachineUpgradeStatus.Failed,
+        // which made operators think their machine was broken. Distinguish
+        // RolledBack so the UI can render the "safely restored" badge instead
+        // of the "broken — investigate" badge.
+        var (strategy, _, observer) = BuildMockedStrategy();
+        var machine = MakeMachine(33, "TentaclePolling", "sub-33", "AABB");
+
+        observer
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .ReturnsAsync(new ScriptExecutionResult
+            {
+                Success = false,
+                ExitCode = LinuxTentacleUpgradeStrategy.LinuxExitRolledBack,
+                LogLines = new List<string> { "Health check failed", "Rollback to previous version succeeded; agent is healthy on the old binary." }
+            });
+
+        var outcome = await strategy.UpgradeAsync(machine, "1.4.2", CancellationToken.None);
+
+        outcome.Status.ShouldBe(MachineUpgradeStatus.RolledBack,
+            customMessage: "H6 — Linux exit code 4 MUST map to RolledBack so the FE can render the 'safely restored' badge instead of the alarming 'failed' badge.");
+        outcome.Detail.ShouldContain("rolled back", Case.Insensitive);
+        outcome.Detail.ShouldContain("safe to retry", Case.Insensitive,
+            customMessage: "Operator MUST be told the machine is safe to use AND retry-able once they understand why the new version failed health check.");
+        outcome.AgentVersionMayHaveChanged.ShouldBeFalse(
+            "rollback restored the baseline binary → cache stays valid");
+    }
+
+    [Fact]
+    public void LinuxExitRolledBack_PinnedToScriptContract()
+    {
+        // Wire-stability pin (Rule 8): the exit code is the contract between
+        // the agent-side install script (upgrade-linux-tentacle.sh) and the
+        // server-side interpreter (InterpretScriptResult). Drift between the
+        // two means rollback outcomes get misclassified as straight Failed —
+        // operators lose the "safely restored to baseline" signal. Pin to 4
+        // so a refactor on either side becomes a test-visible decision.
+        LinuxTentacleUpgradeStrategy.LinuxExitRolledBack.ShouldBe(4,
+            customMessage: "Exit code 4 is the contract with upgrade-linux-tentacle.sh's ROLLED_BACK status emit. " +
+                           "If you change this, also update the .sh script's `exit 4` lines AND the mirroring " +
+                           "test in tests/Squid.Tentacle.Tests for the script side.");
+    }
+
+    [Fact]
     public async Task UpgradeAsync_ScriptFailedWithEmptyLogs_DoesNotIndexExceptionOnLastLog()
     {
         // Guard for the `LogLines[^1]` pattern — empty list would IndexOutOfRange

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeStatusIntegrityTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeStatusIntegrityTests.cs
@@ -1,0 +1,63 @@
+using Shouldly;
+using Squid.Message.Commands.Machine;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// H6 — wire-stability pin (Rule 8 — operator-facing surface) for
+/// <see cref="MachineUpgradeStatus"/>. Values cross the upgrade API boundary
+/// to the FE, CLI, and any external SDK that consumes
+/// <c>UpgradeMachineResponseData.Status</c>. A rename or re-numbering
+/// silently breaks every consumer parsing by ordinal or name.
+///
+/// <para><b>Convention</b>: new statuses MUST be appended at the END with a
+/// strictly-incrementing numeric value. NEVER re-number existing members.
+/// If a status becomes obsolete, mark <c>[Obsolete]</c> but don't delete or
+/// renumber.</para>
+/// </summary>
+public sealed class MachineUpgradeStatusIntegrityTests
+{
+    [Theory]
+    [InlineData(MachineUpgradeStatus.Upgraded, 0)]
+    [InlineData(MachineUpgradeStatus.AlreadyUpToDate, 1)]
+    [InlineData(MachineUpgradeStatus.NotSupported, 2)]
+    [InlineData(MachineUpgradeStatus.Failed, 3)]
+    [InlineData(MachineUpgradeStatus.Initiated, 4)]
+    [InlineData(MachineUpgradeStatus.RolledBack, 5)]    // H6 — appended at end
+    public void NumericValue_PinnedToOrdinal(MachineUpgradeStatus status, int expected)
+    {
+        // Re-numbering breaks every consumer that serialises by ordinal. Pin
+        // values so refactoring becomes a test-visible decision.
+        ((int)status).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(MachineUpgradeStatus.Upgraded, "Upgraded")]
+    [InlineData(MachineUpgradeStatus.AlreadyUpToDate, "AlreadyUpToDate")]
+    [InlineData(MachineUpgradeStatus.NotSupported, "NotSupported")]
+    [InlineData(MachineUpgradeStatus.Failed, "Failed")]
+    [InlineData(MachineUpgradeStatus.Initiated, "Initiated")]
+    [InlineData(MachineUpgradeStatus.RolledBack, "RolledBack")]
+    public void NameLiteral_Pinned(MachineUpgradeStatus status, string expected)
+    {
+        // JSON serialisation uses the member name; renames break every
+        // string-based parser.
+        status.ToString().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TotalCount_PinnedToCurrentSize()
+    {
+        // Adding a new status MUST come with (1) [InlineData] rows in both
+        // tests above and (2) a bump to this expected count. Test forces
+        // conscious update vs. silent skip.
+        System.Enum.GetValues<MachineUpgradeStatus>().Length.ShouldBe(6,
+            customMessage: "If you're adding a new MachineUpgradeStatus, also: " +
+                           "(1) append at the END (never re-number), " +
+                           "(2) add [InlineData] rows to both NumericValue_PinnedToOrdinal and NameLiteral_Pinned, " +
+                           "(3) bump this expected count. " +
+                           "(4) decide whether the new status implies AgentVersionMayHaveChanged true/false " +
+                           "(strategies set this explicitly per-construction — no silent fallthrough).");
+    }
+}


### PR DESCRIPTION
## Summary

H6 of the **1.8.0 Upgrade Hardening initiative** (H1-H5 already merged).

Pre-H6, when an upgrade failed its post-install health check and the agent-side install script's rollback path successfully restored the previous binary, the server reported `MachineUpgradeStatus.Failed` — indistinguishable from "upgrade left machine broken". Operators couldn't tell whether their machine was:

- **Actually broken** → red badge, investigate immediately
- **Safely rolled back to baseline** → yellow/amber badge, OK to retry once root cause is understood

Both install scripts ALREADY implement comprehensive rollback (`.bak`/`.previous` backup → atomic swap → post-restart health check → on failure, restore baseline → write ROLLED_BACK status). H6 just exposes the outcome to the server-facing API.

## Behaviour change

| Scenario | Pre-H6 server response | Post-H6 server response |
|---|---|---|
| Binary swap succeeded, agent healthy on new version | `Upgraded` | `Upgraded` (unchanged) |
| Binary swap committed but post-install health check failed AND rollback restored baseline AND baseline is healthy | `Failed` ("Upgrade script failed exit 4. Last log: rollback succeeded") | **`RolledBack`** ("Upgrade to X failed post-install health check; rolled back to the previous binary. Agent is healthy on the baseline version — safe to retry once root cause is understood.") |
| Binary swap committed, agent broken on new version, rollback ALSO failed | `Failed` (correct) | `Failed` (unchanged — `ROLLBACK_CRITICAL_FAILED` is genuinely broken) |
| Halibut RPC failed before script ran | `Failed` (correct) | `Failed` (unchanged) |

## Why Windows needs no code change

The Windows strategy's outer Halibut wrapper exits 0 after scheduling the detached Task Scheduler task. The actual rollback outcome reaches the server via the agent's `last-upgrade.json` on the next health check, surfaced verbatim through `/api/machines/{id}/upgrade-status`. The existing `ROLLED_BACK` status string from the Windows script is already operator-visible there.

The Linux strategy IS the only place that needs `InterpretScriptResult` adjustment, because its outer Halibut script completes synchronously with the rollback outcome (exit code 4).

## Wire contract pin

- New `MachineUpgradeStatus.RolledBack = 5` — appended at end per wire-stability convention
- 13-row integrity test pins both numeric ordinals AND name literals for all 6 status values + a total-count drift detector
- `LinuxTentacleUpgradeStrategy.LinuxExitRolledBack` constant (= 4) pinned to the script's `exit 4` contract — if either side changes, the test fails

## Test plan

- [x] +13 wire-stability pins on `MachineUpgradeStatus` enum (6 ordinal + 6 name + 1 count)
- [x] +1 strategy test: exit 4 → `RolledBack` with operator-actionable Detail
- [x] +1 constant pin: `LinuxExitRolledBack == 4`
- [x] Existing `ScriptNonZeroExit_ReturnsFailedWithLastLogLine` still covers non-rollback failures (preserves regression coverage)
- [x] **5578/5578 unit tests green** (+15 net new)
- [ ] E2E: deferred to H8 (E2E matrix includes rollback-triggered-by-failing-binary scenarios)

## Operator UX after H6

FE can render three distinct upgrade-status badges based on `MachineUpgradeStatus`:

- 🟢 `Upgraded` / `AlreadyUpToDate` — green, no action
- 🟡 `RolledBack` — yellow, "Safely restored to baseline. Review upgrade.log + last-upgrade.json before retry."
- 🔴 `Failed` / `NotSupported` — red, "Investigation needed."
- 🔵 `Initiated` — blue, "In progress, check back."

## What's NOT in this PR

- **H7**: Role/feature capability slots (next — catches "IIS not installed" at plan-time)
- **H8**: Comprehensive E2E test matrix (validates the full upgrade chain end-to-end)