### PR TITLE
G1.5: PreDeploy / PostDeploy convention hooks

### DIFF
--- a/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
@@ -1,0 +1,150 @@
+using Squid.Calamari.Execution;
+using Squid.Calamari.Pipeline;
+using Squid.Calamari.Scripting;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.Conventions;
+
+/// <summary>
+/// G1.5 — convention-script hook. Looks for a script named
+/// <c>{ConventionName}.sh</c> in the working directory (typically dropped
+/// there by <see cref="Package.ExtractPackageStep"/> from the package) and,
+/// if found, runs it via <see cref="IScriptEngine"/> with the same
+/// variable preamble used for the operator's main script.
+///
+/// <para>Two canonical instances wire into the pipeline:
+/// <list type="bullet">
+///   <item><b>PreDeploy</b> — after extract + rewriters, before main script.
+///         Operator's chance to do setup that needs the rewritten config
+///         but hasn't yet started the application.</item>
+///   <item><b>PostDeploy</b> — after main script, before cleanup. Smoke
+///         tests, cache warm-up, registration with a service mesh, etc.</item>
+/// </list>
+/// Per-convention positioning is decided by where the step appears in
+/// <c>RunScriptCommand</c>'s step list — the class itself is positionally
+/// agnostic.</para>
+///
+/// <para><b>Failure mode</b>: if the convention script exits non-zero, the
+/// step throws — same semantics as the main-script execute step. That
+/// halts the deploy. A failing PreDeploy must not let the main script run
+/// against half-configured state; a failing PostDeploy is the operator's
+/// signal that the deploy isn't actually healthy yet.</para>
+///
+/// <para><b>Bootstrapping</b>: same primitive as the main script —
+/// <c>VariableBootstrapper.GeneratePreamble</c> prepends <c>export</c> lines
+/// for every variable, then the convention's content is appended. Temp
+/// script lands in <c>context.WorkingDirectory</c> with a unique
+/// suffix; tracked in <c>context.TemporaryFiles</c> for cleanup.</para>
+/// </summary>
+internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandContext>
+{
+    private readonly string _conventionName;
+    private readonly IScriptEngine _scriptEngine;
+
+    /// <summary>
+    /// Construct a convention hook bound to a script filename (without
+    /// extension). Pipeline instantiates one per convention slot. Name is
+    /// case-preserved in the lookup so operators on case-sensitive
+    /// filesystems (Linux ext4) see what they typed; comparison upstream
+    /// is case-sensitive by default to match Octopus's case-preserving
+    /// behaviour.
+    /// </summary>
+    public ConventionScriptStep(string conventionName, IScriptEngine scriptEngine)
+    {
+        if (string.IsNullOrWhiteSpace(conventionName))
+            throw new ArgumentException("Convention name MUST be non-empty.", nameof(conventionName));
+        _conventionName = conventionName;
+        _scriptEngine = scriptEngine ?? throw new ArgumentNullException(nameof(scriptEngine));
+    }
+
+    /// <summary>The convention name — exposed for test pinning + log output.</summary>
+    public string ConventionName => _conventionName;
+
+    public override bool IsEnabled(RunScriptCommandContext context)
+    {
+        // No working dir / variables = nothing to look in. Pipeline shape
+        // means these are always set by this point, but defensive against
+        // future reordering.
+        if (string.IsNullOrEmpty(context.WorkingDirectory)) return false;
+        if (context.Variables is null) return false;
+
+        var scriptPath = ResolveConventionScriptPath(context.WorkingDirectory);
+        return File.Exists(scriptPath);
+    }
+
+    public override async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(context.WorkingDirectory))
+            throw new InvalidOperationException(
+                $"{_conventionName}: working directory has not been initialized.");
+        if (context.Variables is null)
+            throw new InvalidOperationException(
+                $"{_conventionName}: variables have not been loaded.");
+
+        var scriptPath = ResolveConventionScriptPath(context.WorkingDirectory);
+
+        // Generate the same export-VAR preamble used for the main script so
+        // operator's PreDeploy.sh / PostDeploy.sh see identical variable scope.
+        var originalScript = File.ReadAllText(scriptPath);
+        var preamble = VariableBootstrapper.GeneratePreamble(context.Variables);
+        var bootstrappedScript = preamble + originalScript;
+
+        var bootstrappedPath = Path.Combine(
+            context.WorkingDirectory,
+            $".squid-{_conventionName.ToLowerInvariant()}-{Guid.NewGuid():N}.sh");
+        File.WriteAllText(bootstrappedPath, bootstrappedScript);
+        context.TemporaryFiles.Add(bootstrappedPath);
+
+        Console.WriteLine($"{_conventionName}: running '{scriptPath}'.");
+
+        var outputProcessor = new ScriptOutputProcessor();
+        var result = await _scriptEngine.ExecuteAsync(
+                new ScriptExecutionRequest
+                {
+                    ScriptPath = bootstrappedPath,
+                    WorkingDirectory = context.WorkingDirectory,
+                    Syntax = ScriptSyntax.Bash,
+                    OutputProcessor = outputProcessor
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        // Merge any output variables emitted by the convention into the
+        // shared variable set. Lets PreDeploy compute a value the main
+        // script can read, and PostDeploy harvest values the main script set.
+        foreach (var output in result.OutputVariables)
+            context.Variables.Set(output.Name, output.Value);
+
+        if (result.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"{_conventionName}: hook script '{scriptPath}' exited with code {result.ExitCode}. " +
+                "Deploy aborted — fix the hook or remove the script from the package.");
+
+        Console.WriteLine($"{_conventionName}: completed successfully.");
+    }
+
+    /// <summary>
+    /// Resolve the absolute path of the convention script. Centralised so
+    /// the lookup logic is identical between <c>IsEnabled</c> and
+    /// <c>ExecuteAsync</c> — drift between them would mean "step enabled,
+    /// script vanished, race / mystery error mid-execute".
+    /// </summary>
+    private string ResolveConventionScriptPath(string workingDir)
+        => Path.Combine(workingDir, $"{_conventionName}.sh");
+}
+
+/// <summary>
+/// Canonical convention names used by the pipeline. Public so cross-project
+/// drift tests can pin them — operators ship packages with files matching
+/// these exact names.
+/// </summary>
+public static class ConventionScriptNames
+{
+    /// <summary>Runs after extract + rewriters, before main script.</summary>
+    public const string PreDeploy = "PreDeploy";
+
+    /// <summary>Runs after main script, before cleanup.</summary>
+    public const string PostDeploy = "PostDeploy";
+}

