### PR TITLE
G1.3: StructuredConfigVariablesStep — JSON-path replacement for appsettings.json

### DIFF
--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -1,4 +1,5 @@
 using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.StructuredConfig;
 using Squid.Calamari.Commands.Substitution;
 using Squid.Calamari.Execution;
 using Squid.Calamari.Pipeline;
@@ -49,6 +50,12 @@ public class RunScriptCommand
             // Runs after SubstituteInFiles so transform sources have
             // concrete values, not unresolved tokens.
             new ConfigurationTransformsStep(),
+            // G1.3 — JSON-path leaf replacement on operator-nominated JSON
+            // files (typically appsettings.json). Runs after XDT so the
+            // ConfigurationTransforms-rewritten *.config files don't get
+            // their JSON cousins out of sync. Matches Octopus pipeline order:
+            // SubstituteInFiles → ConfigurationTransforms → StructuredConfigurationVariables.
+            new StructuredConfigVariablesStep(),
             new WriteBootstrappedBashScriptStep(),
             new ExecuteScriptWithEngineStep(scriptEngine),
             new BuildRunScriptCommandResultStep(),

--- a/src/Squid.Calamari/Commands/StructuredConfig/JsonPathReplacer.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/JsonPathReplacer.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// G1.3 — structure-aware JSON-leaf replacement. For each leaf in the input
+/// JSON, check if its computed path matches any variable name in the
+/// supplied <see cref="VariableSet"/>; if so, replace the leaf value with
+/// the variable's value.
+///
+/// <para><b>Path forms accepted</b> (both lookup styles for the same leaf):
+/// <list type="bullet">
+///   <item>Dot-separated: <c>ConnectionStrings.Default</c></item>
+///   <item>Colon-separated: <c>Logging:LogLevel:Default</c>
+///         (ASP.NET Core IConfiguration idiom)</item>
+/// </list>
+/// At each leaf the replacer asks both forms; the variable set is checked
+/// case-insensitively (operator inputs may be inconsistent across Octopus
+/// imports vs. native Squid).</para>
+///
+/// <para><b>Type preservation</b>: leaf value JSON type is preserved across
+/// replacement. A leaf of type number stays a number if the variable value
+/// parses; falls back to string if not. Booleans similarly. Null leaves
+/// become string-quoted on replacement (operators almost always mean a
+/// real value at that point).</para>
+///
+/// <para><b>Non-leaf paths are silently skipped</b>: a variable matching an
+/// object/array node would corrupt the schema if we replaced it with a
+/// scalar string. Skip + log.</para>
+///
+/// <para><b>Walked once, not per-variable</b>: O(json_leaves) instead of
+/// O(variables × leaves). Most Squid variable sets have 50-200 entries;
+/// most JSON files have &lt;100 leaves. Per-variable iteration would be
+/// 10,000+ lookups per file; per-leaf is 100.</para>
+/// </summary>
+internal static class JsonPathReplacer
+{
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private static readonly JsonDocumentOptions ParseOptions = new()
+    {
+        // Operators sometimes leave commas / comments in appsettings.json
+        // during development. Be tolerant so we don't fail a deploy over
+        // dev-era artifacts.
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
+
+    public static JsonReplaceResult Replace(string json, VariableSet variables)
+    {
+        ArgumentNullException.ThrowIfNull(variables);
+        if (string.IsNullOrWhiteSpace(json)) return JsonReplaceResult.Success(json ?? string.Empty, 0);
+
+        JsonNode? root;
+        try
+        {
+            root = JsonNode.Parse(json, documentOptions: ParseOptions);
+        }
+        catch (JsonException ex)
+        {
+            return JsonReplaceResult.Failure($"Failed to parse JSON: {ex.Message}");
+        }
+
+        if (root is null)
+            return JsonReplaceResult.Success(json, 0);
+
+        var replacedCount = 0;
+        ReplaceRecursive(root, currentPath: string.Empty, variables, ref replacedCount);
+
+        return JsonReplaceResult.Success(root.ToJsonString(WriteOptions), replacedCount);
+    }
+
+    private static void ReplaceRecursive(JsonNode node, string currentPath, VariableSet variables, ref int replacedCount)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                // Materialise list of properties — we may rewrite their values
+                // mid-iteration which would otherwise invalidate the enumerator.
+                foreach (var prop in obj.ToList())
+                {
+                    var childPath = currentPath.Length == 0 ? prop.Key : $"{currentPath}.{prop.Key}";
+
+                    if (prop.Value is null)
+                    {
+                        // Null leaf — try to replace with variable value as string.
+                        if (TryFindVariable(variables, childPath, out var newValue))
+                        {
+                            obj[prop.Key] = JsonValue.Create(newValue);
+                            replacedCount++;
+                        }
+                        continue;
+                    }
+
+                    if (prop.Value is JsonValue leaf)
+                    {
+                        if (TryFindVariable(variables, childPath, out var newValue))
+                        {
+                            obj[prop.Key] = CoerceToOriginalType(leaf, newValue);
+                            replacedCount++;
+                        }
+                    }
+                    else
+                    {
+                        // Recurse into nested object / array.
+                        ReplaceRecursive(prop.Value, childPath, variables, ref replacedCount);
+                    }
+                }
+                break;
+
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                {
+                    var childPath = $"{currentPath}.{i}";
+
+                    if (arr[i] is null)
+                    {
+                        if (TryFindVariable(variables, childPath, out var newValue))
+                        {
+                            arr[i] = JsonValue.Create(newValue);
+                            replacedCount++;
+                        }
+                        continue;
+                    }
+
+                    if (arr[i] is JsonValue leaf)
+                    {
+                        if (TryFindVariable(variables, childPath, out var newValue))
+                        {
+                            arr[i] = CoerceToOriginalType(leaf, newValue);
+                            replacedCount++;
+                        }
+                    }
+                    else
+                    {
+                        ReplaceRecursive(arr[i]!, childPath, variables, ref replacedCount);
+                    }
+                }
+                break;
+
+            // JsonValue at root = scalar JSON file (e.g. just "hello"). Rare;
+            // no path to match against. No-op.
+        }
+    }
+
+    /// <summary>
+    /// Try the dot-form first (the canonical computed path), then the
+    /// colon-form (ASP.NET Core IConfiguration idiom — same leaf, different
+    /// separator). Returns the first match.
+    /// </summary>
+    private static bool TryFindVariable(VariableSet variables, string dotPath, out string value)
+    {
+        var dot = variables.Get(dotPath);
+        if (dot is not null)
+        {
+            value = dot;
+            return true;
+        }
+
+        var colonPath = dotPath.Replace('.', ':');
+        var colon = variables.Get(colonPath);
+        if (colon is not null)
+        {
+            value = colon;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Preserve the leaf's JSON type when substituting. A boolean leaf
+    /// stays boolean if the new value parses; a number leaf stays numeric;
+    /// strings stay strings. Fallback to string when the new value isn't
+    /// parseable in the original type — operator might intentionally want
+    /// the type override (rare but legitimate).
+    /// </summary>
+    private static JsonNode? CoerceToOriginalType(JsonValue originalLeaf, string newValue)
+    {
+        var element = originalLeaf.GetValue<JsonElement>();
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.True or JsonValueKind.False:
+                if (bool.TryParse(newValue, out var boolVal))
+                    return JsonValue.Create(boolVal);
+                return JsonValue.Create(newValue);
+
+            case JsonValueKind.Number:
+                if (long.TryParse(newValue, out var longVal))
+                    return JsonValue.Create(longVal);
+                if (double.TryParse(newValue, out var doubleVal))
+                    return JsonValue.Create(doubleVal);
+                return JsonValue.Create(newValue);
+
+            default:
+                return JsonValue.Create(newValue);
+        }
+    }
+}
+
+internal sealed record JsonReplaceResult(bool Succeeded, string Output, int ReplacedCount, string? FailureReason)
+{
+    public static JsonReplaceResult Success(string output, int replacedCount)
+        => new(true, output, replacedCount, null);
+
+    public static JsonReplaceResult Failure(string reason)
+        => new(false, string.Empty, 0, reason);
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
@@ -1,0 +1,116 @@
+using Squid.Calamari.Commands.Substitution;
+using Squid.Calamari.Pipeline;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// Wire-contract constants for the StructuredConfigVariables feature.
+/// Public so cross-project drift tests in Squid.UnitTests can pin them.
+/// </summary>
+public static class StructuredConfigVariableNames
+{
+    public const string Enabled = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled";
+    public const string Targets = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets";
+}
+
+/// <summary>
+/// G1.3 — applies <see cref="JsonPathReplacer"/> to operator-nominated JSON
+/// files. Closes the IIS handler's third advertised cross-cutting feature
+/// (after G1.1 SubstituteInFiles + G1.2 ConfigurationTransforms).
+///
+/// <para><b>Pipeline position</b>: must run AFTER SubstituteInFilesStep so
+/// any <c>#{Token}</c> references inside the JSON file are resolved first.
+/// Then JSON-path replacement operates on concrete leaf values.</para>
+///
+/// <para><b>Scope</b>: targets are operator-supplied newline-separated globs.
+/// Typically <c>appsettings.json</c> + <c>appsettings.{Env}.json</c>, but
+/// works on any JSON file matching the glob.</para>
+///
+/// <para><b>Glob reuse</b>: <see cref="GlobMatcher"/> is shared with
+/// SubstituteInFilesStep — single source of truth for glob semantics,
+/// path-traversal sandbox, and recursive matching.</para>
+/// </summary>
+internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCommandContext>
+{
+    public override bool IsEnabled(RunScriptCommandContext context)
+    {
+        if (context.Variables is null) return false;
+        var raw = context.Variables.Get(StructuredConfigVariableNames.Enabled);
+        return string.Equals(raw, "True", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(context.WorkingDirectory))
+            throw new InvalidOperationException(
+                "Working directory has not been initialized — StructuredConfigVariablesStep must run after ResolveWorkingDirectoryStep.");
+        if (context.Variables is null)
+            throw new InvalidOperationException(
+                "Variables have not been loaded — StructuredConfigVariablesStep must run after LoadVariablesFromFilesStep.");
+
+        var targetsRaw = context.Variables.Get(StructuredConfigVariableNames.Targets);
+        if (string.IsNullOrWhiteSpace(targetsRaw)) return Task.CompletedTask;
+
+        var totalReplaced = 0;
+        var filesProcessed = 0;
+        var filesFailed = 0;
+
+        foreach (var glob in SplitGlobs(targetsRaw))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var matches = GlobMatcher.Expand(context.WorkingDirectory, glob).ToList();
+            if (matches.Count == 0)
+            {
+                Console.Error.WriteLine(
+                    $"::warning::StructuredConfigVariables: glob '{glob}' matched no files under '{context.WorkingDirectory}'. Continuing.");
+                continue;
+            }
+
+            foreach (var file in matches)
+            {
+                try
+                {
+                    var json = File.ReadAllText(file);
+                    var result = JsonPathReplacer.Replace(json, context.Variables);
+
+                    if (!result.Succeeded)
+                    {
+                        Console.Error.WriteLine(
+                            $"::warning::StructuredConfigVariables: skipping '{file}' — {result.FailureReason}");
+                        filesFailed++;
+                        continue;
+                    }
+
+                    if (result.ReplacedCount > 0)
+                    {
+                        File.WriteAllText(file, result.Output);
+                        Console.WriteLine(
+                            $"StructuredConfigVariables: '{file}' — {result.ReplacedCount} leaf value(s) replaced.");
+                    }
+
+                    filesProcessed++;
+                    totalReplaced += result.ReplacedCount;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    Console.Error.WriteLine(
+                        $"::warning::StructuredConfigVariables: failed to process '{file}' — {ex.GetType().Name}: {ex.Message}");
+                    filesFailed++;
+                }
+            }
+        }
+
+        Console.WriteLine(
+            $"StructuredConfigVariables: processed {filesProcessed} file(s), {filesFailed} failure(s), {totalReplaced} total leaf replacement(s).");
+
+        return Task.CompletedTask;
+    }
+
+    private static IEnumerable<string> SplitGlobs(string raw)
+        => raw.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0);
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/JsonPathReplacerTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/JsonPathReplacerTests.cs
@@ -1,0 +1,219 @@
+using Shouldly;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// G1.3 — pure-function tests for the JSON-path leaf-replacement engine that
+/// backs <c>StructuredConfigVariablesStep</c>. Operator-facing: each Squid
+/// variable name (e.g. <c>Logging:LogLevel:Default</c> or
+/// <c>ConnectionStrings.Default</c>) is checked against every leaf path in
+/// the target JSON; matches replace the leaf value with the variable's
+/// value.
+///
+/// <para><b>Octopus parity</b>: both dot-separated AND colon-separated path
+/// forms match the same JSON leaf. ASP.NET Core operators use <c>:</c>
+/// natively (the framework's `IConfiguration` separator); ports from
+/// pre-ASP.NET-Core code use <c>.</c>. Squid accepts both.</para>
+/// </summary>
+public sealed class JsonPathReplacerTests
+{
+    [Fact]
+    public void Replace_DotPath_SubstitutesLeafValue()
+    {
+        var json = """{"ConnectionStrings":{"Default":"Server=local"}}""";
+        var vars = NewVarSet(("ConnectionStrings.Default", "Server=prod;Database=app"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"Server=prod;Database=app\"");
+        result.Output.ShouldNotContain("\"Server=local\"");
+    }
+
+    [Fact]
+    public void Replace_ColonPath_SubstitutesSameLeaf_AsDotPath()
+    {
+        // ASP.NET Core idiom: operator writes the variable name with `:`
+        // separators (same convention as IConfiguration). The leaf in JSON
+        // is the same; both name forms must match.
+        var json = """{"Logging":{"LogLevel":{"Default":"Information"}}}""";
+        var vars = NewVarSet(("Logging:LogLevel:Default", "Debug"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"Debug\"");
+        result.Output.ShouldNotContain("\"Information\"");
+    }
+
+    [Fact]
+    public void Replace_NestedDeepPath_FindsLeaf()
+    {
+        var json = """{"a":{"b":{"c":{"d":{"e":"old"}}}}}""";
+        var vars = NewVarSet(("a.b.c.d.e", "new"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"new\"");
+    }
+
+    [Fact]
+    public void Replace_PathHitsObject_NotLeaf_NoReplacement()
+    {
+        // Variable name "Logging" alone tries to replace the OBJECT value;
+        // we should refuse — only leaf strings/numbers/booleans/null are
+        // safe to swap. Replacing an object with a string would corrupt
+        // the schema.
+        var json = """{"Logging":{"LogLevel":"Info"}}""";
+        var vars = NewVarSet(("Logging", "Information"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        // Original object preserved (indented output adds " " after ":")
+        result.Output.ShouldContain("\"LogLevel\": \"Info\"",
+            customMessage: "Variable pointing at a non-leaf (object/array) MUST be skipped — replacing the object with a string would corrupt the structure.");
+    }
+
+    [Fact]
+    public void Replace_MultipleVariablesMatchDifferentLeaves_AllApplied()
+    {
+        var json = """{"A":"1","B":{"C":"2"}}""";
+        var vars = NewVarSet(
+            ("A", "10"),
+            ("B.C", "20"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"A\": \"10\"");
+        result.Output.ShouldContain("\"C\": \"20\"");
+    }
+
+    [Fact]
+    public void Replace_VariableNameDoesNotMatchAnyPath_NoOp()
+    {
+        var json = """{"A":"1"}""";
+        var vars = NewVarSet(
+            ("A", "10"),
+            ("DoesNotMatch", "ignored"),
+            ("Squid.Some.Random.Variable", "ignored"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"A\": \"10\"");
+        result.Output.ShouldNotContain("ignored",
+            customMessage: "Variables that don't match any JSON path MUST be silently ignored — most Squid variables won't match, that's expected.");
+    }
+
+    [Fact]
+    public void Replace_ArrayIndexPath_FindsLeaf()
+    {
+        // ASP.NET Core convention: array index in path uses integer.
+        // appsettings.json: {"Hosts": ["a", "b", "c"]}
+        // Variable "Hosts:1" should replace "b" → with operator's value.
+        var json = """{"Hosts":["a","b","c"]}""";
+        var vars = NewVarSet(("Hosts:1", "replaced"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"replaced\"");
+        result.Output.ShouldNotContain("\"b\"");
+        result.Output.ShouldContain("\"a\"");
+        result.Output.ShouldContain("\"c\"");
+    }
+
+    [Fact]
+    public void Replace_ValueIsBool_ReplacementIsBool()
+    {
+        // JSON value types matter: a leaf at `Feature.Enabled` is `true`
+        // (bool). Operator's variable value is the string "false". We should
+        // emit it as a JSON boolean, not a quoted string, so the consumer
+        // still parses it correctly.
+        var json = """{"Feature":{"Enabled":true}}""";
+        var vars = NewVarSet(("Feature.Enabled", "false"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"Enabled\": false",
+            customMessage: "Boolean leaf MUST be replaced with JSON boolean (false), not string (\"false\"). Otherwise downstream JSON consumers parse it as truthy string.");
+    }
+
+    [Fact]
+    public void Replace_ValueIsNumber_ReplacementIsNumber()
+    {
+        var json = """{"Port":8080}""";
+        var vars = NewVarSet(("Port", "9090"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"Port\": 9090",
+            customMessage: "Numeric leaf MUST stay numeric on replacement.");
+    }
+
+    [Fact]
+    public void Replace_ValueIsNumberButNewValueIsNotNumeric_FallsBackToString()
+    {
+        // Edge: leaf is a number, but the variable value isn't parseable as
+        // one (operator typo / intentional string override). Fall back to
+        // string to avoid throwing.
+        var json = """{"Port":8080}""";
+        var vars = NewVarSet(("Port", "https://my-port-name"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"Port\": \"https://my-port-name\"",
+            customMessage: "Non-numeric replacement for numeric leaf MUST fall back to string, not throw — operator might intentionally want a stringy override.");
+    }
+
+    [Fact]
+    public void Replace_MalformedJson_ReturnsFailure_NoCrash()
+    {
+        var vars = NewVarSet(("A", "1"));
+
+        var result = JsonPathReplacer.Replace("not really json {{{{", vars);
+
+        result.Succeeded.ShouldBeFalse(
+            customMessage: "Malformed JSON MUST be caught + reported, not propagate as raw JsonException.");
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Replace_NoVariables_ReturnsInputUnchanged()
+    {
+        var json = """{"A":"1"}""";
+        var vars = NewVarSet();
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Succeeded.ShouldBeTrue();
+        // Whitespace + ordering may change with re-serialization; compare semantically.
+        // Indented output adds " " after ":" — assert the key/value pair regardless.
+        result.Output.ShouldContain("\"A\": \"1\"");
+    }
+
+    [Fact]
+    public void Replace_EmptyJsonObject_NoChange()
+    {
+        var vars = NewVarSet(("A", "1"));
+
+        var result = JsonPathReplacer.Replace("{}", vars);
+
+        result.Succeeded.ShouldBeTrue();
+        result.Output.Trim().ShouldBe("{}");
+    }
+
+    [Fact]
+    public void Replace_NullVariables_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => JsonPathReplacer.Replace("{}", null!));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static VariableSet NewVarSet(params (string name, string value)[] entries)
+    {
+        var set = new VariableSet();
+        foreach (var (name, value) in entries) set.Set(name, value);
+        return set;
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs
@@ -1,0 +1,181 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// G1.3 — pipeline-level tests for <see cref="StructuredConfigVariablesStep"/>.
+///
+/// <para>Operator-facing variables (mirrors the IIS deploy script preamble):
+/// <list type="bullet">
+///   <item><c>Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled</c> ("True"/"False")</item>
+///   <item><c>Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets</c>
+///         (newline-separated globs of JSON files to rewrite)</item>
+/// </list></para>
+/// </summary>
+public sealed class StructuredConfigVariablesStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public StructuredConfigVariablesStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"struct-cfg-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public void IsEnabled_TrueToggle_RunsStep()
+    {
+        var context = BuildContext(enabled: "True", targets: "appsettings.json");
+        new StructuredConfigVariablesStep().IsEnabled(context).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("False")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsEnabled_NotTrue_SkipsStep(string? toggle)
+    {
+        var context = BuildContext(enabled: toggle, targets: "appsettings.json");
+        new StructuredConfigVariablesStep().IsEnabled(context).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Execute_AppsettingsJson_LoggingDefaultPath_Replaced()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"), """
+            {
+              "Logging": { "LogLevel": { "Default": "Information" } },
+              "ConnectionStrings": { "Default": "Server=local" }
+            }
+            """);
+
+        var context = BuildContext(
+            enabled: "True",
+            targets: "appsettings.json",
+            ("Logging:LogLevel:Default", "Debug"),
+            ("ConnectionStrings.Default", "Server=prod"));
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        var result = File.ReadAllText(Path.Combine(_workDir, "appsettings.json"));
+        result.ShouldContain("\"Debug\"");
+        result.ShouldContain("\"Server=prod\"");
+    }
+
+    [Fact]
+    public async Task Execute_MultipleTargetGlobs_AllProcessed()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"), """{"Env":"dev"}""");
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.Production.json"), """{"Env":"dev"}""");
+
+        var context = BuildContext(
+            enabled: "True",
+            targets: "appsettings.json\nappsettings.Production.json",
+            ("Env", "prod"));
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "appsettings.json")).ShouldContain("\"prod\"");
+        File.ReadAllText(Path.Combine(_workDir, "appsettings.Production.json")).ShouldContain("\"prod\"");
+    }
+
+    [Fact]
+    public async Task Execute_GlobMatchesNoFiles_DoesNotCrash()
+    {
+        var context = BuildContext(enabled: "True", targets: "missing.json", ("Any", "v"));
+
+        await Should.NotThrowAsync(() =>
+            new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Execute_MalformedJsonInTarget_LogsWarning_ContinuesWithOtherFiles()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "bad.json"), "not really json {");
+        File.WriteAllText(Path.Combine(_workDir, "good.json"), """{"K":"old"}""");
+
+        var context = BuildContext(
+            enabled: "True",
+            targets: "*.json",
+            ("K", "new"));
+
+        await Should.NotThrowAsync(() =>
+            new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None));
+
+        // Good file gets the update; bad file is left intact.
+        File.ReadAllText(Path.Combine(_workDir, "good.json")).ShouldContain("\"new\"");
+        File.ReadAllText(Path.Combine(_workDir, "bad.json")).ShouldBe("not really json {",
+            customMessage: "Malformed JSON file MUST be left untouched, not partially-overwritten. Other valid files in the same target globs continue to process.");
+    }
+
+    [Fact]
+    public async Task Execute_RecursiveGlob_FindsNestedJson()
+    {
+        Directory.CreateDirectory(Path.Combine(_workDir, "config"));
+        File.WriteAllText(Path.Combine(_workDir, "config", "settings.json"), """{"K":"old"}""");
+
+        var context = BuildContext(enabled: "True", targets: "**/*.json", ("K", "new"));
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "config", "settings.json")).ShouldContain("\"new\"");
+    }
+
+    [Fact]
+    public async Task Execute_EmptyTargets_NoOp()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"), """{"K":"original"}""");
+
+        var context = BuildContext(enabled: "True", targets: "", ("K", "replacement"));
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "appsettings.json")).ShouldContain("\"original\"");
+    }
+
+    [Fact]
+    public async Task Execute_WorkingDirNotSet_Throws()
+    {
+        var context = BuildContext(enabled: "True", targets: "appsettings.json");
+        context.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
+    public void EnabledVariableName_PinnedToIISHandlerContract()
+        => StructuredConfigVariableNames.Enabled.ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled");
+
+    [Fact]
+    public void TargetsVariableName_PinnedToIISHandlerContract()
+        => StructuredConfigVariableNames.Targets.ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets");
+
+    private RunScriptCommandContext BuildContext(string? enabled, string? targets, params (string name, string value)[] extraVars)
+    {
+        var vars = new VariableSet();
+        if (enabled != null) vars.Set(StructuredConfigVariableNames.Enabled, enabled);
+        if (targets != null) vars.Set(StructuredConfigVariableNames.Targets, targets);
+        foreach (var (name, value) in extraVars) vars.Set(name, value);
+
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISStructuredConfigVariablesWireContractTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISStructuredConfigVariablesWireContractTests.cs
@@ -1,0 +1,42 @@
+using Shouldly;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Core.Services.DeploymentExecution;
+using Xunit;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle.Handlers;
+
+/// <summary>
+/// G1.3 — cross-project drift detector for the StructuredConfigVariables
+/// (JSON path) feature. Same pattern as G1.1 (SubstituteInFiles) +
+/// G1.2 (ConfigurationTransforms) wire-contract tests.
+/// </summary>
+public sealed class IISStructuredConfigVariablesWireContractTests
+{
+    [Fact]
+    public void EnabledVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.StructuredConfigurationVariablesEnabled
+            .ShouldBe(StructuredConfigVariableNames.Enabled);
+    }
+
+    [Fact]
+    public void TargetsVariable_ServerLiteral_MatchesCalamariLiteral()
+    {
+        IISDeployProperties.StructuredConfigurationVariablesTargets
+            .ShouldBe(StructuredConfigVariableNames.Targets);
+    }
+
+    [Fact]
+    public void EnabledVariable_LiteralValuePinned()
+    {
+        IISDeployProperties.StructuredConfigurationVariablesEnabled
+            .ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled");
+    }
+
+    [Fact]
+    public void TargetsVariable_LiteralValuePinned()
+    {
+        IISDeployProperties.StructuredConfigurationVariablesTargets
+            .ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets");
+    }
+}


### PR DESCRIPTION
## Summary

- Implements **StructuredConfigVariablesStep** — for each leaf in operator-nominated JSON files (typically `appsettings.json` + `appsettings.{Env}.json`), match its computed path against every variable name and substitute the leaf value with the variable's value. Both dot-form (`ConnectionStrings.Default`) and colon-form (`Logging:LogLevel:Default`, ASP.NET Core `IConfiguration` idiom) lookups are tried — first match wins.
- **Type-preserving**: boolean leaf stays boolean if the new value parses; numeric leaf stays numeric; otherwise falls back to string. Non-leaf path matches (object/array) are silently skipped — replacing an object with a scalar would corrupt the schema.
- **Pipeline position** matches Octopus: `SubstituteInFiles → ConfigurationTransforms → StructuredConfigurationVariables`. JSON parsing tolerates trailing commas + comments so dev-era artefacts don't fail a deploy.
- Closes the IIS handler's third advertised cross-cutting feature — Octopus-parity trio complete after #363 (G1.1) and #364 (G1.2).

## What's in the box

| Layer | File |
|---|---|
| Pure JSON engine | `src/Squid.Calamari/Commands/StructuredConfig/JsonPathReplacer.cs` |
| Pipeline step | `src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs` |
| Pipeline wiring | `src/Squid.Calamari/Commands/RunScriptCommand.cs` |
| Pure-function tests (15) | `tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/JsonPathReplacerTests.cs` |
| Pipeline tests (10) | `tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs` |
| Cross-project drift detector (4) | `tests/Squid.UnitTests/.../Tentacle/Handlers/IISStructuredConfigVariablesWireContractTests.cs` |

## Operator-facing variables (mirrors IIS deploy preamble)

| Variable | Effect |
|---|---|
| `Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled` (`"True"`/`"False"`) | Toggle the step on/off |
| `Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets` | Newline-separated globs of JSON files to rewrite |

## Test plan

- [x] Unit (Squid.Calamari.Tests): 230/230 — includes 25 G1.3 cases (15 replacer + 10 step)
- [x] Cross-project wire contract (Squid.UnitTests): 4/4 — pins `IISDeployProperties.StructuredConfigurationVariables{Enabled,Targets}` against `StructuredConfigVariableNames.{Enabled,Targets}`
- [x] Full Squid.UnitTests: 5615/5615 — no collateral regressions
- [x] `dotnet build` solution-wide: 0 errors
- [ ] Staging IIS deploy of an ASP.NET Core app with `appsettings.Production.json` containing both `:` and `.` variable forms — verify leaf values are rewritten in place with type preservation