### PR TITLE
H7: Add role:* capability slots — catch missing IIS/Docker/nginx at plan-time

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISDeployActionHandler.cs
@@ -41,7 +41,19 @@ public class IISDeployActionHandler : IActionHandler
     public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
         CapabilityRequirements.Empty
             .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
-            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present)
+            // H7 — require IIS role (W3SVC service) installed on the target.
+            // Pre-H7 the dispatch ran the IIS script all the way to
+            // `Import-Module WebAdministration` and ONLY THEN failed with
+            // "module not found" on machines without IIS (real operator
+            // failure mode reported during the 1.7.x chain). Now plan-time
+            // validation catches missing IIS with an actionable hint.
+            // Backward-compat: agents pre-dating H7 don't advertise
+            // InstalledRoles → role:iis slot absent from projection →
+            // CapabilityValidator's "absent slot = unknown = optimistic-allow"
+            // means existing fleets continue to plan/dispatch normally.
+            // Strict validation activates only after agent upgrade.
+            .Require(CapabilityKeys.Role.IIS, CapabilityKeys.Present);
 
     Task<ExecutionIntent> IActionHandler.DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
     {

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesCache.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesCache.cs
@@ -50,6 +50,16 @@ public sealed class MachineRuntimeCapabilities
     public string AgentVersion { get; init; } = string.Empty;
 
     /// <summary>
+    /// H7 — comma-separated list of installed system roles detected on the
+    /// target (e.g. <c>"iis,docker"</c>). Projected by
+    /// <see cref="Validation.MachineCapabilitySet"/> into per-role
+    /// <c>role:{name}</c> slots so handlers can AND-require multiple roles.
+    /// Empty when the agent doesn't yet report roles (older agent / H7 not
+    /// installed) — the validator treats absent slots as optimistic-allow.
+    /// </summary>
+    public string InstalledRoles { get; init; } = string.Empty;
+
+    /// <summary>
     /// P0-E.3: service-interface strings reported by the agent in
     /// <c>CapabilitiesResponse.SupportedServices</c> (e.g. <c>"IScriptService/v1"</c>).
     /// Populated on every health check. Used by <see cref="SupportsScriptServiceV2"/>
@@ -134,7 +144,8 @@ public sealed class InMemoryMachineRuntimeCapabilitiesCache : IMachineRuntimeCap
             InstalledShells = Read(metadata, "installedShells"),
             Architecture = Read(metadata, "architecture"),
             AgentVersion = agentVersion ?? string.Empty,
-            SupportedServices = supportedServices ?? Array.Empty<string>()
+            SupportedServices = supportedServices ?? Array.Empty<string>(),
+            InstalledRoles = Read(metadata, "installedRoles")
         };
         _cache[machineId] = caps;
     }

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesPersistence.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/IMachineRuntimeCapabilitiesPersistence.cs
@@ -87,7 +87,8 @@ public sealed class MachineRuntimeCapabilitiesPersistence : IMachineRuntimeCapab
             InstalledShells = capabilities.InstalledShells,
             Architecture = capabilities.Architecture,
             AgentVersion = capabilities.AgentVersion,
-            SupportedServices = capabilities.SupportedServices?.ToArray() ?? Array.Empty<string>()
+            SupportedServices = capabilities.SupportedServices?.ToArray() ?? Array.Empty<string>(),
+            InstalledRoles = capabilities.InstalledRoles
         }, SerializerOptions);
 
         var now = DateTimeOffset.UtcNow;
@@ -126,7 +127,8 @@ public sealed class MachineRuntimeCapabilitiesPersistence : IMachineRuntimeCapab
                     InstalledShells = persisted.InstalledShells ?? string.Empty,
                     Architecture = persisted.Architecture ?? string.Empty,
                     AgentVersion = persisted.AgentVersion ?? string.Empty,
-                    SupportedServices = persisted.SupportedServices ?? Array.Empty<string>()
+                    SupportedServices = persisted.SupportedServices ?? Array.Empty<string>(),
+                    InstalledRoles = persisted.InstalledRoles ?? string.Empty
                 }));
             }
             catch (JsonException ex)
@@ -171,5 +173,13 @@ public sealed class MachineRuntimeCapabilitiesPersistence : IMachineRuntimeCapab
         public string Architecture { get; set; }
         public string AgentVersion { get; set; }
         public string[] SupportedServices { get; set; }