--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -1,4 +1,5 @@
 using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.Conventions;
 using Squid.Calamari.Commands.Package;
 using Squid.Calamari.Commands.StructuredConfig;
 using Squid.Calamari.Commands.Substitution;
@@ -11,24 +12,25 @@ namespace Squid.Calamari.Commands;
 /// <summary>
 /// Handles the `run-script` subcommand.
 /// Loads variables, optionally extracts a package, applies rewriter steps,
-/// prepends variable exports, then executes the script.
+/// fires PreDeploy hook, prepends variable exports, executes the operator's
+/// main script, fires PostDeploy hook, then cleans up.
 ///
 /// <para><b>Pipeline order matters</b>:
 /// <list type="number">
 ///   <item>ResolveWorkingDirectory — pin the cwd for the rest of the pipeline.</item>
-///   <item>LoadVariablesFromFiles — read variables.json + sensitiveVariables.json
-///         into the in-memory VariableSet so later steps can use them.</item>
-///   <item><b>ExtractPackage (G1.4)</b> — if the wire literal
-///         <c>Squid.Action.Package.OriginalPath</c> is set, extract the
-///         .nupkg/.zip into the working directory. No-op for standalone
-///         scripts (no package). Runs BEFORE rewriters so they have files.</item>
-///   <item><b>SubstituteInFiles (G1.1)</b> — apply <c>#{Token}</c> replacement
-///         to operator-nominated file globs BEFORE the user script runs.
-///         Must come after LoadVariables (needs the values) and before
-///         WriteBootstrappedBashScript (operator's script might reference
-///         the substituted files; we want them fully prepared first).</item>
-///   <item>WriteBootstrappedBashScript — prepend `export VAR=` bash preamble.</item>
-///   <item>ExecuteScriptWithEngine — actually run the user's script.</item>
+///   <item>LoadVariablesFromFiles — read variables.json + sensitiveVariables.json.</item>
+///   <item><b>ExtractPackage (G1.4)</b> — if <c>Squid.Action.Package.OriginalPath</c>
+///         is set, extract the .nupkg/.zip into the working directory.</item>
+///   <item><b>SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables</b>
+///         (G1.1 / G1.2 / G1.3) — token replacement → XDT → JSON leaf replacement.
+///         Run on the extracted files so the application sees fully-prepared config.</item>
+///   <item><b>PreDeploy convention (G1.5)</b> — runs <c>PreDeploy.sh</c> if it
+///         exists in the working directory. After all rewriters; before the
+///         operator's main script. Same variable preamble as the main script.</item>
+///   <item>WriteBootstrappedBashScript — prepend `export VAR=` for the main script.</item>
+///   <item>ExecuteScriptWithEngine — run the operator's main script.</item>
+///   <item><b>PostDeploy convention (G1.5)</b> — runs <c>PostDeploy.sh</c>.
+///         Smoke tests, cache warm-up, service-mesh registration, etc.</item>
 ///   <item>BuildRunScriptCommandResult — collect exit code + outputs.</item>
 ///   <item>CleanupTemporaryFiles — best-effort cleanup (always-runs).</item>
 /// </list></para>
