### PR TITLE
Harden G1.x rewriter pipeline: 5 correctness/security fixes

### DIFF
--- a/src/Squid.Calamari/Commands/Common/EncodingPreservingFileIO.cs
+++ b/src/Squid.Calamari/Commands/Common/EncodingPreservingFileIO.cs
@@ -1,0 +1,97 @@
+using System.Text;
+
+namespace Squid.Calamari.Commands.Common;
+
+/// <summary>
+/// Shared file-IO primitives used by every step that rewrites operator-
+/// nominated text files (SubstituteInFilesStep / StructuredConfigVariablesStep
+/// / ConfigurationTransformsStep).
+///
+/// <para><b>Why centralise</b>: each rewriter MUST behave identically on the
+/// two cross-cutting concerns where operators silently get burned by sloppy
+/// implementations:
+/// <list type="bullet">
+///   <item><b>UTF-8 BOM preservation</b> — Visual Studio writes appsettings.json
+///         / web.config with a BOM by default. .NET's <c>File.ReadAllText</c>
+///         silently strips it; <c>File.WriteAllText</c> never re-adds it.
+///         A rewrite would change the byte content even when the logical text
+///         is identical, polluting diffs and confusing operators chasing a
+///         "what changed?" question.</item>
+///   <item><b>Atomic write</b> — write to a sibling temp path, fsync via
+///         <c>File.Move(... overwrite: true)</c>. If the writer dies mid-way
+///         (disk full, kill -9, OS panic) the operator's original file stays
+///         intact; the worst case is a leftover <c>.calamari-tmp</c> sibling
+///         that cleanup can mop up.</item>
+/// </list></para>
+///
+/// <para><b>Scope</b>: text files only. Binary or encoding-detected-as-binary
+/// files are not this class's concern — the caller skips them upstream.</para>
+/// </summary>
+internal static class EncodingPreservingFileIO
+{
+    /// <summary>
+    /// Read file contents detecting the UTF-8 BOM so the caller can write it
+    /// back exactly the same way. Returns the text content AND the encoding
+    /// object to thread back to <see cref="WriteAllTextAtomic"/>.
+    ///
+    /// <para>UTF-8 with BOM and UTF-8 without BOM are different at the byte
+    /// level; the <see cref="UTF8Encoding"/> instances returned here encode
+    /// that distinction via <c>encoderShouldEmitUTF8Identifier</c>.</para>
+    /// </summary>
+    public static (string Text, Encoding Encoding) ReadAllTextPreservingEncoding(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+
+        // UTF-8 BOM: EF BB BF
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        {
+            var withBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            return (withBom.GetString(bytes, 3, bytes.Length - 3), withBom);
+        }
+
+        // No BOM — operator's text content; assume UTF-8.
+        var noBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        return (noBom.GetString(bytes), noBom);
+    }
+
+    /// <summary>
+    /// Atomic text write: render to a sibling temp file, then
+    /// <c>File.Move(overwrite: true)</c> into place. Crash mid-write leaves
+    /// the original file untouched.
+    ///
+    /// <para>Caller picks the <paramref name="encoding"/> — typically the
+    /// encoding returned by <see cref="ReadAllTextPreservingEncoding"/> on
+    /// the same path, so BOM is preserved on round-trip.</para>
+    /// </summary>
+    public static void WriteAllTextAtomic(string path, string content, Encoding encoding)
+    {
+        var tempPath = path + TempSuffix;
+
+        // Write to sibling temp first. If this throws (disk full / permission)
+        // the original file is intact — the temp may exist but is junk we tag
+        // with a known suffix so cleanup can find it.
+        File.WriteAllText(tempPath, content, encoding);
+
+        // File.Move with overwrite=true on .NET 9 is atomic on POSIX (rename(2))
+        // and atomic-equivalent on Windows (MoveFileEx + MOVEFILE_REPLACE_EXISTING).
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// Atomic byte write — same pattern, used by step that already has the
+    /// bytes ready (e.g. XDT writes via <c>XmlDocument.Save</c> to the temp
+    /// path directly and then renames).
+    /// </summary>
+    public static void WriteAllBytesAtomic(string path, byte[] bytes)
+    {
+        var tempPath = path + TempSuffix;
+        File.WriteAllBytes(tempPath, bytes);
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    /// <summary>
+    /// Sibling-temp-file suffix. Public so cleanup tooling (and tests) can
+    /// scan for leftover temps without hard-coding the suffix string.
+    /// </summary>
+    public const string TempSuffix = ".calamari-tmp";
+}

--- a/src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs
+++ b/src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 using Microsoft.Web.XmlTransform;
+using Squid.Calamari.Commands.Common;
 
 namespace Squid.Calamari.Commands.Configuration;
 
@@ -73,9 +74,10 @@ internal static class XdtTransformer
                                                "Check the transform's Locator + xdt:Transform attributes for missing matches.");
             }
 
