### PR TITLE
Decouple G1.x wire literals from the IIS handler

### DIFF
--- a/src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs
+++ b/src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs
@@ -4,15 +4,40 @@ namespace Squid.Calamari.Commands.Configuration;
 
 /// <summary>
 /// Wire-contract constants for the ConfigurationTransforms (XDT) feature.
-/// Public so cross-project drift tests in Squid.UnitTests can assert these
-/// match the server-side IIS handler's <c>IISDeployProperties</c> constants
-/// without forcing InternalsVisibleTo pollution.
+/// Public so cross-project drift tests in Squid.UnitTests can assert the
+/// contract without InternalsVisibleTo pollution.
+///
+/// <para><b>Canonical vs Legacy</b>: top-level constants are the
+/// handler-agnostic canonical wire literals — preferred for new handlers.
+/// The nested <see cref="Legacy"/> class holds the IIS-prefixed names that
+/// the IIS handler's PS1 script + existing operator deployments emit.
+/// <see cref="ConfigurationTransformsStep"/> reads canonical first, falls
+/// back to legacy.</para>
 /// </summary>
 public static class ConfigurationTransformsVariableNames
 {
-    public const string Enabled = "Squid.Action.IISWebSite.ConfigurationTransforms.Enabled";
-    public const string EnvironmentName = "Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName";
-    public const string AdditionalTransforms = "Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms";
+    /// <summary>Canonical, handler-agnostic Enabled toggle.</summary>
+    public const string Enabled = "Squid.Action.ConfigurationTransforms.Enabled";
+
+    /// <summary>Canonical environment name driving <c>*.{Env}.config</c> auto-pairs.</summary>
+    public const string EnvironmentName = "Squid.Action.ConfigurationTransforms.EnvironmentName";
+
+    /// <summary>Canonical operator-supplied explicit transform pairs
+    /// (<c>transform.config =&gt; base.config</c>, newline-separated).</summary>
+    public const string AdditionalTransforms = "Squid.Action.ConfigurationTransforms.AdditionalTransforms";
+
+    /// <summary>
+    /// Legacy IIS-handler-specific wire literals. Existing operator deployments
+    /// + the IIS PS1 script still emit these.
+    /// <see cref="ConfigurationTransformsStep"/> falls back to these when the
+    /// canonical literals above are not set.
+    /// </summary>
+    public static class Legacy
+    {
+        public const string Enabled = "Squid.Action.IISWebSite.ConfigurationTransforms.Enabled";
+        public const string EnvironmentName = "Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName";
+        public const string AdditionalTransforms = "Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms";
+    }
 }
 
 /// <summary>
@@ -44,7 +69,9 @@ internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptComma
     public override bool IsEnabled(RunScriptCommandContext context)
     {
         if (context.Variables is null) return false;
-        var raw = context.Variables.Get(ConfigurationTransformsVariableNames.Enabled);
+        // Canonical first, legacy fallback.
+        var raw = context.Variables.Get(ConfigurationTransformsVariableNames.Enabled)
+                  ?? context.Variables.Get(ConfigurationTransformsVariableNames.Legacy.Enabled);
         return string.Equals(raw, "True", StringComparison.OrdinalIgnoreCase);
     }
 
@@ -66,8 +93,11 @@ internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptComma
             return Task.CompletedTask;
         }
 
-        var environmentName = context.Variables.Get(ConfigurationTransformsVariableNames.EnvironmentName);
-        var additionalRaw = context.Variables.Get(ConfigurationTransformsVariableNames.AdditionalTransforms);
+        // Canonical first, legacy fallback — same pattern as IsEnabled.
+        var environmentName = context.Variables.Get(ConfigurationTransformsVariableNames.EnvironmentName)
+                              ?? context.Variables.Get(ConfigurationTransformsVariableNames.Legacy.EnvironmentName);
+        var additionalRaw = context.Variables.Get(ConfigurationTransformsVariableNames.AdditionalTransforms)
+                            ?? context.Variables.Get(ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms);
 
         var applied = 0;
         var failed = 0;

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
@@ -5,13 +5,49 @@ using Squid.Calamari.Pipeline;
 namespace Squid.Calamari.Commands.StructuredConfig;
 
 /// <summary>
-/// Wire-contract constants for the StructuredConfigVariables feature.
+/// Wire-contract constants for the JSON-leaf configuration-variable feature.
 /// Public so cross-project drift tests in Squid.UnitTests can pin them.
+///
+/// <para><b>Canonical naming</b>: the canonical wire literals use
+/// <c>Squid.Action.JsonConfigVariables.*</c> — matches the frontend feature
+/// ID (<c>Squid.Features.JsonConfigurationVariables</c>) and accurately
+/// describes what the step does (JSON-only leaf replacement). The legacy
+/// literal <c>StructuredConfigurationVariables</c> is kept for back-compat
+/// with the IIS handler's existing emission + operator deployments saved
+/// before the rename.</para>
+///
+/// <para>The C# class keeps the original name <c>StructuredConfigVariableNames</c>
+/// to avoid rippling-rename through tests; <see cref="JsonConfigVariableNames"/>
+/// is provided as a forward-looking alias for new handlers.</para>
 /// </summary>
 public static class StructuredConfigVariableNames
 {
-    public const string Enabled = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled";
-    public const string Targets = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets";
+    /// <summary>Canonical, handler-agnostic Enabled toggle.</summary>
+    public const string Enabled = "Squid.Action.JsonConfigVariables.Enabled";
+
+    /// <summary>Canonical, handler-agnostic Targets glob list.</summary>
+    public const string Targets = "Squid.Action.JsonConfigVariables.Targets";
+
+    /// <summary>
+    /// Legacy IIS-handler-specific wire literals. Existing operator deployments
+    /// emit these. <see cref="StructuredConfigVariablesStep"/> falls back to
+    /// these names when the canonical literals above are not set.
+    /// </summary>
+    public static class Legacy
+    {
+        public const string Enabled = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled";
+        public const string Targets = "Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets";
+    }
+}
+
+/// <summary>Forward-looking alias matching the canonical feature name
+/// (<c>JsonConfigVariables</c>). New handlers SHOULD reference this name —
+/// it telegraphs that the toggle is JSON-only, not "structured config"
+/// in the generic sense (no YAML / XML / Properties support).</summary>
+public static class JsonConfigVariableNames
+{
+    public const string Enabled = StructuredConfigVariableNames.Enabled;
+    public const string Targets = StructuredConfigVariableNames.Targets;
 }
 
 /// <summary>