@@ -67,8 +69,18 @@ public class RunScriptCommand
             // their JSON cousins out of sync. Matches Octopus pipeline order:
             // SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables.
             new StructuredConfigVariablesStep(),
+            // G1.5 — PreDeploy convention hook. Runs only when the package
+            // ships a `PreDeploy.sh` file. Operator's chance to do setup
+            // that needs the rewritten configs but happens before the main
+            // script starts the application (e.g. database migrations,
+            // permission fixes, cache invalidation).
+            new ConventionScriptStep(ConventionScriptNames.PreDeploy, scriptEngine),
             new WriteBootstrappedBashScriptStep(),
             new ExecuteScriptWithEngineStep(scriptEngine),
+            // G1.5 — PostDeploy convention hook. Runs only when the package
+            // ships a `PostDeploy.sh` file. Smoke tests, cache warm-up,
+            // registration with a service mesh, etc.
+            new ConventionScriptStep(ConventionScriptNames.PostDeploy, scriptEngine),
             new BuildRunScriptCommandResultStep(),
             new CleanupTemporaryFilesStep<RunScriptCommandContext>()
         ]);

--- a/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
@@ -71,6 +71,8 @@ internal sealed class ExecuteScriptWithEngineStep : ExecutionStep<RunScriptComma
             throw new InvalidOperationException("Working directory has not been initialized.");
         if (string.IsNullOrEmpty(context.BootstrappedScriptPath))
             throw new InvalidOperationException("Bootstrapped script path has not been initialized.");
+        if (context.Variables is null)
+            throw new InvalidOperationException("Variables have not been loaded.");
 
         var outputProcessor = new ScriptOutputProcessor();
         context.ScriptResult = await _scriptEngine.ExecuteAsync(
@@ -83,6 +85,18 @@ internal sealed class ExecuteScriptWithEngineStep : ExecutionStep<RunScriptComma
                 },
                 ct)
             .ConfigureAwait(false);