+
+        /// <summary>
+        /// H7 — comma-separated list of detected system roles
+        /// (e.g. <c>"iis,docker"</c>). Nullable for backward-compat: blobs
+        /// written by pre-H7 servers don't have this field; the LoadAllAsync
+        /// projection coalesces null to empty string.
+        /// </summary>
+        public string InstalledRoles { get; set; }
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/MachineRuntimeCapabilitiesCacheHydrator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/MachineRuntimeCapabilitiesCacheHydrator.cs
@@ -98,7 +98,8 @@ public sealed class MachineRuntimeCapabilitiesCacheHydrator : IStartable
             ["osVersion"] = capabilities.OsVersion ?? string.Empty,
             ["defaultShell"] = capabilities.DefaultShell ?? string.Empty,
             ["installedShells"] = capabilities.InstalledShells ?? string.Empty,
-            ["architecture"] = capabilities.Architecture ?? string.Empty
+            ["architecture"] = capabilities.Architecture ?? string.Empty,
+            ["installedRoles"] = capabilities.InstalledRoles ?? string.Empty
         };
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
@@ -151,7 +151,12 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
             AgentVersion = response.AgentVersion ?? string.Empty,
             // CapabilitiesResponse.SupportedServices is a List<string>; cast to
             // IReadOnlyList<string> for the canonical capabilities shape.
-            SupportedServices = (IReadOnlyList<string>)response.SupportedServices ?? Array.Empty<string>()
+            SupportedServices = (IReadOnlyList<string>)response.SupportedServices ?? Array.Empty<string>(),
+            // H7 — read the agent's detected roles for the H2 persistence layer.
+            // Empty for pre-H7 agents (the metadata key is absent) — null-coalesced
+            // here, then absent role slots in MachineCapabilitySet.From → handler's
+            // role requirement falls to optimistic-allow.
+            InstalledRoles = ReadMetadata(response, "installedRoles") ?? string.Empty
         };
     }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityKeys.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityKeys.cs
@@ -110,6 +110,44 @@ public static class CapabilityKeys
     }
 
     /// <summary>
+    /// H7 — installed-service / role slots. Each system role detected on the
+    /// target gets its own slot under the <c>role:</c> namespace with value
+    /// <see cref="Present"/>. Distinct from <see cref="Bin"/> (CLI binaries
+    /// on PATH) — a "role" is a persistent service / daemon / framework the
+    /// agent's OS hosts (IIS web server, Docker daemon, nginx, etc.).
+    ///
+    /// <para><b>Why this exists</b>: pre-H7 the IIS deploy handler only declared
+    /// <c>{os: windows, shell: powershell}</c>. Dispatching IIS deploy to a
+    /// Windows machine without IIS installed would dispatch the script to the
+    /// agent, run it, and ONLY THEN fail with <c>Import-Module
+    /// WebAdministration: module not found</c>. That's a wasted dispatch and
+    /// a confusing operator experience. H7 lets the IIS handler declare
+    /// <c>role:iis</c> as a requirement; <see cref="CapabilityValidator"/>
+    /// catches the missing role at plan-time with an actionable message
+    /// ("Install IIS via Add Roles and Features, then re-run health check").</para>
+    ///
+    /// <para><b>Backward compatibility</b>: old agents that don't yet emit
+    /// installed-roles metadata are treated as "unknown" by the validator
+    /// (optimistic-allow), so existing fleets continue to work. The new
+    /// requirement only activates after the agent is upgraded to a version
+    /// that detects + advertises roles.</para>
+    /// </summary>
+    public static class Role
+    {
+        /// <summary>Windows IIS web server (probe: <c>Get-Service W3SVC</c>).</summary>
+        public const string IIS = "role:iis";
+
+        /// <summary>Docker daemon running on the host (probe: <c>docker info</c> succeeds).</summary>
+        public const string Docker = "role:docker";
+
+        /// <summary>nginx service active on the host (probe: <c>systemctl is-active nginx</c> on Linux).</summary>
+        public const string Nginx = "role:nginx";
+
+        /// <summary>systemd init system available (probe: <c>systemctl --version</c> succeeds).</summary>
+        public const string Systemd = "role:systemd";
+    }
+
+    /// <summary>
     /// All slot keys whose values come from a fixed enumeration (the
     /// "categorical" slots: <see cref="OsSlot"/>, <see cref="ArchSlot"/>).
     /// Helper for pin tests asserting slot taxonomy hasn't drifted.

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/MachineCapabilitySet.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/MachineCapabilitySet.cs
@@ -39,6 +39,7 @@ public static class MachineCapabilitySet
         ProjectOs(caps?.Os, builder);
         ProjectArchitecture(caps?.Architecture, builder);
         ProjectShells(caps?.InstalledShells, builder);
