### PR TITLE
G1.1: SubstituteInFilesStep — close the IIS UI-theatre toggle

### DIFF
--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -1,3 +1,4 @@
+using Squid.Calamari.Commands.Substitution;
 using Squid.Calamari.Execution;
 using Squid.Calamari.Pipeline;
 using Squid.Calamari.Scripting;
@@ -7,6 +8,22 @@ namespace Squid.Calamari.Commands;
 /// <summary>
 /// Handles the `run-script` subcommand.
 /// Loads variables, prepends them as bash exports, then executes the script.
+///
+/// <para><b>Pipeline order matters</b>:
+/// <list type="number">
+///   <item>ResolveWorkingDirectory — pin the cwd for the rest of the pipeline.</item>
+///   <item>LoadVariablesFromFiles — read variables.json + sensitiveVariables.json
+///         into the in-memory VariableSet so later steps can use them.</item>
+///   <item><b>SubstituteInFiles (G1.1)</b> — apply <c>#{Token}</c> replacement
+///         to operator-nominated file globs BEFORE the user script runs.
+///         Must come after LoadVariables (needs the values) and before
+///         WriteBootstrappedBashScript (operator's script might reference
+///         the substituted files; we want them fully prepared first).</item>
+///   <item>WriteBootstrappedBashScript — prepend `export VAR=` bash preamble.</item>
+///   <item>ExecuteScriptWithEngine — actually run the user's script.</item>
+///   <item>BuildRunScriptCommandResult — collect exit code + outputs.</item>
+///   <item>CleanupTemporaryFiles — best-effort cleanup (always-runs).</item>
+/// </list></para>
 /// </summary>
 public class RunScriptCommand
 {
@@ -23,6 +40,7 @@ public class RunScriptCommand
         [
             new ResolveWorkingDirectoryStep<RunScriptCommandContext>(),
             new LoadVariablesFromFilesStep<RunScriptCommandContext>(),
+            new SubstituteInFilesStep(),
             new WriteBootstrappedBashScriptStep(),
             new ExecuteScriptWithEngineStep(scriptEngine),
             new BuildRunScriptCommandResultStep(),

--- a/src/Squid.Calamari/Commands/Substitution/GlobMatcher.cs
+++ b/src/Squid.Calamari/Commands/Substitution/GlobMatcher.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Squid.Calamari.Commands.Substitution;
+
+/// <summary>
+/// G1.1 — minimal in-house glob-to-file-enumeration utility. Backs
+/// <see cref="SubstituteInFilesStep"/>'s target-files matching. Deliberately
+/// avoids the <c>Microsoft.Extensions.FileSystemGlobbing</c> NuGet because
+/// Squid.Calamari ships in the agent zip and we want the smallest possible
+/// agent footprint (per the Architecture Decision — Squid.Calamari stays
+/// lean, no heavy plugin distribution).
+///
+/// <para><b>Supported patterns</b> (operator-facing — matches Octopus's
+/// <c>Octopus.Action.SubstituteInFiles.TargetFiles</c> shape):
+/// <list type="bullet">
+///   <item><c>web.config</c> — literal filename, exact match in root</item>
+///   <item><c>*.config</c> — wildcard within a single segment</item>
+///   <item><c>**/*.config</c> — recursive across subdirectories</item>
+///   <item><c>config/*.json</c> — sub-segment wildcard</item>
+///   <item><c>**/appsettings.*.json</c> — recurse + wildcard suffix</item>
+/// </list></para>
+///
+/// <para><b>Anti-injection</b>: dots in glob patterns are literal, not
+/// regex any-char. Path-traversal globs (<c>../*.config</c>) yield zero
+/// matches — substitution stays sandboxed to the working dir. Pinned by
+/// <c>Expand_DotIsLiteral_NotRegexAnyChar</c> and
+/// <c>Expand_PathTraversalAttempt_BoundedToRoot</c>.</para>
+/// </summary>
+internal static class GlobMatcher
+{
+    public static IEnumerable<string> Expand(string rootDir, string pattern)
+    {
+        if (string.IsNullOrEmpty(pattern)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(rootDir)) return Array.Empty<string>();
+        if (!Directory.Exists(rootDir)) return Array.Empty<string>();
+
+        // Path-traversal sandbox: reject any pattern that uses `..` segments.
+        // No legitimate config-substitution glob needs to escape the working
+        // dir; a malicious package could otherwise use this to rewrite host
+        // files outside the deploy work area.
+        var normalised = pattern.Replace('\\', '/');
+        if (normalised.Split('/').Any(seg => seg == ".."))
+            return Array.Empty<string>();
+
+        var regex = GlobToRegex(normalised);
+        var rootFull = Path.GetFullPath(rootDir);
+
+        return EnumerateAllFiles(rootDir)
+            .Select(absPath => (absPath, relPath: GetRelativePath(rootFull, absPath)))
+            .Where(t => regex.IsMatch(t.relPath))
+            .Select(t => t.absPath)
+            .ToList();    // materialise so caller can mutate files without enumeration races
+    }
+
+    private static IEnumerable<string> EnumerateAllFiles(string rootDir)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(rootDir, "*", SearchOption.AllDirectories);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Array.Empty<string>();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Skip directories we can't read — log? for now, silent skip;
+            // the SubstituteInFilesStep logs the overall outcome.
+            return Array.Empty<string>();
+        }
+    }
+
+    private static string GetRelativePath(string root, string fullPath)
+    {
+        var rel = Path.GetRelativePath(root, fullPath);
+        return rel.Replace('\\', '/');    // normalise so glob patterns are platform-agnostic
+    }
+
+    /// <summary>
+    /// Translate a glob pattern into a regex. Pure function — pinned by
+    /// <c>GlobMatcherTests</c>.
+    /// </summary>
+    internal static Regex GlobToRegex(string pattern)
+    {
+        var sb = new StringBuilder("^");
+
+        var i = 0;
+        while (i < pattern.Length)
+        {
+            var c = pattern[i];
+
+            if (c == '*' && i + 1 < pattern.Length && pattern[i + 1] == '*')
+            {
+                // `**` = match anything including path separators (recursive).
+                // Skip optional trailing slash so `**/*.config` works.
+                sb.Append(".*");
+                i += 2;
+                if (i < pattern.Length && pattern[i] == '/') i++;
+            }
+            else if (c == '*')
+            {
+                // `*` = match any char EXCEPT path separator (within-segment).
+                sb.Append("[^/]*");
+                i++;
+            }
+            else if (c == '?')
+            {
+                // `?` = single non-separator char.
+                sb.Append("[^/]");
+                i++;
+            }
+            else
+            {
+                // Everything else (including `.`) is literal — escape for regex.
+                sb.Append(Regex.Escape(c.ToString()));
+                i++;
+            }
+        }
+
+        sb.Append('$');
+        return new Regex(sb.ToString(), RegexOptions.Compiled);
+    }
+}

