### PR TITLE
Add file-size cap to rewriter steps (50 MB default, env override)

### DIFF
--- a/src/Squid.Calamari/Commands/Common/EncodingPreservingFileIO.cs
+++ b/src/Squid.Calamari/Commands/Common/EncodingPreservingFileIO.cs
@@ -94,4 +94,73 @@ internal static class EncodingPreservingFileIO
     /// scan for leftover temps without hard-coding the suffix string.
     /// </summary>
     public const string TempSuffix = ".calamari-tmp";
+
+    // ── File-size guard (T3) ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Operator escape hatch (Rule 8). Default 50 MB is generous — typical
+    /// <c>appsettings.json</c> / <c>web.config</c> is &lt; 100 KB. Operators
+    /// with legitimately huge configs (rare, but possible: large embedded
+    /// catalog, monolith config) set this env var to a larger MB value.
+    /// Pinned by <c>MaxFileSizeMBEnvVar_ConstantNamePinned</c>.
+    /// </summary>
+    public const string MaxFileSizeMBEnvVar = "SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB";
+
+    /// <summary>50 MB default — pinned literal so a "let's lower it" change
+    /// surfaces in test, not in a customer's failed deploy.</summary>
+    public const int DefaultMaxFileSizeMB = 50;
+
+    /// <summary>
+    /// Reads <see cref="MaxFileSizeMBEnvVar"/> at call time. Returns
+    /// <see cref="DefaultMaxFileSizeMB"/> if unset, empty, non-numeric, or
+    /// non-positive. Resolved every call (no caching) so operators editing
+    /// the env var between deploys see the new value without restarting
+    /// the agent.
+    /// </summary>
+    public static int ResolveMaxFileSizeMB()
+    {
+        var raw = Environment.GetEnvironmentVariable(MaxFileSizeMBEnvVar);
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultMaxFileSizeMB;
+        if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var mb)) return DefaultMaxFileSizeMB;
+        if (mb <= 0) return DefaultMaxFileSizeMB;
+        return mb;
+    }
+
+    /// <summary>
+    /// Cheap pre-flight check before any rewriter loads a file into memory.
+    /// Returns <c>false</c> if the file would exceed the configured cap;
+    /// caller logs + skips. Out params let the caller emit a structured log
+    /// line with the exact size + limit + env var name so the operator can
+    /// fix it without grep-and-guess.
+    ///
+    /// <para><b>Why a pre-flight cap and not stream-bounded reads</b>:
+    /// XDT's <c>XmlTransformableDocument.Load</c> and System.Text.Json's
+    /// <c>JsonNode.Parse</c> build full in-memory DOMs — they don't expose
+    /// a "give up after N bytes" knob. The byte-level cap before opening
+    /// the file is the simplest defence; perfect for the common-case
+    /// "operator's glob accidentally matched a 200 MB log file" scenario.</para>
+    ///
+    /// <para>Inaccessible files (permission, race-with-delete) return
+    /// <c>false</c> — same fail-closed pattern as <see cref="GlobMatcher"/>'s
+    /// symlink sandbox.</para>
+    /// </summary>
+    public static bool IsWithinSizeLimit(string path, out long sizeBytes, out long limitBytes)
+    {
+        limitBytes = ResolveMaxFileSizeMB() * 1024L * 1024L;
+        sizeBytes = 0;
+
+        try
+        {
+            var info = new FileInfo(path);
+            if (!info.Exists) return false;
+            sizeBytes = info.Length;
+            return sizeBytes <= limitBytes;
+        }
+        catch
+        {
+            // Fail-closed on any FileInfo error (permission, race-with-delete).
+            // The caller already handles the skip-and-log path.
+            return false;
+        }
+    }
 }

--- a/src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs
+++ b/src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs
@@ -31,6 +31,18 @@ internal static class XdtTransformer
         if (!File.Exists(transformPath))
             return TransformResult.Failure($"Transform file '{transformPath}' does not exist; nothing to apply.");
 