@@ -36,7 +72,9 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
     public override bool IsEnabled(RunScriptCommandContext context)
     {
         if (context.Variables is null) return false;
-        var raw = context.Variables.Get(StructuredConfigVariableNames.Enabled);
+        // Canonical first, legacy fallback.
+        var raw = context.Variables.Get(StructuredConfigVariableNames.Enabled)
+                  ?? context.Variables.Get(StructuredConfigVariableNames.Legacy.Enabled);
         return string.Equals(raw, "True", StringComparison.OrdinalIgnoreCase);
     }
 
@@ -51,7 +89,9 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
             throw new InvalidOperationException(
                 "Variables have not been loaded — StructuredConfigVariablesStep must run after LoadVariablesFromFilesStep.");
 
-        var targetsRaw = context.Variables.Get(StructuredConfigVariableNames.Targets);
+        // Canonical first, legacy fallback for the Targets glob list.
+        var targetsRaw = context.Variables.Get(StructuredConfigVariableNames.Targets)
+                         ?? context.Variables.Get(StructuredConfigVariableNames.Legacy.Targets);
         if (string.IsNullOrWhiteSpace(targetsRaw)) return Task.CompletedTask;
 
         var totalReplaced = 0;

--- a/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
+++ b/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
@@ -50,26 +50,56 @@ namespace Squid.Calamari.Commands.Substitution;
 /// PUBLIC class so the cross-project drift test in Squid.UnitTests can
 /// reference them without InternalsVisibleTo pollution. The step
 /// implementation stays internal — only the literals are public.
