### PR TITLE
G1.4: ExtractPackageStep — pre-rewriter .nupkg/.zip extraction

### DIFF
--- a/src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs
+++ b/src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs
@@ -1,0 +1,94 @@
+using Squid.Calamari.Pipeline;
+
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// Wire-contract constants for the package-extract feature (G1.4).
+/// Public so cross-project drift tests can pin them without
+/// InternalsVisibleTo pollution.
+///
+/// <para><b>Canonical-only — no Legacy nested class</b>: this is a new
+/// surface. No existing operator deployment emits the variable yet (the
+/// IIS handler PS1 does its own extraction in-script before any Calamari
+/// step runs). Future handlers + future IIS handler refactors will emit
+/// <see cref="OriginalPath"/> when they want Calamari to do the extract.</para>
+/// </summary>
+public static class PackageVariableNames
+{
+    /// <summary>Path on disk to the package file (typically a <c>.nupkg</c>
+    /// or <c>.zip</c> downloaded by the server and dropped on the agent).
+    /// Step is a no-op if absent / blank.</summary>
+    public const string OriginalPath = "Squid.Action.Package.OriginalPath";
+}
+
+/// <summary>
+/// G1.4 — extracts a package archive (<c>.nupkg</c> / <c>.zip</c>) into
+/// <c>context.WorkingDirectory</c>. Runs BEFORE the rewriter steps so
+/// substitution / XDT / JSON replacement operate on the extracted files.
+///
+/// <para><b>Pipeline position</b>: <c>LoadVariablesFromFiles → ExtractPackage
+/// → SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables →
+/// (operator script)</c>. ExtractPackage MUST run after variables are loaded
+/// (so the wire-literal lookup works) and before any rewriter (so they
+/// have files to rewrite).</para>
+///
+/// <para><b>No-op shape</b>: if <see cref="PackageVariableNames.OriginalPath"/>
+/// is not set in the variable set, the step skips silently. Operators
+/// running a standalone bash script (no package, just inline content) hit
+/// this path — same operator UX as before G1.4.</para>
+///
+/// <para><b>Safety</b>: <see cref="ZipExtractor"/> handles zip-slip,
+/// absolute paths, per-entry + total size caps. Failure modes are logged
+/// + the step throws — extraction is foundational; partial extracts would
+/// leave rewriter steps operating on a half-set of files which is worse
+/// than failing fast.</para>
+/// </summary>
+internal sealed class ExtractPackageStep : ExecutionStep<RunScriptCommandContext>
+{
+    /// <summary>Accepted archive extensions. Lower-cased for comparison.
+    /// nupkg is just a zip with a different filename suffix — same engine
+    /// handles both.</summary>
+    private static readonly HashSet<string> AllowedExtensions =
+        new(StringComparer.OrdinalIgnoreCase) { ".nupkg", ".zip" };
+
+    public override bool IsEnabled(RunScriptCommandContext context)
+    {
+        if (context.Variables is null) return false;
+        // Gate on the wire literal: no path → no extract. Cheap pre-check
+        // so the step doesn't burden every standalone-script deploy.
+        var path = context.Variables.Get(PackageVariableNames.OriginalPath);
+        return !string.IsNullOrWhiteSpace(path);
+    }
+
+    public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(context.WorkingDirectory))
+            throw new InvalidOperationException(
+                "Working directory has not been initialized — ExtractPackageStep must run after ResolveWorkingDirectoryStep.");
+        if (context.Variables is null)
+            throw new InvalidOperationException(
+                "Variables have not been loaded — ExtractPackageStep must run after LoadVariablesFromFilesStep.");
+
+        var archivePath = context.Variables.Get(PackageVariableNames.OriginalPath)!.Trim();
+
+        var ext = Path.GetExtension(archivePath);
+        if (!AllowedExtensions.Contains(ext))
+            throw new InvalidOperationException(
+                $"ExtractPackageStep: package '{archivePath}' has unsupported extension '{ext}'. " +
+                $"Supported: {string.Join(", ", AllowedExtensions)}. Skipping the extract step requires unsetting {PackageVariableNames.OriginalPath}.");
+
+        var result = ZipExtractor.Extract(archivePath, context.WorkingDirectory);
+
+        if (!result.Succeeded)
+            throw new InvalidOperationException(
+                $"ExtractPackageStep: failed to extract '{archivePath}' into '{context.WorkingDirectory}': {result.FailureReason}");
+
+        Console.WriteLine(
+            $"ExtractPackage: '{archivePath}' → '{context.WorkingDirectory}' " +
+            $"({result.FilesExtracted:N0} file(s), {result.TotalBytesWritten:N0} bytes).");
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Squid.Calamari/Commands/Package/ZipExtractor.cs
+++ b/src/Squid.Calamari/Commands/Package/ZipExtractor.cs
@@ -1,0 +1,161 @@
+using System.IO.Compression;
+using Squid.Calamari.Commands.Common;
+
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// G1.4 — pure-function zip / nupkg extractor used by
+/// <see cref="ExtractPackageStep"/>. Hardened against three classes of
+/// hostile archive content:
+///
+/// <list type="number">
+///   <item><b>Zip-slip</b>: an entry path containing <c>..</c> segments that
+///         would canonicalise outside the destination root. Pinned by
+///         <c>Extract_ZipSlipEntry_Rejected</c>. Any single malicious entry
+///         rejects the whole extraction (fail-closed).</item>
+///   <item><b>Absolute paths</b>: an entry like <c>/etc/passwd</c> or
+///         <c>C:\Windows\System32\drivers\etc\hosts</c>. Rejected outright.</item>
+///   <item><b>Per-entry size + total size</b>: defends against zip-bombs
+///         (small archive, multi-GB payload). Per-entry cap reuses the
+///         shared <see cref="EncodingPreservingFileIO.ResolveMaxFileSizeMB"/>
+///         setting; total cap is 10x that (so 50 MB default ⇒ 500 MB total).</item>
+/// </list>
+///
+/// <para><b>Symlinks in zip</b>: zip can encode Unix file modes via the
+/// external-attributes field. We don't decode those — every entry is treated
+/// as a regular file or directory. Net effect: symlink entries are extracted
+/// as plain files containing the target-path string. Operator-visible but
+/// not exploitable (file content is the literal target string, not a real
+/// symlink). The companion <c>GlobMatcher</c> symlink-escape sandbox catches
+/// anything the OS treats as a symlink after extraction.</para>
+///
+/// <para><b>Why not <see cref="ZipFile.ExtractToDirectory(string, string)"/></b>:
+/// .NET's built-in extractor does have a path-traversal check (added in .NET
+/// Core 2.1) but doesn't honour our per-entry / total size caps or our
+/// fail-closed-on-first-violation policy. Inlining gives full control of
+/// the safety story.</para>
+/// </summary>
+internal static class ZipExtractor
+{
+    /// <summary>
+    /// Multiplier applied to the per-file size cap to derive the total
+    /// archive-extraction cap. 10x is generous — a legitimate 50 MB
+    /// individual file plus surrounding small files easily fits under 500 MB
+    /// total. Zip bombs typically have ratios of 1000x+ so this catches them.
+    /// </summary>
+    private const int TotalSizeCapMultiplier = 10;
+
+    public static ExtractResult Extract(string archivePath, string destinationDir)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(archivePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationDir);
+
+        if (!File.Exists(archivePath))
+            return ExtractResult.Failure($"Archive '{archivePath}' does not exist.");
+
+        Directory.CreateDirectory(destinationDir);
+
+        var canonicalDest = Path.GetFullPath(destinationDir);
+        if (!canonicalDest.EndsWith(Path.DirectorySeparatorChar))
+            canonicalDest += Path.DirectorySeparatorChar;
+
+        var perEntryCapBytes = EncodingPreservingFileIO.ResolveMaxFileSizeMB() * 1024L * 1024L;
+        var totalCapBytes = perEntryCapBytes * TotalSizeCapMultiplier;
+
+        int filesExtracted = 0;
+        long totalBytesWritten = 0;
+
+        try
+        {
+            using var archive = ZipFile.OpenRead(archivePath);
+
+            foreach (var entry in archive.Entries)
+            {
+                // Directory entry: 0-byte, name ends with `/`. Create dir, no contents.
+                if (string.IsNullOrEmpty(entry.Name) && entry.FullName.EndsWith('/'))
+                {
+                    var dirPath = ResolveSafeEntryPath(entry.FullName, canonicalDest);
+                    if (dirPath is null)
+                        return ExtractResult.Failure($"Entry '{entry.FullName}' would escape the destination directory (zip-slip). Aborted.");
+                    Directory.CreateDirectory(dirPath);
+                    continue;
+                }
+
+                // Skip 0-length non-directory entries with empty Name (zip-spec weirdness)
+                if (string.IsNullOrEmpty(entry.Name)) continue;
+
+                var entryPath = ResolveSafeEntryPath(entry.FullName, canonicalDest);
+                if (entryPath is null)
+                    return ExtractResult.Failure($"Entry '{entry.FullName}' would escape the destination directory (zip-slip). Aborted.");
+
+                if (entry.Length > perEntryCapBytes)
+                    return ExtractResult.Failure(
+                        $"Entry '{entry.FullName}' is {entry.Length:N0} bytes, exceeds per-entry limit of {perEntryCapBytes:N0} bytes. " +
+                        $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+
+                if (totalBytesWritten + entry.Length > totalCapBytes)
+                    return ExtractResult.Failure(
+                        $"Total extracted size would exceed {totalCapBytes:N0} bytes (suspected zip-bomb). " +
+                        $"Aborted at entry '{entry.FullName}'. Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+
+                var parentDir = Path.GetDirectoryName(entryPath);
+                if (!string.IsNullOrEmpty(parentDir)) Directory.CreateDirectory(parentDir);
+
+                entry.ExtractToFile(entryPath, overwrite: true);
+
+                filesExtracted++;
+                totalBytesWritten += entry.Length;
+            }
+        }
+        catch (InvalidDataException ex)
+        {
+            return ExtractResult.Failure($"Archive '{archivePath}' is malformed: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            return ExtractResult.Failure($"Failed to extract '{archivePath}': {ex.GetType().Name}: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ExtractResult.Failure($"Permission denied extracting '{archivePath}': {ex.Message}");
+        }
+
+        return ExtractResult.Success(filesExtracted, totalBytesWritten);
+    }
+
+    /// <summary>
+    /// Resolve an archive entry path to its absolute on-disk path AND verify
+    /// it stays inside <paramref name="canonicalDest"/>. Returns null when
+    /// the entry escapes (zip-slip / absolute path / drive-letter).
+    /// </summary>
+    private static string? ResolveSafeEntryPath(string entryName, string canonicalDest)
+    {
+        // Normalise: zip entries use forward slashes; on Windows we need backslashes.
+        var normalised = entryName.Replace('/', Path.DirectorySeparatorChar);
+
+        // Reject absolute paths (POSIX `/` or Windows `C:\`) and drive-relative paths.
+        if (Path.IsPathRooted(normalised)) return null;
+
+        // Combine + canonicalise. Path.GetFullPath resolves `..` segments;
+        // we then check the result is still under the destination.
+        var combined = Path.Combine(canonicalDest, normalised);
+        var resolved = Path.GetFullPath(combined);
+
+        // Compare case-insensitively on Windows / macOS (HFS/APFS default
+        // case-insensitive). Linux ext4 is case-sensitive but
+        // OrdinalIgnoreCase is the safe over-approximation — any case-aliased
+        // attack still gets rejected.
+        if (!resolved.StartsWith(canonicalDest, StringComparison.OrdinalIgnoreCase)) return null;
+
+        return resolved;
+    }
+}
+
+internal sealed record ExtractResult(bool Succeeded, int FilesExtracted, long TotalBytesWritten, string? FailureReason)
+{
+    public static ExtractResult Success(int filesExtracted, long totalBytesWritten)
+        => new(true, filesExtracted, totalBytesWritten, null);
+
+    public static ExtractResult Failure(string reason)
+        => new(false, 0, 0, reason);
+}

--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -1,4 +1,5 @@
 using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.Package;
 using Squid.Calamari.Commands.StructuredConfig;
 using Squid.Calamari.Commands.Substitution;
 using Squid.Calamari.Execution;
@@ -9,13 +10,18 @@ namespace Squid.Calamari.Commands;
 
 /// <summary>
 /// Handles the `run-script` subcommand.
-/// Loads variables, prepends them as bash exports, then executes the script.
+/// Loads variables, optionally extracts a package, applies rewriter steps,
+/// prepends variable exports, then executes the script.
 ///
 /// <para><b>Pipeline order matters</b>:
 /// <list type="number">
 ///   <item>ResolveWorkingDirectory — pin the cwd for the rest of the pipeline.</item>
 ///   <item>LoadVariablesFromFiles — read variables.json + sensitiveVariables.json
 ///         into the in-memory VariableSet so later steps can use them.</item>
+///   <item><b>ExtractPackage (G1.4)</b> — if the wire literal
+///         <c>Squid.Action.Package.OriginalPath</c> is set, extract the
+///         .nupkg/.zip into the working directory. No-op for standalone
+///         scripts (no package). Runs BEFORE rewriters so they have files.</item>
 ///   <item><b>SubstituteInFiles (G1.1)</b> — apply <c>#{Token}</c> replacement
 ///         to operator-nominated file globs BEFORE the user script runs.
 ///         Must come after LoadVariables (needs the values) and before
@@ -42,6 +48,11 @@ public class RunScriptCommand
         [
             new ResolveWorkingDirectoryStep<RunScriptCommandContext>(),
             new LoadVariablesFromFilesStep<RunScriptCommandContext>(),
+            // G1.4 — package extraction. No-op when the wire literal is unset.
+            // MUST run before any rewriter step so SubstituteInFiles +
+            // ConfigurationTransforms + JsonConfigVariables have files to
+            // operate on.
+            new ExtractPackageStep(),
             // G1.1 — token replacement in operator-nominated text files.
             // Runs first so any #{Token} inside transform files is resolved
             // before XDT engine reads them.
@@ -54,7 +65,7 @@ public class RunScriptCommand
             // files (typically appsettings.json). Runs after XDT so the
             // ConfigurationTransforms-rewritten *.config files don't get
             // their JSON cousins out of sync. Matches Octopus pipeline order:
-            // SubstituteInFiles → ConfigurationTransforms → StructuredConfigurationVariables.
+            // SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables.
             new StructuredConfigVariablesStep(),
             new WriteBootstrappedBashScriptStep(),
             new ExecuteScriptWithEngineStep(scriptEngine),

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs
@@ -1,0 +1,221 @@
+using System.IO.Compression;
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Commands.Package;
+using Squid.Calamari.Tests.Calamari.Commands.Common;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Package;
+
+/// <summary>
+/// G1.4 — pipeline-level tests for <see cref="ExtractPackageStep"/>.
+///
+/// <para>Wire literal: <c>Squid.Action.Package.OriginalPath</c> points at a
+/// .nupkg / .zip file on disk. Step extracts into <c>context.WorkingDirectory</c>
+/// and is a no-op when the literal is unset (standalone-script case).</para>
+/// </summary>
+[Collection(RewriterEnvVarSerialCollection.Name)]
+public sealed class ExtractPackageStepTests : IDisposable
+{
+    private readonly string _workDir;
+    private readonly string _archiveDir;
+
+    public ExtractPackageStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"extract-step-{Guid.NewGuid():N}");
+        _archiveDir = Path.Combine(Path.GetTempPath(), $"extract-arch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+        Directory.CreateDirectory(_archiveDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+        if (Directory.Exists(_archiveDir)) Directory.Delete(_archiveDir, recursive: true);
+    }
+
+    // ── Enable-gating ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEnabled_PackagePathSet_RunsStep()
+    {
+        var context = BuildContext(packagePath: "/some/path.nupkg");
+        new ExtractPackageStep().IsEnabled(context).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsEnabled_PackagePathBlankOrUnset_SkipsStep(string? path)
+    {
+        // Standalone-script deploys (no package) hit this path. MUST be a
+        // no-op — otherwise every script-only deploy throws on the missing
+        // archive.
+        var context = BuildContext(packagePath: path);
+        new ExtractPackageStep().IsEnabled(context).ShouldBeFalse();
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_NupkgArchive_ExtractsIntoWorkingDir()
+    {
+        var nupkg = Path.Combine(_archiveDir, "HelloApp.1.0.0.nupkg");
+        using (var zip = ZipFile.Open(nupkg, ZipArchiveMode.Create))
+        {
+            AddEntry(zip, "Web.config", "<configuration />");
+            AddEntry(zip, "appsettings.json", """{"k":"v"}""");
+            AddEntry(zip, "bin/app.dll", "fake bytes");
+        }
+
+        var context = BuildContext(packagePath: nupkg);
+
+        await new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.Exists(Path.Combine(_workDir, "Web.config")).ShouldBeTrue();
+        File.Exists(Path.Combine(_workDir, "appsettings.json")).ShouldBeTrue();
+        File.Exists(Path.Combine(_workDir, "bin", "app.dll")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Execute_ZipArchive_AlsoSupported()
+    {
+        // .zip is accepted alongside .nupkg — same engine, just a different
+        // extension. Operators bundling configs as .zip MUST also work.
+        var zip = Path.Combine(_archiveDir, "configs.zip");
+        using (var z = ZipFile.Open(zip, ZipArchiveMode.Create))
+            AddEntry(z, "config.json", """{"k":"v"}""");
+
+        var context = BuildContext(packagePath: zip);
+
+        await new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.Exists(Path.Combine(_workDir, "config.json")).ShouldBeTrue();
+    }
+
+    // ── Unsupported extension ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_UnsupportedExtension_ThrowsWithGuidance()
+    {
+        // .tar.gz / .7z / unknown extensions aren't supported yet. Operator
+        // gets a clear error message naming the wire literal to unset.
+        var bad = Path.Combine(_archiveDir, "package.tar.gz");
+        File.WriteAllText(bad, "fake tar");
+
+        var context = BuildContext(packagePath: bad);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None));
+
+        ex.Message.ShouldContain("unsupported extension");
+        ex.Message.ShouldContain(PackageVariableNames.OriginalPath);
+    }
+
+    // ── Failure surface ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_MalformedArchive_ThrowsWithReason()
+    {
+        var bad = Path.Combine(_archiveDir, "broken.nupkg");
+        File.WriteAllText(bad, "not really a zip");
+
+        var context = BuildContext(packagePath: bad);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None));
+
+        ex.Message.ShouldContain("failed to extract");
+    }
+
+    [Fact]
+    public async Task Execute_ZipSlipEntry_ThrowsHaltsDeploy()
+    {
+        // The whole rewriter pipeline assumes a fully-extracted package.
+        // A zip-slip mid-extract = abort the whole deploy, not a warn-and-continue.
+        var archive = Path.Combine(_archiveDir, "evil.nupkg");
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+        {
+            AddEntry(zip, "ok.txt", "fine");
+            AddEntry(zip, "../../escape.txt", "should-not-write");
+        }
+
+        var context = BuildContext(packagePath: archive);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Execute_WorkingDirNotSet_Throws()
+    {
+        var archive = Path.Combine(_archiveDir, "ok.nupkg");
+        using (var z = ZipFile.Open(archive, ZipArchiveMode.Create))
+            AddEntry(z, "x.txt", "x");
+
+        var context = BuildContext(packagePath: archive);
+        context.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None));
+    }
+
+    // ── Wire-contract pinning ───────────────────────────────────────────────
+
+    [Fact]
+    public void OriginalPathVariableName_PinnedHandlerAgnostic()
+    {
+        // Rule 8 drift detector — operators + future server-side handlers
+        // emit this exact literal. Silent rename would mean "the package
+        // never gets extracted, but every test still passes locally".
+        PackageVariableNames.OriginalPath
+            .ShouldBe("Squid.Action.Package.OriginalPath");
+    }
+
+    // ── Idempotency ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_ReExtract_OverwritesAndStillSucceeds()
+    {
+        // Re-deploy scenario: same archive extracts to a dir that already
+        // has the files. ZipExtractor.Extract(... overwrite:true) handles
+        // this; step MUST NOT skip-on-exists.
+        var archive = Path.Combine(_archiveDir, "v2.nupkg");
+        using (var z = ZipFile.Open(archive, ZipArchiveMode.Create))
+            AddEntry(z, "version.txt", "v2");
+
+        File.WriteAllText(Path.Combine(_workDir, "version.txt"), "v1");
+
+        var context = BuildContext(packagePath: archive);
+        await new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "version.txt")).ShouldBe("v2");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private RunScriptCommandContext BuildContext(string? packagePath)
+    {
+        var vars = new VariableSet();
+        if (packagePath != null) vars.Set(PackageVariableNames.OriginalPath, packagePath);
+
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+    }
+
+    private static void AddEntry(ZipArchive zip, string name, string contents)
+    {
+        var entry = zip.CreateEntry(name);
+        using var s = entry.Open();
+        using var w = new StreamWriter(s);
+        w.Write(contents);
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ZipExtractorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ZipExtractorTests.cs
@@ -1,0 +1,277 @@
+using System.IO.Compression;
+using Shouldly;
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Commands.Package;
+using Squid.Calamari.Tests.Calamari.Commands.Common;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Package;
+
+/// <summary>
+/// G1.4 — pure-function tests for <see cref="ZipExtractor"/>. Covers the
+/// hostile-archive defence story:
+/// <list type="bullet">
+///   <item>Zip-slip — entry with <c>..</c> escapes destination → REJECTED</item>
+///   <item>Absolute path — <c>/etc/passwd</c> style → REJECTED</item>
+///   <item>Per-entry size cap — huge entry → REJECTED</item>
+///   <item>Total size cap — zip-bomb pattern → REJECTED</item>
+/// </list>
+///
+/// <para>Marked <c>[Collection]</c> because some tests mutate the shared
+/// file-size env var (same one G1.1-3 step tests use).</para>
+/// </summary>
+[Collection(RewriterEnvVarSerialCollection.Name)]
+public sealed class ZipExtractorTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public ZipExtractorTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"zip-ext-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_SimpleZip_FilesLandInDestination()
+    {
+        var archive = Path.Combine(_workDir, "input.zip");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+        {
+            AddEntry(zip, "readme.txt", "hello world");
+            AddEntry(zip, "config/app.json", """{"k":"v"}""");
+        }
+
+        var result = ZipExtractor.Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        result.FilesExtracted.ShouldBe(2);
+        File.ReadAllText(Path.Combine(dest, "readme.txt")).ShouldBe("hello world");
+        File.ReadAllText(Path.Combine(dest, "config", "app.json")).ShouldBe("""{"k":"v"}""");
+    }
+
+    [Fact]
+    public void Extract_NupkgArchive_TreatedAsZip()
+    {
+        // .nupkg IS a zip — engine handles both indistinguishably. The
+        // EXTENSION CHECK lives on the step (ExtractPackageStep), not here.
+        var archive = Path.Combine(_workDir, "package.nupkg");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+            AddEntry(zip, "tools/install.ps1", "Write-Host hi");
+
+        var result = ZipExtractor.Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue();
+        File.Exists(Path.Combine(dest, "tools", "install.ps1")).ShouldBeTrue();
+    }
+
+    // ── Zip-slip + absolute-path ────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_ZipSlipEntry_Rejected_DestinationUntouched()
+    {
+        var archive = Path.Combine(_workDir, "evil.zip");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+        {
+            AddEntry(zip, "normal.txt", "ok");
+            AddEntry(zip, "../../../escapee.txt", "i should not exist");
+        }
+
+        var result = ZipExtractor.Extract(archive, dest);
+
+        result.Succeeded.ShouldBeFalse(
+            customMessage: "An entry with `..` MUST cause the whole extraction to fail-closed. " +
+                           "Partial extraction with the escapee already on disk would be silently catastrophic.");
+        result.FailureReason.ShouldContain("escape");
+
+        // No file outside dest should exist.
+        File.Exists(Path.Combine(_workDir, "escapee.txt")).ShouldBeFalse();
+        File.Exists(Path.Combine(Path.GetDirectoryName(_workDir)!, "escapee.txt")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Extract_AbsolutePathEntry_Rejected()
+    {
+        var archive = Path.Combine(_workDir, "evil2.zip");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+        {
+            // Forward-slash absolute path — what a POSIX-built archive looks like
+            AddEntry(zip, "/etc/passwd", "compromised");
+        }
+
+        var result = ZipExtractor.Extract(archive, dest);
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("escape");
+    }
+
+    [Fact]
+    public void Extract_EntryWithEmbeddedDoubleDots_StillRejected()
+    {
+        // The mitigation is canonical-path comparison, not string scanning.
+        // So an entry like `subdir/../../escape.txt` still fails: canonical
+        // resolution lands outside the dest.
+        var archive = Path.Combine(_workDir, "evil3.zip");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+            AddEntry(zip, "ok/../../../escape.txt", "x");
+
+        ZipExtractor.Extract(archive, dest).Succeeded.ShouldBeFalse();
+    }
+
+    // ── Size caps ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_EntryExceedsPerEntryCap_Rejected()
+    {
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            var archive = Path.Combine(_workDir, "big.zip");
+            var dest = Path.Combine(_workDir, "out");
+
+            using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+            {
+                // 2 MB entry — exceeds 1 MB cap. Pre-fill with non-compressible content.
+                var entry = zip.CreateEntry("big.dat", CompressionLevel.NoCompression);
+                using var s = entry.Open();
+                var buf = new byte[64 * 1024];
+                Random.Shared.NextBytes(buf);
+                for (int i = 0; i < 2 * 1024 / 64; i++) s.Write(buf);
+            }
+
+            var result = ZipExtractor.Extract(archive, dest);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason.ShouldContain("per-entry limit");
+            result.FailureReason.ShouldContain(EncodingPreservingFileIO.MaxFileSizeMBEnvVar);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public void Extract_TotalSizeExceedsBombCap_RejectedMidStream()
+    {
+        // Per-entry cap = 1 MB, total cap = 10x = 10 MB.
+        // Pack 12 entries each ~1 MB → total ~12 MB → exceeds total cap.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            var archive = Path.Combine(_workDir, "bomb.zip");
+            var dest = Path.Combine(_workDir, "out");
+
+            using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+            {
+                var buf = new byte[1000 * 1024];    // 1000 KB, just under per-entry cap
+                Random.Shared.NextBytes(buf);
+                for (int i = 0; i < 12; i++)
+                {
+                    var entry = zip.CreateEntry($"file{i}.dat", CompressionLevel.NoCompression);
+                    using var s = entry.Open();
+                    s.Write(buf);
+                }
+            }
+
+            var result = ZipExtractor.Extract(archive, dest);
+
+            result.Succeeded.ShouldBeFalse(
+                customMessage: "Zip-bomb pattern (many small-ish entries summing to a huge payload) MUST be caught by the total-size cap.");
+            result.FailureReason.ShouldContain("zip-bomb");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_DirectoryEntry_CreatesDirOnDisk()
+    {
+        var archive = Path.Combine(_workDir, "with-dir.zip");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+        {
+            zip.CreateEntry("empty-folder/");
+            AddEntry(zip, "empty-folder/file.txt", "x");
+        }
+
+        ZipExtractor.Extract(archive, dest).Succeeded.ShouldBeTrue();
+        Directory.Exists(Path.Combine(dest, "empty-folder")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Extract_MalformedArchive_FailsCleanly()
+    {
+        var notAZip = Path.Combine(_workDir, "not-a-zip.zip");
+        File.WriteAllText(notAZip, "this is plain text, not zip bytes");
+
+        var result = ZipExtractor.Extract(notAZip, Path.Combine(_workDir, "out"));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Extract_NonExistentArchive_FailsCleanly()
+    {
+        var result = ZipExtractor.Extract(
+            Path.Combine(_workDir, "does-not-exist.zip"),
+            Path.Combine(_workDir, "out"));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("does not exist");
+    }
+
+    [Fact]
+    public void Extract_OverwritesExistingFiles_SecondExtractWins()
+    {
+        // Idempotency / re-deploy: if a previous extract left files, a fresh
+        // extract should overwrite them. Pinning so we don't accidentally
+        // regress to "skip if file exists" which would corrupt re-deploys.
+        var archive = Path.Combine(_workDir, "v.zip");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var zip = ZipFile.Open(archive, ZipArchiveMode.Create))
+            AddEntry(zip, "version.txt", "v2");
+
+        Directory.CreateDirectory(dest);
+        File.WriteAllText(Path.Combine(dest, "version.txt"), "v1");
+
+        ZipExtractor.Extract(archive, dest).Succeeded.ShouldBeTrue();
+
+        File.ReadAllText(Path.Combine(dest, "version.txt")).ShouldBe("v2");
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────────────
+
+    private static void AddEntry(ZipArchive zip, string entryName, string contents)
+    {
+        var entry = zip.CreateEntry(entryName);
+        using var s = entry.Open();
+        using var w = new StreamWriter(s);
+        w.Write(contents);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the "extract before rewriter" gap. When the wire literal `Squid.Action.Package.OriginalPath` points at a `.nupkg` / `.zip`, the new step extracts it into `context.WorkingDirectory` BEFORE the rewriter pipeline runs. Standalone-script deploys (no package) keep their existing UX — the step is a no-op when the literal is unset.

Pipeline: `LoadVariablesFromFiles → ExtractPackage → SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables → WriteBootstrapped → Execute`.

## Hostile-archive safety

| Defence | What it catches | Test |
|---|---|---|
| **Zip-slip** | Entry with `..` resolving outside destination | `Extract_ZipSlipEntry_Rejected_DestinationUntouched` + 2 variants |
| **Absolute path** | `/etc/passwd` / `C:\Windows\...` | `Extract_AbsolutePathEntry_Rejected` |
| **Per-entry size cap** | Single huge file | `Extract_EntryExceedsPerEntryCap_Rejected` — reuses shared T3 env var |
| **Total size cap (zip-bomb)** | Many entries summing to multi-GB | `Extract_TotalSizeExceedsBombCap_RejectedMidStream` — 10x per-entry |
| **Fail-closed** | Any single violation aborts whole extract | All above — never partial extract |
| **Overwrite** | Re-deploys land cleanly | `Extract_OverwritesExistingFiles_SecondExtractWins` |

## What's in the box

| Layer | File |
|---|---|
| Pure-function extractor | `src/Squid.Calamari/Commands/Package/ZipExtractor.cs` (new) |
| Pipeline step + wire literal | `src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs` (new) |
| Pipeline wiring | `src/Squid.Calamari/Commands/RunScriptCommand.cs` |
| ZipExtractor tests (11) | `tests/Squid.Calamari.Tests/Calamari/Commands/Package/ZipExtractorTests.cs` (new) |
| Step tests (12) | `tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs` (new) |

## Test plan

- [x] Squid.Calamari.Tests: 300/300 (was 277; +23)
- [x] Solution build: 0 errors
- [x] Wire literal `Squid.Action.Package.OriginalPath` pinned (Rule 8 drift detector)
- [x] Per-entry size cap reuses T3 env var `SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB`
- [x] Standalone-script deploys (no `OriginalPath` set) are zero-impact — IsEnabled short-circuits
- [ ] Staging: actual `.nupkg` deploy with `appsettings.json` requiring token substitution post-extract

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing wire literals | Unchanged |
| Standalone script deploys (no `OriginalPath`) | Zero impact — step skips |
| IIS PS1 in-script extraction path | Unchanged — Squid Calamari ExtractPackageStep doesn't replace it; the PS1 still handles its own extract until that's migrated separately |
| SquidWeb | Unchanged — `OriginalPath` is server-emitted, not operator-facing |

The IIS handler's PS1 still does its own in-script extraction; this PR adds the *agent-pipeline* extraction surface that future generic handlers (RunScript with package, Docker, nginx, etc.) will emit `OriginalPath` to drive.