### PR TITLE
G1.2: ConfigurationTransformsStep — apply XDT to *.config files

### DIFF
--- a/src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs
+++ b/src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs
@@ -1,0 +1,208 @@
+using Squid.Calamari.Pipeline;
+
+namespace Squid.Calamari.Commands.Configuration;
+
+/// <summary>
+/// Wire-contract constants for the ConfigurationTransforms (XDT) feature.
+/// Public so cross-project drift tests in Squid.UnitTests can assert these
+/// match the server-side IIS handler's <c>IISDeployProperties</c> constants
+/// without forcing InternalsVisibleTo pollution.
+/// </summary>
+public static class ConfigurationTransformsVariableNames
+{
+    public const string Enabled = "Squid.Action.IISWebSite.ConfigurationTransforms.Enabled";
+    public const string EnvironmentName = "Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName";
+    public const string AdditionalTransforms = "Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms";
+}
+
+/// <summary>
+/// G1.2 — applies XDT (XML Document Transform) <c>web.{Env}.config</c> style
+/// transforms to <c>*.config</c> files in the working directory. Mirrors
+/// Octopus's <c>ConfigurationTransformsBehaviour</c>.
+///
+/// <para><b>Two transform-source modes</b> (both run, additively):
+/// <list type="number">
+///   <item><b>Auto-pairing by <see cref="ConfigurationTransformsVariableNames.EnvironmentName"/></b>:
+///         for each <c>*.config</c> in the working dir, look for a sibling
+///         <c>*.{EnvironmentName}.config</c> and apply it. Also unconditionally
+///         applies <c>*.Release.config</c> (matches .NET FX build-time XDT
+///         defaults — operators rely on this).</item>
+///   <item><b>Operator-supplied pairs in
+///         <see cref="ConfigurationTransformsVariableNames.AdditionalTransforms"/></b>:
+///         newline-separated lines of <c>transform.config => base.config</c>
+///         shape. Applied in order. Malformed lines (no <c>=&gt;</c> separator)
+///         are skipped with a warning, not fatal.</item>
+/// </list></para>
+///
+/// <para><b>Order in the pipeline</b>: must run AFTER
+/// <c>SubstituteInFilesStep</c> so any <c>#{Token}</c> references inside
+/// transform files are resolved first. Then XDT applies the now-concrete
+/// values to the base config. Matches Octopus's pipeline order.</para>
+/// </summary>
+internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptCommandContext>
+{
+    public override bool IsEnabled(RunScriptCommandContext context)
+    {
+        if (context.Variables is null) return false;
+        var raw = context.Variables.Get(ConfigurationTransformsVariableNames.Enabled);
+        return string.Equals(raw, "True", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(context.WorkingDirectory))
+            throw new InvalidOperationException(
+                "Working directory has not been initialized — ConfigurationTransformsStep must run after ResolveWorkingDirectoryStep.");
+        if (context.Variables is null)
+            throw new InvalidOperationException(
+                "Variables have not been loaded — ConfigurationTransformsStep must run after LoadVariablesFromFilesStep.");
+
+        if (!Directory.Exists(context.WorkingDirectory))
+        {
+            Console.WriteLine(
+                $"ConfigurationTransforms: working dir '{context.WorkingDirectory}' does not exist; skipping.");
+            return Task.CompletedTask;
+        }
+
+        var environmentName = context.Variables.Get(ConfigurationTransformsVariableNames.EnvironmentName);
+        var additionalRaw = context.Variables.Get(ConfigurationTransformsVariableNames.AdditionalTransforms);
+
+        var applied = 0;
+        var failed = 0;
+
+        // Auto-pair pass.
+        applied += ApplyAutoPairs(context.WorkingDirectory, environmentName, ref failed);
+
+        // Operator-supplied explicit pairs pass.
+        if (!string.IsNullOrWhiteSpace(additionalRaw))
+            applied += ApplyAdditionalPairs(context.WorkingDirectory, additionalRaw, ref failed);
+
+        Console.WriteLine(
+            $"ConfigurationTransforms: applied {applied} transform(s), {failed} failure(s). " +
+            "Operator can grep the deploy log for 'ConfigurationTransforms:' lines to see per-pair outcomes.");
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Find each <c>*.config</c> in the working dir + look for matching
+    /// <c>*.{Env}.config</c> AND <c>*.Release.config</c> siblings. Both get
+    /// applied to the base. .NET FX build-time XDT semantic.
+    /// </summary>
+    private static int ApplyAutoPairs(string workingDir, string? environmentName, ref int failed)
+    {
+        var applied = 0;
+
+        foreach (var baseConfig in EnumerateBaseConfigs(workingDir))
+        {
+            var baseName = Path.GetFileNameWithoutExtension(baseConfig);
+            var baseDir = Path.GetDirectoryName(baseConfig)!;
+
+            // Release.config — always applied (matches .NET FX build-time default).
+            var releaseTransform = Path.Combine(baseDir, $"{baseName}.Release.config");
+            if (File.Exists(releaseTransform))
+                applied += TryApply(releaseTransform, baseConfig, ref failed);
+
+            // EnvironmentName-specific transform.
+            if (!string.IsNullOrWhiteSpace(environmentName))
+            {
+                var envTransform = Path.Combine(baseDir, $"{baseName}.{environmentName}.config");
+                if (File.Exists(envTransform) && !string.Equals(envTransform, releaseTransform, StringComparison.OrdinalIgnoreCase))
+                    applied += TryApply(envTransform, baseConfig, ref failed);
+            }
+        }
+
+        return applied;
+    }
+
+    /// <summary>
+    /// Operator's explicit transform list — newline-separated lines of shape
+    /// <c>transform.config =&gt; base.config</c>. Paths are relative to
+    /// working dir.
+    /// </summary>
+    private static int ApplyAdditionalPairs(string workingDir, string raw, ref int failed)
+    {
+        var applied = 0;
+
+        foreach (var line in SplitLines(raw))
+        {
+            var (transform, baseFile, ok) = ParsePair(line);
+            if (!ok)
+            {
+                Console.Error.WriteLine(
+                    $"::warning::ConfigurationTransforms: malformed AdditionalTransforms line '{line}' — expected 'transform.config => base.config' shape. Skipping this line, continuing with the rest.");
+                continue;
+            }
+
+            var transformPath = Path.Combine(workingDir, transform);
+            var basePath = Path.Combine(workingDir, baseFile);
+
+            applied += TryApply(transformPath, basePath, ref failed);
+        }
+
+        return applied;
+    }
+
+    private static int TryApply(string transformPath, string basePath, ref int failed)
+    {
+        var result = XdtTransformer.Transform(basePath, transformPath);
+
+        if (result.Succeeded)
+        {
+            Console.WriteLine($"ConfigurationTransforms: applied '{transformPath}' → '{basePath}'.");
+            return 1;
+        }
+
+        Console.Error.WriteLine($"::warning::ConfigurationTransforms: {result.FailureReason}");
+        failed++;
+        return 0;
+    }
+
+    /// <summary>
+    /// Enumerate <c>*.config</c> files that are BASE files, not transform
+    /// sources. Skip <c>*.Release.config</c> + <c>*.Debug.config</c> +
+    /// <c>*.{Env}.config</c>-shape files. Heuristic: a base file's stem has
+    /// no second dot (e.g. <c>web</c>), a transform's stem does
+    /// (e.g. <c>web.Production</c>).
+    /// </summary>
+    private static IEnumerable<string> EnumerateBaseConfigs(string workingDir)
+    {
+        IEnumerable<string> allConfigs;
+        try
+        {
+            allConfigs = Directory.EnumerateFiles(workingDir, "*.config", SearchOption.AllDirectories);
+        }
+        catch (DirectoryNotFoundException) { return Array.Empty<string>(); }
+        catch (UnauthorizedAccessException) { return Array.Empty<string>(); }
+
+        return allConfigs.Where(IsBaseConfig);
+    }
+
+    private static bool IsBaseConfig(string path)
+    {
+        // Stem with no dots = base. Stem with at least one dot = transform.
+        // `web.config`  → stem `web`           → base ✓
+        // `web.Production.config` → stem `web.Production` → transform (has dot)
+        var fileName = Path.GetFileNameWithoutExtension(path);
+        return !fileName.Contains('.');
+    }
+
+    private static (string transform, string baseFile, bool ok) ParsePair(string line)
+    {
+        var idx = line.IndexOf("=>", StringComparison.Ordinal);
+        if (idx < 0) return ("", "", false);
+
+        var transform = line[..idx].Trim();
+        var baseFile = line[(idx + 2)..].Trim();
+        if (transform.Length == 0 || baseFile.Length == 0) return ("", "", false);
+
+        return (transform, baseFile, true);
+    }
+
+    private static IEnumerable<string> SplitLines(string raw)
+        => raw.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0);
+}