+///
+/// <para><b>Canonical vs Legacy</b>: the top-level constants
+/// (<see cref="Enabled"/>, <see cref="TargetFiles"/>) are the
+/// <b>canonical</b>, handler-agnostic wire literals — preferred for new
+/// handlers (Docker, nginx, generic RunScript, …) and what
+/// <see cref="SubstituteInFilesStep"/> reads first. The nested
+/// <see cref="Legacy"/> class holds the IIS-handler-specific names that
+/// existing operator deployments still emit via
+/// <c>IISDeployProperties</c>. The step falls back to those when the
+/// canonical name is absent — fully back-compat with deploys saved before
+/// the canonical surface existed.</para>
 /// </summary>
 public static class SubstituteInFilesVariableNames
 {
-    /// <summary>Wire-contract literal pinned by test (Rule 8). Must match
-    /// <c>IISDeployProperties.SubstituteInFilesEnabled</c> on the server.</summary>
-    public const string Enabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+    /// <summary>Canonical, handler-agnostic Enabled toggle. Preferred for
+    /// new handlers + Squid.Web migrations.</summary>
+    public const string Enabled = "Squid.Action.SubstituteInFiles.Enabled";
 
-    /// <summary>Wire-contract literal pinned by test (Rule 8).</summary>
-    public const string TargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+    /// <summary>Canonical, handler-agnostic TargetFiles glob list.</summary>
+    public const string TargetFiles = "Squid.Action.SubstituteInFiles.TargetFiles";
 
-    /// <summary>Octopus-parity wire literal pinned by test (Rule 8).</summary>
+    /// <summary>Strict-mode toggle — already handler-agnostic in the wire
+    /// (never had an IIS-prefixed variant). Pinned by test (Rule 8).</summary>
     public const string ShouldFailOnUnresolved =
         "Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails";
+
+    /// <summary>
+    /// Legacy IIS-handler-specific wire literals. The IIS handler's PS1
+    /// script + existing operator deployment definitions emit these.
+    /// <see cref="SubstituteInFilesStep"/> falls back to these names when
+    /// the canonical literals above are not set. Do not use for new
+    /// handlers — emit the canonical names instead.
+    /// </summary>
+    public static class Legacy
+    {
+        /// <summary>IIS-specific Enabled — kept for back-compat.</summary>
+        public const string Enabled = "Squid.Action.IISWebSite.SubstituteInFiles.Enabled";
+
+        /// <summary>IIS-specific TargetFiles — kept for back-compat.</summary>
+        public const string TargetFiles = "Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles";
+    }
 }
 
 internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandContext>
 {
     /// <summary>Re-exported for backward-compat with the original test
-    /// suite that referenced these on the step. Pin both names so a future
-    /// rename surfaces in tests.</summary>
+    /// suite that referenced these on the step. The values point at the
+    /// CANONICAL names — tests writing to these will exercise the
+    /// canonical-first read path. To exercise the legacy fallback
+    /// explicitly, write to <c>SubstituteInFilesVariableNames.Legacy.Enabled</c>.</summary>
     internal const string EnabledVariableName = SubstituteInFilesVariableNames.Enabled;
     internal const string TargetFilesVariableName = SubstituteInFilesVariableNames.TargetFiles;
     internal const string ShouldFailOnUnresolvedVariableName = SubstituteInFilesVariableNames.ShouldFailOnUnresolved;
@@ -78,7 +108,10 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
     {
         if (context.Variables is null) return false;
 
-        var raw = context.Variables.Get(EnabledVariableName);
+        // Canonical first, legacy fallback. Either-name-set wins → True.
+        // Pinned by IsEnabled_LegacyIISName_StillRunsStep + IsEnabled_CanonicalName_RunsStep.
+        var raw = context.Variables.Get(SubstituteInFilesVariableNames.Enabled)
+                  ?? context.Variables.Get(SubstituteInFilesVariableNames.Legacy.Enabled);
         return string.Equals(raw, "True", StringComparison.OrdinalIgnoreCase);
     }
 
@@ -91,11 +124,16 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
         if (context.Variables is null)
             throw new InvalidOperationException("Variables have not been loaded — SubstituteInFilesStep must run after LoadVariablesFromFilesStep.");
 
-        var targetFilesRaw = context.Variables.Get(TargetFilesVariableName);
+        // Canonical first, legacy fallback for both Enabled-gate and TargetFiles
+        // glob list. Operators with deploys saved before the canonical surface
+        // existed still hit the legacy path; new handlers emit the canonical name.
+        var targetFilesRaw = context.Variables.Get(SubstituteInFilesVariableNames.TargetFiles)
+                             ?? context.Variables.Get(SubstituteInFilesVariableNames.Legacy.TargetFiles);
         if (string.IsNullOrWhiteSpace(targetFilesRaw)) return;    // no-op, operator left blank
 
+        // ShouldFailOnUnresolved was always handler-agnostic in the wire — no legacy variant.
         var failOnUnresolved = string.Equals(
-            context.Variables.Get(ShouldFailOnUnresolvedVariableName),
+            context.Variables.Get(SubstituteInFilesVariableNames.ShouldFailOnUnresolved),
             "True",
             StringComparison.OrdinalIgnoreCase);
 

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/ConfigurationTransformsStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/ConfigurationTransformsStepTests.cs
@@ -248,16 +248,60 @@ public sealed class ConfigurationTransformsStepTests : IDisposable
     // ── Wire-contract pinning ──────────────────────────────────────────────
 
     [Fact]
-    public void EnabledVariableName_PinnedToIISHandlerContract()
-        => ConfigurationTransformsVariableNames.Enabled.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
+    public void EnabledVariableName_Canonical_PinnedHandlerAgnostic()
+        => ConfigurationTransformsVariableNames.Enabled.ShouldBe("Squid.Action.ConfigurationTransforms.Enabled");
 
     [Fact]
-    public void EnvironmentNameVariableName_PinnedToIISHandlerContract()
-        => ConfigurationTransformsVariableNames.EnvironmentName.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName");
+    public void EnvironmentNameVariableName_Canonical_PinnedHandlerAgnostic()
+        => ConfigurationTransformsVariableNames.EnvironmentName.ShouldBe("Squid.Action.ConfigurationTransforms.EnvironmentName");
 
     [Fact]
-    public void AdditionalTransformsVariableName_PinnedToIISHandlerContract()
-        => ConfigurationTransformsVariableNames.AdditionalTransforms.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms");
+    public void AdditionalTransformsVariableName_Canonical_PinnedHandlerAgnostic()
+        => ConfigurationTransformsVariableNames.AdditionalTransforms.ShouldBe("Squid.Action.ConfigurationTransforms.AdditionalTransforms");
+
+    [Fact]
+    public void LegacyVariableNames_PinnedToIISHandlerContract()
+    {
+        // Legacy half — the IIS handler's PS1 script emits these. Pin so a
+        // rename on either side surfaces in tests, not in production deploys.
+        ConfigurationTransformsVariableNames.Legacy.Enabled.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
+        ConfigurationTransformsVariableNames.Legacy.EnvironmentName.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName");
+        ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms");
+    }
+
+    [Fact]
+    public async Task IsEnabled_LegacyIISNames_StillRunsStep_BackCompat()
+    {
+        // Existing IIS deploys emit only the IIS-prefixed names. Step MUST
+        // still run when the canonical names are absent.
+        var vars = new VariableSet();
+        vars.Set(ConfigurationTransformsVariableNames.Legacy.Enabled, "True");
+        vars.Set(ConfigurationTransformsVariableNames.Legacy.EnvironmentName, "Production");
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        new ConfigurationTransformsStep().IsEnabled(context).ShouldBeTrue(
+            customMessage: "Legacy IIS-prefixed Enabled MUST trigger the step (back-compat).");
+
+        // Confirm the EnvironmentName legacy fallback is also honored — by
+        // creating a web.Production.config transform file + ensuring it gets applied.
+        File.WriteAllText(Path.Combine(_workDir, "web.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"x\" value=\"old\" /></appSettings></configuration>");
+        File.WriteAllText(Path.Combine(_workDir, "web.Production.config"),
+            "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+            "<appSettings><add key=\"x\" value=\"prod\" xdt:Transform=\"SetAttributes\" xdt:Locator=\"Match(key)\" /></appSettings></configuration>");
+
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "web.config")).ShouldContain("value=\"prod\"",
+            customMessage: "Legacy EnvironmentName MUST drive auto-pair discovery — operator's existing deploys depend on this.");
+    }
 
     // ── Helpers ────────────────────────────────────────────────────────────
 

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/RewriterPipelineCompositionTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/RewriterPipelineCompositionTests.cs
@@ -1,0 +1,218 @@
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Commands.Substitution;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands;
+
+/// <summary>
+/// G1.x composition test (review gap T1). The 3 rewriter steps had unit
+/// coverage in isolation, but no test asserted they COMPOSE correctly when
+/// all three run in pipeline order against the same workspace.
+///
+/// <para><b>Scenario simulated</b> — operator's real deploy:
+/// <list type="number">
+///   <item>A <c>web.config</c> with a <c>#{Token}</c> reference</item>
+///   <item>A sibling <c>web.Production.config</c> transform that itself uses
+///         <c>#{Token}</c> — so the substitution step (1) must resolve those
+///         BEFORE the XDT step (2) reads them.</item>
+///   <item>An <c>appsettings.json</c> that needs JSON-path leaf replacement</item>
+/// </list>
+/// Expected order: SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables.
+/// </para>
+///
+/// <para><b>Why canonical literals</b>: this test deliberately uses the new
+/// canonical (handler-agnostic) wire literals, demonstrating that a future
+/// generic handler (RunScript / Docker / nginx) can drive all 3 features
+/// without touching any IIS-specific names. If this test ever needs the
+/// legacy names to pass, the wire-literal generalization regressed.</para>
+/// </summary>
+public sealed class RewriterPipelineCompositionTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public RewriterPipelineCompositionTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"rewriter-compose-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ThreeSteps_CanonicalLiterals_ProduceCorrectEndState()
+    {
+        // ── Stage workspace ──────────────────────────────────────────────────
+        // web.config — has #{ConnString} token. Will be #{Token}-substituted,
+        // then XDT-transformed by web.Production.config. ConnString value
+        // is XML-attribute-safe (no `&` / `<` / `>`) — operator is expected
+        // to pre-escape values that target XML, matching Octostache semantics.
+        File.WriteAllText(Path.Combine(_workDir, "web.config"),
+            "<?xml version=\"1.0\"?><configuration>" +
+            "<connectionStrings><add name=\"default\" connectionString=\"#{ConnString}\" /></connectionStrings>" +
+            "<appSettings><add key=\"env\" value=\"dev\" /></appSettings>" +
+            "</configuration>");
+
+        // Transform file — also uses #{Token}. Substitution MUST resolve this
+        // before the XDT step reads it, otherwise XDT applies a literal `#{Env}`
+        // to the base, producing garbage.
+        File.WriteAllText(Path.Combine(_workDir, "web.Production.config"),
+            "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+            "<appSettings><add key=\"env\" value=\"#{Env}\" xdt:Transform=\"SetAttributes\" xdt:Locator=\"Match(key)\" /></appSettings>" +
+            "</configuration>");
+
+        // JSON file — needs leaf replacement. NO #{Token} (Json step doesn't
+        // do token sub; it does path matching). Operator's value contains `&`
+        // / `+` which are JSON-string-safe — exercises the H1-#4 relaxed encoder
+        // (raw chars survive instead of being escaped to \uXXXX).
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"),
+            """{"ConnectionStrings":{"Default":"server=local"},"Logging":{"LogLevel":{"Default":"Information"}},"Server":{"Port":8080}}""");
+
+        // ── Variables: ALL canonical (non-IIS) literals — proving a generic handler can drive this ──
+        var vars = new VariableSet();
+
+        // SubstituteInFiles
+        vars.Set(SubstituteInFilesVariableNames.Enabled, "True");
+        vars.Set(SubstituteInFilesVariableNames.TargetFiles, "web.config\nweb.Production.config");
+
+        // ConfigurationTransforms
+        vars.Set(ConfigurationTransformsVariableNames.Enabled, "True");
+        vars.Set(ConfigurationTransformsVariableNames.EnvironmentName, "Production");
+
+        // JsonConfigVariables (a.k.a. StructuredConfig)
+        vars.Set(StructuredConfigVariableNames.Enabled, "True");
+        vars.Set(StructuredConfigVariableNames.Targets, "appsettings.json");
+
+        // Operator-supplied values driving the rewrites.
+        vars.Set("ConnString", "Server=prod;Database=app;User=prod-u;Password=safe-password");
+        vars.Set("Env", "production");
+        vars.Set("Logging:LogLevel:Default", "Debug");
+        vars.Set("Server.Port", "9090");
+        // URL-special-chars in the JSON replacement value — JSON encoder MUST
+        // keep them literal (H1-#4 relaxed encoder) so diffs read sensibly.
+        vars.Set("ConnectionStrings.Default", "Server=prod-db;User=u;Password=p+x&Trusted_Connection=true");
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        // ── Drive the 3 steps in pipeline order ──────────────────────────────
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        // ── Assert end-state — web.config ────────────────────────────────────
+        var webConfig = File.ReadAllText(Path.Combine(_workDir, "web.config"));
+        webConfig.ShouldContain("Server=prod;Database=app;User=prod-u;Password=safe-password",
+            customMessage: "Step 1 (SubstituteInFiles) MUST resolve #{ConnString} in web.config. " +
+                           "If you see #{ConnString} literally, the step didn't run.");
+        webConfig.ShouldContain("value=\"production\"",
+            customMessage: "Step 2 (XDT) MUST apply web.Production.config's <appSettings> to the base. " +
+                           "The transform file's #{Env} was resolved by step 1; XDT sees the literal 'production'.");
+        webConfig.ShouldNotContain("#{",
+            customMessage: "No raw #{Token} should survive the chain — if you see one, step 1 didn't run before step 2.");
+
+        // ── Assert end-state — appsettings.json ──────────────────────────────
+        var appsettings = File.ReadAllText(Path.Combine(_workDir, "appsettings.json"));
+        appsettings.ShouldContain("\"Default\": \"Debug\"",
+            customMessage: "Step 3 (JsonConfigVariables) MUST replace the colon-form variable into the JSON leaf at Logging:LogLevel:Default.");
+        appsettings.ShouldContain("\"Port\": 9090",
+            customMessage: "Step 3 MUST also handle dot-form lookups (Server.Port → Server/Port leaf).");
+        appsettings.ShouldContain("p+x&Trusted_Connection=true",
+            customMessage: "URL-special chars MUST stay literal in JSON output (H1-#4 relaxed encoder). " +
+                           "If you see \\u0026 here, the encoder regressed to HTML-safe mode.");
+        appsettings.ShouldNotContain("\"Information\"");
+        appsettings.ShouldNotContain("8080");
+    }
+
+    [Fact]
+    public async Task ThreeSteps_TokenInsideTransform_ResolvedBeforeXdt_PipelineOrderMatters()
+    {
+        // Focused regression test for the inter-step ordering invariant: a
+        // transform file with #{Token} references MUST be substituted FIRST,
+        // before XDT reads it. If steps ran in reverse order, XDT would
+        // process the file with literal #{X} placeholders and write garbage.
+        File.WriteAllText(Path.Combine(_workDir, "app.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"k\" value=\"base\" /></appSettings></configuration>");
+        File.WriteAllText(Path.Combine(_workDir, "app.Production.config"),
+            "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+            "<appSettings><add key=\"k\" value=\"#{Replacement}\" xdt:Transform=\"SetAttributes\" xdt:Locator=\"Match(key)\" /></appSettings>" +
+            "</configuration>");
+
+        var vars = new VariableSet();
+        vars.Set(SubstituteInFilesVariableNames.Enabled, "True");
+        vars.Set(SubstituteInFilesVariableNames.TargetFiles, "app.Production.config");
+        vars.Set(ConfigurationTransformsVariableNames.Enabled, "True");
+        vars.Set(ConfigurationTransformsVariableNames.EnvironmentName, "Production");
+        vars.Set("Replacement", "resolved-value");
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+        await new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "app.config")).ShouldContain("value=\"resolved-value\"",
+            customMessage: "If this test fails with value=\"#{Replacement}\" or a literal in the output, the pipeline order is inverted — fix RunScriptCommand step list.");
+    }
+
+    [Fact]
+    public async Task ThreeSteps_AllIdempotent_SecondRunIsNoOp()
+    {
+        // Operator clicks 'Redeploy' or a step fails and the deploy retries.
+        // None of the 3 steps should change anything on the second pass —
+        // tokens have all been resolved, XDT directives are gone from the
+        // base, JSON leaves are at their final values.
+        File.WriteAllText(Path.Combine(_workDir, "web.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"x\" value=\"#{Val}\" /></appSettings></configuration>");
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"),
+            """{"K":"old"}""");
+
+        var vars = new VariableSet();
+        vars.Set(SubstituteInFilesVariableNames.Enabled, "True");
+        vars.Set(SubstituteInFilesVariableNames.TargetFiles, "web.config");
+        vars.Set(StructuredConfigVariableNames.Enabled, "True");
+        vars.Set(StructuredConfigVariableNames.Targets, "appsettings.json");
+        vars.Set("Val", "first-value");
+        vars.Set("K", "new-value");
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        // First pass
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        var webAfterFirst = File.ReadAllBytes(Path.Combine(_workDir, "web.config"));
+        var jsonAfterFirst = File.ReadAllBytes(Path.Combine(_workDir, "appsettings.json"));
+
+        // Second pass — same inputs, same context
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllBytes(Path.Combine(_workDir, "web.config")).ShouldBe(webAfterFirst,
+            customMessage: "SubstituteInFiles MUST be idempotent — second run with no remaining tokens MUST leave the file byte-identical.");
+        File.ReadAllBytes(Path.Combine(_workDir, "appsettings.json")).ShouldBe(jsonAfterFirst,
+            customMessage: "JsonConfigVariables MUST be idempotent — second run with all leaves at final values MUST leave the file byte-identical.");
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs
@@ -156,12 +156,61 @@ public sealed class StructuredConfigVariablesStepTests : IDisposable
     }
 
     [Fact]