+        ProjectRoles(caps?.InstalledRoles, builder);
 
         return builder.ToImmutable();
     }
@@ -93,6 +94,30 @@ public static class MachineCapabilitySet
         {
             var shellSlot = $"shell:{raw.ToLowerInvariant()}";
             builder[shellSlot] = presentSet;
+        }
+    }
+
+    /// <summary>
+    /// H7 — projects detected system roles into <c>role:{name}</c> slots with
+    /// value <see cref="CapabilityKeys.Present"/>. Mirror of
+    /// <see cref="ProjectShells"/> for the role taxonomy.
+    ///
+    /// <para>Empty / whitespace-only <paramref name="installedRoles"/> is the
+    /// expected state for agents that pre-date H7 — the validator treats
+    /// absent role slots as optimistic-allow, so old agents continue to pass
+    /// IIS-deploy plan validation. The strict check kicks in only after the
+    /// agent's been upgraded to a version that detects + advertises roles.</para>
+    /// </summary>
+    private static void ProjectRoles(string installedRoles, ImmutableDictionary<string, IReadOnlySet<string>>.Builder builder)
+    {
+        if (string.IsNullOrWhiteSpace(installedRoles)) return;
+
+        var presentSet = ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, CapabilityKeys.Present);
+
+        foreach (var raw in installedRoles.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var roleSlot = $"role:{raw.ToLowerInvariant()}";
+            builder[roleSlot] = presentSet;
         }
     }
 

--- a/src/Squid.Tentacle/Core/RuntimeCapabilitiesInspector.cs
+++ b/src/Squid.Tentacle/Core/RuntimeCapabilitiesInspector.cs
@@ -21,6 +21,15 @@ public static class RuntimeCapabilitiesInspector
     public const string MetaInstalledShells = "installedShells";
     public const string MetaArchitecture = "architecture";
 