--- a/src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs
+++ b/src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs
@@ -1,0 +1,100 @@
+using System.Xml;
+using Microsoft.Web.XmlTransform;
+
+namespace Squid.Calamari.Commands.Configuration;
+
+/// <summary>
+/// G1.2 — thin wrapper over Microsoft's <c>Microsoft.Web.XmlTransform</c>
+/// XDT engine. Pure-function API: takes paths, returns a result record.
+/// All exception handling centralised here so the pipeline step orchestrator
+/// stays focused on the loop + logging.
+///
+/// <para><b>Why not use XmlTransformableDocument directly</b>: the raw API
+/// throws <c>XmlException</c> on malformed input, leaves partial writes on
+/// I/O errors, and requires the caller to manage encoding manually. This
+/// wrapper:
+/// <list type="bullet">
+///   <item>Returns a typed <see cref="TransformResult"/> instead of throwing
+///         for predictable failure modes (missing file, malformed XML)</item>
+///   <item>Writes through a temp file + atomic rename so partial transforms
+///         don't leave a corrupted base file on disk</item>
+///   <item>Preserves the original XML declaration + encoding</item>
+/// </list></para>
+/// </summary>
+internal static class XdtTransformer
+{
+    public static TransformResult Transform(string basePath, string transformPath)
+    {
+        if (!File.Exists(basePath))
+            return TransformResult.Failure($"Base file '{basePath}' does not exist; cannot apply XDT transform.");
+        if (!File.Exists(transformPath))
+            return TransformResult.Failure($"Transform file '{transformPath}' does not exist; nothing to apply.");
+
+        XmlTransformableDocument document;
+        try
+        {
+            document = new XmlTransformableDocument { PreserveWhitespace = true };
+            document.Load(basePath);
+        }
+        catch (XmlException ex)
+        {
+            return TransformResult.Failure($"Base file '{basePath}' is not well-formed XML: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            return TransformResult.Failure($"Failed to read base file '{basePath}': {ex.Message}");
+        }
+
+        XmlTransformation transformation;
+        try
+        {
+            transformation = new XmlTransformation(transformPath);
+        }
+        catch (XmlException ex)
+        {
+            document.Dispose();
+            return TransformResult.Failure($"Transform file '{transformPath}' is not well-formed XML: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            document.Dispose();
+            return TransformResult.Failure($"Failed to read transform file '{transformPath}': {ex.Message}");
+        }
+
+        try
+        {
+            var applied = transformation.Apply(document);
+
+            if (!applied)
+            {
+                // XDT engine returned false — usually means a transform directive
+                // failed (e.g. Locator matched nothing). Continue but report.
+                return TransformResult.Failure($"XDT engine declined to apply '{transformPath}' to '{basePath}'. " +
+                                               "Check the transform's Locator + xdt:Transform attributes for missing matches.");
+            }
+
+            // Atomic write: serialise to temp file, then rename. Avoids
+            // half-written base file on disk if the write itself dies mid-way.
+            var tempPath = basePath + ".xdt-tmp";
+            document.Save(tempPath);
+            File.Move(tempPath, basePath, overwrite: true);
+
+            return TransformResult.Success();
+        }
+        catch (Exception ex) when (ex is XmlException or IOException)
+        {
+            return TransformResult.Failure($"XDT transform failed: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            document.Dispose();
+            transformation.Dispose();
+        }
+    }
+}
+
+internal sealed record TransformResult(bool Succeeded, string? FailureReason)
+{
+    public static TransformResult Success() => new(true, null);
+    public static TransformResult Failure(string reason) => new(false, reason);
+}

--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -1,3 +1,4 @@
+using Squid.Calamari.Commands.Configuration;
 using Squid.Calamari.Commands.Substitution;
 using Squid.Calamari.Execution;
 using Squid.Calamari.Pipeline;
@@ -40,7 +41,14 @@ public class RunScriptCommand
         [
             new ResolveWorkingDirectoryStep<RunScriptCommandContext>(),
             new LoadVariablesFromFilesStep<RunScriptCommandContext>(),
+            // G1.1 — token replacement in operator-nominated text files.
+            // Runs first so any #{Token} inside transform files is resolved
+            // before XDT engine reads them.
             new SubstituteInFilesStep(),
+            // G1.2 — XDT (web.{Env}.config) transforms on *.config files.
+            // Runs after SubstituteInFiles so transform sources have
+            // concrete values, not unresolved tokens.
+            new ConfigurationTransformsStep(),
             new WriteBootstrappedBashScriptStep(),
             new ExecuteScriptWithEngineStep(scriptEngine),
             new BuildRunScriptCommandResultStep(),

--- a/src/Squid.Calamari/Squid.Calamari.csproj
+++ b/src/Squid.Calamari/Squid.Calamari.csproj
@@ -19,6 +19,15 @@
 
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <!--
+    G1.2 — Microsoft.Web.Xdt: XML Document Transform engine, Microsoft's
+    official package backing the .NET Framework `web.{Env}.config` transform
+    feature. Used by ConfigurationTransformsStep. ~150 KB on disk;
+    acceptable agent-zip cost given the operator value of fully working
+    web.config transforms (previously the IIS PS path degraded with a
+    warning when the assembly wasn't on the host).
+    -->
+    <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/ConfigurationTransformsStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/ConfigurationTransformsStepTests.cs
@@ -1,0 +1,279 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Configuration;
+
+/// <summary>
+/// G1.2 — pipeline-level tests for <see cref="ConfigurationTransformsStep"/>.
+///
+/// <para>Operator-facing variables (mirrors the IIS deploy script preamble):
+/// <list type="bullet">
+///   <item><c>Squid.Action.IISWebSite.ConfigurationTransforms.Enabled</c> ("True"/"False")</item>
+///   <item><c>Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName</c>
+///         (e.g. "Production" — drives auto-pairing of <c>web.{Env}.config</c>)</item>
+///   <item><c>Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms</c>
+///         (newline-separated "transform.config => base.config" explicit pairs)</item>
+/// </list></para>
+///
+/// <para>Auto-pairing rule (Octopus parity): for each <c>*.config</c> in the
+/// working dir, look for a sibling <c>*.{EnvironmentName}.config</c> and
+/// apply it. <c>*.Release.config</c> is also applied unconditionally
+/// (matches .NET FX build-time XDT defaults).</para>
+/// </summary>
+public sealed class ConfigurationTransformsStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public ConfigurationTransformsStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"xdt-step-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── Enable-gating ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEnabled_TrueToggle_RunsStep()
+    {
+        var context = BuildContext(enabled: "True", environmentName: "Production");
+        new ConfigurationTransformsStep().IsEnabled(context).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("False")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not-a-bool")]
+    public void IsEnabled_NotTrue_SkipsStep(string? toggle)
+    {
+        var context = BuildContext(enabled: toggle, environmentName: "Production");
+        new ConfigurationTransformsStep().IsEnabled(context).ShouldBeFalse();
+    }
+
+    // ── Auto-pairing by EnvironmentName ─────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_EnvironmentSpecificTransform_AppliedToMatchingBase()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "web.config"), """
+            <?xml version="1.0"?>
+            <configuration>
+              <appSettings>
+                <add key="Env" value="Dev" />
+              </appSettings>
+            </configuration>
+            """);
+        File.WriteAllText(Path.Combine(_workDir, "web.Production.config"), """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+              <appSettings>
+                <add key="Env" value="Prod" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+              </appSettings>
+            </configuration>
+            """);
+
+        var context = BuildContext(enabled: "True", environmentName: "Production");
+
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "web.config")).ShouldContain("value=\"Prod\"");
+    }
+
+    [Fact]
+    public async Task Execute_NoMatchingEnvironmentTransform_NoOp_DoesNotCrash()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "web.config"), """
+            <?xml version="1.0"?>
+            <configuration><appSettings><add key="A" value="1" /></appSettings></configuration>
+            """);
+        // intentionally no web.Staging.config exists
+
+        var context = BuildContext(enabled: "True", environmentName: "Staging");
+
+        await Should.NotThrowAsync(() =>
+            new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None));
+
+        File.ReadAllText(Path.Combine(_workDir, "web.config")).ShouldContain("value=\"1\"",
+            customMessage: "No transform for this environment = no change; base file untouched.");
+    }
+
+    [Fact]
+    public async Task Execute_TransformsAlsoNonWebConfig_AppSettings_Etc()
+    {
+        // The auto-pair rule applies to ANY *.config, not just web.config.
+        // appsettings.config, custom.config, etc. all get the {Env}.config
+        // pair treatment.
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.config"), """
+            <?xml version="1.0"?>
+            <configuration><add key="K" value="v0" /></configuration>
+            """);
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.Production.config"), """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+              <add key="K" value="v1" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+            </configuration>
+            """);
+
+        var context = BuildContext(enabled: "True", environmentName: "Production");
+
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "appsettings.config")).ShouldContain("value=\"v1\"");
+    }
+
+    // ── AdditionalTransforms — operator-supplied explicit pairs ──────────────
+
+    [Fact]
+    public async Task Execute_AdditionalTransforms_OperatorPairs_Applied()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "app.config"), """
+            <?xml version="1.0"?>
+            <configuration><appSettings><add key="A" value="x" /></appSettings></configuration>
+            """);
+        File.WriteAllText(Path.Combine(_workDir, "custom-override.config"), """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+              <appSettings>
+                <add key="A" value="y" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+              </appSettings>
+            </configuration>
+            """);
+
+        var context = BuildContext(
+            enabled: "True",
+            environmentName: null,
+            additionalTransforms: "custom-override.config => app.config");
+
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "app.config")).ShouldContain("value=\"y\"",
+            customMessage: "Operator-supplied 'transform => target' pair MUST be applied even without an EnvironmentName auto-pair match.");
+    }
+
+    [Fact]
+    public async Task Execute_AdditionalTransforms_MultiplePairs_NewlineSeparated()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "a.config"), """<?xml version="1.0"?><c><add key="K" value="0" /></c>""");
+        File.WriteAllText(Path.Combine(_workDir, "b.config"), """<?xml version="1.0"?><c><add key="K" value="0" /></c>""");
+        File.WriteAllText(Path.Combine(_workDir, "a-prod.config"), """<?xml version="1.0"?><c xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"><add key="K" value="1" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" /></c>""");
+        File.WriteAllText(Path.Combine(_workDir, "b-prod.config"), """<?xml version="1.0"?><c xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"><add key="K" value="2" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" /></c>""");
+
+        var context = BuildContext(
+            enabled: "True",
+            environmentName: null,
+            additionalTransforms: "a-prod.config => a.config\nb-prod.config => b.config");
+
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "a.config")).ShouldContain("value=\"1\"");
+        File.ReadAllText(Path.Combine(_workDir, "b.config")).ShouldContain("value=\"2\"");
+    }
+
+    [Fact]
+    public async Task Execute_AdditionalTransforms_MalformedLine_SkippedWithWarning()
+    {
+        // Line without `=>` separator is operator typo — skip with warning,
+        // continue with other pairs. Don't fail the whole deploy on a
+        // formatting mistake.
+        File.WriteAllText(Path.Combine(_workDir, "a.config"), """<?xml version="1.0"?><c><add key="K" value="0" /></c>""");
+        File.WriteAllText(Path.Combine(_workDir, "a-prod.config"), """<?xml version="1.0"?><c xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"><add key="K" value="1" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" /></c>""");
+
+        var context = BuildContext(
+            enabled: "True",
+            environmentName: null,
+            additionalTransforms: "malformed line no arrow\na-prod.config => a.config");
+
+        await Should.NotThrowAsync(() =>
+            new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None));
+
+        File.ReadAllText(Path.Combine(_workDir, "a.config")).ShouldContain("value=\"1\"",
+            customMessage: "Valid pair after malformed line MUST still be applied — one typo doesn't break the entire transform list.");
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_BaseFileMissing_WarningContinue_NoCrash()
+    {
+        // AdditionalTransforms references a base file that doesn't exist —
+        // probably extracted to a different location. Warn + continue.
+        File.WriteAllText(Path.Combine(_workDir, "transform.config"), """<?xml version="1.0"?><c />""");
+
+        var context = BuildContext(
+            enabled: "True",
+            environmentName: null,
+            additionalTransforms: "transform.config => missing-base.config");
+
+        await Should.NotThrowAsync(() =>
+            new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Execute_EnabledButNoTransformsAtAll_NoOp()
+    {
+        // Operator enabled the toggle but provided no environment-name AND
+        // no additional transforms. No-op cleanly.
+        File.WriteAllText(Path.Combine(_workDir, "web.config"), """<?xml version="1.0"?><c />""");
+
+        var context = BuildContext(enabled: "True", environmentName: null, additionalTransforms: null);
+
+        await Should.NotThrowAsync(() =>
+            new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None));
+
+        File.ReadAllText(Path.Combine(_workDir, "web.config")).ShouldContain("<c />",
+            customMessage: "Enabled but no transform pairs = base files untouched.");
+    }
+
+    [Fact]
+    public async Task Execute_WorkingDirNotSet_Throws()
+    {
+        var context = BuildContext(enabled: "True", environmentName: "Production");
+        context.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    // ── Wire-contract pinning ──────────────────────────────────────────────
+
+    [Fact]
+    public void EnabledVariableName_PinnedToIISHandlerContract()
+        => ConfigurationTransformsVariableNames.Enabled.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
+
+    [Fact]
+    public void EnvironmentNameVariableName_PinnedToIISHandlerContract()
+        => ConfigurationTransformsVariableNames.EnvironmentName.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName");
+
+    [Fact]
+    public void AdditionalTransformsVariableName_PinnedToIISHandlerContract()
+        => ConfigurationTransformsVariableNames.AdditionalTransforms.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms");
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private RunScriptCommandContext BuildContext(string? enabled, string? environmentName, string? additionalTransforms = null)
+    {
+        var vars = new VariableSet();
+        if (enabled != null) vars.Set(ConfigurationTransformsVariableNames.Enabled, enabled);
+        if (environmentName != null) vars.Set(ConfigurationTransformsVariableNames.EnvironmentName, environmentName);
+        if (additionalTransforms != null) vars.Set(ConfigurationTransformsVariableNames.AdditionalTransforms, additionalTransforms);
+
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/XdtTransformerTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/XdtTransformerTests.cs
@@ -1,0 +1,196 @@
+using System.IO;
+using System.Xml;
+using Shouldly;
+using Squid.Calamari.Commands.Configuration;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Configuration;
+
+/// <summary>
+/// G1.2 — pure-function tests for the XDT transformer that backs
+/// <c>ConfigurationTransformsStep</c>. Pins the operator-observable behaviour
+/// of Microsoft's standard <c>Microsoft.Web.Xdt</c> engine via our thin
+/// wrapper. The wrapper exists to:
+///   1. Centralise error handling (XDT throws raw XmlException on malformed)
+///   2. Provide a pure-function API (TransformResult record vs side-effects)
+///   3. Be testable in isolation (the step is a thin pipeline orchestrator)
+/// </summary>
+public sealed class XdtTransformerTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public XdtTransformerTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"xdt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public void Transform_SetAttributeWithLocatorMatch_AppliesChange()
+    {
+        var basePath = WriteFile("web.config", """
+            <?xml version="1.0"?>
+            <configuration>
+              <appSettings>
+                <add key="EnvironmentName" value="Development" />
+              </appSettings>
+            </configuration>
+            """);
+
+        var transformPath = WriteFile("web.Production.config", """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+              <appSettings>
+                <add key="EnvironmentName" value="Production" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+              </appSettings>
+            </configuration>
+            """);
+
+        var result = XdtTransformer.Transform(basePath, transformPath);
+
+        result.Succeeded.ShouldBeTrue();
+
+        var transformed = File.ReadAllText(basePath);
+        transformed.ShouldContain("value=\"Production\"",
+            customMessage: "XDT SetAttributes Match(key) should rewrite the Development → Production value in-place.");
+    }
+
+    [Fact]
+    public void Transform_InsertElement_AddsNewChild()
+    {
+        var basePath = WriteFile("app.config", """
+            <?xml version="1.0"?>
+            <configuration>
+              <appSettings>
+                <add key="A" value="1" />
+              </appSettings>
+            </configuration>
+            """);
+        var transformPath = WriteFile("app.Production.config", """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+              <appSettings>
+                <add key="B" value="2" xdt:Transform="Insert" />
+              </appSettings>
+            </configuration>
+            """);
+
+        var result = XdtTransformer.Transform(basePath, transformPath);
+
+        result.Succeeded.ShouldBeTrue();
+        var transformed = File.ReadAllText(basePath);
+        transformed.ShouldContain("key=\"A\"");
+        transformed.ShouldContain("key=\"B\"");
+    }
+
+    [Fact]
+    public void Transform_MissingBaseFile_FailureResult_DoesNotThrow()
+    {
+        var transformPath = WriteFile("web.Production.config", """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" />
+            """);
+
+        var result = XdtTransformer.Transform(Path.Combine(_workDir, "nonexistent.config"), transformPath);
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("base", Case.Insensitive,
+            customMessage: "Missing base file MUST be reported as failure-reason mentioning 'base' so the operator knows which side is missing.");
+    }
+
+    [Fact]
+    public void Transform_MissingTransformFile_FailureResult_DoesNotThrow()
+    {
+        var basePath = WriteFile("web.config", "<configuration />");
+
+        var result = XdtTransformer.Transform(basePath, Path.Combine(_workDir, "nonexistent.transform"));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("transform", Case.Insensitive);
+    }
+
+    [Fact]
+    public void Transform_MalformedXmlInBase_FailureResult_NoCrash()
+    {
+        var basePath = WriteFile("web.config", "<not really xml");
+        var transformPath = WriteFile("web.Production.config", """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform" />
+            """);
+
+        var result = XdtTransformer.Transform(basePath, transformPath);
+
+        result.Succeeded.ShouldBeFalse(
+            customMessage: "Malformed base XML MUST be caught + reported as failure, not propagate as raw XmlException — operator gets a clean error in the deploy log.");
+    }
+
+    [Fact]
+    public void Transform_NoXdtNamespaceInTransform_ProducesEffectivelyIdentityCopy()
+    {
+        // Edge case: operator writes a transform file that DOESN'T declare the
+        // xdt: namespace and has no actual XDT directives. XDT engine treats
+        // it as identity (no changes). We should report success.
+        var basePath = WriteFile("web.config", """
+            <?xml version="1.0"?>
+            <configuration>
+              <appSettings>
+                <add key="A" value="1" />
+              </appSettings>
+            </configuration>
+            """);
+        var transformPath = WriteFile("web.Production.config", """
+            <?xml version="1.0"?>
+            <configuration />
+            """);
+
+        var result = XdtTransformer.Transform(basePath, transformPath);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Transform_PreservesXmlDeclaration()
+    {
+        // Operator's web.config typically has <?xml version="1.0"?>. Microsoft's
+        // XmlTransformableDocument preserves it but our wrapper's write path
+        // could accidentally drop it. Pin the round-trip.
+        var basePath = WriteFile("web.config", """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <configuration>
+              <appSettings>
+                <add key="A" value="old" />
+              </appSettings>
+            </configuration>
+            """);
+        var transformPath = WriteFile("web.Production.config", """
+            <?xml version="1.0"?>
+            <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+              <appSettings>
+                <add key="A" value="new" xdt:Transform="SetAttributes" xdt:Locator="Match(key)" />
+              </appSettings>
+            </configuration>
+            """);
+
+        var result = XdtTransformer.Transform(basePath, transformPath);
+
+        result.Succeeded.ShouldBeTrue();
+        var transformed = File.ReadAllText(basePath);
+        transformed.ShouldContain("<?xml",
+            customMessage: "XML declaration MUST be preserved across transform — some downstream parsers (legacy .NET FX configManager) require it.");
+        transformed.ShouldContain("value=\"new\"");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private string WriteFile(string name, string content)
+    {
+        var path = Path.Combine(_workDir, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISConfigurationTransformsWireContractTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISConfigurationTransformsWireContractTests.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using Squid.Calamari.Commands.Configuration;
+using Squid.Core.Services.DeploymentExecution;
+using Xunit;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle.Handlers;
+
+/// <summary>
+/// G1.2 — cross-project drift detector for the ConfigurationTransforms (XDT)
+/// feature. Same pattern as the G1.1 SubstituteInFiles wire-contract test.
+///
+/// <para>Three variable literals form the contract between the server-side
+/// IIS handler preamble and the Calamari pipeline step. A rename on either
+/// side without the other = silent UI-theatre regression (operator flips
+/// toggle, deploy runs as if disabled).</para>
+/// </summary>
+public sealed class IISConfigurationTransformsWireContractTests
+{
+    [Fact]
+    public void EnabledVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.ConfigurationTransformsEnabled
+            .ShouldBe(ConfigurationTransformsVariableNames.Enabled);
+    }
+
+    [Fact]
+    public void EnvironmentNameVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.ConfigurationTransformsEnvironmentName
+            .ShouldBe(ConfigurationTransformsVariableNames.EnvironmentName);
+    }
+
+    [Fact]
+    public void AdditionalTransformsVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.ConfigurationTransformsAdditional
+            .ShouldBe(ConfigurationTransformsVariableNames.AdditionalTransforms);
+    }
+
+    [Fact]
+    public void EnabledVariable_LiteralValuePinned()
+    {
+        // Defence-in-depth pin (coordinate rename → still test-visible).
+        IISDeployProperties.ConfigurationTransformsEnabled
+            .ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
+    }
+}


### PR DESCRIPTION
## Summary

**Phase G1.2** of the Calamari Refactor Roadmap. Closes the IIS deploy handler's currently-degraded "Configuration transforms" toggle by giving Calamari a real XDT engine for the Bash deploy path.

## What's new

Two components under `Squid.Calamari.Commands.Configuration`:

| Component | Lines | Tests | Purpose |
|---|---|---|---|
| `XdtTransformer` | ~80 | 7 | Pure-function wrapper over Microsoft.Web.XmlTransform with typed `TransformResult`, atomic write, XML-decl preservation |
| `ConfigurationTransformsStep` | ~140 | 13 | Pipeline step: auto-pair `*.{Env}.config` + `*.Release.config`, operator-supplied `transform => base` pairs, malformed-line tolerance |

Plus `ConfigurationTransformsVariableNames` public constants for cross-project wire-contract pinning.

## Dependency add

- **`Microsoft.Web.Xdt` 3.1.0** (~150 KB) — Microsoft's official XDT engine, used by .NET Framework `web.config` transform tooling. Per the Calamari Architecture Decision, heavy-lifting work like this belongs in Calamari (fork-isolated child process, has access to extracted files on the agent).

## Pipeline order

```
ResolveWorkingDirectory
  → LoadVariablesFromFiles
  → SubstituteInFiles         (G1.1 — #{Token} replacement; runs first so transform files have concrete values)
  → ConfigurationTransforms   (G1.2 — XDT; runs on already-substituted files)
  → WriteBootstrappedBashScript
  → ExecuteScriptWithEngine
  → BuildRunScriptCommandResult
  → CleanupTemporaryFiles
```

Matches Octopus's `Octopus.Features.ConfigurationTransforms` ordering — `SubstituteInFiles → ConfigurationTransforms` is critical: if the order were reversed, transform files containing `#{Token}` references would be parsed by the XDT engine BEFORE the tokens were resolved, producing garbage transforms.

## Auto-pairing semantic (Octopus parity)

For each `*.config` file in the working directory:

1. **Always applied** (if it exists): `*.Release.config` — matches .NET FX build-time XDT default
2. **Conditionally applied**: `*.{EnvironmentName}.config` — driven by `Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName` variable

A "base config" is any `*.config` whose stem has no `.` (e.g. `web.config` ✓, `web.Production.config` ✗). Heuristic avoids treating transforms as their own targets.

## Operator-supplied pairs

`ConfigurationTransforms.AdditionalTransforms` (newline-separated):
```
custom-overrides.config => app.config
overrides/prod.config => web.config
```

Malformed line (no `=>`) → skip with stderr warning, continue with the rest. Don't fail the whole deploy on a typo.

## Wire-contract pinning

Cross-project drift detector in `Squid.UnitTests.IISConfigurationTransformsWireContractTests` asserts all three variable literals match between server (`IISDeployProperties`) and agent (`ConfigurationTransformsVariableNames`). Same pattern as G1.1.

## Test plan

- [x] **7 unit tests** on `XdtTransformer` — SetAttributes/Insert directives, missing files, malformed XML, identity transform, XML-declaration preservation
- [x] **13 unit tests** on `ConfigurationTransformsStep` — enable-gate × 5, auto-pair × 3, operator-pair × 3, edge cases × 2
- [x] **4 cross-project drift tests** in `Squid.UnitTests` pinning server ↔ agent contract
- [x] **5611/5611 Squid.UnitTests green** (+4)
- [x] **203/203 Squid.Calamari.Tests green** (+24 net new)

## What's NOT in this PR

- **G1.3 (StructuredConfigVariablesStep)** — JSON path edits on appsettings.json; next PR
- **G1.4 (ExtractPackageStep)** — package archive extraction; separate PR
- **G1.5 (Convention hooks)** — PreDeploy/Deploy/PostDeploy scripts; separate PR

## Operator-visible improvement

Per the failed-deploy log the operator shared earlier:
```
ConfigurationTransforms: processing *.config under '.'
警告: ConfigurationTransforms: Microsoft.Web.XmlTransform not available on this agent.
```

For Bash deploys, the Calamari child now has the assembly bundled — transforms apply cleanly. For Windows IIS deploys (which use the PowerShell path per PR #353), the PS script still has its own inline XDT check; making that path also benefit from this is a future PR.

## Refs

- Notion: 🦑 Squid — Calamari Refactor Roadmap (Post 1.8.1) — phase plan
- PR #363 (G1.1) — the precedent for the wire-contract pinning + pipeline integration shape