-    public void EnabledVariableName_PinnedToIISHandlerContract()
-        => StructuredConfigVariableNames.Enabled.ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled");
+    public void EnabledVariableName_Canonical_PinnedHandlerAgnostic()
+        => StructuredConfigVariableNames.Enabled.ShouldBe("Squid.Action.JsonConfigVariables.Enabled");
 
     [Fact]
-    public void TargetsVariableName_PinnedToIISHandlerContract()
-        => StructuredConfigVariableNames.Targets.ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets");
+    public void TargetsVariableName_Canonical_PinnedHandlerAgnostic()
+        => StructuredConfigVariableNames.Targets.ShouldBe("Squid.Action.JsonConfigVariables.Targets");
+
+    [Fact]
+    public void LegacyVariableNames_PinnedToIISHandlerContract()
+    {
+        // The IIS handler's PS1 script + existing operator deployments emit
+        // the legacy names. The step's fallback read path MUST find them.
+        StructuredConfigVariableNames.Legacy.Enabled
+            .ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled");
+        StructuredConfigVariableNames.Legacy.Targets
+            .ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets");
+    }
+
+    [Fact]
+    public void JsonConfigVariableNames_ForwardAlias_PointsAtCanonical()
+    {
+        // New handlers SHOULD reference JsonConfigVariableNames — the
+        // forward-looking alias matching the canonical feature name. Pin
+        // it stays in sync with the underlying canonical literal.
+        JsonConfigVariableNames.Enabled.ShouldBe(StructuredConfigVariableNames.Enabled);
+        JsonConfigVariableNames.Targets.ShouldBe(StructuredConfigVariableNames.Targets);
+    }
+
+    [Fact]
+    public async Task IsEnabled_LegacyIISNames_StillRunsStep_BackCompat()
+    {
+        // Existing IIS deploys emit only the legacy names — step MUST still run.
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"), """{"K":"old"}""");
+
+        var vars = new VariableSet();
+        vars.Set(StructuredConfigVariableNames.Legacy.Enabled, "True");
+        vars.Set(StructuredConfigVariableNames.Legacy.Targets, "appsettings.json");
+        vars.Set("K", "new");
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "s.sh"),
+            VariablesPath = Path.Combine(_workDir, "v.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        new StructuredConfigVariablesStep().IsEnabled(context).ShouldBeTrue(
+            customMessage: "Legacy IIS-prefixed Enabled MUST trigger the step (back-compat).");
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "appsettings.json")).ShouldContain("\"new\"",
+            customMessage: "Legacy Targets glob MUST be honored when canonical is absent.");
+    }
 
     private RunScriptCommandContext BuildContext(string? enabled, string? targets, params (string name, string value)[] extraVars)
     {

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/SubstituteInFilesStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/SubstituteInFilesStepTests.cs
@@ -240,26 +240,97 @@ public sealed class SubstituteInFilesStepTests : IDisposable
     // ── Wire-contract pinning ───────────────────────────────────────────────
 
     [Fact]
-    public void EnabledVariableName_PinnedToIISHandlerContract()
+    public void EnabledVariableName_Canonical_PinnedHandlerAgnostic()
     {
-        // Drift detector (Rule 8): if either side renames this, the chain
-        // silently no-ops. Pin the wire literal.
+        // Drift detector (Rule 8): canonical wire literal — handler-agnostic.
+        // What new handlers (RunScript, Docker, nginx) MUST emit.
         SubstituteInFilesStep.EnabledVariableName
+            .ShouldBe("Squid.Action.SubstituteInFiles.Enabled");
+    }
+
+    [Fact]
+    public void TargetFilesVariableName_Canonical_PinnedHandlerAgnostic()
+    {
+        SubstituteInFilesStep.TargetFilesVariableName
+            .ShouldBe("Squid.Action.SubstituteInFiles.TargetFiles");
+    }
+
+    [Fact]
+    public void ShouldFailVariableName_HandlerAgnostic_AlwaysWasGeneric()
+    {
+        SubstituteInFilesStep.ShouldFailOnUnresolvedVariableName
+            .ShouldBe("Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails");
+    }
+
+    [Fact]
+    public void LegacyEnabledVariableName_StillExposed_PinnedToIISHandlerContract()
+    {
+        // The IIS handler's PS1 script + existing operator deployments emit
+        // the IIS-prefixed name. The Legacy nested class MUST keep exposing
+        // it so the step's fallback read path works. Drift detector — if the
+        // IIS server-side ever renames its emitted literal, the legacy fallback
+        // here MUST follow.
+        SubstituteInFilesVariableNames.Legacy.Enabled
             .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.Enabled");
     }
 
     [Fact]
-    public void TargetFilesVariableName_PinnedToIISHandlerContract()
+    public void LegacyTargetFilesVariableName_StillExposed_PinnedToIISHandlerContract()
     {
-        SubstituteInFilesStep.TargetFilesVariableName
+        SubstituteInFilesVariableNames.Legacy.TargetFiles
             .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles");
     }
 
     [Fact]
-    public void ShouldFailVariableName_PinnedToOctopusParity()
+    public async Task IsEnabled_LegacyIISName_StillRunsStep_BackCompat()
     {
-        SubstituteInFilesStep.ShouldFailOnUnresolvedVariableName
-            .ShouldBe("Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails");
+        // Critical back-compat test: operator's existing deployment emits ONLY
+        // the IIS-prefixed name (no canonical). The step MUST still fire.
+        var vars = new VariableSet();
+        vars.Set(SubstituteInFilesVariableNames.Legacy.Enabled, "True");
+        vars.Set(SubstituteInFilesVariableNames.Legacy.TargetFiles, "*.config");
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "s.sh"),
+            VariablesPath = Path.Combine(_workDir, "v.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        new SubstituteInFilesStep().IsEnabled(context).ShouldBeTrue(
+            customMessage: "Legacy IIS-prefixed Enabled MUST trigger the step (back-compat with deploys saved before canonical literals existed).");
+
+        // Also verify ExecuteAsync reads the legacy TargetFiles glob.
+        File.WriteAllText(Path.Combine(_workDir, "test.config"), "value=#{Foo}");
+        vars.Set("Foo", "bar");
+
+        await new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "test.config")).ShouldBe("value=bar",
+            customMessage: "Legacy TargetFiles glob list MUST be honored when canonical is absent.");
+    }
+
+    [Fact]
+    public void IsEnabled_CanonicalPresent_TakesPrecedenceOverLegacy()
+    {
+        // Both names emitted (server in transition emitting both for safety).
+        // Canonical wins — guarantees one source of truth on the agent side.
+        var vars = new VariableSet();
+        vars.Set(SubstituteInFilesVariableNames.Enabled, "False");           // canonical → skip
+        vars.Set(SubstituteInFilesVariableNames.Legacy.Enabled, "True");     // legacy → run
+
+        var context = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "s.sh"),
+            VariablesPath = Path.Combine(_workDir, "v.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+
+        new SubstituteInFilesStep().IsEnabled(context).ShouldBeFalse(
+            customMessage: "When both canonical AND legacy are set, canonical MUST win (precedence). " +
+                           "If this flips, dual-emitting servers would get unpredictable behavior.");
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISConfigurationTransformsWireContractTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISConfigurationTransformsWireContractTests.cs
@@ -7,41 +7,73 @@ namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle.Handlers
 
 /// <summary>
 /// G1.2 — cross-project drift detector for the ConfigurationTransforms (XDT)
-/// feature. Same pattern as the G1.1 SubstituteInFiles wire-contract test.
+/// feature. After A1 generalization, the contract has TWO halves:
 ///
-/// <para>Three variable literals form the contract between the server-side
-/// IIS handler preamble and the Calamari pipeline step. A rename on either
-/// side without the other = silent UI-theatre regression (operator flips
-/// toggle, deploy runs as if disabled).</para>
+/// <list type="bullet">
+///   <item><b>Legacy half</b>: IIS handler's <c>IISDeployProperties</c> +
+///         PS1 script emit the IIS-prefixed names. Calamari step's
+///         <c>Legacy</c> nested class exposes the matching names so the
+///         fallback read path finds them. Existing deployments depend on
+///         this half.</item>
+///   <item><b>Canonical half</b>: handler-agnostic names — what new
+///         handlers (RunScript / Docker / nginx) MUST emit. Calamari step
+///         reads them first.</item>
+/// </list>
 /// </summary>
 public sealed class IISConfigurationTransformsWireContractTests
 {
+    // ── Legacy half: IIS server emits these; Calamari step falls back to them ──
+
     [Fact]
-    public void EnabledVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyEnabledVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.ConfigurationTransformsEnabled
-            .ShouldBe(ConfigurationTransformsVariableNames.Enabled);
+            .ShouldBe(ConfigurationTransformsVariableNames.Legacy.Enabled);
     }
 
     [Fact]
-    public void EnvironmentNameVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyEnvironmentNameVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.ConfigurationTransformsEnvironmentName
-            .ShouldBe(ConfigurationTransformsVariableNames.EnvironmentName);
+            .ShouldBe(ConfigurationTransformsVariableNames.Legacy.EnvironmentName);
     }
 
     [Fact]
-    public void AdditionalTransformsVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyAdditionalTransformsVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.ConfigurationTransformsAdditional
-            .ShouldBe(ConfigurationTransformsVariableNames.AdditionalTransforms);
+            .ShouldBe(ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms);
     }
 
     [Fact]
-    public void EnabledVariable_LiteralValuePinned()
+    public void LegacyEnabledVariable_LiteralValuePinned()
     {
-        // Defence-in-depth pin (coordinate rename → still test-visible).
+        // Defence-in-depth pin — coordinated rename surfaces in tests.
         IISDeployProperties.ConfigurationTransformsEnabled
             .ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
+    }
+
+    // ── Canonical half: handler-agnostic; no server-side counterpart yet ──
+
+    [Fact]
+    public void CanonicalLiterals_PinnedHandlerAgnostic()
+    {
+        ConfigurationTransformsVariableNames.Enabled
+            .ShouldBe("Squid.Action.ConfigurationTransforms.Enabled");
+        ConfigurationTransformsVariableNames.EnvironmentName
+            .ShouldBe("Squid.Action.ConfigurationTransforms.EnvironmentName");
+        ConfigurationTransformsVariableNames.AdditionalTransforms
+            .ShouldBe("Squid.Action.ConfigurationTransforms.AdditionalTransforms");
+    }
+
+    [Fact]
+    public void CanonicalAndLegacy_AreDistinctLiterals()
+    {
+        ConfigurationTransformsVariableNames.Enabled
+            .ShouldNotBe(ConfigurationTransformsVariableNames.Legacy.Enabled);
+        ConfigurationTransformsVariableNames.EnvironmentName
+            .ShouldNotBe(ConfigurationTransformsVariableNames.Legacy.EnvironmentName);
+        ConfigurationTransformsVariableNames.AdditionalTransforms
+            .ShouldNotBe(ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms);
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISStructuredConfigVariablesWireContractTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISStructuredConfigVariablesWireContractTests.cs
@@ -6,37 +6,79 @@ using Xunit;
 namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle.Handlers;
 
 /// <summary>
-/// G1.3 — cross-project drift detector for the StructuredConfigVariables
-/// (JSON path) feature. Same pattern as G1.1 (SubstituteInFiles) +
-/// G1.2 (ConfigurationTransforms) wire-contract tests.
+/// G1.3 — cross-project drift detector for the JsonConfigVariables (JSON
+/// leaf replacement) feature. After A1 generalization the contract has two
+/// halves: canonical (handler-agnostic, what new handlers MUST emit) +
+/// legacy (IIS-prefixed, what the existing IIS handler + saved deployments
+/// emit). Same shape as G1.1 + G1.2 wire-contract tests.
 /// </summary>
 public sealed class IISStructuredConfigVariablesWireContractTests
 {
+    // ── Legacy half: IIS server emits these; Calamari step falls back to them ──
+
     [Fact]
-    public void EnabledVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyEnabledVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.StructuredConfigurationVariablesEnabled
-            .ShouldBe(StructuredConfigVariableNames.Enabled);
+            .ShouldBe(StructuredConfigVariableNames.Legacy.Enabled);
     }
 
     [Fact]
-    public void TargetsVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyTargetsVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.StructuredConfigurationVariablesTargets
-            .ShouldBe(StructuredConfigVariableNames.Targets);
+            .ShouldBe(StructuredConfigVariableNames.Legacy.Targets);
     }
 
     [Fact]
-    public void EnabledVariable_LiteralValuePinned()
+    public void LegacyEnabledVariable_LiteralValuePinned()
     {
         IISDeployProperties.StructuredConfigurationVariablesEnabled
             .ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled");
     }
 
     [Fact]
-    public void TargetsVariable_LiteralValuePinned()
+    public void LegacyTargetsVariable_LiteralValuePinned()
     {
         IISDeployProperties.StructuredConfigurationVariablesTargets
             .ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets");
+    }
+
+    // ── Canonical half: handler-agnostic; no server-side counterpart yet ──
+
+    [Fact]
+    public void CanonicalEnabledVariable_LiteralValuePinned_HandlerAgnostic()
+    {
+        // What new handlers (RunScript / Docker / nginx) MUST emit. Rename
+        // = silent break for those handlers. Pin the literal.
+        StructuredConfigVariableNames.Enabled
+            .ShouldBe("Squid.Action.JsonConfigVariables.Enabled");
+    }
+
+    [Fact]
+    public void CanonicalTargetsVariable_LiteralValuePinned_HandlerAgnostic()
+    {
+        StructuredConfigVariableNames.Targets
+            .ShouldBe("Squid.Action.JsonConfigVariables.Targets");
+    }
+
+    [Fact]
+    public void CanonicalAndLegacy_AreDistinctLiterals()
+    {
+        StructuredConfigVariableNames.Enabled
+            .ShouldNotBe(StructuredConfigVariableNames.Legacy.Enabled);
+        StructuredConfigVariableNames.Targets
+            .ShouldNotBe(StructuredConfigVariableNames.Legacy.Targets);
+    }
+
+    [Fact]
+    public void JsonConfigVariableNames_ForwardAlias_PinnedAtCanonical()
+    {
+        // Forward-looking alias for new handlers — keep it in sync with the
+        // underlying canonical literal.
+        JsonConfigVariableNames.Enabled
+            .ShouldBe("Squid.Action.JsonConfigVariables.Enabled");
+        JsonConfigVariableNames.Targets
+            .ShouldBe("Squid.Action.JsonConfigVariables.Targets");
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISSubstituteInFilesWireContractTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/Handlers/IISSubstituteInFilesWireContractTests.cs
@@ -7,60 +7,104 @@ namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle.Handlers
 
 /// <summary>
 /// G1.1 — server ↔ Calamari wire-contract drift detector for the
-/// SubstituteInFiles feature. Three variable literals form the contract:
+/// SubstituteInFiles feature. After the A1 wire-literal generalization,
+/// the contract has TWO halves:
 ///
 /// <list type="bullet">
-///   <item><b>Server-side</b>: <c>IISDeployProperties.SubstituteInFilesEnabled</c> /
-///         <c>SubstituteInFilesTargetFiles</c> /
-///         <c>ShouldFailDeploymentOnSubstitutionFails</c> — included in the
-///         deploy-script preamble built by <c>IISDeployScriptBuilder</c>.</item>
-///   <item><b>Agent-side</b>: <c>SubstituteInFilesVariableNames.Enabled</c> /
-///         <c>TargetFiles</c> / <c>ShouldFailOnUnresolved</c> — read by the
-///         Calamari pipeline step.</item>
+///   <item><b>Legacy (IIS-specific) half</b>: the IIS handler's
+///         <c>IISDeployScriptBuilder</c> + its PS1 script emit the
+///         IIS-prefixed names (<c>IISDeployProperties.SubstituteInFiles*</c>).
+///         The Calamari step's <see cref="SubstituteInFilesVariableNames.Legacy"/>
+///         class exposes the matching names so the step's fallback read path
+///         finds them. Existing operator deployments stored before A1
+///         depend on this half.</item>
+///   <item><b>Canonical (handler-agnostic) half</b>: top-level
+///         <see cref="SubstituteInFilesVariableNames.Enabled"/> /
+///         <c>TargetFiles</c> are the preferred names for new handlers
+///         (RunScript, Docker, nginx, …) and for Squid.Web migrations.
+///         The step reads them FIRST, then falls back to legacy. There is
+///         deliberately NO server-side <c>IISDeployProperties</c>
+///         counterpart for these — IIS keeps emitting legacy for
+///         back-compat.</item>
 /// </list>
 ///
-/// <para>If either side renames its constant without the other, the toggle
-/// silently no-ops in production: operator sets it to True, deploy runs as
-/// if substitution were disabled. Pin both sides to the same string
-/// literals so a rename surfaces at build time, not in a customer's
-/// production deploy.</para>
-///
-/// <para><b>Why this test lives in Squid.UnitTests, not Squid.Calamari.Tests</b>:
-/// it spans both projects. Server-side IIS handler constants are in
-/// <c>Squid.Core</c>, agent-side step constants are in <c>Squid.Calamari</c>.
-/// Squid.UnitTests references both, which is why the test lives here.</para>
+/// <para>If either side renames a literal without the other, the toggle
+/// silently no-ops in production. Pin both halves.</para>
 /// </summary>
 public sealed class IISSubstituteInFilesWireContractTests
 {
+    // ── Legacy half: IIS handler emits legacy names; step's Legacy fallback reads them ──
+
     [Fact]
-    public void EnabledVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyEnabledVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.SubstituteInFilesEnabled
-            .ShouldBe(SubstituteInFilesVariableNames.Enabled,
-                customMessage: "Wire-contract drift: IIS deploy handler advertises this variable in the script preamble; Calamari's SubstituteInFilesStep reads it. A rename on either side breaks the operator's UI toggle silently. Pin BOTH sides to the same literal.");
+            .ShouldBe(SubstituteInFilesVariableNames.Legacy.Enabled,
+                customMessage: "Wire-contract drift: IIS handler advertises the IIS-prefixed Enabled in its PS1 preamble; Calamari's step falls back to it. A rename on either side silently breaks the IIS UI toggle for existing operators. Pin BOTH halves.");
     }
 
     [Fact]
-    public void TargetFilesVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyTargetFilesVariable_ServerLiteral_MatchesCalamariLegacyLiteral()
     {
         IISDeployProperties.SubstituteInFilesTargetFiles
-            .ShouldBe(SubstituteInFilesVariableNames.TargetFiles);
+            .ShouldBe(SubstituteInFilesVariableNames.Legacy.TargetFiles);
     }
 
     [Fact]
-    public void ShouldFailVariable_ServerLiteral_MatchesCalamariLiteral()
+    public void LegacyEnabledVariable_LiteralValuePinned()
     {
-        IISDeployProperties.ShouldFailDeploymentOnSubstitutionFails
-            .ShouldBe(SubstituteInFilesVariableNames.ShouldFailOnUnresolved);
-    }
-
-    [Fact]
-    public void EnabledVariable_LiteralValuePinned()
-    {
-        // Defence-in-depth: if BOTH sides happened to rename in lock-step, the
-        // contract-match tests still pass. This third test pins the actual
-        // wire string so a coordinated rename is also a test-visible decision.
+        // Defence-in-depth: a coordinated rename on both sides still passes the
+        // match test above. Pin the actual wire string so the rename is also a
+        // test-visible decision.
         IISDeployProperties.SubstituteInFilesEnabled
             .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.Enabled");
+    }
+
+    [Fact]
+    public void LegacyTargetFilesVariable_LiteralValuePinned()
+    {
+        IISDeployProperties.SubstituteInFilesTargetFiles
+            .ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles");
+    }
+
+    // ── ShouldFailDeployment toggle: always handler-agnostic on both sides ──
+
+    [Fact]
+    public void ShouldFailVariable_ServerLiteral_MatchesCalamariCanonicalLiteral()
+    {
+        IISDeployProperties.ShouldFailDeploymentOnSubstitutionFails
+            .ShouldBe(SubstituteInFilesVariableNames.ShouldFailOnUnresolved,
+                customMessage: "ShouldFailDeploymentOnSubstitutionFails was always handler-agnostic — no IIS-prefixed variant exists on either side.");
+    }
+
+    // ── Canonical half: preferred for new handlers; no server-side counterpart yet ──
+
+    [Fact]
+    public void CanonicalEnabledVariable_LiteralValuePinned_HandlerAgnostic()
+    {
+        // What new handlers (RunScript, Docker, nginx) MUST emit to trigger
+        // the step. If you rename this, every handler-agnostic deploy is
+        // silently broken. Pin the literal.
+        SubstituteInFilesVariableNames.Enabled
+            .ShouldBe("Squid.Action.SubstituteInFiles.Enabled");
+    }
+
+    [Fact]
+    public void CanonicalTargetFilesVariable_LiteralValuePinned_HandlerAgnostic()
+    {
+        SubstituteInFilesVariableNames.TargetFiles
+            .ShouldBe("Squid.Action.SubstituteInFiles.TargetFiles");
+    }
+
+    [Fact]
+    public void CanonicalAndLegacy_AreDistinctLiterals()
+    {
+        // Sanity: if these ever collapsed to the same value, the dual-read
+        // fallback in SubstituteInFilesStep would silently degrade to a
+        // single-read. Pin that they differ.
+        SubstituteInFilesVariableNames.Enabled
+            .ShouldNotBe(SubstituteInFilesVariableNames.Legacy.Enabled);
+        SubstituteInFilesVariableNames.TargetFiles
+            .ShouldNotBe(SubstituteInFilesVariableNames.Legacy.TargetFiles);
     }
 }


### PR DESCRIPTION
## Summary

Architectural fix from the G1.x review. The rewriter steps had generic implementations but were silently coupled to the IIS handler via IIS-prefixed wire literals. A future RunScript / Docker / nginx handler wanting these features would have had to emit IIS-prefixed variable names — wrong on its face, and a breaking change to fix later. Fix it now.

**Stacks on #366** (the H1 hardening PR). After both #365 and #366 merge, this PR's base can be retargeted at `master`.

**SquidWeb zero-impact**: the IIS editor's wire-literal arrays all reference the IIS-prefixed names; the IIS handler emits them; the Calamari step's legacy fallback reads them. The new canonical names are purely additive — for future generic handlers.

## The two-halves wire contract

Each of the 3 features (SubstituteInFiles / ConfigurationTransforms / JsonConfigVariables) now has:

| Half | Where | What new code should use | Back-compat |
|---|---|---|---|
| **Canonical** (top-level on `*VariableNames`) | `Squid.Action.<Feature>.<Property>` | ✅ Yes — new handlers emit these | Step reads FIRST |
| **Legacy** (nested `.Legacy` class) | `Squid.Action.IISWebSite.<Feature>.<Property>` | ❌ No — kept for the IIS PS1 script + saved deploys | Step falls back to it when canonical is absent |

```csharp
// IsEnabled / Execute pattern in each step
var raw = context.Variables.Get(<Feature>VariableNames.Enabled)              // canonical first
          ?? context.Variables.Get(<Feature>VariableNames.Legacy.Enabled);   // legacy fallback
```

## What's renamed at the wire-literal level

| Feature | Legacy (kept, IIS emits this) | Canonical (new, generic) |
|---|---|---|
| SubstituteInFiles | `Squid.Action.IISWebSite.SubstituteInFiles.Enabled` | `Squid.Action.SubstituteInFiles.Enabled` |
| ConfigurationTransforms | `Squid.Action.IISWebSite.ConfigurationTransforms.Enabled` | `Squid.Action.ConfigurationTransforms.Enabled` |
| **StructuredConfigurationVariables → JsonConfigVariables** | `Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled` | `Squid.Action.JsonConfigVariables.Enabled` |

The JSON-leaf feature's canonical name drops the `StructuredConfigurationVariables` label — aligns with the frontend's existing feature ID `Squid.Features.JsonConfigurationVariables`, and accurately describes the JSON-only scope.

The C# class `StructuredConfigVariableNames` keeps its name (no ripple-rename); new alias `JsonConfigVariableNames` exposes the same canonical literals for new handlers.

## What's in the box

| Layer | File |
|---|---|
| Canonical + Legacy constants + dual-read | `src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs` |
| Same | `src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs` |
| Same + new `JsonConfigVariableNames` alias | `src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs` |
| Drift detector — Sub | `tests/Squid.UnitTests/.../IISSubstituteInFilesWireContractTests.cs` (8 tests; was 4) |
| Drift detector — Conf | `tests/Squid.UnitTests/.../IISConfigurationTransformsWireContractTests.cs` (6 tests; was 4) |
| Drift detector — Json | `tests/Squid.UnitTests/.../IISStructuredConfigVariablesWireContractTests.cs` (8 tests; was 4) |
| Back-compat + precedence per-step | step test files |
| 3-step composition E2E (review gap T1) | `tests/Squid.Calamari.Tests/Calamari/Commands/RewriterPipelineCompositionTests.cs` (new, 3 tests) |

## Test plan

- [x] Squid.Calamari.Tests: 258/258 (was 246; +12)
- [x] Squid.UnitTests cross-project wire-contract: 5625/5625 (was 5615; +10)
- [x] Build solution-wide: 0 errors
- [x] **3-step composition test** drives all 3 steps in order using ONLY canonical literals — proves a future generic handler can use the pipeline without any IIS-specific knowledge
- [x] **Back-compat tests** drive the steps with ONLY legacy literals + real file rewriting — confirms existing IIS deploys keep working
- [x] **Precedence test** confirms canonical wins when both are set (dual-emit scenario)
- [x] **Idempotency byte-identity test** confirms running the chain twice produces no diff (review gap T2)
- [ ] Staging: real IIS deploy with existing project definitions (IIS-prefixed variables) — backward-compat smoke
- [ ] Staging: synthetic test with canonical-only variables driving a RunScript handler (no such handler exists yet, but the wire surface is ready)

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing wire literals (`Squid.Action.IISWebSite.*`) | Preserved as `.Legacy.*`; same string values |
| IIS PS1 script | Unchanged — still reads IIS-prefixed names |
| `IISDeployProperties` constants | Unchanged |
| Frontend (`DeployToIisEditor.tsx`) | Unchanged — arrays still reference IIS-prefixed names |
| Operator's existing deployment definitions in DB | Unchanged behavior |
| `SubstituteInFilesStep.EnabledVariableName` etc. (internal) | Value changes from IIS-prefixed to canonical — only referenced by the test file that's updated in the same PR |