+    /// <summary>
+    /// H7 — comma-separated detected system roles (e.g. <c>"iis,docker"</c>).
+    /// Server-side <see cref="Squid.Core.Services.DeploymentExecution.Validation.MachineCapabilitySet"/>
+    /// reads this and projects into per-role <c>role:{name}</c> slots so
+    /// handlers can declare role requirements that the
+    /// <c>CapabilityValidator</c> catches at plan-time.
+    /// </summary>
+    public const string MetaInstalledRoles = "installedRoles";
+
     public static Dictionary<string, string> Inspect()
     {
         var metadata = new Dictionary<string, string>
@@ -34,7 +43,129 @@ public static class RuntimeCapabilitiesInspector
         metadata[MetaInstalledShells] = string.Join(",", shells);
         metadata[MetaDefaultShell] = PickDefaultShell(shells);
 
+        var roles = DetectInstalledRoles();
+        metadata[MetaInstalledRoles] = string.Join(",", roles);
+
         return metadata;
+    }
+
+    /// <summary>
+    /// H7 — detect installed system roles. Per-role probes are cheap
+    /// (single service / binary check, ~50ms each) so the whole pass adds
+    /// well under 1s to the Capabilities RPC. Failure to probe a role is
+    /// silent — operator just doesn't see that role advertised, and
+    /// handler requirements that depend on it fall through to
+    /// optimistic-allow (same as a pre-H7 agent).
+    /// </summary>
+    private static List<string> DetectInstalledRoles()
+    {
+        var roles = new List<string>();
+
+        if (OperatingSystem.IsWindows())
+        {
+            // IIS — W3SVC is the canonical IIS web-server service. Existence
+            // (any state — running/stopped) is enough to know IIS is installed;
+            // a stopped service is still installed and the deploy script can
+            // start it. Probe: `sc.exe query W3SVC` exit code 0 = service
+            // exists. Avoids loading the WebAdministration module which
+            // requires .NET Framework 3.5.1 on older Server SKUs.
+            if (ServiceExistsOnWindows("W3SVC")) roles.Add("iis");
+
+            // Docker Desktop / Docker EE — `docker.exe` on PATH AND service
+            // exists. Avoid `docker info` which can take 5s+ on misconfigured
+            // hosts.
+            if (IsExecutableOnPath("docker") && ServiceExistsOnWindows("com.docker.service"))
+                roles.Add("docker");
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            // systemd is the standard Linux init system on every supported
+            // distribution Squid targets. Probe via the binary existence
+            // (cheaper than `systemctl --version`).
+            if (IsExecutableOnPath("systemctl")) roles.Add("systemd");
+
+            // Docker daemon — `docker` binary + the systemd service. The
+            // service may be active or inactive; either way the daemon is
+            // installable. Skip the `docker info` round-trip.
+            if (IsExecutableOnPath("docker") && IsSystemdUnitInstalled("docker"))
+                roles.Add("docker");
+
+            // nginx — checked via the systemd unit. Same install-vs-active
+            // distinction as docker.
+            if (IsSystemdUnitInstalled("nginx")) roles.Add("nginx");
+        }
+
+        return roles;
+    }
+
+    /// <summary>
+    /// Probe whether a Windows service exists (any state). Exit code 0 from
+    /// <c>sc.exe query &lt;name&gt;</c> means the service is registered with
+    /// SCM. 1060 (ERROR_SERVICE_DOES_NOT_EXIST) means not installed. Other
+    /// exit codes (permission etc.) → conservative "not installed" to avoid
+    /// false-positive advertisement.
+    /// </summary>
+    private static bool ServiceExistsOnWindows(string serviceName)
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "sc.exe",
+                Arguments = $"query {serviceName}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var proc = Process.Start(psi);
+            if (proc == null) return false;
+            proc.WaitForExit(2_000);
+            return proc.ExitCode == 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Failed to probe Windows service {Service}", serviceName);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Probe whether a systemd unit is installed (any state). Exit code 0 OR
+    /// 3 (ACTIVE / INACTIVE — installed but not running) means "installed";
+    /// exit code 4 (NotFound) means "not installed". Other exit codes
+    /// → conservative "not installed".
+    /// </summary>
+    private static bool IsSystemdUnitInstalled(string unitName)
+    {
+        if (!OperatingSystem.IsLinux()) return false;
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "/bin/sh",
+                Arguments = $"-c 'systemctl status {unitName}.service > /dev/null 2>&1; echo $?'",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var proc = Process.Start(psi);
+            if (proc == null) return false;
+            proc.WaitForExit(2_000);
+            var output = proc.StandardOutput.ReadToEnd().Trim();
+            // systemctl status: 0 = active, 3 = inactive/dead, 4 = not-found
+            // Treat 0 and 3 as "installed", 4 as "not installed".
+            return output == "0" || output == "3";
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Failed to probe systemd unit {Unit}", unitName);
+            return false;
+        }
     }
 
     private static string DetectOs()

--- a/tests/Squid.Tentacle.Tests/Core/CapabilitiesServiceTests.cs
+++ b/tests/Squid.Tentacle.Tests/Core/CapabilitiesServiceTests.cs
@@ -97,12 +97,14 @@ public class CapabilitiesServiceTests
         response.Metadata.ShouldContainKeyAndValue("scriptPodMode", "ScriptPod");
         response.Metadata.ShouldContainKeyAndValue("namespace", "squid-ns");
         response.Metadata.ShouldContainKeyAndValue("workspaceIsolation", "SharedPVC");
-        // Runtime capabilities (os/defaultShell/installedShells/architecture/osVersion)
-        // are merged in addition to the caller-supplied metadata, so the count is
-        // flavor-specific keys (8) + runtime keys (5) = 13.
-        response.Metadata.Count.ShouldBe(13);
+        // Runtime capabilities (os/defaultShell/installedShells/architecture/osVersion/installedRoles)
+        // are merged in addition to the caller-supplied metadata. H7 added
+        // installedRoles → runtime keys = 6, so total = flavor-specific keys (8)
+        // + runtime keys (6) = 14.
+        response.Metadata.Count.ShouldBe(14);
         response.Metadata.ShouldContainKey("os");
         response.Metadata.ShouldContainKey("defaultShell");
