### PR TITLE
1.8.0 hardening review followups — fix H4 clock skew + backfill H7 test gaps

### DIFF
--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -628,8 +628,15 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         var deadline = metadata.DispatchedAt + LockExpiry;
         var remaining = deadline - DateTimeOffset.UtcNow;
 
+        // 1.8.0 hardening audit followup — clock-skew guard. Two server pods
+        // can disagree on UTC by seconds-to-minutes during NTP slew / fresh
+        // pod startup before time-sync converges. If pod B reads metadata
+        // pod A wrote, B can see DispatchedAt in B's future → elapsed turns
+        // negative and the operator sees the cosmetically wrong "~-3599s ago"
+        // in the contention message. `remaining` was already clamped at
+        // construction-time of H4; `elapsed` needed the same treatment.
         return $"Machine '{machine.Name}' is currently being upgraded by another request " +
-               $"(dispatched at {metadata.DispatchedAt:HH:mm:ss} UTC, ~{elapsed.TotalSeconds:F0}s ago, " +
+               $"(dispatched at {metadata.DispatchedAt:HH:mm:ss} UTC, ~{Math.Max(0, elapsed.TotalSeconds):F0}s ago, " +
                $"targeting {metadata.TargetVersion ?? "unknown"}). " +
                $"Expected to complete by {deadline:HH:mm:ss} UTC " +
                $"(~{Math.Max(0, remaining.TotalSeconds):F0}s remaining). " +

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/MachineRuntimeCapabilitiesPersistenceTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/MachineRuntimeCapabilitiesPersistenceTests.cs
@@ -29,7 +29,8 @@ public sealed class MachineRuntimeCapabilitiesPersistenceTests
             InstalledShells = "powershell,cmd",
             Architecture = "X64",
             AgentVersion = "1.7.9",
-            SupportedServices = new[] { "IScriptService/v1" }
+            SupportedServices = new[] { "IScriptService/v1" },
+            InstalledRoles = "iis,docker"
         };
 
         var json = JsonSerializer.Serialize(persisted, MachineRuntimeCapabilitiesPersistence.SerializerOptions);
@@ -42,6 +43,12 @@ public sealed class MachineRuntimeCapabilitiesPersistenceTests
         json.ShouldContain("\"architecture\":\"X64\"");
         json.ShouldContain("\"agentVersion\":\"1.7.9\"");
         json.ShouldContain("\"supportedServices\":[\"IScriptService/v1\"]");
+        // H7 — installedRoles wire-name pinned. Audit followup: H7 added the
+        // property but the shape-stability tests didn't assert it appears in
+        // serialised JSON. A rename to PascalCase or a JsonPropertyName attribute
+        // drift would have gone undetected → cross-version hydration silently
+        // skips roles → IIS deploy plan-time validation silently regresses.
+        json.ShouldContain("\"installedRoles\":\"iis,docker\"");
     }
 
     [Fact]
@@ -60,7 +67,8 @@ public sealed class MachineRuntimeCapabilitiesPersistenceTests
               "installedShells": "bash,zsh",
               "architecture": "Arm64",
               "agentVersion": "1.8.0",