-            // Atomic write: serialise to temp file, then rename. Avoids
-            // half-written base file on disk if the write itself dies mid-way.
-            var tempPath = basePath + ".xdt-tmp";
+            // Atomic write via the shared FileIO primitive: serialise to a
+            // sibling temp first, then rename. Avoids a half-written base
+            // config on disk if the writer dies mid-way (disk full, kill -9).
+            var tempPath = basePath + EncodingPreservingFileIO.TempSuffix;
             document.Save(tempPath);
             File.Move(tempPath, basePath, overwrite: true);
 

--- a/src/Squid.Calamari/Commands/StructuredConfig/JsonPathReplacer.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/JsonPathReplacer.cs
@@ -1,3 +1,4 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Squid.Calamari.Variables;
@@ -39,7 +40,16 @@ internal static class JsonPathReplacer
 {
     private static readonly JsonSerializerOptions WriteOptions = new()
     {
-        WriteIndented = true
+        WriteIndented = true,
+        // Default encoder escapes `<`, `>`, `&`, `+` into `\uXXXX` for HTML safety.
+        // That mangles operator URL strings and any descriptive text containing
+        // those characters — appsettings.json diff after a rewrite looks like
+        // gibberish to the operator (even though .NET IConfiguration parses it
+        // correctly). UnsafeRelaxedJsonEscaping keeps those characters readable.
+        // The "Unsafe" prefix only matters for HTML-embedded JSON; appsettings.json
+        // is consumed by IConfiguration, never injected into HTML.
+        // Pinned by Replace_OperatorStringContainsUrlSpecialChars_StaysReadable.
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
     private static readonly JsonDocumentOptions ParseOptions = new()
@@ -152,14 +162,39 @@ internal static class JsonPathReplacer
     /// Try the dot-form first (the canonical computed path), then the
     /// colon-form (ASP.NET Core IConfiguration idiom — same leaf, different
     /// separator). Returns the first match.
+    ///
+    /// <para><b>Self-namespace guard</b>: paths starting with <c>Squid.</c>
+    /// are skipped — Squid's own internal variables (e.g. step toggles,
+    /// release metadata, deployment ids) carry implementation details, and
+    /// letting them clobber an operator's JSON leaf at the same path
+    /// produces surprise corruption with no operator-visible cause.
+    /// Operators targeting a JSON path that genuinely begins with
+    /// <c>Squid.</c> can still hit it via the colon form
+    /// (<c>Squid:Some:Path</c>) — that encodes explicit intent and is
+    /// allowed.</para>
     /// </summary>
     private static bool TryFindVariable(VariableSet variables, string dotPath, out string value)
     {
-        var dot = variables.Get(dotPath);
-        if (dot is not null)
+        value = string.Empty;
+
+        // Self-namespace guard — only on the DOT form (which is what Squid's
+        // own runtime emits for its internal variables, e.g.
+        // `Squid.Action.IISWebSite.Foo.Bar`, `Squid.Deployment.Id`).
+        // Squid's runtime never emits colon-keyed names, so a colon-form
+        // variable with `Squid:...` IS operator-deliberate intent and is
+        // allowed through below. Pinned by
+        // Replace_SquidNamespacedVariable_DoesNotClobberJsonLeaf +
+        // Replace_SquidNamespacedVariable_OperatorCanStillForceWithColonForm.
+        var dotFormAllowed = !dotPath.StartsWith("Squid.", StringComparison.OrdinalIgnoreCase);
+
+        if (dotFormAllowed)
         {
-            value = dot;
-            return true;
+            var dot = variables.Get(dotPath);
+            if (dot is not null)
+            {
+                value = dot;
+                return true;
+            }
         }
 
         var colonPath = dotPath.Replace('.', ':');
@@ -170,7 +205,6 @@ internal static class JsonPathReplacer
             return true;
         }
 
-        value = string.Empty;
         return false;
     }
 

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
@@ -1,3 +1,4 @@
+using Squid.Calamari.Commands.Common;
 using Squid.Calamari.Commands.Substitution;
 using Squid.Calamari.Pipeline;
 
@@ -73,7 +74,12 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
             {
                 try
                 {
-                    var json = File.ReadAllText(file);
+                    // BOM preservation — Visual Studio writes appsettings.json
+                    // with a UTF-8 BOM by default; .NET's File.ReadAllText
+                    // strips it. Without the shared helper, every rewrite
+                    // would silently change the file's byte content (BOM gone)
+                    // even when no leaves matched, polluting deploy diffs.
+                    var (json, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(file);
                     var result = JsonPathReplacer.Replace(json, context.Variables);
 
                     if (!result.Succeeded)
@@ -86,7 +92,12 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
 
                     if (result.ReplacedCount > 0)
                     {
-                        File.WriteAllText(file, result.Output);
+                        // Atomic write — temp + rename. A 50MB appsettings.json
+                        // half-written on a `kill -9` would leave the operator
+                        // with a corrupt config; the temp+rename pattern keeps
+                        // the original intact until the new bytes are fully on
+                        // disk. Same primitive G1.2 XDT uses.
+                        EncodingPreservingFileIO.WriteAllTextAtomic(file, result.Output, encoding);
                         Console.WriteLine(
                             $"StructuredConfigVariables: '{file}' — {result.ReplacedCount} leaf value(s) replaced.");
                     }

--- a/src/Squid.Calamari/Commands/Substitution/GlobMatcher.cs
+++ b/src/Squid.Calamari/Commands/Substitution/GlobMatcher.cs
@@ -21,11 +21,19 @@ namespace Squid.Calamari.Commands.Substitution;
 ///   <item><c>**/appsettings.*.json</c> — recurse + wildcard suffix</item>
 /// </list></para>
 ///
-/// <para><b>Anti-injection</b>: dots in glob patterns are literal, not
-/// regex any-char. Path-traversal globs (<c>../*.config</c>) yield zero
-/// matches — substitution stays sandboxed to the working dir. Pinned by
-/// <c>Expand_DotIsLiteral_NotRegexAnyChar</c> and
-/// <c>Expand_PathTraversalAttempt_BoundedToRoot</c>.</para>
+/// <para><b>Anti-injection — two layers</b>:
+/// <list type="number">
+///   <item><b>Pattern-level</b>: dots in glob patterns are literal, not regex
+///         any-char. Path-traversal globs (<c>../*.config</c>) yield zero
+///         matches. Pinned by <c>Expand_DotIsLiteral_NotRegexAnyChar</c> and
+///         <c>Expand_PathTraversalAttempt_BoundedToRoot</c>.</item>
+///   <item><b>Match-level</b>: after a path matches, its canonical real path
+///         (with symlinks resolved) MUST still be inside <c>rootDir</c>.
+///         A malicious package can plant a symlink <c>config -&gt; /etc</c>;
+///         a naive glob <c>**/*.conf</c> would match <c>config/passwd-like</c>
+///         and the rewriter would happily overwrite <c>/etc/passwd</c>.
+///         Pinned by <c>Expand_SymlinkEscapingRoot_Excluded</c>.</item>
+/// </list></para>
 /// </summary>
 internal static class GlobMatcher
 {
@@ -50,7 +58,59 @@ internal static class GlobMatcher
             .Select(absPath => (absPath, relPath: GetRelativePath(rootFull, absPath)))
             .Where(t => regex.IsMatch(t.relPath))
             .Select(t => t.absPath)
+            .Where(absPath => IsCanonicalPathInsideRoot(absPath, rootFull))
             .ToList();    // materialise so caller can mutate files without enumeration races
+    }
+
+    /// <summary>
+    /// After a regex match, resolve the file's REAL canonical path (following
+    /// every symlink in the chain) and confirm it still lives under
+    /// <paramref name="rootFull"/>. Layer-2 sandbox: protects against a
+    /// malicious package planting a symlink inside the working dir that
+    /// points outside.
+    ///
+    /// <para><b>Why .NET's <c>ResolveLinkTarget</c> is preferred over
+    /// <c>Path.GetFullPath</c></b>: <c>GetFullPath</c> only canonicalises
+    /// dots / case / separators — it does NOT follow symlinks. We need to
+    /// follow links to detect the attack. <c>FileInfo.ResolveLinkTarget</c>
+    /// walks the link chain.</para>
+    ///
+    /// <para>On any resolution error (broken link, permission denied), we
+    /// exclude the file — fail-closed. Better to skip a rewrite than to
+    /// accidentally rewrite the wrong file.</para>
+    /// </summary>
+    private static bool IsCanonicalPathInsideRoot(string absPath, string rootFull)
+    {
+        try
+        {
+            var info = new FileInfo(absPath);
+
+            // Walk the link chain. ResolveLinkTarget(returnFinalTarget: true)
+            // resolves through all intermediate symlinks; returns null if not
+            // a link (i.e. the path is its own real target).
+            var realTarget = info.ResolveLinkTarget(returnFinalTarget: true);
+            var realPath = realTarget?.FullName ?? info.FullName;
+
+            // Path.GetFullPath normalises separators + case so the prefix
+            // check below is robust across OSes. Trailing-separator check
+            // avoids false positives like `/workdir-evil` matching `/workdir`.
+            var canonicalReal = Path.GetFullPath(realPath);
+            var canonicalRoot = Path.GetFullPath(rootFull);
+
+            // Ensure root ends with separator so prefix comparison is segment-aligned.
+            if (!canonicalRoot.EndsWith(Path.DirectorySeparatorChar))
+                canonicalRoot += Path.DirectorySeparatorChar;
+
+            // Case-insensitive comparison on Windows + macOS (HFS/APFS default
+            // case-insensitive); on Linux this still works because the FS
+            // would have returned the actual case in EnumerateFiles.
+            return canonicalReal.StartsWith(canonicalRoot, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Resolution failed (broken link, permission, race). Fail-closed.
+            return false;
+        }
     }
 
     private static IEnumerable<string> EnumerateAllFiles(string rootDir)

--- a/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
+++ b/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using Squid.Calamari.Commands.Common;
 using Squid.Calamari.Pipeline;
 
 namespace Squid.Calamari.Commands.Substitution;
@@ -133,13 +133,13 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
                         continue;
                     }
 
-                    var (text, encoding) = ReadFilePreservingEncoding(file);
+                    var (text, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(file);
                     var result = TokenSubstituter.Replace(text, context.Variables);
 
                     if (result.UnresolvedTokens.Count > 0)
                         allUnresolved.Add((file, result.UnresolvedTokens));
 
-                    File.WriteAllText(file, result.Output, encoding);
+                    EncodingPreservingFileIO.WriteAllTextAtomic(file, result.Output, encoding);
                     filesProcessed++;
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -195,27 +195,6 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
         }
     }
 
-    /// <summary>
-    /// Read file detecting UTF-8 BOM so we can write it back exactly the
-    /// same way. Operator's web.config with BOM stays with BOM; without
-    /// stays without. .NET <c>StreamReader</c> with default args would
-    /// strip the BOM and we'd lose it on write-back.
-    /// </summary>
-    private static (string text, Encoding encoding) ReadFilePreservingEncoding(string file)
-    {
-        var bytes = File.ReadAllBytes(file);
-
-        // UTF-8 BOM: EF BB BF
-        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
-        {
-            var withBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
-            return (withBom.GetString(bytes, 3, bytes.Length - 3), withBom);
-        }
-
-        // No BOM — assume UTF-8 (operator's app is text).
-        var noBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        return (noBom.GetString(bytes), noBom);
-    }
 }
 
 /// <summary>

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Common/EncodingPreservingFileIOTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Common/EncodingPreservingFileIOTests.cs
@@ -1,0 +1,163 @@
+using System.Text;
+using Shouldly;
+using Squid.Calamari.Commands.Common;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Common;
+
+/// <summary>
+/// Pinning tests for the shared file-IO primitive used by all 3 rewriter
+/// steps (G1.1 SubstituteInFiles / G1.2 ConfigurationTransforms /
+/// G1.3 StructuredConfigVariables). These tests guarantee that every
+/// rewriter behaves identically on the two cross-cutting concerns
+/// (BOM preservation + atomic write).
+/// </summary>
+public sealed class EncodingPreservingFileIOTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public EncodingPreservingFileIOTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"enc-io-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── BOM preservation ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Read_FileWithBom_ReturnsTextWithoutBom_AndBomEncoding()
+    {
+        var path = Path.Combine(_workDir, "with-bom.json");
+        var withBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        File.WriteAllText(path, """{"a":1}""", withBom);
+
+        var (text, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(path);
+
+        text.ShouldBe("""{"a":1}""",
+            customMessage: "BOM bytes MUST NOT appear in the returned text — only at the file level.");
+        encoding.ShouldBeOfType<UTF8Encoding>();
+        encoding.GetPreamble().ShouldBe(new byte[] { 0xEF, 0xBB, 0xBF },
+            customMessage: "Returned encoding MUST emit BOM on write-back so round-trip preserves the file's byte signature.");
+    }
+
+    [Fact]
+    public void Read_FileWithoutBom_ReturnsTextAndNonBomEncoding()
+    {
+        var path = Path.Combine(_workDir, "no-bom.json");
+        File.WriteAllText(path, """{"a":1}""", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var (text, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(path);
+
+        text.ShouldBe("""{"a":1}""");
+        encoding.GetPreamble().ShouldBeEmpty(
+            customMessage: "BOM-less input MUST round-trip to BOM-less output.");
+    }
+
+    [Fact]
+    public void RoundTrip_FileWithBom_ByteIdentical()
+    {
+        // The integration concern: read → write back unchanged → file bytes match.
+        // Without BOM preservation, this round-trip would lose the 3 leading
+        // BOM bytes, polluting every operator's deploy diff.
+        var path = Path.Combine(_workDir, "round-trip-bom.txt");
+        var withBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        File.WriteAllText(path, "<config><value>x</value></config>", withBom);
+        var originalBytes = File.ReadAllBytes(path);
+
+        var (text, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(path);
+        EncodingPreservingFileIO.WriteAllTextAtomic(path, text, encoding);
+
+        File.ReadAllBytes(path).ShouldBe(originalBytes,
+            customMessage: "Read → write-back MUST be byte-identical for BOM-prefixed files. " +
+                           "If this fails, a rewrite-no-changes operation will still produce a non-empty diff.");
+    }
+
+    [Fact]
+    public void RoundTrip_FileWithoutBom_ByteIdentical()
+    {
+        var path = Path.Combine(_workDir, "round-trip-no-bom.txt");
+        File.WriteAllText(path, "plain content", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        var originalBytes = File.ReadAllBytes(path);
+
+        var (text, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(path);
+        EncodingPreservingFileIO.WriteAllTextAtomic(path, text, encoding);
+
+        File.ReadAllBytes(path).ShouldBe(originalBytes);
+    }
+
+    // ── Atomic write ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void WriteAtomic_OriginalFile_ReplacedWithNewContent()
+    {
+        var path = Path.Combine(_workDir, "target.txt");
+        File.WriteAllText(path, "old content");
+
+        EncodingPreservingFileIO.WriteAllTextAtomic(path, "new content", new UTF8Encoding(false));
+
+        File.ReadAllText(path).ShouldBe("new content");
+    }
+
+    [Fact]
+    public void WriteAtomic_NoSiblingTempLeftBehind_OnSuccess()
+    {
+        var path = Path.Combine(_workDir, "target.txt");
+        File.WriteAllText(path, "old");
+
+        EncodingPreservingFileIO.WriteAllTextAtomic(path, "new", new UTF8Encoding(false));
+
+        var siblings = Directory.GetFiles(_workDir).Select(Path.GetFileName).ToList();
+        siblings.ShouldNotContain($"target.txt{EncodingPreservingFileIO.TempSuffix}",
+            customMessage: "Successful atomic write MUST clean up its sibling temp file. " +
+                           "Leftover temps accumulate across deploys and look like garbage to operators.");
+        siblings.ShouldContain("target.txt");
+        siblings.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void WriteAtomic_TempSuffix_PinnedAsPublicConstant()
+    {
+        // Rule 8: any name an external operator / cleanup tool might pin
+        // against MUST be a public const + pinned in test. Cleanup tooling
+        // grep-scans for this suffix to mop up leftover temps from crashed
+        // deploys.
+        EncodingPreservingFileIO.TempSuffix.ShouldBe(".calamari-tmp");
+    }
+
+    [Fact]
+    public void WriteAtomic_FailsBeforeRename_OriginalFileUntouched()
+    {
+        // Force the temp-write to fail by passing a path whose parent dir
+        // doesn't exist. The atomic primitive MUST raise without ever
+        // touching the existing file at the supplied path.
+        var realPath = Path.Combine(_workDir, "real.txt");
+        File.WriteAllText(realPath, "preserved-content");
+
+        // Sabotage: write to a sibling temp that can't be created.
+        // We simulate by removing the dir between read + write. The cleanest
+        // failure injection: target path's PARENT directory doesn't exist.
+        var ghostTarget = Path.Combine(_workDir, "nonexistent-subdir", "ghost.txt");
+
+        Should.Throw<DirectoryNotFoundException>(() =>
+            EncodingPreservingFileIO.WriteAllTextAtomic(ghostTarget, "x", new UTF8Encoding(false)));
+
+        // Now confirm the unrelated existing file is intact (sanity).
+        File.ReadAllText(realPath).ShouldBe("preserved-content");
+    }
+
+    [Fact]
+    public void WriteAtomicBytes_RoundTrip_Identical()
+    {
+        var path = Path.Combine(_workDir, "binary.bin");
+        var payload = new byte[] { 0x01, 0x02, 0x03, 0xFF, 0x00, 0x42 };
+
+        EncodingPreservingFileIO.WriteAllBytesAtomic(path, payload);
+
+        File.ReadAllBytes(path).ShouldBe(payload);
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/JsonPathReplacerTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/JsonPathReplacerTests.cs
@@ -208,6 +208,99 @@ public sealed class JsonPathReplacerTests
         Should.Throw<ArgumentNullException>(() => JsonPathReplacer.Replace("{}", null!));
     }
 
+    [Fact]
+    public void Replace_SquidNamespacedVariable_DoesNotClobberJsonLeaf()
+    {
+        // Operators sometimes have JSON like {"Squid": {"Deployment": {"Id": "..."}}}
+        // in their appsettings (an audit / observability section, say). Squid's
+        // own internal variables include `Squid.Deployment.Id` populated to the
+        // CURRENT deploy. If we blindly matched dot-paths we'd silently overwrite
+        // the operator's literal with our runtime id — silent corruption with
+        // no operator-facing cause. Self-namespaced variables MUST be skipped.
+        var json = """{"Squid":{"Deployment":{"Id":"operator-intended-literal"}}}""";
+        var vars = NewVarSet(("Squid.Deployment.Id", "runtime-deploy-guid"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Succeeded.ShouldBeTrue();
+        result.Output.ShouldContain("\"operator-intended-literal\"",
+            customMessage: "Squid-namespaced variables MUST NOT clobber operator JSON leaves at the same path. " +
+                           "If this fails: a Squid runtime variable is leaking into operator's appsettings.json.");
+        result.Output.ShouldNotContain("runtime-deploy-guid");
+        result.ReplacedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Replace_SquidNamespacedVariable_OperatorCanStillForceWithColonForm()
+    {
+        // Escape hatch: an operator who DOES want a Squid-prefixed path replaced
+        // (genuinely useful for power users mirroring runtime values into their
+        // JSON) can submit the variable in colon form. The colon form encodes
+        // explicit intent — it's not what Squid's own runtime ever emits.
+        var json = """{"Squid":{"Custom":{"Field":"placeholder"}}}""";
+        var vars = NewVarSet(("Squid:Custom:Field", "operator-chosen-value"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"operator-chosen-value\"");
+        result.ReplacedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Replace_OperatorStringContainsUrlSpecialChars_StaysReadable()
+    {
+        // Operator's connection string contains `&` (URL query separator).
+        // The DEFAULT System.Text.Json encoder would escape it to `&`,
+        // making the diff incomprehensible to operators reviewing the rewrite.
+        // UnsafeRelaxedJsonEscaping preserves `& < > +` as-is — safe for
+        // IConfiguration consumption, readable in operator diffs.
+        var json = """{"ConnectionStrings":{"Default":"old"}}""";
+        var vars = NewVarSet(("ConnectionStrings.Default",
+            "Server=db;Database=app;User=u;Password=p+x&Trusted_Connection=true"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("&Trusted_Connection=true",
+            customMessage: "Operator's `&` MUST stay literal in the rewritten JSON. " +
+                           "If you see `\\u0026` here, the JSON encoder regressed to HTML-safe mode.");
+        result.Output.ShouldContain("p+x",
+            customMessage: "Operator's `+` MUST stay literal.");
+        result.Output.ShouldNotContain("\\u0026");
+        result.Output.ShouldNotContain("\\u002B");
+    }
+
+    [Fact]
+    public void Replace_OperatorStringContainsHtmlAngleBrackets_StaysReadable()
+    {
+        // Operator might have a config string with literal `<` `>` (e.g. an
+        // XML-template description field). Same encoder concern.
+        var json = """{"Description":{"Template":"placeholder"}}""";
+        var vars = NewVarSet(("Description.Template", "Use <env> placeholders, not ${env}."));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("<env>");
+        result.Output.ShouldNotContain("\\u003C");
+        result.Output.ShouldNotContain("\\u003E");
+    }
+
+    [Fact]
+    public void Replace_SquidNamespacedDeepPath_StillSkipped_IgnoredAtAnyDepth()
+    {
+        // Make sure the guard applies at ALL depths, not just the root.
+        // A JSON file deeply nested under e.g. {"Wrapper": {"Squid": {...}}}
+        // would compute a path like "Wrapper.Squid.X" — this is NOT a Squid
+        // self-namespace path (doesn't start with Squid.), so it MUST be allowed.
+        var json = """{"Wrapper":{"Squid":{"X":"old"}}}""";
+        var vars = NewVarSet(("Wrapper.Squid.X", "new"));
+
+        var result = JsonPathReplacer.Replace(json, vars);
+
+        result.Output.ShouldContain("\"new\"",
+            customMessage: "Self-namespace guard MUST only fire when path STARTS WITH 'Squid.', not when 'Squid' appears mid-path.");
+        result.ReplacedCount.ShouldBe(1);
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static VariableSet NewVarSet(params (string name, string value)[] entries)

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/GlobMatcherTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/GlobMatcherTests.cs
@@ -127,4 +127,77 @@ public sealed class GlobMatcherTests : IDisposable
         matches.ShouldBeEmpty(
             customMessage: "Path-traversal globs MUST yield zero matches — substitution is sandboxed to the working dir to prevent malicious package content from rewriting host files.");
     }
+
+    [Fact]
+    public void Expand_SymlinkEscapingRoot_Excluded()
+    {
+        // Attack scenario: a malicious package unpacks a symlink
+        // `evil.config -> /etc/passwd` (or any host file). A naive glob
+        // `*.config` would match `evil.config`; the rewriter would happily
+        // overwrite `/etc/passwd`. On a Tentacle running as root (systemd
+        // unit), that's a host compromise.
+        //
+        // The match-level sandbox MUST detect the link target, resolve to
+        // canonical real path, and drop matches whose real path lives
+        // outside the working dir.
+        //
+        // Symlink creation requires elevated privileges on Windows pre-1809;
+        // skip there cleanly so cross-OS dev hosts get green tests.
+        if (OperatingSystem.IsWindows()) return;
+
+        // Set up a victim file OUTSIDE the working dir.
+        var outsideDir = Path.Combine(Path.GetTempPath(), $"glob-victim-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outsideDir);
+        var victim = Path.Combine(outsideDir, "secret.config");
+        File.WriteAllText(victim, "host-secret-content");
+
+        try
+        {
+            // Plant a symlink inside the working dir pointing at the victim.
+            var attackLink = Path.Combine(_root, "evil.config");
+            File.CreateSymbolicLink(attackLink, victim);
+
+            // Also drop a legitimate sibling that SHOULD match — to confirm
+            // the sandbox only excludes the escapee, not the entire glob.
+            File.WriteAllText(Path.Combine(_root, "legit.config"), "");
+
+            var matches = GlobMatcher.Expand(_root, "*.config").ToList();
+
+            matches.Select(Path.GetFileName).ShouldNotContain("evil.config",
+                customMessage: "Symlink pointing outside the working dir MUST be excluded from glob matches. " +
+                               "If this fails, a malicious package can rewrite host files via planted symlinks.");
+            matches.Select(Path.GetFileName).ShouldContain("legit.config",
+                customMessage: "Sibling files NOT pointing outside MUST still match — only the escapee is excluded.");
+
+            // Sanity: the victim file is still intact (the matcher didn't
+            // even need to touch it, but assert just so the test reads honestly).
+            File.ReadAllText(victim).ShouldBe("host-secret-content");
+        }
+        finally
+        {
+            if (Directory.Exists(outsideDir)) Directory.Delete(outsideDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Expand_SymlinkPointingInsideRoot_StillIncluded()
+    {
+        // Counter-test: not every symlink is hostile. A symlink that resolves
+        // to a file INSIDE the working dir is legitimate (operator's package
+        // might use them for shared-config patterns). The sandbox MUST NOT
+        // be overly aggressive — only excludes escapees.
+        if (OperatingSystem.IsWindows()) return;
+
+        var realFile = Path.Combine(_root, "real.config");
+        File.WriteAllText(realFile, "real-content");
+
+        var insideLink = Path.Combine(_root, "alias.config");
+        File.CreateSymbolicLink(insideLink, realFile);
+
+        var matches = GlobMatcher.Expand(_root, "*.config").ToList();
+
+        matches.Select(Path.GetFileName).ShouldContain("alias.config",
+            customMessage: "Symlinks resolving INSIDE the working dir are legitimate and MUST be included.");
+        matches.Select(Path.GetFileName).ShouldContain("real.config");
+    }
 }


### PR DESCRIPTION
## Summary

Followups to the G1.1–G1.3 architectural review. Stacks on #365 (G1.3) — base is the G1.3 branch so the JsonPathReplacer changes here build on the file landed in that PR. After #365 merges, this PR can be retargeted at `master` (or just merged through after a rebase).

**Zero wire-literal changes — SquidWeb unaffected. Purely internal correctness + security hardening.**

## What's fixed

| # | Concern | What broke | Fix |
|---|---|---|---|
| **#1** | JSON namespace pollution | A variable named `Squid.Deployment.Id` would clobber an operator's literal JSON leaf at the same path — silent corruption with no operator-facing cause | `JsonPathReplacer.TryFindVariable` skips dot-form lookups starting with `Squid.`. Colon form (`Squid:X:Y`) stays as the explicit-intent escape hatch |
| **#2** | G1.3 non-atomic write | A 50MB `appsettings.json` write killed mid-way left the operator with a corrupted config | New shared `EncodingPreservingFileIO.WriteAllTextAtomic` (sibling temp + rename), reused by G1.1 + G1.2 + G1.3 |
| **#3** | G1.3 BOM loss | VS-generated `appsettings.json` with UTF-8 BOM lost the BOM on every rewrite — polluted deploy diffs | Same shared helper exposes `ReadAllTextPreservingEncoding` (extracted from G1.1's local copy); G1.3 + G1.1 both use it |
| **#4** | JSON encoder over-escape | Default `System.Text.Json` encoder turns `<`, `>`, `&`, `+` into `\uXXXX` — operator's URL/HTML strings unreadable in diffs | `WriteOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping`. Safe because target is `IConfiguration`, never injected into HTML |
| **#5** | Symlink-escape attack | Malicious package can plant `evil.config -> /etc/passwd`; on Linux Tentacle running as root, the rewriter overwrites host files | `GlobMatcher` adds match-level layer: resolve canonical real path via `FileInfo.ResolveLinkTarget`; drop matches whose real path escapes `rootDir`. Fail-closed on resolution errors |

## What's in the box

| Layer | File |
|---|---|
| Shared file-IO primitive | `src/Squid.Calamari/Commands/Common/EncodingPreservingFileIO.cs` (new) |
| JSON namespace + encoder | `src/Squid.Calamari/Commands/StructuredConfig/JsonPathReplacer.cs` |
| G1.3 atomic + BOM | `src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs` |
| G1.1 migration to shared | `src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs` |
| G1.2 migration to shared | `src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs` |
| Symlink sandbox | `src/Squid.Calamari/Commands/Substitution/GlobMatcher.cs` |
| Tests — shared helper (8) | `tests/Squid.Calamari.Tests/Calamari/Commands/Common/EncodingPreservingFileIOTests.cs` (new) |
| Tests — JSON guard + encoder (5) | `tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/JsonPathReplacerTests.cs` |
| Tests — symlink (2) | `tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/GlobMatcherTests.cs` |

## Test plan

- [x] Squid.Calamari.Tests: 246/246 (was 230; +16 new for the 5 fixes — 13 directly + 3 round-trip integrations)
- [x] Squid.UnitTests cross-project wire-contract: 5615/5615 — no regression on the 12 G1.1/G1.2/G1.3 drift detectors
- [x] `dotnet build` solution-wide: 0 errors
- [x] Symlink-escape test guarded behind `OperatingSystem.IsWindows()` skip — symlink creation needs elevation on Windows pre-1809; cross-OS dev hosts stay green
- [ ] Staging IIS deploy of an ASP.NET Core app with `appsettings.Production.json` containing `Squid.*` literals (drift-detection scenario from #1) + URL connection strings (encoder scenario from #4)

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Wire literals (`Squid.Action.IISWebSite.*`) | Unchanged |
| Operator-facing variable names | Unchanged |
| Step toggles + behavior on the happy path | Unchanged |
| Step output / log format | Unchanged |
| Frontend (SquidWeb) wire-literal references | None touched — confirmed via grep against `SquidWeb/src/pages/project-detail/step-editors/iis/DeployToIisEditor.tsx` |

The behavior changes (Squid.* skip, symlink reject) are corrections — they reject inputs that produced silent corruption or security bypass before. No correct deploy ever depended on those broken paths.