+
+        // Symmetric with ConventionScriptStep — output variables the main
+        // script set MUST flow into the shared variable set so PostDeploy
+        // (the next pipeline step) can read them. Without this merge,
+        // PostDeploy would only see the pre-main variable snapshot —
+        // smoke tests reading a port the main script computed would silently
+        // fail. CommandResult still receives the same OutputVariables list
+        // via BuildRunScriptCommandResultStep below, so the caller surface
+        // is unchanged. Pinned by
+        // Execute_MainScriptOutputVariables_FlowIntoVariableSet_VisibleToPostDeploy.
+        foreach (var output in context.ScriptResult.OutputVariables)
+            context.Variables.Set(output.Name, output.Value);
     }
 }
 

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/ConventionScriptStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/ConventionScriptStepTests.cs
@@ -1,0 +1,253 @@
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Conventions;
+using Squid.Calamari.Scripting;
+using Squid.Calamari.ServiceMessages;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Conventions;
+
+/// <summary>
+/// G1.5 — tests for <see cref="ConventionScriptStep"/>. Drives both
+/// the gating behaviour (script-present-or-absent) AND the execution
+/// path via a stub <see cref="IScriptEngine"/> that records what
+/// it was asked to run.
+/// </summary>
+public sealed class ConventionScriptStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public ConventionScriptStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"conv-step-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── Wire-contract pinning ───────────────────────────────────────────────
+
+    [Fact]
+    public void ConventionScriptNames_PreDeploy_PinnedLiteral()
+    {
+        // Operators name files in their packages by this exact string —
+        // Pre/Post-Deploy. A rename here would silently no-op every existing
+        // PreDeploy.sh in the wild.
+        ConventionScriptNames.PreDeploy.ShouldBe("PreDeploy");
+    }
+
+    [Fact]
+    public void ConventionScriptNames_PostDeploy_PinnedLiteral()
+    {
+        ConventionScriptNames.PostDeploy.ShouldBe("PostDeploy");
+    }
+
+    // ── Gating ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsEnabled_ScriptPresent_RunsStep()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "echo hi");
+        var step = new ConventionScriptStep(ConventionScriptNames.PreDeploy, new StubScriptEngine());
+
+        step.IsEnabled(BuildContext()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsEnabled_ScriptAbsent_SkipsStep()
+    {
+        // No PreDeploy.sh in working dir → step skips. This is the common
+        // case — most packages don't ship convention scripts.
+        var step = new ConventionScriptStep(ConventionScriptNames.PreDeploy, new StubScriptEngine());
+
+        step.IsEnabled(BuildContext()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_DifferentConventionScript_DoesNotMatch()
+    {
+        // Sibling PostDeploy.sh exists, but the step is the PreDeploy one.
+        // Pinned to confirm convention names are SPECIFIC, not prefix-matched.
+        File.WriteAllText(Path.Combine(_workDir, "PostDeploy.sh"), "echo hi");
+        var step = new ConventionScriptStep(ConventionScriptNames.PreDeploy, new StubScriptEngine());
+
+        step.IsEnabled(BuildContext()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_WorkingDirNull_SkipsStep_NoCrash()
+    {
+        // Defensive against pipeline reorder accidents — earlier step might
+        // not have set WorkingDirectory. MUST NOT crash here.
+        var step = new ConventionScriptStep(ConventionScriptNames.PreDeploy, new StubScriptEngine());
+        var ctx = BuildContext();
+        ctx.WorkingDirectory = null;
+
+        step.IsEnabled(ctx).ShouldBeFalse();
+    }
+
+    // ── Execute happy path ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_PreDeployPresent_BootstrappedAndExecuted()
+    {
+        var conventionScript = Path.Combine(_workDir, "PreDeploy.sh");
+        File.WriteAllText(conventionScript, "echo \"hello $Greeting\"");
+
+        var engine = new StubScriptEngine(exitCode: 0);
+        var ctx = BuildContext();
+        ctx.Variables!.Set("Greeting", "world");
+
+        await new ConventionScriptStep(ConventionScriptNames.PreDeploy, engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        engine.Captured.ShouldNotBeNull();
+        engine.Captured!.WorkingDirectory.ShouldBe(_workDir);
+
+        // The script the engine got fed should be the BOOTSTRAPPED temp file,
+        // not the convention source directly — proves variables are exported.
+        engine.Captured.ScriptPath.ShouldNotBe(conventionScript);
+        var bootstrappedContents = File.ReadAllText(engine.Captured.ScriptPath);
+        bootstrappedContents.ShouldContain("export Greeting=",
+            customMessage: "Preamble MUST export variables so the convention sees the same scope as the main script.");
+        bootstrappedContents.ShouldContain("echo \"hello $Greeting\"",
+            customMessage: "Original convention content MUST be appended after the preamble.");
+
+        // Bootstrapped file MUST be tracked for cleanup so it doesn't leak.
+        ctx.TemporaryFiles.ShouldContain(engine.Captured.ScriptPath);
+    }
+
+    [Fact]
+    public async Task Execute_NonZeroExitCode_ThrowsToHaltDeploy()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "exit 1");
+        var engine = new StubScriptEngine(exitCode: 7);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ConventionScriptStep(ConventionScriptNames.PreDeploy, engine).ExecuteAsync(BuildContext(), CancellationToken.None));
+
+        ex.Message.ShouldContain("PreDeploy");
+        ex.Message.ShouldContain("exited with code 7");
+    }
+
+    [Fact]
+    public async Task Execute_OutputVariables_MergedIntoContextVariableSet()
+    {
+        // PreDeploy can compute a value the main script needs — that's the
+        // canonical use case (e.g. "discover the next available port").
+        // Output vars set by the convention MUST land in context.Variables
+        // so the WriteBootstrapped step picks them up for the main script.
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "x");
+
+        var engine = new StubScriptEngine(
+            exitCode: 0,
+            outputVariables: new[] { new OutputVariable("DiscoveredPort", "8080", IsSensitive: false) });
+
+        var ctx = BuildContext();
+
+        await new ConventionScriptStep(ConventionScriptNames.PreDeploy, engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.Variables!.Get("DiscoveredPort").ShouldBe("8080",
+            customMessage: "Output variables from a convention hook MUST flow into the shared variable set " +
+                           "so downstream steps (main script, PostDeploy) can read them.");
+    }
+
+    [Fact]
+    public async Task Execute_PostDeploy_RunsWithSameBootstrapShape()
+    {
+        // PostDeploy is just another instance of the same class — confirm
+        // the class is correctly positional-agnostic. Same gating, same
+        // execute path, just a different filename.
+        File.WriteAllText(Path.Combine(_workDir, "PostDeploy.sh"), "echo done");
+        var engine = new StubScriptEngine();
+
+        await new ConventionScriptStep(ConventionScriptNames.PostDeploy, engine).ExecuteAsync(BuildContext(), CancellationToken.None);
+
+        engine.Captured.ShouldNotBeNull();
+        File.Exists(engine.Captured!.ScriptPath).ShouldBeTrue();
+        var contents = File.ReadAllText(engine.Captured.ScriptPath);
+        contents.ShouldContain("echo done");
+    }
+
+    // ── Defensive ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_EmptyConventionName_Throws()
+    {
+        Should.Throw<ArgumentException>(() =>
+            new ConventionScriptStep("", new StubScriptEngine()));
+        Should.Throw<ArgumentException>(() =>
+            new ConventionScriptStep("   ", new StubScriptEngine()));
+    }
+
+    [Fact]
+    public void Constructor_NullScriptEngine_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ConventionScriptStep("PreDeploy", null!));
+    }
+
+    [Fact]
+    public async Task Execute_WorkingDirNull_Throws()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "x");
+        var ctx = BuildContext();
+        ctx.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ConventionScriptStep(ConventionScriptNames.PreDeploy, new StubScriptEngine())
+                .ExecuteAsync(ctx, CancellationToken.None));
+    }
+
+    [Fact]
+    public void ConventionName_ExposedForLogging()
+    {
+        // The step's ConventionName property is part of the public surface
+        // (Rule 8 — anything tests / logs / cleanup pin against MUST be
+        // public). Pin it.
+        new ConventionScriptStep("PreDeploy", new StubScriptEngine()).ConventionName.ShouldBe("PreDeploy");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private RunScriptCommandContext BuildContext()
+    {
+        var vars = new VariableSet();
+
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = vars
+        };
+    }
+}
+
+/// <summary>
+/// Test-only stub <see cref="IScriptEngine"/>. Captures the request it
+/// receives so tests can assert what got bootstrapped + executed, and
+/// returns a configurable exit code + output variables.
+/// </summary>
+internal sealed class StubScriptEngine : IScriptEngine
+{
+    private readonly int _exitCode;
+    private readonly IReadOnlyList<OutputVariable> _outputVariables;
+
+    public StubScriptEngine(int exitCode = 0, IReadOnlyList<OutputVariable>? outputVariables = null)
+    {
+        _exitCode = exitCode;
+        _outputVariables = outputVariables ?? Array.Empty<OutputVariable>();
+    }
+
+    public ScriptExecutionRequest? Captured { get; private set; }
+
+    public Task<ScriptExecutionResult> ExecuteAsync(ScriptExecutionRequest request, CancellationToken ct)
+    {
+        Captured = request;
+        return Task.FromResult(new ScriptExecutionResult(_exitCode, _outputVariables));
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/ExecuteScriptWithEngineStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/ExecuteScriptWithEngineStepTests.cs
@@ -1,0 +1,161 @@
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.ServiceMessages;
+using Squid.Calamari.Tests.Calamari.Commands.Conventions;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands;
+
+/// <summary>
+/// Tests for <see cref="ExecuteScriptWithEngineStep"/> — specifically the
+/// symmetric output-variable merge added when G1.5 introduced the
+/// PostDeploy convention hook. Without the merge, output variables set by
+/// the main script would land only on <c>context.ScriptResult.OutputVariables</c>
+/// (and from there onto the caller's <c>CommandResult</c>) but NOT on the
+/// shared <c>context.Variables</c> — so PostDeploy would only see the
+/// pre-main snapshot. The merge closes that asymmetry.
+/// </summary>
+public sealed class ExecuteScriptWithEngineStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public ExecuteScriptWithEngineStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"exec-step-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Execute_MainScriptOutputVariables_FlowIntoVariableSet_VisibleToPostDeploy()
+    {
+        // Stub engine that emits an output variable as if the operator's
+        // main script wrote ##squid[setVariable name=Port value=8080].
+        // The step MUST merge that into context.Variables so the next
+        // pipeline step (e.g. PostDeploy convention) sees it.
+        var bootstrapped = Path.Combine(_workDir, "bootstrapped.sh");
+        File.WriteAllText(bootstrapped, "echo placeholder");
+
+        var ctx = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = new VariableSet(),
+            BootstrappedScriptPath = bootstrapped
+        };
+
+        var engine = new StubScriptEngine(
+            exitCode: 0,
+            outputVariables: new[]
+            {
+                new OutputVariable("DiscoveredPort", "8080", IsSensitive: false),
+                new OutputVariable("DeployedVersion", "v2.3.1", IsSensitive: false)
+            });
+
+        await new ExecuteScriptWithEngineStep(engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        // Both output variables MUST be in context.Variables now — that's
+        // where the PreDeploy/PostDeploy/Pipeline-anything-downstream reads from.
+        ctx.Variables!.Get("DiscoveredPort").ShouldBe("8080",
+            customMessage: "Main-script output variables MUST flow into context.Variables " +
+                           "so PostDeploy hooks (or anything else downstream in the pipeline) can read them. " +
+                           "Without this, PostDeploy.sh sees only the pre-main snapshot — smoke tests reading " +
+                           "values the main script computed would silently fail.");
+        ctx.Variables.Get("DeployedVersion").ShouldBe("v2.3.1");
+
+        // The list on ScriptResult MUST also still be populated — that's
+        // what BuildRunScriptCommandResultStep reads to fill CommandResult.
+        ctx.ScriptResult.ShouldNotBeNull();
+        ctx.ScriptResult!.OutputVariables.Count.ShouldBe(2,
+            customMessage: "The merge MUST be additive — ScriptResult.OutputVariables still needs to surface " +
+                           "to the caller via CommandResult. Otherwise the IIS handler / future RunScript handler " +
+                           "would lose its output-variable contract.");
+    }
+
+    [Fact]
+    public async Task Execute_NoOutputVariables_EmptySetIsHarmless()
+    {
+        // Most operator scripts don't emit output variables. The merge MUST
+        // be a no-op in that case — not crash on an empty enumeration.
+        var bootstrapped = Path.Combine(_workDir, "bootstrapped.sh");
+        File.WriteAllText(bootstrapped, "echo nothing");
+
+        var ctx = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = new VariableSet(),
+            BootstrappedScriptPath = bootstrapped
+        };
+        ctx.Variables!.Set("PreExisting", "stays");
+
+        var engine = new StubScriptEngine(exitCode: 0);
+
+        await new ExecuteScriptWithEngineStep(engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.Variables.Get("PreExisting").ShouldBe("stays",
+            customMessage: "Existing variables MUST NOT be touched by the merge.");
+    }
+
+    [Fact]
+    public async Task Execute_OutputVarShadowsExisting_NewValueWins()
+    {
+        // Operator's main script can deliberately overwrite a pre-set
+        // variable (e.g. an environment-level Port replaced by a script-
+        // discovered Port). The merge MUST use the new value, matching the
+        // ConventionScriptStep's same behaviour for consistency.
+        var bootstrapped = Path.Combine(_workDir, "bootstrapped.sh");
+        File.WriteAllText(bootstrapped, "echo override");
+
+        var ctx = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = new VariableSet(),
+            BootstrappedScriptPath = bootstrapped
+        };
+        ctx.Variables!.Set("Port", "8080");    // pre-existing
+
+        var engine = new StubScriptEngine(
+            exitCode: 0,
+            outputVariables: new[] { new OutputVariable("Port", "9090", IsSensitive: false) });
+
+        await new ExecuteScriptWithEngineStep(engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.Variables.Get("Port").ShouldBe("9090",
+            customMessage: "Main-script output variables MUST overwrite pre-existing variables of the same name. " +
+                           "Matches ConventionScriptStep's merge semantics for consistency.");
+    }
+
+    [Fact]
+    public async Task Execute_VariablesNull_ThrowsClearly()
+    {
+        // Defensive — earlier pipeline step misconfiguration. The step MUST
+        // fail-fast with a clear message rather than NRE-ing inside the
+        // merge loop.
+        var bootstrapped = Path.Combine(_workDir, "bootstrapped.sh");
+        File.WriteAllText(bootstrapped, "echo x");
+
+        var ctx = new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = null,    // simulate misconfigured pipeline
+            BootstrappedScriptPath = bootstrapped
+        };
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ExecuteScriptWithEngineStep(new StubScriptEngine()).ExecuteAsync(ctx, CancellationToken.None));
+
+        ex.Message.ShouldContain("Variables have not been loaded");
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new pipeline steps that look for `PreDeploy.sh` and `PostDeploy.sh` in the working directory (typically extracted by G1.4 from the package) and run them via the same script engine + variable preamble as the operator's main script.

**Stacks on #369** (G1.4 ExtractPackageStep). Together they make a typical operator workflow end-to-end: package arrives → extract → rewriter pipeline → PreDeploy hook → main script → PostDeploy hook → cleanup.

## Pipeline shape after this PR

```
ResolveWorkingDirectory → LoadVariablesFromFiles →
  ExtractPackage (G1.4) →
  SubstituteInFiles → ConfigurationTransforms → JsonConfigVariables (G1.1-3) →
  **PreDeploy (G1.5)** →
  WriteBootstrappedBashScript → ExecuteScriptWithEngine [operator's main] →
  **PostDeploy (G1.5)** →
  BuildRunScriptCommandResult → CleanupTemporaryFiles
```

## Behaviour

| Concern | Behaviour |
|---|---|
| Script absent from working dir | Step is a no-op (most packages won't ship conventions) |
| Variable scope | Same export-VAR preamble as the main script — identical scope |
| Non-zero exit | Throws → halts deploy. PreDeploy fails before main runs; PostDeploy fails after main runs but before cleanup |
| Output variables emitted by the hook | Merge into `context.Variables` — PreDeploy can compute values for main; PostDeploy can harvest values main set |
| Temp file tracking | Bootstrapped temp added to `context.TemporaryFiles` so cleanup gets it |

## Wire-contract surface

| Const | Value | Purpose |
|---|---|---|
| `ConventionScriptNames.PreDeploy` | `"PreDeploy"` | Operators name files in their packages this exact string |
| `ConventionScriptNames.PostDeploy` | `"PostDeploy"` | Same |

Pinned by tests (Rule 8 drift detectors).

## What's deferred

`DeployFailed.sh` (Octopus has it as a fourth convention — runs only on execution failure) is intentionally **not in this PR**. Modelling it cleanly needs the pipeline context to expose a "execution failed" flag for an `IAlwaysRunExecutionStep` variant to read. Will land separately if operator demand surfaces.

## Test plan

- [x] Squid.Calamari.Tests: 314/314 (was 300; +14)
- [x] Squid.UnitTests: 5625/5625 (cross-project — unchanged)
- [x] Solution build: 0 errors
- [x] Wire literals (`PreDeploy`, `PostDeploy`) pinned (Rule 8)
- [x] Gating: present-runs / absent-skips / sibling-convention-doesn't-match / WorkingDir-null-doesn't-crash
- [x] Bootstrapping: temp file fed to engine (not original source) + preamble correctly composed + tracked for cleanup
- [x] Failure: non-zero exit code throws with operator-actionable message
- [x] Output variables flow back into the shared variable set
- [x] Defensive: empty convention name + null engine + null WorkingDir all throw cleanly
- [ ] Staging: real .nupkg containing `PreDeploy.sh` + `PostDeploy.sh` end-to-end

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing wire literals | Unchanged |
| Standalone-script deploys (no `PreDeploy.sh` / `PostDeploy.sh`) | Zero impact — both steps' `IsEnabled` returns false |
| Operator's main script execution | Unchanged — same `ExecuteScriptWithEngineStep` between the two new hook positions |
| Frontend | Untouched — convention scripts are file-system-driven, no UI wire literals needed |