--- a/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
+++ b/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
@@ -1,0 +1,256 @@
+using System.Text;
+using Squid.Calamari.Pipeline;
+
+namespace Squid.Calamari.Commands.Substitution;
+
+/// <summary>
+/// G1.1 — pipeline step that does <c>#{Token}</c> substitution on operator-
+/// nominated files (per IIS handler's <c>SubstituteInFiles.TargetFiles</c> globs).
+///
+/// <para><b>Why this exists</b>: pre-G1.1 the IIS handler advertised a
+/// "Substitute variables in files" toggle but no Calamari step actually
+/// consumed the variables. Operators saw the UI toggle, set
+/// <c>SubstituteInFiles.Enabled = True</c>, and the deployment ran without
+/// any substitution happening — silently. The parent decision document
+/// (Squid Calamari Architecture Decision 2026-05-23) committed to filling
+/// out these advertised features inside Calamari (rather than moving them
+/// server-side) precisely because XDT-style + token-replacement work needs
+/// to happen on the agent where the extracted files live.</para>
+///
+/// <para><b>Operator semantics</b> (mirrors Octopus's
+/// <c>SubstituteInFilesBehaviour</c>):
+/// <list type="bullet">
+///   <item>Gated by <see cref="EnabledVariableName"/> (default OFF — skip
+///         entirely if anything other than <c>"True"</c>).</item>
+///   <item>Files specified by <see cref="TargetFilesVariableName"/> as
+///         newline-separated globs (relative to working dir).</item>
+///   <item>Tokens matching <c>#{Name.Of.Variable}</c> are replaced with the
+///         variable's value from the loaded <c>VariableSet</c>.</item>
+///   <item>Unknown tokens are LENIENT by default — left as-is. Operator can
+///         flip <see cref="ShouldFailOnUnresolvedVariableName"/> to "True"
+///         to make any unresolved token fail the whole deployment.</item>
+///   <item>UTF-8 BOM is preserved on round-trip; encoding inferred from the
+///         first 3 bytes of the file.</item>
+/// </list></para>
+///
+/// <para><b>Failure modes the step deliberately ignores</b> (logs + continues):
+/// <list type="bullet">
+///   <item>Glob matches no files — operator typo or extract location
+///         mismatch; not worth failing the whole deploy.</item>
+///   <item>Binary file matches glob — skip silently (binary detection by
+///         leading null byte).</item>
+///   <item>Single file unreadable (permissions, locked) — log + skip that
+///         file, continue with the rest.</item>
+/// </list>
+/// All of these surface as Serilog warnings the operator can see in the
+/// deploy log + activity timeline.</para>
+/// </summary>
+/// <summary>
+/// Wire-contract constants for the SubstituteInFiles feature. Hosted in a
+/// PUBLIC class so the cross-project drift test in Squid.UnitTests can
+/// reference them without InternalsVisibleTo pollution. The step
+/// implementation stays internal — only the literals are public.
+/// </summary>
+public static class SubstituteInFilesVariableNames
+{
+    /// <summary>Wire-contract literal pinned by test (Rule 8). Must match
+    /// <c>IISDeployProperties.SubstituteInFilesEnabled</c> on the server.</summary>
+    public const string Enabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+
+    /// <summary>Wire-contract literal pinned by test (Rule 8).</summary>
+    public const string TargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+
+    /// <summary>Octopus-parity wire literal pinned by test (Rule 8).</summary>
+    public const string ShouldFailOnUnresolved =
+        "Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails";
+}
+
+internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandContext>
+{
+    /// <summary>Re-exported for backward-compat with the original test
+    /// suite that referenced these on the step. Pin both names so a future
+    /// rename surfaces in tests.</summary>
+    internal const string EnabledVariableName = SubstituteInFilesVariableNames.Enabled;
+    internal const string TargetFilesVariableName = SubstituteInFilesVariableNames.TargetFiles;
+    internal const string ShouldFailOnUnresolvedVariableName = SubstituteInFilesVariableNames.ShouldFailOnUnresolved;
+
+    public override bool IsEnabled(RunScriptCommandContext context)
+    {
+        if (context.Variables is null) return false;
+
+        var raw = context.Variables.Get(EnabledVariableName);
+        return string.Equals(raw, "True", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(context.WorkingDirectory))
+            throw new InvalidOperationException("Working directory has not been initialized — SubstituteInFilesStep must run after ResolveWorkingDirectoryStep.");
+        if (context.Variables is null)
+            throw new InvalidOperationException("Variables have not been loaded — SubstituteInFilesStep must run after LoadVariablesFromFilesStep.");
+
+        var targetFilesRaw = context.Variables.Get(TargetFilesVariableName);
+        if (string.IsNullOrWhiteSpace(targetFilesRaw)) return;    // no-op, operator left blank
+
+        var failOnUnresolved = string.Equals(
+            context.Variables.Get(ShouldFailOnUnresolvedVariableName),
+            "True",
+            StringComparison.OrdinalIgnoreCase);
+
+        var globs = SplitGlobs(targetFilesRaw);
+        var allUnresolved = new List<(string file, IReadOnlyList<string> tokens)>();
+        var filesProcessed = 0;
+        var filesSkipped = 0;
+
+        foreach (var glob in globs)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var matches = GlobMatcher.Expand(context.WorkingDirectory, glob).ToList();
+
+            if (matches.Count == 0)
+            {
+                // Calamari output convention: stderr for warnings. The Tentacle
+                // host captures stdout + stderr line-by-line and forwards both
+                // into the deploy log; stderr lines surface in the activity
+                // timeline tagged as warnings.
+                Console.Error.WriteLine(
+                    $"::warning::SubstituteInFiles: glob '{glob}' matched no files under '{context.WorkingDirectory}' " +
+                    "— operator typo, or files extracted to a different location? Continuing.");
+                continue;
+            }
+
+            foreach (var file in matches)
+            {
+                try
+                {
+                    if (IsBinaryFile(file))
+                    {
+                        Console.WriteLine($"SubstituteInFiles: skipping '{file}' (binary content detected).");
+                        filesSkipped++;
+                        continue;
+                    }
+
+                    var (text, encoding) = ReadFilePreservingEncoding(file);
+                    var result = TokenSubstituter.Replace(text, context.Variables);
+
+                    if (result.UnresolvedTokens.Count > 0)
+                        allUnresolved.Add((file, result.UnresolvedTokens));
+
+                    File.WriteAllText(file, result.Output, encoding);
+                    filesProcessed++;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    Console.Error.WriteLine(
+                        $"::warning::SubstituteInFiles: failed to process '{file}' — skipping. {ex.GetType().Name}: {ex.Message}");
+                    filesSkipped++;
+                }
+            }
+        }
+
+        Console.WriteLine(
+            $"SubstituteInFiles: processed {filesProcessed} file(s), skipped {filesSkipped}. " +
+            $"Unresolved tokens in {allUnresolved.Count} file(s).");
+
+        if (failOnUnresolved && allUnresolved.Count > 0)
+            throw new SubstituteInFilesException(allUnresolved);
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Operator wire format: newline-separated. Tolerate <c>\r\n</c> +
+    /// <c>\n</c> + whitespace-only lines (operators paste from various
+    /// editors). Each line is one glob.
+    /// </summary>
+    private static IEnumerable<string> SplitGlobs(string raw)
+        => raw.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0);
+
+    /// <summary>
+    /// Detect binary files by scanning the first 8KB for a null byte. Same
+    /// heuristic git uses. Fast — single read + linear scan.
+    /// </summary>
+    private static bool IsBinaryFile(string file)
+    {
+        try
+        {
+            using var stream = File.OpenRead(file);
+            var buffer = new byte[Math.Min(8192, stream.Length)];
+            var read = stream.Read(buffer, 0, buffer.Length);
+
+            for (var i = 0; i < read; i++)
+                if (buffer[i] == 0) return true;
+
+            return false;
+        }
+        catch
+        {
+            // If we can't read it to detect, treat as binary → skip safely.
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Read file detecting UTF-8 BOM so we can write it back exactly the
+    /// same way. Operator's web.config with BOM stays with BOM; without
+    /// stays without. .NET <c>StreamReader</c> with default args would
+    /// strip the BOM and we'd lose it on write-back.
+    /// </summary>
+    private static (string text, Encoding encoding) ReadFilePreservingEncoding(string file)
+    {
+        var bytes = File.ReadAllBytes(file);
+
+        // UTF-8 BOM: EF BB BF
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        {
+            var withBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            return (withBom.GetString(bytes, 3, bytes.Length - 3), withBom);
+        }
+
+        // No BOM — assume UTF-8 (operator's app is text).
+        var noBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        return (noBom.GetString(bytes), noBom);
+    }
+}
+
+/// <summary>
+/// Strict-mode failure for SubstituteInFiles — raised only when the operator
+/// has set <c>Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails = True</c>
+/// AND at least one token in the target files was unresolved. Message lists
+/// the unresolved tokens grouped by file so the operator can fix their
+/// variable set without grep-and-guess.
+/// </summary>
+internal sealed class SubstituteInFilesException : Exception
+{
+    public SubstituteInFilesException(IReadOnlyList<(string file, IReadOnlyList<string> tokens)> unresolvedPerFile)
+        : base(BuildMessage(unresolvedPerFile))
+    {
+        UnresolvedPerFile = unresolvedPerFile;
+    }
+
+    public IReadOnlyList<(string file, IReadOnlyList<string> tokens)> UnresolvedPerFile { get; }
+
+    private static string BuildMessage(IReadOnlyList<(string file, IReadOnlyList<string> tokens)> unresolvedPerFile)
+    {
+        var lines = new List<string>
+        {
+            "SubstituteInFiles: deployment failed because one or more #{Token} references could not be resolved " +
+            "AND Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails is set to True."
+        };
+
+        foreach (var (file, tokens) in unresolvedPerFile)
+            lines.Add($"  {file}: {string.Join(", ", tokens.Distinct())}");
+
+        lines.Add(
+            "Either: (a) add the missing variables to your project / environment / library variable set, " +
+            "(b) flip ShouldFailDeploymentOnSubstitutionFails to False to allow lenient (Octostache-compatible) behavior, " +
+            "or (c) remove the unresolved tokens from your target files.");
+
+        return string.Join('\n', lines);
+    }
+}

--- a/src/Squid.Calamari/Commands/Substitution/TokenSubstituter.cs
+++ b/src/Squid.Calamari/Commands/Substitution/TokenSubstituter.cs
@@ -1,0 +1,83 @@
+using System.Text.RegularExpressions;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.Substitution;
+
+/// <summary>
+/// G1.1 — pure-function <c>#{Token}</c> replacer for the SubstituteInFiles
+/// feature. Octostache-shape token syntax so operator templates from Octopus
+/// port over unchanged (web.config / appsettings.json with <c>#{Connection.String}</c>
+/// references work in Squid without rewriting).
+///
+/// <para><b>Single-pass</b>: substitution is one-pass; a variable value
+/// containing <c>#{B}</c> stays as <c>#{B}</c>. Avoids mutual-reference loops
+/// + downstream shell-injection surprises. Pinned by
+/// <c>Replace_NestedTokenInValue_NotRecursive</c>.</para>
+///
+/// <para><b>Lenient by default</b>: unknown tokens stay verbatim in the
+/// output and are returned in <see cref="SubstitutionResult.UnresolvedTokens"/>.
+/// The caller (<see cref="SubstituteInFilesStep"/>) inspects the unresolved
+/// list to decide whether to fail per
+/// <c>Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails</c>.</para>
+///
+/// <para><b>Escape sequence</b>: <c>##{Foo}</c> emits literal <c>#{Foo}</c>
+/// — matches Octopus. Operators use this when their config file genuinely
+/// contains the <c>#{...}</c> syntax meant for a different consumer.</para>
+/// </summary>
+internal static class TokenSubstituter
+{
+    // Token name accepts alphanumeric + dot + underscore + hyphen.
+    // Pinned by Replace_TokenNameWithSpaces_NotMatched_TreatedAsLiteral —
+    // a space inside braces means the operator wrote literal text, not a
+    // token, so we MUST NOT match it.
+    //
+    // The leading `(?<!#)` avoids matching when preceded by another `#`,
+    // implementing the `##{Foo}` literal-escape semantic. The post-match
+    // step replaces the escaped form with the unescaped form.
+    private static readonly Regex TokenPattern = new(
+        @"(?<!#)#\{(?<name>[A-Za-z0-9_.\-]+)\}",
+        RegexOptions.Compiled);
+
+    private const string EscapedMarker = "##{";
+    private const string UnescapedMarker = "#{";
+
+    public static SubstitutionResult Replace(string input, VariableSet variables)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(variables);
+
+        if (input.Length == 0) return new SubstitutionResult(string.Empty, Array.Empty<string>());
+
+        var unresolved = new List<string>();
+
+        var substituted = TokenPattern.Replace(input, match =>
+        {
+            var name = match.Groups["name"].Value;
+            var value = variables.Get(name);
+
+            if (value is null)
+            {
+                // Lenient: leave the placeholder, record the name so the
+                // caller can decide whether to fail in strict mode.
+                unresolved.Add(name);
+                return match.Value;
+            }
+
+            return value;
+        });
+
+        // Resolve `##{Foo}` escape AFTER the main pass so the lookahead
+        // didn't try to substitute the escaped form. The lookbehind in the
+        // pattern ensures the escaped form wasn't substituted; this final
+        // pass just strips the escape prefix.
+        var withEscapesResolved = substituted.Replace(EscapedMarker, UnescapedMarker, StringComparison.Ordinal);
+
+        return new SubstitutionResult(withEscapesResolved, unresolved);
+    }
+}
+
+/// <summary>
+/// Pure-data outcome of a single substitution pass. Caller inspects
+/// <see cref="UnresolvedTokens"/> to decide strict-mode failure.
+/// </summary>
+internal sealed record SubstitutionResult(string Output, IReadOnlyList<string> UnresolvedTokens);

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/GlobMatcherTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/GlobMatcherTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+using Shouldly;
+using Squid.Calamari.Commands.Substitution;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Substitution;
+
+/// <summary>
+/// G1.1 — glob-to-file-enumeration tests. Operator-facing patterns the IIS
+/// handler advertises (per <c>Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles</c>
+/// preamble in the deploy script) are newline-separated globs that operators
+/// already use with Octopus, e.g. <c>web.config</c>, <c>**/*.config</c>,
+/// <c>appsettings*.json</c>. Pin the matcher behaviour for each shape.
+/// </summary>
+public sealed class GlobMatcherTests : IDisposable
+{
+    private readonly string _root;
+
+    public GlobMatcherTests()
+    {
+        // Use a unique temp dir per test class instance — xUnit creates a new
+        // instance per test so this is per-test isolated.
+        _root = Path.Combine(Path.GetTempPath(), $"glob-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void Expand_LiteralFilename_ReturnsExactFile()
+    {
+        File.WriteAllText(Path.Combine(_root, "web.config"), "");
+        File.WriteAllText(Path.Combine(_root, "appsettings.json"), "");
+
+        var matches = GlobMatcher.Expand(_root, "web.config").ToList();
+
+        matches.Count.ShouldBe(1);
+        matches[0].ShouldEndWith("web.config");
+    }
+
+    [Fact]
+    public void Expand_AsteriskInName_MatchesAllInSegment()
+    {
+        File.WriteAllText(Path.Combine(_root, "web.config"), "");
+        File.WriteAllText(Path.Combine(_root, "app.config"), "");
+        File.WriteAllText(Path.Combine(_root, "readme.txt"), "");
+
+        var matches = GlobMatcher.Expand(_root, "*.config").Select(Path.GetFileName).OrderBy(x => x).ToList();
+
+        matches.ShouldBe(new[] { "app.config", "web.config" });
+    }
+
+    [Fact]
+    public void Expand_DoubleAsterisk_RecursesAllSubdirs()
+    {
+        File.WriteAllText(Path.Combine(_root, "top.config"), "");
+        Directory.CreateDirectory(Path.Combine(_root, "sub"));
+        File.WriteAllText(Path.Combine(_root, "sub", "nested.config"), "");
+        Directory.CreateDirectory(Path.Combine(_root, "sub", "deep"));
+        File.WriteAllText(Path.Combine(_root, "sub", "deep", "buried.config"), "");
+
+        var matches = GlobMatcher.Expand(_root, "**/*.config").Select(p => Path.GetFileName(p)).OrderBy(x => x).ToList();
+
+        matches.ShouldBe(new[] { "buried.config", "nested.config", "top.config" });
+    }
+
+    [Fact]
+    public void Expand_NoMatches_ReturnsEmpty_DoesNotThrow()
+    {
+        File.WriteAllText(Path.Combine(_root, "web.config"), "");
+
+        var matches = GlobMatcher.Expand(_root, "*.notreal").ToList();
+
+        matches.ShouldBeEmpty(
+            customMessage: "Operator-typo globs MUST yield empty enumeration, not exception — the step logs a warning and continues.");
+    }
+
+    [Fact]
+    public void Expand_DotIsLiteral_NotRegexAnyChar()
+    {
+        // Defence against regex injection: `web.config` should match ONLY
+        // `web.config`, not `webXconfig` or `webconfig`.
+        File.WriteAllText(Path.Combine(_root, "web.config"), "");
+        File.WriteAllText(Path.Combine(_root, "webXconfig"), "");
+
+        var matches = GlobMatcher.Expand(_root, "web.config").Select(Path.GetFileName).ToList();
+
+        matches.Count.ShouldBe(1);
+        matches[0].ShouldBe("web.config",
+            customMessage: "Dot in glob MUST be literal, not regex any-char — otherwise `web.config` would also match `webXconfig`.");
+    }
+
+    [Fact]
+    public void Expand_RootDirDoesNotExist_ReturnsEmpty_DoesNotThrow()
+    {
+        var matches = GlobMatcher.Expand(Path.Combine(_root, "missing"), "*.config").ToList();
+
+        matches.ShouldBeEmpty(
+            customMessage: "Pre-extract scenario: working dir not yet created → step gracefully skips, doesn't crash the pipeline.");
+    }
+
+    [Fact]
+    public void Expand_EmptyPattern_ReturnsEmpty()
+    {
+        File.WriteAllText(Path.Combine(_root, "web.config"), "");
+
+        var matches = GlobMatcher.Expand(_root, "").ToList();
+
+        matches.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Expand_PathTraversalAttempt_BoundedToRoot()
+    {
+        // Security: `../../etc/passwd` MUST NOT escape the working dir.
+        // The matcher resolves relative to the root + filters anything outside.
+        // Even if not paranoid, no operator config would legitimately need
+        // this — fail-safe to reject.
+        Directory.CreateDirectory(Path.Combine(_root, "sub"));
+        File.WriteAllText(Path.Combine(_root, "sub", "inside.config"), "");
+
+        var matches = GlobMatcher.Expand(_root, "../*.config").ToList();
+
+        matches.ShouldBeEmpty(
+            customMessage: "Path-traversal globs MUST yield zero matches — substitution is sandboxed to the working dir to prevent malicious package content from rewriting host files.");
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/SubstituteInFilesStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/SubstituteInFilesStepTests.cs
@@ -1,0 +1,285 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Substitution;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Substitution;
+
+/// <summary>
+/// G1.1 — pipeline-level tests for <see cref="SubstituteInFilesStep"/>.
+///
+/// <para>Operator-facing context: the IIS deploy handler advertises a
+/// "Substitute variables in files" toggle backed by these two variables:
+/// <list type="bullet">
+///   <item><c>Squid.Action.IISWebSite.SubstituteInFiles.Enabled</c> ("True"/"False")</item>
+///   <item><c>Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles</c>
+///         (newline-separated file globs, relative to working dir)</item>
+/// </list>
+/// Pre-G1.1 those variables existed in the script preamble but no Calamari
+/// step consumed them — the toggle was UI theatre. Pin the operator-
+/// observable behaviours of the new step:</para>
+/// </summary>
+public sealed class SubstituteInFilesStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public SubstituteInFilesStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"sub-step-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── Enable-gating ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEnabled_TrueToggle_RunsStep()
+    {
+        var context = BuildContext(enabled: "True", targetFiles: "*.config");
+        new SubstituteInFilesStep().IsEnabled(context).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("False")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not-a-bool")]
+    public void IsEnabled_NotTrue_SkipsStep(string? toggle)
+    {
+        var context = BuildContext(enabled: toggle, targetFiles: "*.config");
+        new SubstituteInFilesStep().IsEnabled(context).ShouldBeFalse(
+            customMessage: "Default-OFF semantic: anything other than 'True' must skip. Matches Octopus's bool-variable parsing.");
+    }
+
+    // ── Happy path ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_SingleGlob_OneMatchingFile_TokensReplacedInPlace()
+    {
+        var file = Path.Combine(_workDir, "appsettings.json");
+        File.WriteAllText(file, """{"ConnectionString":"#{Db.ConnectionString}","Env":"#{Squid.Environment.Name}"}""");
+
+        var context = BuildContext(
+            enabled: "True",
+            targetFiles: "appsettings.json",
+            ("Db.ConnectionString", "Server=prod-db;Database=app"),
+            ("Squid.Environment.Name", "Production"));
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        var result = File.ReadAllText(file);
+        result.ShouldBe("""{"ConnectionString":"Server=prod-db;Database=app","Env":"Production"}""");
+    }
+
+    [Fact]
+    public async Task Execute_MultipleGlobs_NewlineSeparated_AllProcessed()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "web.config"), "<env>#{Env}</env>");
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"), """{"env":"#{Env}"}""");
+        File.WriteAllText(Path.Combine(_workDir, "ignored.txt"), "literal #{Env}");
+
+        var context = BuildContext(
+            enabled: "True",
+            targetFiles: "web.config\nappsettings.json",  // wire shape: newline-separated, NOT comma
+            ("Env", "Staging"));
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "web.config")).ShouldBe("<env>Staging</env>");
+        File.ReadAllText(Path.Combine(_workDir, "appsettings.json")).ShouldBe("""{"env":"Staging"}""");
+        File.ReadAllText(Path.Combine(_workDir, "ignored.txt"))
+            .ShouldBe("literal #{Env}",
+                customMessage: "Files NOT in target globs MUST stay untouched. Pin the no-collateral-edit invariant.");
+    }
+
+    [Fact]
+    public async Task Execute_RecursiveGlob_FindsFilesInSubdirs()
+    {
+        Directory.CreateDirectory(Path.Combine(_workDir, "config"));
+        Directory.CreateDirectory(Path.Combine(_workDir, "config", "envs"));
+        File.WriteAllText(Path.Combine(_workDir, "config", "envs", "prod.json"), """{"k":"#{V}"}""");
+
+        var context = BuildContext(enabled: "True", targetFiles: "**/*.json", ("V", "ok"));
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "config", "envs", "prod.json")).ShouldBe("""{"k":"ok"}""");
+    }
+
+    // ── Encoding preservation ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_FileHasUtf8Bom_BomPreservedOnWriteBack()
+    {
+        // BOM round-trip: an operator's web.config with UTF-8 BOM MUST come
+        // out the other side with the same BOM. Without this, IIS / .NET
+        // Framework configuration parsers can choke on the same file after
+        // we substitute.
+        var file = Path.Combine(_workDir, "web.config");
+        var utf8WithBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        File.WriteAllText(file, "<env>#{Env}</env>", utf8WithBom);
+
+        var context = BuildContext(enabled: "True", targetFiles: "*.config", ("Env", "QA"));
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        var bytes = File.ReadAllBytes(file);
+        bytes.Take(3).ToArray().ShouldBe(new byte[] { 0xEF, 0xBB, 0xBF },
+            customMessage: "UTF-8 BOM MUST be preserved across substitution. Stripping it breaks IIS / .NET FX config parsers that detect encoding via BOM.");
+    }
+
+    [Fact]
+    public async Task Execute_FileHasNoBom_NoBomAdded()
+    {
+        var file = Path.Combine(_workDir, "appsettings.json");
+        var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        File.WriteAllText(file, """{"env":"#{Env}"}""", utf8NoBom);
+
+        var context = BuildContext(enabled: "True", targetFiles: "*.json", ("Env", "QA"));
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        var bytes = File.ReadAllBytes(file);
+        bytes.Take(3).ToArray().ShouldNotBe(new byte[] { 0xEF, 0xBB, 0xBF },
+            customMessage: "File without BOM MUST stay without BOM — JSON parsers in node/python toolchains reject leading BOM.");
+    }
+
+    // ── Lenient vs strict missing-token handling ───────────────────────────
+
+    [Fact]
+    public async Task Execute_UnknownToken_DefaultLenient_LeavesPlaceholderAndContinues()
+    {
+        var file = Path.Combine(_workDir, "web.config");
+        File.WriteAllText(file, "<env>#{NotDefined}</env>");
+
+        var context = BuildContext(enabled: "True", targetFiles: "*.config");
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(file).ShouldBe("<env>#{NotDefined}</env>",
+            customMessage: "Default-lenient: unresolved tokens stay as literal placeholders so the deployed file is still parseable. Operator can flip ShouldFailDeploymentOnSubstitutionFails=True to harden.");
+    }
+
+    [Fact]
+    public async Task Execute_UnknownToken_StrictMode_ThrowsWithListOfUnresolved()
+    {
+        var file = Path.Combine(_workDir, "web.config");
+        File.WriteAllText(file, "<a>#{Missing1}</a><b>#{Missing2}</b><c>#{Found}</c>");
+
+        var context = BuildContext(
+            enabled: "True",
+            targetFiles: "*.config",
+            ("Found", "yes"),
+            ("Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails", "True"));
+
+        var ex = await Should.ThrowAsync<SubstituteInFilesException>(() =>
+            new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None));
+
+        ex.Message.ShouldContain("Missing1");
+        ex.Message.ShouldContain("Missing2");
+        ex.Message.ShouldNotContain("Found",
+            customMessage: "Strict-mode error MUST list ONLY unresolved tokens, not resolved ones (those got substituted fine).");
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_EmptyTargetFiles_NoOp()
+    {
+        var file = Path.Combine(_workDir, "web.config");
+        File.WriteAllText(file, "<env>#{Env}</env>");
+
+        var context = BuildContext(enabled: "True", targetFiles: "", ("Env", "Production"));
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(file).ShouldBe("<env>#{Env}</env>",
+            customMessage: "Empty TargetFiles MUST be a no-op. Operator left the field blank intentionally; we don't second-guess.");
+    }
+
+    [Fact]
+    public async Task Execute_GlobMatchesNoFiles_DoesNotCrash()
+    {
+        // Operator typo / file moved → glob matches nothing. We log a warning
+        // and continue. Deploy doesn't fail on this alone (operator wants
+        // strict mode for that — same variable as missing-token).
+        var context = BuildContext(enabled: "True", targetFiles: "nonexistent.config");
+
+        await Should.NotThrowAsync(() => new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Execute_WorkingDirNotSet_Throws()
+    {
+        var context = BuildContext(enabled: "True", targetFiles: "*.config");
+        context.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Execute_VariablesNotLoaded_Throws()
+    {
+        var context = BuildContext(enabled: "True", targetFiles: "*.config");
+        context.Variables = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    // ── Wire-contract pinning ───────────────────────────────────────────────
+
+    [Fact]
+    public void EnabledVariableName_PinnedToIISHandlerContract()
+    {
+        // Drift detector (Rule 8): if either side renames this, the chain
+        // silently no-ops. Pin the wire literal.
+        SubstituteInFilesStep.EnabledVariableName
+            .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.Enabled");
+    }
+
+    [Fact]
+    public void TargetFilesVariableName_PinnedToIISHandlerContract()
+    {
+        SubstituteInFilesStep.TargetFilesVariableName
+            .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles");
+    }
+
+    [Fact]
+    public void ShouldFailVariableName_PinnedToOctopusParity()
+    {
+        SubstituteInFilesStep.ShouldFailOnUnresolvedVariableName
+            .ShouldBe("Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private RunScriptCommandContext BuildContext(string? enabled, string? targetFiles, params (string name, string value)[] extraVars)
+    {
+        var vars = new VariableSet();
+        if (enabled != null)
+            vars.Set(SubstituteInFilesStep.EnabledVariableName, enabled);
+        if (targetFiles != null)
+            vars.Set(SubstituteInFilesStep.TargetFilesVariableName, targetFiles);
+        foreach (var (name, value) in extraVars)
+            vars.Set(name, value);
+
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/TokenSubstituterTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/TokenSubstituterTests.cs
@@ -1,0 +1,184 @@
+using Shouldly;
+using Squid.Calamari.Commands.Substitution;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Substitution;
+
+/// <summary>
+/// G1.1 — pure-function tests for the <c>#{Token}</c> replacer that backs
+/// <c>SubstituteInFilesStep</c>. Pin the operator-visible behaviours in
+/// isolation so a regression in the replacer doesn't require running the
+/// full pipeline to surface.
+///
+/// <para><b>Octopus parity</b>: token syntax + missing-token behaviour mirror
+/// Octostache's <c>#{Variable}</c> semantics (the wire shape operators
+/// already expect from Octopus, so their existing variable-aware
+/// <c>web.config</c> / <c>appsettings.json</c> templates port over
+/// unchanged).</para>
+/// </summary>
+public sealed class TokenSubstituterTests
+{
+    [Fact]
+    public void Replace_SimpleToken_SubstitutesValue()
+    {
+        var vars = NewVarSet(("Squid.Environment.Name", "Production"));
+
+        var result = TokenSubstituter.Replace("Deploying to #{Squid.Environment.Name}", vars);
+
+        result.Output.ShouldBe("Deploying to Production");
+        result.UnresolvedTokens.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Replace_RepeatedTokens_AllReplaced()
+    {
+        var vars = NewVarSet(("Name", "alice"));
+
+        var result = TokenSubstituter.Replace("Hi #{Name}, welcome #{Name}!", vars);
+
+        result.Output.ShouldBe("Hi alice, welcome alice!");
+    }
+
+    [Fact]
+    public void Replace_NoTokens_ReturnsInputUnchanged()
+    {
+        var vars = NewVarSet(("Unused", "value"));
+
+        var result = TokenSubstituter.Replace("plain text with no tokens", vars);
+
+        result.Output.ShouldBe("plain text with no tokens");
+        result.UnresolvedTokens.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Replace_MissingToken_LeavesPlaceholderByDefault()
+    {
+        // Lenient default mirrors Octostache: unknown tokens stay verbatim in
+        // the output so the deployed file is still parseable. Operator can
+        // opt-in to strict mode via ShouldFailDeploymentOnSubstitutionFails
+        // (tested at the SubstituteInFilesStep level).
+        var vars = NewVarSet();
+
+        var result = TokenSubstituter.Replace("hello #{Missing} world", vars);
+
+        result.Output.ShouldBe("hello #{Missing} world");
+        result.UnresolvedTokens.ShouldBe(new[] { "Missing" });
+    }
+
+    [Fact]
+    public void Replace_MissingTokenMixedWithKnown_UnresolvedListedOnlyForMissing()
+    {
+        var vars = NewVarSet(("Known", "yes"));
+
+        var result = TokenSubstituter.Replace("#{Known} and #{Unknown} and #{Known}", vars);
+
+        result.Output.ShouldBe("yes and #{Unknown} and yes");
+        result.UnresolvedTokens.ShouldBe(new[] { "Unknown" });
+    }
+
+    [Fact]
+    public void Replace_NestedTokenInValue_NotRecursive()
+    {
+        // Octopus invariant: substitution is single-pass. A value containing
+        // "#{B}" stays as "#{B}" — we do NOT loop the substitution to resolve
+        // it. Recursion would invite mutual-reference loops + security
+        // surprises (variable holding "$(rm -rf /)" expanded by a downstream
+        // shell). Pin the single-pass semantic.
+        var vars = NewVarSet(
+            ("A", "wraps #{B}"),
+            ("B", "inner"));
+
+        var result = TokenSubstituter.Replace("outer: #{A}", vars);
+
+        result.Output.ShouldBe("outer: wraps #{B}",
+            customMessage: "Replacement MUST be single-pass — the inner #{B} from A's value MUST NOT be resolved a second time.");
+    }
+
+    [Fact]
+    public void Replace_AdjacentTokens_BothReplaced()
+    {
+        var vars = NewVarSet(
+            ("A", "left"),
+            ("B", "right"));
+
+        var result = TokenSubstituter.Replace("#{A}#{B}", vars);
+
+        result.Output.ShouldBe("leftright");
+    }
+
+    [Fact]
+    public void Replace_TokenWithDottedName_SubstitutesValue()
+    {
+        // The whole Squid variable namespace uses dotted names
+        // (Squid.Action.IISWebSite.WebSiteName). The regex must accept dots
+        // inside the token name without being greedy across braces.
+        var vars = NewVarSet(("Squid.Action.IISWebSite.WebSiteName", "MyWeb"));
+
+        var result = TokenSubstituter.Replace("site: #{Squid.Action.IISWebSite.WebSiteName}", vars);
+
+        result.Output.ShouldBe("site: MyWeb");
+    }
+
+    [Fact]
+    public void Replace_TokenNameWithSpaces_NotMatched_TreatedAsLiteral()
+    {
+        // Defence: don't match `#{Name with space}` — that's not a token, it's
+        // probably an accidental literal in someone's config. Octopus does the
+        // same: token names are alphanumeric + dots + underscores + hyphens.
+        var vars = NewVarSet(("Name", "alice"));
+
+        var result = TokenSubstituter.Replace("#{Name with space}", vars);
+
+        result.Output.ShouldBe("#{Name with space}");
+        result.UnresolvedTokens.ShouldBeEmpty(
+            customMessage: "Malformed token (space inside braces) MUST NOT be reported as unresolved — it's literal text, not a token.");
+    }
+
+    [Fact]
+    public void Replace_EscapedHash_NotTreatedAsToken()
+    {
+        // Operators write `##{Foo}` to mean "literal #{Foo}" — same as Octopus.
+        // The first # escapes the second one's token start.
+        var vars = NewVarSet(("Foo", "bar"));
+
+        var result = TokenSubstituter.Replace("Literal: ##{Foo}, replaced: #{Foo}", vars);
+
+        result.Output.ShouldBe("Literal: #{Foo}, replaced: bar",
+            customMessage: "Double-hash MUST escape the token marker so operators can write literal #{...} in their files.");
+    }
+
+    [Fact]
+    public void Replace_EmptyInput_ReturnsEmpty()
+    {
+        var vars = NewVarSet(("A", "1"));
+
+        var result = TokenSubstituter.Replace("", vars);
+
+        result.Output.ShouldBe("");
+        result.UnresolvedTokens.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Replace_NullInput_ThrowsArgumentNull()
+    {
+        var vars = NewVarSet();
+
+        Should.Throw<ArgumentNullException>(() => TokenSubstituter.Replace(null!, vars));
+    }
+
+    [Fact]
+    public void Replace_NullVariables_ThrowsArgumentNull()
+    {
+        Should.Throw<ArgumentNullException>(() => TokenSubstituter.Replace("anything", null!));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static VariableSet NewVarSet(params (string name, string value)[] entries)
+    {
+        var set = new VariableSet();
+        foreach (var (name, value) in entries) set.Set(name, value);
+        return set;
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISSubstituteInFilesWireContractTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISSubstituteInFilesWireContractTests.cs
@@ -1,0 +1,66 @@
+using Shouldly;
+using Squid.Calamari.Commands.Substitution;
+using Squid.Core.Services.DeploymentExecution;
+using Xunit;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle.Handlers;
+
+/// <summary>
+/// G1.1 — server ↔ Calamari wire-contract drift detector for the
+/// SubstituteInFiles feature. Three variable literals form the contract:
+///
+/// <list type="bullet">
+///   <item><b>Server-side</b>: <c>IISDeployProperties.SubstituteInFilesEnabled</c> /
+///         <c>SubstituteInFilesTargetFiles</c> /
+///         <c>ShouldFailDeploymentOnSubstitutionFails</c> — included in the
+///         deploy-script preamble built by <c>IISDeployScriptBuilder</c>.</item>
+///   <item><b>Agent-side</b>: <c>SubstituteInFilesVariableNames.Enabled</c> /
+///         <c>TargetFiles</c> / <c>ShouldFailOnUnresolved</c> — read by the
+///         Calamari pipeline step.</item>
+/// </list>
+///
+/// <para>If either side renames its constant without the other, the toggle
+/// silently no-ops in production: operator sets it to True, deploy runs as
+/// if substitution were disabled. Pin both sides to the same string
+/// literals so a rename surfaces at build time, not in a customer's
+/// production deploy.</para>
+///
+/// <para><b>Why this test lives in Squid.UnitTests, not Squid.Calamari.Tests</b>:
+/// it spans both projects. Server-side IIS handler constants are in
+/// <c>Squid.Core</c>, agent-side step constants are in <c>Squid.Calamari</c>.
+/// Squid.UnitTests references both, which is why the test lives here.</para>
+/// </summary>
+public sealed class IISSubstituteInFilesWireContractTests
+{
+    [Fact]
+    public void EnabledVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.SubstituteInFilesEnabled
+            .ShouldBe(SubstituteInFilesVariableNames.Enabled,
+                customMessage: "Wire-contract drift: IIS deploy handler advertises this variable in the script preamble; Calamari's SubstituteInFilesStep reads it. A rename on either side breaks the operator's UI toggle silently. Pin BOTH sides to the same literal.");
+    }
+
+    [Fact]
+    public void TargetFilesVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.SubstituteInFilesTargetFiles
+            .ShouldBe(SubstituteInFilesVariableNames.TargetFiles);
+    }
+
+    [Fact]
+    public void ShouldFailVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.ShouldFailDeploymentOnSubstitutionFails
+            .ShouldBe(SubstituteInFilesVariableNames.ShouldFailOnUnresolved);
+    }
+
+    [Fact]
+    public void EnabledVariable_LiteralValuePinned()
+    {
+        // Defence-in-depth: if BOTH sides happened to rename in lock-step, the
+        // contract-match tests still pass. This third test pins the actual
+        // wire string so a coordinated rename is also a test-visible decision.
+        IISDeployProperties.SubstituteInFilesEnabled
+            .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.Enabled");
+    }
+}


### PR DESCRIPTION
## Summary

**Phase G1.1** of the Calamari Refactor Roadmap (Notion). First concrete PR that follows from the parent Architecture Decision document.

Closes the IIS deploy handler's currently-fake "Substitute variables in files" toggle. Pre-G1.1, operators set `SubstituteInFiles.Enabled = True` in the UI, the deploy ran, and the script preamble inlined the variable as `'True'` — but **no Calamari step consumed it**. Silent UI theatre.

## What's new

Three components under `Squid.Calamari.Commands.Substitution`:

| Component | Lines | Tests | Purpose |
|---|---|---|---|
| `TokenSubstituter` | ~80 | 13 | Pure `#{Token}` regex replacer with Octostache parity (single-pass, `##{Foo}` escape, lenient default) |
| `GlobMatcher` | ~110 | 8 | In-house glob→regex + file enumeration, no NuGet dep, path-traversal sandboxed |
| `SubstituteInFilesStep` | ~180 | 18 | Pipeline step orchestrating both; encoding-preserving; strict + lenient modes |

Wired into `RunScriptCommandPipeline` between `LoadVariablesFromFilesStep` and `WriteBootstrappedBashScriptStep`.

## Operator-visible behaviour

**Enabled + with file globs** (operator's typical case):
```
Variables:
  Squid.Action.IISWebSite.SubstituteInFiles.Enabled = "True"
  Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles = "web.config\n**/*.json"
  Db.ConnectionString = "Server=prod;Database=app"
  Squid.Environment.Name = "Production"

File before:  {"ConnectionString":"#{Db.ConnectionString}","Env":"#{Squid.Environment.Name}"}
File after:   {"ConnectionString":"Server=prod;Database=app","Env":"Production"}
```

**Disabled or missing toggle**: step is skipped entirely (`IsEnabled` returns false).

**Unresolved token, lenient (default)**: stays as `#{NotDefined}` in the file + stderr warning.

**Unresolved token, strict** (`ShouldFailDeploymentOnSubstitutionFails = True`): step throws `SubstituteInFilesException` listing unresolved tokens grouped by file.

## Architectural anchors

- **Sandboxed**: `../etc/passwd` globs yield zero matches. Substitution stays within working dir.
- **Encoding-preserving**: UTF-8 BOM round-trips exactly. IIS / .NET FX config parsers detect encoding via BOM; stripping it breaks them.
- **Binary-safe**: null-byte heuristic (same as git) skips binary files silently.
- **Lean**: no NuGet deps added — Calamari binary stays minimal (parent decision: keep agent zip small).

## Wire-contract pinning (Rule 8 — both sides)

Cross-project drift detector in `Squid.UnitTests.IISSubstituteInFilesWireContractTests` asserts:
```
SubstituteInFilesVariableNames.Enabled    (Squid.Calamari, public)
  == IISDeployProperties.SubstituteInFilesEnabled  (Squid.Core)
  == "Squid.Action.IISWebSite.SubstituteInFiles.Enabled"
```
A rename on either side without the other = failing test, not silent production no-op.

## Test plan

- [x] **13 unit tests** on `TokenSubstituter` — regex shape, escape, single-pass, dotted names, edge cases
- [x] **8 unit tests** on `GlobMatcher` — patterns, recursion, dot-literal, path-traversal sandbox
- [x] **18 unit tests** on `SubstituteInFilesStep` — enable-gate × 4, happy path × 3, encoding × 2, strict/lenient × 2, edge cases × 4, wire pins × 3
- [x] **4 cross-project drift tests** in `Squid.UnitTests` pinning server ↔ agent contract
- [x] **5607/5607 Squid.UnitTests green** (+4 net new)
- [x] **179/179 Squid.Calamari.Tests green** (+39 net new)

## What's NOT in this PR

- **G1.2 (ConfigurationTransformsStep — XDT)**: next, separate PR
- **G1.3 (StructuredConfigVariablesStep — JSON path edits)**: separate PR
- **G1.4 (ExtractPackageStep)**: separate PR
- **G1.5 (Convention hooks PreDeploy/Deploy/PostDeploy)**: separate PR

## Refs

- Notion: 🦑 Squid — Calamari Architecture Decision (2026-05-23) — parent decision
- Notion: 🦑 Squid — Calamari Refactor Roadmap (Post 1.8.1) — phase plan
- PR #353 — the bypass that prompted the strategic question