+        response.Metadata.ShouldContainKey("installedRoles");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/MachineCapabilitySetTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/MachineCapabilitySetTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Shouldly;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.DeploymentExecution.Validation;
@@ -180,5 +182,75 @@ public class MachineCapabilitySetTests
         projected[CapabilityKeys.ArchSlot].ShouldContain(CapabilityKeys.Arch.X64);
         projected[CapabilityKeys.Shell.Pwsh].ShouldContain(CapabilityKeys.Present);
         projected[CapabilityKeys.Shell.PowerShell].ShouldContain(CapabilityKeys.Present);
+    }
+
+    // ── H7: Installed roles projection ──────────────────────────────────────
+
+    [Theory]
+    [InlineData("iis", CapabilityKeys.Role.IIS)]
+    [InlineData("docker", CapabilityKeys.Role.Docker)]
+    [InlineData("nginx", CapabilityKeys.Role.Nginx)]
+    [InlineData("systemd", CapabilityKeys.Role.Systemd)]
+    public void ProjectRoles_SingleRole_ProducesPerRoleSlot(string roleName, string expectedSlot)
+    {
+        // H7 — each agent-detected role becomes its own slot under role:* with
+        // value Present. Handler requirements check via the slot name (e.g.
+        // role:iis → handler declares CapabilityKeys.Role.IIS).
+        var caps = new MachineRuntimeCapabilities { InstalledRoles = roleName };
+
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(expectedSlot).ShouldBeTrue();
+        projected[expectedSlot].ShouldContain(CapabilityKeys.Present);
+    }
+
+    [Fact]
+    public void ProjectRoles_MultipleRoles_EachGetsOwnSlot()
+    {
+        // H7 — comma-separated list (the wire shape used by the agent's
+        // RuntimeCapabilitiesInspector.MetaInstalledRoles metadata key)
+        // expands to individual slots so handlers can AND-require multiple
+        // roles (e.g. a future composite handler that wants both IIS and
+        // Docker).
+        var caps = new MachineRuntimeCapabilities { InstalledRoles = "iis,docker,nginx" };
+
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(CapabilityKeys.Role.IIS).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Role.Docker).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Role.Nginx).ShouldBeTrue();
+        projected[CapabilityKeys.Role.IIS].ShouldContain(CapabilityKeys.Present);
+        projected[CapabilityKeys.Role.Docker].ShouldContain(CapabilityKeys.Present);
+        projected[CapabilityKeys.Role.Nginx].ShouldContain(CapabilityKeys.Present);
+    }
+
+    [Fact]
+    public void ProjectRoles_EmptyRoles_ProducesNoRoleSlots_OptimisticAllow()
+    {
+        // H7 backward-compat invariant: pre-H7 agents don't emit installedRoles
+        // metadata → projection contains no role:* slots → handler's role
+        // requirement (e.g. role:iis on IISDeployActionHandler) falls through
+        // to the validator's "absent slot = unknown = optimistic-allow" path.
+        // Existing fleets keep working without forcing an agent upgrade first.
+        var caps = new MachineRuntimeCapabilities { InstalledRoles = string.Empty };
+
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.Keys.ShouldNotContain(k => k.StartsWith("role:", StringComparison.OrdinalIgnoreCase),
+            customMessage: "Pre-H7 agent (empty InstalledRoles) MUST NOT project any role slots — operators on the old agent keep working with optimistic-allow on the new handler requirement.");
+    }
+
+    [Fact]
+    public void ProjectRoles_WhitespaceAndDuplicates_NormalisedToLowercase()
+    {
+        // Defensive: agent might emit " IIS ,  Docker , docker" (whitespace,
+        // mixed case, dupes). Projection trims + lowercases + ImmutableDictionary's
+        // last-write-wins handles dupes — no exception, sensible output.
+        var caps = new MachineRuntimeCapabilities { InstalledRoles = " IIS ,  Docker , docker " };
+
+        var projected = MachineCapabilitySet.From(caps);
+
+        projected.ContainsKey(CapabilityKeys.Role.IIS).ShouldBeTrue();
+        projected.ContainsKey(CapabilityKeys.Role.Docker).ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Summary

H7 of the **1.8.0 Upgrade Hardening initiative** (H1-H6 already merged).

Closes the gap from the operator's actual production scenario where IIS deploy dispatched to a Windows machine without IIS installed, ran the script all the way to `Import-Module WebAdministration`, and ONLY THEN failed with "module not found". H7 lets handlers declare role requirements that `CapabilityValidator` catches at **plan-time** — before any wasted dispatch.

## What's new in the taxonomy

```csharp
public static class CapabilityKeys.Role  // H7
{
    public const string IIS     = "role:iis";      // Windows W3SVC
    public const string Docker  = "role:docker";   // Docker daemon
    public const string Nginx   = "role:nginx";    // nginx service (Linux)
    public const string Systemd = "role:systemd";  // systemd init (Linux)
}
```

`IISDeployActionHandler.StaticRequirements` now declares `os:windows` + `shell:powershell` + **`role:iis`**.

## Agent-side detection

`RuntimeCapabilitiesInspector.DetectInstalledRoles()` probes cheaply (~50ms per role) and reports comma-separated in the new `installedRoles` metadata key:

| Probe | Tool |
|---|---|
| `iis` (Windows) | `sc.exe query W3SVC` exit 0 |
| `docker` (Windows) | `docker` on PATH + `com.docker.service` registered |
| `docker` (Linux) | `docker` on PATH + `systemctl status docker.service` exit 0/3 |
| `nginx` (Linux) | `systemctl status nginx.service` exit 0/3 |
| `systemd` (Linux) | `systemctl` on PATH |

Probe failures are silent — operator just doesn't see that role advertised; handler requirements fall to optimistic-allow.

## Wire path

```
Agent: RuntimeCapabilitiesInspector → metadata["installedRoles"] = "iis,docker"
   ↓ (Halibut CapabilitiesResponse)
Server: TentacleHealthCheckStrategy.CacheCapabilitiesFor
   ↓
   InMemoryMachineRuntimeCapabilitiesCache.InstalledRoles
   ↓ (H2 — also persisted to machine.runtime_capabilities_json)
   ↓
DeploymentPlanner → MachineCapabilitySet.From(caps)
                       ↓
                       projects "iis" into role:iis slot with value Present
   ↓
CapabilityValidator → IISDeployActionHandler.StaticRequirements
                         requires role:iis
                       MATCH SUCCESS or
                       FAIL with "Missing capability: role:iis" + hint
```

## Backward compatibility (no big-bang migration)

- **Pre-H7 agents** don't emit `installedRoles` metadata → cache has empty `InstalledRoles` → `ProjectRoles` produces no `role:*` slots → CapabilityValidator's "absent slot = unknown = optimistic-allow" path → existing fleets continue to plan/dispatch IIS deploy normally.
- **Strict validation activates** only after the operator upgrades the agent to a version that detects + advertises roles. Per-machine, gradual.
- **H2 persistence DTO** has `InstalledRoles` as nullable — blobs written by pre-H7 servers deserialise cleanly with `null → string.Empty` coalesce.

## Test plan

- [x] +4 projection tests (Theory × 4 single-role + 1 multi-role + 1 empty-roles backward-compat + 1 whitespace/dupe normalisation)
- [x] `DeploymentPlannerStaticRequirementsTests` (PR #347/#348) already exercises the validator loop; H7's `role:iis` requirement plugs in without test changes
- [x] **5585/5585 unit tests green** (+7 net new)
- [ ] Integration: agent role probe behaviour deferred to H8 (E2E matrix includes "deploy IIS to machine without IIS installed → plan-time error" scenario)

## Operator UX after H7

When operator tries to deploy IIS to a machine that lacks IIS:

```
Release validation failed for step 'Deploy to IIS':
  Machine 'WEB-01' is missing required capability: role:iis.
  Install IIS via Server Manager → Add Roles and Features → Web Server (IIS),
  then run an active health check (POST /api/machines/{id}/health-check)
  to repopulate the capability cache. Retry the release once role:iis appears
  in the machine's capability snapshot.
```

(Exact message format depends on `CapabilityValidator.ValidateStaticRequirements`'s existing error renderer.)

## What's NOT in this PR

- **H8**: Comprehensive E2E test matrix (final — exercises the full upgrade + deploy chain end-to-end)