-              "supportedServices": ["IScriptService/v1", "IScriptService/v2"]
+              "supportedServices": ["IScriptService/v1", "IScriptService/v2"],
+              "installedRoles": "docker,nginx,systemd"
             }
             """;
 
@@ -75,6 +83,36 @@ public sealed class MachineRuntimeCapabilitiesPersistenceTests
         persisted.Architecture.ShouldBe("Arm64");
         persisted.AgentVersion.ShouldBe("1.8.0");
         persisted.SupportedServices.ShouldBe(new[] { "IScriptService/v1", "IScriptService/v2" });
+        persisted.InstalledRoles.ShouldBe("docker,nginx,systemd");
+    }
+
+    [Fact]
+    public void Deserialise_PreH7Blob_WithoutInstalledRoles_BackwardCompatible()
+    {
+        // H7 backward-compat invariant: blobs written by 1.8.0 servers (which
+        // didn't have InstalledRoles yet) MUST still deserialise on H7-aware
+        // servers. The DTO's InstalledRoles property is nullable specifically
+        // for this — a server upgrading from 1.8.0 → 1.8.x reading its OWN
+        // older DB rows shouldn't get a hydration failure.
+        var preH7Json = """
+            {
+              "os": "Linux",
+              "osVersion": "5.15.0",
+              "defaultShell": "bash",
+              "installedShells": "bash",
+              "architecture": "X64",
+              "agentVersion": "1.8.0",
+              "supportedServices": ["IScriptService/v1"]
+            }
+            """;
+
+        var persisted = JsonSerializer.Deserialize<MachineRuntimeCapabilitiesPersistence.PersistedCapabilities>(
+            preH7Json, MachineRuntimeCapabilitiesPersistence.SerializerOptions);
+
+        persisted.ShouldNotBeNull();
+        persisted!.Os.ShouldBe("Linux");
+        persisted.InstalledRoles.ShouldBeNull(
+            customMessage: "Pre-H7 JSON (no installedRoles field) MUST deserialise to InstalledRoles=null; the hydrator's null-coalesce makes this safe for the cache.");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleHealthCheckStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleHealthCheckStrategyTests.cs
@@ -137,6 +137,46 @@ public class TentacleHealthCheckStrategyTests
     }
 
     [Fact]
+    public async Task CheckHealth_InstalledRolesInMetadata_PopulatedIntoCache()
+    {
+        // H7 audit followup. The original H7 test for the cache-population
+        // path didn't include installedRoles in the metadata fixture, so a
+        // regression that broke BuildCapabilitiesFromResponse's read of the
+        // installedRoles key would have gone undetected. The wire contract
+        // is: agent reports comma-separated roles in metadata["installedRoles"]
+        // → server reads into MachineRuntimeCapabilities.InstalledRoles →
+        // MachineCapabilitySet.ProjectRoles produces role:* slots →
+        // CapabilityValidator catches missing role at plan-time. If the read
+        // breaks, the whole chain silently optimistic-allows.
+        var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-99","Thumbprint":"EEFF"}""", machineId: 199);
+
+        var capsClient = new Mock<IAsyncCapabilitiesService>();
+        capsClient.Setup(c => c.GetCapabilitiesAsync(It.IsAny<CapabilitiesRequest>()))
+            .ReturnsAsync(new CapabilitiesResponse
+            {
+                AgentVersion = "1.8.1",
+                SupportedServices = new List<string> { "IScriptService/v1" },
+                Metadata = new Dictionary<string, string>
+                {
+                    ["os"] = "Windows",
+                    ["defaultShell"] = "powershell",
+                    ["installedShells"] = "powershell,cmd",
+                    ["installedRoles"] = "iis,docker"
+                }
+            });
+        _clientFactory.Setup(f => f.CreateCapabilitiesClient(It.IsAny<ServiceEndPoint>())).Returns(capsClient.Object);
+
+        var cache = new InMemoryMachineRuntimeCapabilitiesCache();
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, cache);
+
+        await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+
+        var cached = cache.TryGet(199);
+        cached.InstalledRoles.ShouldBe("iis,docker",
+            customMessage: "H7 wire contract: BuildCapabilitiesFromResponse MUST read metadata[\"installedRoles\"] verbatim into MachineRuntimeCapabilities.InstalledRoles. A read-side regression here silently breaks the IIS deploy plan-time validation chain.");
+    }
+
+    [Fact]
     public async Task CheckHealth_NoMetadata_StillHealthy_AndCacheStoresAgentVersion()
     {
         var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-1","Thumbprint":"CCDD"}""", machineId: 88);

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityKeysConstantsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Validation/CapabilityKeysConstantsTests.cs
@@ -101,6 +101,27 @@ public class CapabilityKeysConstantsTests
         actual.ShouldBe(expectedKey);
     }
 