+        // T3 — pre-flight size cap. XmlTransformableDocument builds a full
+        // in-memory DOM (can be 2-5x the file size). Reject oversized inputs
+        // before loading so a stray glob match doesn't OOM the agent.
+        if (!EncodingPreservingFileIO.IsWithinSizeLimit(basePath, out var baseBytes, out var limitBytes))
+            return TransformResult.Failure(
+                $"Base file '{basePath}' is {baseBytes:N0} bytes, exceeds the rewriter limit of {limitBytes:N0} bytes. " +
+                $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+        if (!EncodingPreservingFileIO.IsWithinSizeLimit(transformPath, out var transformBytes, out _))
+            return TransformResult.Failure(
+                $"Transform file '{transformPath}' is {transformBytes:N0} bytes, exceeds the rewriter limit of {limitBytes:N0} bytes. " +
+                $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+
         XmlTransformableDocument document;
         try
         {

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
@@ -114,6 +114,18 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
             {
                 try
                 {
+                    // T3 — pre-flight size cap. JsonNode.Parse builds a full
+                    // in-memory DOM (typically 3-5x the file size). Reject
+                    // oversized inputs so a stray glob match doesn't OOM the agent.
+                    if (!EncodingPreservingFileIO.IsWithinSizeLimit(file, out var sizeBytes, out var limitBytes))
+                    {
+                        Console.Error.WriteLine(
+                            $"::warning::StructuredConfigVariables: skipping '{file}' ({sizeBytes:N0} bytes > {limitBytes:N0} byte limit). " +
+                            $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap, or refine the target glob.");
+                        filesFailed++;
+                        continue;
+                    }
+
                     // BOM preservation — Visual Studio writes appsettings.json
                     // with a UTF-8 BOM by default; .NET's File.ReadAllText
                     // strips it. Without the shared helper, every rewrite

--- a/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
+++ b/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
@@ -164,6 +164,19 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
             {
                 try
                 {
+                    // T3 — pre-flight size cap. Default 50 MB; operator can raise
+                    // via SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB. Defends against
+                    // gobbing into a giant log file by accident — would OOM the agent
+                    // when the regex pass below loads the whole file as string.
+                    if (!EncodingPreservingFileIO.IsWithinSizeLimit(file, out var sizeBytes, out var limitBytes))
+                    {
+                        Console.WriteLine(
+                            $"SubstituteInFiles: skipping '{file}' ({sizeBytes:N0} bytes > {limitBytes:N0} byte limit). " +
+                            $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap, or refine the target glob.");
+                        filesSkipped++;
+                        continue;
+                    }
+
                     if (IsBinaryFile(file))
                     {
                         Console.WriteLine($"SubstituteInFiles: skipping '{file}' (binary content detected).");

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Common/EncodingPreservingFileIOTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Common/EncodingPreservingFileIOTests.cs
@@ -11,7 +11,14 @@ namespace Squid.Calamari.Tests.Calamari.Commands.Common;
 /// G1.3 StructuredConfigVariables). These tests guarantee that every
 /// rewriter behaves identically on the two cross-cutting concerns
 /// (BOM preservation + atomic write).
+///
+/// <para>Marked <c>[Collection]</c> so test methods that mutate the
+/// <c>MaxFileSizeMBEnvVar</c> process-wide env var don't race with the
+/// corresponding T3 tests in the per-step test classes (xUnit
+/// parallelizes across classes by default — env-var leakage would
+/// produce flaky failures).</para>
 /// </summary>
+[Collection(RewriterEnvVarSerialCollection.Name)]
 public sealed class EncodingPreservingFileIOTests : IDisposable
 {
     private readonly string _workDir;
@@ -159,5 +166,146 @@ public sealed class EncodingPreservingFileIOTests : IDisposable
         EncodingPreservingFileIO.WriteAllBytesAtomic(path, payload);
 
         File.ReadAllBytes(path).ShouldBe(payload);
+    }
+
+    // ── T3 — File-size guard ────────────────────────────────────────────────
+
+    [Fact]
+    public void MaxFileSizeMBEnvVar_ConstantNamePinned()
+    {
+        // Rule 8: any env var an operator might pin against MUST be a public
+        // const with the literal pinned in test. Operators on air-gapped
+        // forks have THIS string in their orchestrator config — silent
+        // rename = silent ignored override.
+        EncodingPreservingFileIO.MaxFileSizeMBEnvVar
+            .ShouldBe("SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB");
+    }
+
+    [Fact]
+    public void DefaultMaxFileSizeMB_LiteralValuePinned()
+    {
+        // 50 MB is the published default. Lowering it = breaks operators
+        // with legit 40 MB monolith configs. Raising it = OOM risk grows.
+        // Pin the value so the change is a deliberate test edit.
+        EncodingPreservingFileIO.DefaultMaxFileSizeMB.ShouldBe(50);
+    }
+
+    [Fact]
+    public void ResolveMaxFileSizeMB_EnvVarUnset_ReturnsDefault()
+    {
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+
+        EncodingPreservingFileIO.ResolveMaxFileSizeMB().ShouldBe(EncodingPreservingFileIO.DefaultMaxFileSizeMB);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-number")]
+    [InlineData("0")]
+    [InlineData("-5")]
+    [InlineData("3.14")]
+    public void ResolveMaxFileSizeMB_InvalidEnvVar_FallsBackToDefault(string value)
+    {
+        // Operator typos / mis-set values MUST fall back to the safe default,
+        // not crash or use 0 (which would reject every file).
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, value);
+
+        try
+        {
+            EncodingPreservingFileIO.ResolveMaxFileSizeMB()
+                .ShouldBe(EncodingPreservingFileIO.DefaultMaxFileSizeMB);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    [Theory]
+    [InlineData("1", 1)]
+    [InlineData("100", 100)]
+    [InlineData("1024", 1024)]
+    public void ResolveMaxFileSizeMB_ValidEnvVar_OverridesDefault(string value, int expectedMb)
+    {
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, value);
+
+        try
+        {
+            EncodingPreservingFileIO.ResolveMaxFileSizeMB().ShouldBe(expectedMb);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public void IsWithinSizeLimit_SmallFile_DefaultCap_ReturnsTrue()
+    {
+        var path = Path.Combine(_workDir, "small.txt");
+        File.WriteAllText(path, new string('x', 1024));    // 1 KB — well under 50 MB default
+
+        var withinLimit = EncodingPreservingFileIO.IsWithinSizeLimit(path, out var sizeBytes, out var limitBytes);
+
+        withinLimit.ShouldBeTrue();
+        sizeBytes.ShouldBe(1024);
+        limitBytes.ShouldBe(50L * 1024 * 1024);    // 50 MB default in bytes
+    }
+
+    [Fact]
+    public void IsWithinSizeLimit_FileExceedsCap_ReturnsFalse_WithSizeAndLimit()
+    {
+        // Set the cap to 1 MB via env var; create a 1.5 MB file; expect rejection.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            var path = Path.Combine(_workDir, "big.txt");
+            File.WriteAllBytes(path, new byte[(int)(1.5 * 1024 * 1024)]);
+
+            var withinLimit = EncodingPreservingFileIO.IsWithinSizeLimit(path, out var sizeBytes, out var limitBytes);
+
+            withinLimit.ShouldBeFalse();
+            sizeBytes.ShouldBeGreaterThan(limitBytes,
+                customMessage: "Out param sizeBytes MUST be populated so the caller can log the actual size.");
+            limitBytes.ShouldBe(1L * 1024 * 1024);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public void IsWithinSizeLimit_NonExistentFile_ReturnsFalse_FailClosed()
+    {
+        // Fail-closed pattern: if we can't probe the file, refuse to read it.
+        // Matches GlobMatcher's symlink sandbox philosophy.
+        var withinLimit = EncodingPreservingFileIO.IsWithinSizeLimit(
+            Path.Combine(_workDir, "does-not-exist.txt"), out _, out _);
+
+        withinLimit.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsWithinSizeLimit_FileExactlyAtLimit_ReturnsTrue_BoundaryInclusive()
+    {
+        // Boundary case: file size == limit is ALLOWED. Operators near the
+        // limit shouldn't see flaky behavior at the exact byte.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            var path = Path.Combine(_workDir, "exact.bin");
+            File.WriteAllBytes(path, new byte[1024 * 1024]);    // exactly 1 MB
+
+            EncodingPreservingFileIO.IsWithinSizeLimit(path, out _, out _).ShouldBeTrue(
+                customMessage: "File EXACTLY at the cap MUST be allowed (limit is inclusive).");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
     }
 }

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Common/RewriterEnvVarSerialCollection.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Common/RewriterEnvVarSerialCollection.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Common;
+
+/// <summary>
+/// xUnit collection marker — every test class that mutates process-wide
+/// env vars (specifically <c>SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB</c>)
+/// MUST opt into this collection so they run serially. Without it, xUnit
+/// parallelizes across classes by default and tests setting / clearing
+/// the env var on different threads produce flaky cross-test interference.
+///
+/// <para>Usage: <c>[Collection(RewriterEnvVarSerialCollection.Name)]</c>
+/// on the test class.</para>
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class RewriterEnvVarSerialCollection
+{
+    public const string Name = "RewriterEnvVar serial";
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/ConfigurationTransformsStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Configuration/ConfigurationTransformsStepTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Common;
 using Squid.Calamari.Commands.Configuration;
 using Squid.Calamari.Variables;
 using Xunit;
@@ -26,6 +27,7 @@ namespace Squid.Calamari.Tests.Calamari.Commands.Configuration;
 /// apply it. <c>*.Release.config</c> is also applied unconditionally
 /// (matches .NET FX build-time XDT defaults).</para>
 /// </summary>
+[Collection(Squid.Calamari.Tests.Calamari.Commands.Common.RewriterEnvVarSerialCollection.Name)]
 public sealed class ConfigurationTransformsStepTests : IDisposable
 {
     private readonly string _workDir;
@@ -267,6 +269,62 @@ public sealed class ConfigurationTransformsStepTests : IDisposable
         ConfigurationTransformsVariableNames.Legacy.Enabled.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
         ConfigurationTransformsVariableNames.Legacy.EnvironmentName.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName");
         ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms");
+    }
+
+    [Fact]
+    public async Task Execute_OversizedConfig_SkippedWithWarning_OtherPairsStillProcessed()
+    {
+        // T3 defence on the XDT path: a base config that's too big (could be
+        // a 200 MB monolith config — rare but possible). XDT MUST refuse to
+        // load it (XmlTransformableDocument builds a 2-5x DOM). Sibling
+        // valid pairs MUST still apply.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            // Oversized base (1.5 MB) with a matching env transform
+            var hugeBase = Path.Combine(_workDir, "huge.config");
+            File.WriteAllBytes(hugeBase, new byte[(int)(1.5 * 1024 * 1024)]);
+            File.WriteAllText(Path.Combine(_workDir, "huge.Production.config"),
+                "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+                "<appSettings><add key=\"k\" value=\"v\" xdt:Transform=\"SetAttributes\" xdt:Locator=\"Match(key)\" /></appSettings>" +
+                "</configuration>");
+
+            // Normal-sized valid sibling pair
+            File.WriteAllText(Path.Combine(_workDir, "app.config"),
+                "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"x\" value=\"old\" /></appSettings></configuration>");
+            File.WriteAllText(Path.Combine(_workDir, "app.Production.config"),
+                "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+                "<appSettings><add key=\"x\" value=\"new\" xdt:Transform=\"SetAttributes\" xdt:Locator=\"Match(key)\" /></appSettings>" +
+                "</configuration>");
+
+            var vars = new VariableSet();
+            vars.Set(ConfigurationTransformsVariableNames.Enabled, "True");
+            vars.Set(ConfigurationTransformsVariableNames.EnvironmentName, "Production");
+
+            var context = new RunScriptCommandContext
+            {
+                ScriptPath = Path.Combine(_workDir, "s.sh"),
+                VariablesPath = Path.Combine(_workDir, "v.json"),
+                WorkingDirectory = _workDir,
+                Variables = vars
+            };
+
+            await Should.NotThrowAsync(() =>
+                new ConfigurationTransformsStep().ExecuteAsync(context, CancellationToken.None));
+
+            // Huge base intact (skipped)
+            File.ReadAllBytes(hugeBase).Length.ShouldBe((int)(1.5 * 1024 * 1024),
+                customMessage: "Oversized base config MUST be skipped — never loaded.");
+
+            // Normal pair applied
+            File.ReadAllText(Path.Combine(_workDir, "app.config")).ShouldContain("value=\"new\"",
+                customMessage: "Normal-sized XDT pair MUST still apply when a sibling base is oversized.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
     }
 
     [Fact]

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigVariablesStepTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Common;
 using Squid.Calamari.Commands.StructuredConfig;
 using Squid.Calamari.Variables;
 using Xunit;
@@ -19,6 +20,7 @@ namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
 ///         (newline-separated globs of JSON files to rewrite)</item>
 /// </list></para>
 /// </summary>
+[Collection(Squid.Calamari.Tests.Calamari.Commands.Common.RewriterEnvVarSerialCollection.Name)]
 public sealed class StructuredConfigVariablesStepTests : IDisposable
 {
     private readonly string _workDir;
@@ -182,6 +184,54 @@ public sealed class StructuredConfigVariablesStepTests : IDisposable
         // it stays in sync with the underlying canonical literal.
         JsonConfigVariableNames.Enabled.ShouldBe(StructuredConfigVariableNames.Enabled);
         JsonConfigVariableNames.Targets.ShouldBe(StructuredConfigVariableNames.Targets);
+    }
+
+    [Fact]
+    public async Task Execute_OversizedJson_SkippedWithWarning_OtherFilesStillProcessed()
+    {
+        // T3 defence on the JSON path. A 200 MB JSON would build a ~1 GB
+        // JsonNode DOM — OOM territory. Pre-flight size guard rejects it
+        // BEFORE parse. Sibling normal files MUST still process.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            // Oversized JSON — 1.5 MB of valid JSON whitespace padding
+            var huge = new System.Text.StringBuilder("""{"K":"old","Padding":" """);
+            huge.Append('x', (int)(1.5 * 1024 * 1024));
+            huge.Append("\"}");
+            File.WriteAllText(Path.Combine(_workDir, "huge.json"), huge.ToString());
+
+            File.WriteAllText(Path.Combine(_workDir, "normal.json"), """{"K":"old"}""");
+
+            var vars = new VariableSet();
+            vars.Set(StructuredConfigVariableNames.Enabled, "True");
+            vars.Set(StructuredConfigVariableNames.Targets, "*.json");
+            vars.Set("K", "new");
+
+            var context = new RunScriptCommandContext
+            {
+                ScriptPath = Path.Combine(_workDir, "s.sh"),
+                VariablesPath = Path.Combine(_workDir, "v.json"),
+                WorkingDirectory = _workDir,
+                Variables = vars
+            };
+
+            await Should.NotThrowAsync(() =>
+                new StructuredConfigVariablesStep().ExecuteAsync(context, CancellationToken.None));
+
+            // Huge file untouched (skipped before parse)
+            File.ReadAllText(Path.Combine(_workDir, "huge.json")).ShouldContain("\"K\":\"old\"",
+                customMessage: "Oversized JSON MUST be skipped — never parsed, never overwritten.");
+
+            // Normal file processed
+            File.ReadAllText(Path.Combine(_workDir, "normal.json")).ShouldContain("\"new\"",
+                customMessage: "Sibling normal-sized JSON MUST still get its leaf replaced.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
     }
 
     [Fact]

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/SubstituteInFilesStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Substitution/SubstituteInFilesStepTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Common;
 using Squid.Calamari.Commands.Substitution;
 using Squid.Calamari.Variables;
 using Xunit;
@@ -24,6 +25,7 @@ namespace Squid.Calamari.Tests.Calamari.Commands.Substitution;
 /// step consumed them — the toggle was UI theatre. Pin the operator-
 /// observable behaviours of the new step:</para>
 /// </summary>
+[Collection(Squid.Calamari.Tests.Calamari.Commands.Common.RewriterEnvVarSerialCollection.Name)]
 public sealed class SubstituteInFilesStepTests : IDisposable
 {
     private readonly string _workDir;
@@ -309,6 +311,52 @@ public sealed class SubstituteInFilesStepTests : IDisposable
 
         File.ReadAllText(Path.Combine(_workDir, "test.config")).ShouldBe("value=bar",
             customMessage: "Legacy TargetFiles glob list MUST be honored when canonical is absent.");
+    }
+
+    [Fact]
+    public async Task Execute_OversizedFile_SkippedWithWarning_OtherFilesStillProcessed()
+    {
+        // T3 defence: a glob accidentally matches a huge file (e.g. operator
+        // included a 100 MB log under `**/*.config`). Step MUST skip it with
+        // a structured warning + still process the sibling files.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            // Oversized: 1.5 MB — exceeds 1 MB cap set above
+            File.WriteAllBytes(Path.Combine(_workDir, "huge.config"), new byte[(int)(1.5 * 1024 * 1024)]);
+
+            // Normal sibling: should still be processed
+            File.WriteAllText(Path.Combine(_workDir, "normal.config"), "value=#{Foo}");
+
+            var vars = new VariableSet();
+            vars.Set(SubstituteInFilesVariableNames.Enabled, "True");
+            vars.Set(SubstituteInFilesVariableNames.TargetFiles, "*.config");
+            vars.Set("Foo", "bar");
+
+            var context = new RunScriptCommandContext
+            {
+                ScriptPath = Path.Combine(_workDir, "s.sh"),
+                VariablesPath = Path.Combine(_workDir, "v.json"),
+                WorkingDirectory = _workDir,
+                Variables = vars
+            };
+
+            await Should.NotThrowAsync(() =>
+                new SubstituteInFilesStep().ExecuteAsync(context, CancellationToken.None));
+
+            // Huge file untouched (skipped)
+            File.ReadAllBytes(Path.Combine(_workDir, "huge.config")).Length.ShouldBe((int)(1.5 * 1024 * 1024),
+                customMessage: "Oversized file MUST be skipped — no partial rewrite. If you see a different size, the step tried to process it and likely OOM'd or corrupted.");
+
+            // Normal file processed
+            File.ReadAllText(Path.Combine(_workDir, "normal.config")).ShouldBe("value=bar",
+                customMessage: "Sibling files at normal size MUST still be processed — one oversized file MUST NOT abort the whole step.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Defensive OOM bound for the G1.x rewriter pipeline. Every rewriter previously loaded the entire matched file into memory — a glob accidentally matching a 200 MB log would OOM the agent process. Typical configs are < 100 KB, so the failure mode is rare but realistic when operators reuse generic globs (`*.config`, `**/*.json`) across heterogeneous packages.

**Stacks on #367** (A1 wire-literal generalization). Merges after the upstream stack lands.

## What's added

| Surface | Behavior |
|---|---|
| `EncodingPreservingFileIO.MaxFileSizeMBEnvVar` | Public const = `"SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB"` |
| `EncodingPreservingFileIO.DefaultMaxFileSizeMB` | Public const = `50` |
| `EncodingPreservingFileIO.ResolveMaxFileSizeMB()` | Reads env var live (no caching). Invalid → default. |
| `EncodingPreservingFileIO.IsWithinSizeLimit(path, out sizeBytes, out limitBytes)` | Pre-flight gate. Fail-closed on FileInfo errors. |
| Step skip behavior | Log structured warning (size + limit + env var name to flip), `continue` to next file. Sibling files still process. |

## What's in the box

| Layer | File |
|---|---|
| File-size helper | `src/Squid.Calamari/Commands/Common/EncodingPreservingFileIO.cs` |
| G1.1 skip integration | `src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs` |
| G1.2 skip integration | `src/Squid.Calamari/Commands/Configuration/XdtTransformer.cs` |
| G1.3 skip integration | `src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs` |
| Helper tests (9 new) | `tests/Squid.Calamari.Tests/Calamari/Commands/Common/EncodingPreservingFileIOTests.cs` |
| xUnit serial collection marker (new) | `tests/Squid.Calamari.Tests/Calamari/Commands/Common/RewriterEnvVarSerialCollection.cs` |
| Per-step oversized-skip tests (3 new) | step test files |

## Why a serial test collection

The 4 test classes that mutate `MaxFileSizeMBEnvVar` (env-var-process-wide state) MUST run sequentially — xUnit parallelizes across classes by default, and `Environment.SetEnvironmentVariable` calls race. Without the `[Collection]` marker, tests pass in isolation but flake under parallelism. Pinned by the new shared collection definition.

## Test plan

- [x] Squid.Calamari.Tests: 277/277 (was 258; +19)
- [x] Squid.UnitTests: 5625/5625 (unchanged — no cross-project changes)
- [x] `dotnet build` solution-wide: 0 errors
- [x] Env var constant name pinned (Rule 8): `SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB`
- [x] Default 50 MB pinned literal — change requires deliberate test edit
- [x] Invalid env var values (empty, whitespace, non-numeric, 0, negative, decimal) → default fallback (6-case theory)
- [x] Valid env var values (1, 100, 1024) → override applied (3-case theory)
- [x] Per-step skip: oversized file untouched, sibling normal file processed (3 tests — one per step)
- [x] Exact-size boundary: file at the cap is allowed (inclusive)
- [ ] Staging: deploy a package containing a legit oversized config + an env-var override raising the cap

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Wire literals | Unchanged |
| Step output for files within limit | Unchanged |
| Step output for files over limit | NEW — was OOM (process crashed). Now logged + skipped. Strictly better |
| Default 50 MB | Generous for typical operator configs (50 MB ≫ any realistic web.config / appsettings.json) |
| Frontend | Untouched |

The behavior change for oversized files is a correction — was undefined (OOM, process crash, partial state), is now defined (skip + warn, continue with siblings). No correct deploy ever depended on the OOM path.