+    [Theory]
+    [InlineData("role:iis", "IIS")]
+    [InlineData("role:docker", "Docker")]
+    [InlineData("role:nginx", "Nginx")]
+    [InlineData("role:systemd", "Systemd")]
+    public void Role_SlotNamespacePinned(string expectedKey, string name)
+    {
+        // H7 — audit followup. Shell / Bin / Privilege namespaces had pinning
+        // tests; the Role namespace shipped in 1.8.0 without one. A rename like
+        // CapabilityKeys.Role.IIS → .Iis would have been a silent contract
+        // break — IISDeployActionHandler.StaticRequirements references the
+        // constant symbol, but a downgrade of its value (e.g. "role:iis" →
+        // "role:IIS") would silently make the validator's case-insensitive
+        // overlap check stop matching the agent's lowercase "iis" advertisement.
+        var actual = typeof(CapabilityKeys.Role)
+            .GetField(name, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            ?.GetRawConstantValue() as string;
+
+        actual.ShouldBe(expectedKey);
+    }
+
     [Fact]
     public void CategoricalSlots_ContainsOsAndArch_Only()
     {

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
@@ -747,6 +747,63 @@ public sealed class MachineUpgradeServiceTests
     }
 
     [Fact]
+    public async Task UpgradeAsync_Contention_DispatchedAtInFuture_ClockSkewGuarded_NoNegativeSeconds()
+    {
+        // 1.8.0 hardening audit followup. When two server pods disagree on UTC
+        // by seconds-to-minutes during NTP slew, pod B reading metadata pod A
+        // wrote can see DispatchedAt in B's future → `elapsed = now - dispatchedAt`
+        // turns negative → operator sees the cosmetically wrong "~-3599s ago"
+        // in the contention message. `remaining` was already clamped at
+        // construction-time of H4; `elapsed` got the same Math.Max(0, ...)
+        // guard in the followup.
+        ArrangeMachine(id: 64, style: nameof(CommunicationStyle.TentaclePolling));
+        _runtimeCache.Store(64, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.9");
+
+        // Simulate clock skew — DispatchedAt is 5 minutes IN THE FUTURE from
+        // this server's perspective (i.e. the writer pod's clock was ahead).
+        var futureDispatch = DateTimeOffset.UtcNow.AddMinutes(5);
+        var metadataStore = new Mock<IUpgradeDispatchMetadataStore>();
+        metadataStore
+            .Setup(s => s.ReadAsync(64, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpgradeDispatchMetadata
+            {
+                DispatchedAt = futureDispatch,
+                TargetVersion = "1.8.1",
+                CurrentVersion = "1.7.9"
+            });
+
+        _redisLock
+            .Setup(x => x.ExecuteWithLockAsync<UpgradeMachineResponseData>(
+                It.IsAny<string>(),
+                It.IsAny<Func<Task<UpgradeMachineResponseData>>>(),
+                It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<RedisServer>()))
+            .ReturnsAsync((UpgradeMachineResponseData)null);
+
+        var service = new MachineUpgradeService(
+            _machineDataProvider.Object,
+            _runtimeCache,
+            _versionRegistry.Object,
+            new[] { _linuxStrategy.Object, _k8sStrategy.Object },
+            _redisLock.Object,
+            _backgroundJobClient.Object,
+            runtimePersistence: null,
+            dispatchMetadata: metadataStore.Object);
+
+        var resp = await service.UpgradeAsync(new UpgradeMachineCommand { MachineId = 64 }, CancellationToken.None);
+
+        // The specific failure mode the guard prevents: '~-{N}s ago'. Pre-fix
+        // a 5-minute-future DispatchedAt produced '~-300s ago' in the message;
+        // the Math.Max(0, ...) clamp turns this into '~0s ago'. Search for
+        // the negative pattern specifically (not all `-` — timestamps in some
+        // cultures legitimately contain hyphens).
+        resp.Detail.ShouldNotContain("~-",
+            customMessage: "Clock-skew guard MUST clamp `elapsed` at zero so operators never see '~-{N}s ago' in the contention message. Pre-fix this happened during NTP slew or fresh-pod startup before time-sync converged.");
+        resp.Detail.ShouldContain("~0s ago",
+            customMessage: "When DispatchedAt is in the future (clock skew), the floor-clamped elapsed MUST format as '~0s ago' — degraded but readable.");
+    }
+
+    [Fact]
     public async Task UpgradeAsync_Contention_NoDispatchMetadata_FallsBackToGenericMessage()
     {
         // H4 fallback path: when the metadata store is unavailable (e.g. Redis


### PR DESCRIPTION
## Summary

Post-merge self-audit of the 1.8.0 Upgrade Hardening initiative (8 PRs #354-#361) surfaced **one real cosmetic bug** and **three test-coverage gaps** that would not have caught a future regression. This PR addresses both in one go for 1.8.1.

## 🔴 Bug fix — H4 clock-skew negative `elapsed`

**File**: `src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs`

`BuildContentionMessageAsync` was clamping `remaining` with `Math.Max(0, ...)` but the symmetric guard was missing for `elapsed`:

```diff
- $"... ~{elapsed.TotalSeconds:F0}s ago ... ~{Math.Max(0, remaining.TotalSeconds):F0}s remaining)"
+ $"... ~{Math.Max(0, elapsed.TotalSeconds):F0}s ago ... ~{Math.Max(0, remaining.TotalSeconds):F0}s remaining)"
```

**Failure scenario:** Two server pods disagree on UTC by seconds-to-minutes (NTP slew / fresh-pod startup before time-sync converges). Pod B reading metadata pod A wrote sees `DispatchedAt` in B's future → `elapsed` turns negative → operator sees the cosmetically wrong `"~-3599s ago"` in the contention message.

**Cosmetic only** — dispatch itself worked correctly. But operator UX regression. New test `UpgradeAsync_Contention_DispatchedAtInFuture_ClockSkewGuarded_NoNegativeSeconds` simulates 5-min skew and pins the guard.

## ⚠️ H7 test gaps backfilled

### Gap 1 — `CapabilityKeys.Role.*` constants not pinned

Shell / Bin / Privilege namespaces each had a Theory-based pinning test in `CapabilityKeysConstantsTests`. The Role namespace shipped in 1.8.0 without one. A rename `Role.IIS → Role.Iis` OR a downgrade `"role:iis" → "role:IIS"` would have been a silent contract break with the agent's lowercase emission.

→ Added Theory pinning the 4-tuple (IIS / Docker / Nginx / Systemd).

### Gap 2 — `TentacleHealthCheckStrategy` cache test missing `installedRoles` in metadata

The wire chain is: agent emits `metadata["installedRoles"]` → server reads into `MachineRuntimeCapabilities.InstalledRoles` → `MachineCapabilitySet` projects `role:*` slots → `CapabilityValidator` catches missing IIS at plan-time. If `BuildCapabilitiesFromResponse`'s read of the `installedRoles` key broke, **the whole chain silently optimistic-allows**.

→ Added `CheckHealth_InstalledRolesInMetadata_PopulatedIntoCache` test verifying the read-side wire contract.

### Gap 3 — `MachineRuntimeCapabilitiesPersistence` JSON shape didn't pin `installedRoles`

The DTO had the field but the serialisation/deserialisation tests didn't assert it appears in the canonical JSON. PascalCase regression OR `[JsonPropertyName]` drift would have caused cross-version hydration to silently skip roles.

→ Added `installedRoles` assertion to the existing serialisation + deserialisation tests. New `Deserialise_PreH7Blob_WithoutInstalledRoles_BackwardCompatible` test verifies 1.8.0 blobs (no `installedRoles` field) still deserialise with null on H7-aware servers — the in-place upgrade path from 1.8.0 to 1.8.1.

## Test plan

- [x] +1 H4 clock-skew guard regression test
- [x] +4 H7 Role constant pinning (Theory rows)
- [x] +1 H7 cache-population read-side test with `installedRoles`
- [x] +1 H7 backward-compat deserialisation test
- [x] Modified 2 existing serialisation tests to pin `installedRoles`
- [x] **5603/5603 unit tests green** (+7 net new vs 5596 baseline post-H8)
- [ ] Operator-side: no operator-visible behaviour change beyond cosmetic contention-message fix (1.8.0 dispatches succeeded already)

## Acceptance criteria

After 1.8.1 ships, this 8-PR initiative chain has BOTH:
1. **Behavioural correctness** pinned by H1-H8 + this fix (the operator's 1.7.x failure chain is structurally impossible to reproduce)
2. **Contract stability** pinned by the new test additions (a future refactor can't silently break the agent ↔ server wire format without a test-time-visible decision)

## What's NOT in this PR

- Other minor test gaps mentioned in audit (e.g. `LoadAllAsync` mixed corrupted/valid rows, `BuildMetadataDictionary` keys symmetry) — deferred to a separate audit-coverage PR if needed. The three highest-value gaps (wire-shape stability for the new H7 `installedRoles` field) are the ones that would silently regress the operator's IIS deploy plan-time validation if not pinned.