### PR TITLE
Add DeployFailed convention hook (cleanup-phase failure handler)

### DIFF
--- a/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
@@ -147,4 +147,8 @@ public static class ConventionScriptNames
 
     /// <summary>Runs after main script, before cleanup.</summary>
     public const string PostDeploy = "PostDeploy";
+
+    /// <summary>Runs in cleanup phase, ONLY when the main deploy failed
+    /// (prior step exception OR non-zero main-script exit code).</summary>
+    public const string DeployFailed = "DeployFailed";
 }

--- a/src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs
@@ -1,0 +1,124 @@
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Execution;
+using Squid.Calamari.Pipeline;
+using Squid.Calamari.Scripting;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.Conventions;
+
+/// <summary>
+/// Convention hook that fires ONLY when the main deploy path failed.
+/// Operator drops a <c>DeployFailed.sh</c> in the package; on a failed
+/// deploy the step runs it before cleanup, so the script can do partial
+/// teardown / send alerts / capture forensic data while temp files are
+/// still on disk.
+///
+/// <para><b>Why a separate class vs reusing <see cref="ConventionScriptStep"/></b>:
+/// the runtime conditions are different in two ways:
+/// <list type="bullet">
+///   <item>Lives in the <b>cleanup phase</b> — implements
+///         <see cref="IAlwaysRunExecutionStep{TContext}"/> so it runs
+///         even when an upstream step threw. PreDeploy / PostDeploy live
+///         in the normal phase and are skipped on prior failure.</item>
+///   <item>Predicate is "did the deploy fail?" not "does this file exist?".
+///         Combines <see cref="IFailureAwareExecutionContext.ExecutionFailed"/>
+///         (any prior step threw) OR a non-zero
+///         <see cref="ScriptExecutionResult.ExitCode"/> (main script ran but
+///         returned an error code without throwing).</item>
+/// </list></para>
+///
+/// <para><b>Re-failure semantics</b>: if <c>DeployFailed.sh</c> itself
+/// exits non-zero, the step logs but does NOT throw. The pipeline already
+/// has a captured execution failure from the original cause; throwing
+/// again would either replace the operator's actual cause with the
+/// failure-handler's noise (worse forensics) or AggregateException-stack
+/// both, which is hard to debug. Octopus has the same semantics.</para>
+/// </summary>
+internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunScriptCommandContext>
+{
+    private readonly IScriptEngine _scriptEngine;
+
+    public DeployFailedConventionStep(IScriptEngine scriptEngine)
+    {
+        _scriptEngine = scriptEngine ?? throw new ArgumentNullException(nameof(scriptEngine));
+    }
+
+    /// <summary>Convention name — pinned in test. Operators ship a file
+    /// with exactly this stem in their package.</summary>
+    public string ConventionName => ConventionScriptNames.DeployFailed;
+
+    public bool IsEnabled(RunScriptCommandContext context)
+    {
+        if (string.IsNullOrEmpty(context.WorkingDirectory)) return false;
+        if (context.Variables is null) return false;
+
+        // Predicate: at least one of (a) something threw before cleanup
+        // phase, or (b) main script ran but exit code is non-zero.
+        var hadFailure = context.ExecutionFailed
+                         || (context.ScriptResult is not null && context.ScriptResult.ExitCode != 0);
+        if (!hadFailure) return false;
+
+        var scriptPath = Path.Combine(context.WorkingDirectory, $"{ConventionName}.sh");
+        return File.Exists(scriptPath);
+    }
+
+    public async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrEmpty(context.WorkingDirectory))
+            throw new InvalidOperationException(
+                $"{ConventionName}: working directory has not been initialized.");
+        if (context.Variables is null)
+            throw new InvalidOperationException(
+                $"{ConventionName}: variables have not been loaded.");
+
+        var scriptPath = Path.Combine(context.WorkingDirectory, $"{ConventionName}.sh");
+
+        var originalScript = File.ReadAllText(scriptPath);
+        var preamble = VariableBootstrapper.GeneratePreamble(context.Variables);
+        var bootstrappedScript = preamble + originalScript;
+
+        var bootstrappedPath = Path.Combine(
+            context.WorkingDirectory,
+            $".squid-{ConventionName.ToLowerInvariant()}-{Guid.NewGuid():N}.sh");
+        File.WriteAllText(bootstrappedPath, bootstrappedScript);
+        context.TemporaryFiles.Add(bootstrappedPath);
+
+        var failureSignal = context.ExecutionFailed
+            ? "prior step exception"
+            : $"main script exit code {context.ScriptResult?.ExitCode}";
+        Console.WriteLine($"{ConventionName}: deploy failed ({failureSignal}); running '{scriptPath}'.");
+
+        var outputProcessor = new ScriptOutputProcessor();
+        var result = await _scriptEngine.ExecuteAsync(
+                new ScriptExecutionRequest
+                {
+                    ScriptPath = bootstrappedPath,
+                    WorkingDirectory = context.WorkingDirectory,
+                    Syntax = ScriptSyntax.Bash,
+                    OutputProcessor = outputProcessor
+                },
+                ct)
+            .ConfigureAwait(false);
+
+        // Merge output vars (same as normal conventions) so downstream
+        // cleanup steps / log analytics can read them.
+        foreach (var output in result.OutputVariables)
+            context.Variables.Set(output.Name, output.Value);
+
+        if (result.ExitCode != 0)
+        {
+            // Deliberately do NOT throw — the pipeline already has the
+            // original failure captured; replacing it with the handler's
+            // non-zero exit would obscure forensic data. Log loudly so the
+            // operator can grep the deploy log for it.
+            Console.Error.WriteLine(
+                $"::warning::{ConventionName}: hook exited with code {result.ExitCode}. " +
+                "Original deploy failure is preserved.");
+            return;
+        }
+
+        Console.WriteLine($"{ConventionName}: completed successfully.");
+    }
+}

--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -82,6 +82,11 @@ public class RunScriptCommand
             // registration with a service mesh, etc.
             new ConventionScriptStep(ConventionScriptNames.PostDeploy, scriptEngine),
             new BuildRunScriptCommandResultStep(),
+            // DeployFailed convention — IAlwaysRun (cleanup phase). Fires only
+            // when an upstream step threw OR the main script returned non-zero.
+            // Listed BEFORE the temp-file cleanup so the failure script can
+            // still see the bootstrapped + extracted files for forensic capture.
+            new DeployFailedConventionStep(scriptEngine),
             new CleanupTemporaryFilesStep<RunScriptCommandContext>()
         ]);
     }

--- a/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
@@ -5,7 +5,7 @@ using Squid.Calamari.Variables;
 
 namespace Squid.Calamari.Commands;
 
-internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVariableLoadingExecutionContext, ITemporaryFileTrackingExecutionContext
+internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVariableLoadingExecutionContext, ITemporaryFileTrackingExecutionContext, IFailureAwareExecutionContext
 {
     public required string ScriptPath { get; init; }
 
@@ -28,6 +28,13 @@ internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVar
     public CommandExecutionResult? CommandResult { get; set; }
 
     public ICollection<string> TemporaryFiles { get; } = new List<string>();
+
+    /// <summary>
+    /// Set to <c>true</c> by <see cref="ExecutionPipeline{TContext}"/> when
+    /// any non-cleanup step raised. Consumed by the DeployFailed convention
+    /// hook (G1.5 followup) to fire only on failure paths. Default false.
+    /// </summary>
+    public bool ExecutionFailed { get; set; }
 }
 
 internal sealed class WriteBootstrappedBashScriptStep : ExecutionStep<RunScriptCommandContext>

--- a/src/Squid.Calamari/Pipeline/ExecutionPipeline.cs
+++ b/src/Squid.Calamari/Pipeline/ExecutionPipeline.cs
@@ -32,6 +32,13 @@ public sealed class ExecutionPipeline<TContext>
         }
         catch (Exception ex)
         {
+            // Surface the failure to opt-in failure-aware contexts so cleanup-
+            // phase steps (DeployFailed convention etc.) can fire conditionally.
+            // SourceException is still preserved for re-throw at end of pipeline —
+            // this flag is an additional signal, not a substitution.
+            if (context is IFailureAwareExecutionContext failureAware)
+                failureAware.ExecutionFailed = true;
+
             executionFailure = ExceptionDispatchInfo.Capture(ex);
         }
 

--- a/src/Squid.Calamari/Pipeline/IFailureAwareExecutionContext.cs
+++ b/src/Squid.Calamari/Pipeline/IFailureAwareExecutionContext.cs
@@ -1,0 +1,35 @@
+namespace Squid.Calamari.Pipeline;
+
+/// <summary>
+/// Opt-in marker for execution contexts whose <c>IAlwaysRunExecutionStep</c>
+/// cleanup-phase steps need to know whether the main execution phase failed.
+///
+/// <para><b>Canonical use case</b>: the DeployFailed convention hook —
+/// runs a <c>DeployFailed.sh</c> script ONLY when the operator's main
+/// deploy raised (exception in any pre-cleanup step). Without this flag,
+/// an <c>IAlwaysRunExecutionStep</c> can't distinguish "main script
+/// succeeded, just doing cleanup" from "main script crashed, run my
+/// failure-handler".</para>
+///
+/// <para><b>Contract</b>: <see cref="ExecutionPipeline{TContext}"/> sets
+/// the flag to <c>true</c> in its catch block (the SourceException is
+/// preserved for re-throw at end of pipeline as before; the flag is just
+/// an additional signal for cleanup steps). Contexts that don't implement
+/// this interface get the existing behaviour — cleanup steps run
+/// unconditionally as before.</para>
+///
+/// <para><b>Why an opt-in interface vs hard-coded property on every
+/// context</b>: avoids forcing the property into the existing
+/// IPathBasedExecutionContext / IVariableLoadingExecutionContext etc.
+/// surfaces. Same lightweight extension pattern as those interfaces.
+/// Pinned by <c>ExecutionPipeline_SetsFailureFlag_OnException</c>.</para>
+/// </summary>
+public interface IFailureAwareExecutionContext
+{
+    /// <summary>
+    /// <c>true</c> when at least one non-cleanup pipeline step raised an
+    /// exception. Set by <see cref="ExecutionPipeline{TContext}"/>;
+    /// cleanup-phase steps read this to decide whether to fire.
+    /// </summary>
+    bool ExecutionFailed { get; set; }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/DeployFailedConventionStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/DeployFailedConventionStepTests.cs
@@ -1,0 +1,209 @@
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Conventions;
+using Squid.Calamari.Scripting;
+using Squid.Calamari.ServiceMessages;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Conventions;
+
+/// <summary>
+/// Tests for <see cref="DeployFailedConventionStep"/>. Pins the "fires only
+/// on failure" predicate + the bootstrap shape (matches PreDeploy / PostDeploy)
+/// + the "do not re-throw if the hook itself fails" semantic.
+/// </summary>
+public sealed class DeployFailedConventionStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public DeployFailedConventionStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"depfail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── Wire-contract pinning ───────────────────────────────────────────────
+
+    [Fact]
+    public void ConventionScriptNames_DeployFailed_PinnedLiteral()
+    {
+        // Operators ship files matching this exact stem. Rename = silent
+        // no-op for every existing DeployFailed.sh in the wild.
+        ConventionScriptNames.DeployFailed.ShouldBe("DeployFailed");
+    }
+
+    [Fact]
+    public void StepConventionName_MatchesPublicConstant()
+    {
+        // Step's exposed property MUST stay in sync with the public const.
+        new DeployFailedConventionStep(new StubScriptEngine()).ConventionName
+            .ShouldBe(ConventionScriptNames.DeployFailed);
+    }
+
+    // ── Predicate truth table ───────────────────────────────────────────────
+
+    [Fact]
+    public void IsEnabled_NoScript_NoFailure_ReturnsFalse()
+    {
+        // The "happy path nobody ships DeployFailed.sh" case — by far the
+        // most common operator state. MUST short-circuit cleanly.
+        var ctx = BuildContext(executionFailed: false, exitCode: null);
+        new DeployFailedConventionStep(new StubScriptEngine()).IsEnabled(ctx).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_ScriptPresent_NoFailure_ReturnsFalse()
+    {
+        // Critical: success deploy with DeployFailed.sh shipped MUST NOT fire it.
+        // If this regresses, every successful deploy runs the failure handler.
+        WriteConventionScript("echo failure-handler-ran");
+        var ctx = BuildContext(executionFailed: false, exitCode: 0);
+        new DeployFailedConventionStep(new StubScriptEngine()).IsEnabled(ctx).ShouldBeFalse(
+            customMessage: "DeployFailed MUST NOT fire on a successful deploy. " +
+                           "If you see this fail, the predicate confused 'script exists' with 'should run'.");
+    }
+
+    [Fact]
+    public void IsEnabled_ScriptPresent_ExecutionFailedFlagSet_ReturnsTrue()
+    {
+        WriteConventionScript("echo handler");
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+        new DeployFailedConventionStep(new StubScriptEngine()).IsEnabled(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsEnabled_ScriptPresent_NonZeroExitCode_ReturnsTrue()
+    {
+        // The other failure signal: main script ran but returned non-zero.
+        // No exception was raised (ExecuteScriptWithEngineStep doesn't throw
+        // on non-zero exit), but the deploy still failed.
+        WriteConventionScript("echo handler");
+        var ctx = BuildContext(executionFailed: false, exitCode: 7);
+        new DeployFailedConventionStep(new StubScriptEngine()).IsEnabled(ctx).ShouldBeTrue(
+            customMessage: "DeployFailed MUST fire on non-zero main-script exit code even when no exception was raised.");
+    }
+
+    [Fact]
+    public void IsEnabled_FailureFlagSet_ButNoScriptFile_ReturnsFalse()
+    {
+        // Operator hasn't shipped a DeployFailed.sh — nothing to run.
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+        new DeployFailedConventionStep(new StubScriptEngine()).IsEnabled(ctx).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_WorkingDirNull_DoesNotCrash_ReturnsFalse()
+    {
+        // Defensive: if some prior pipeline step didn't initialise WorkingDir,
+        // the cleanup-phase step MUST NOT crash trying to probe a null path.
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+        ctx.WorkingDirectory = null;
+        new DeployFailedConventionStep(new StubScriptEngine()).IsEnabled(ctx).ShouldBeFalse();
+    }
+
+    // ── Execute happy path ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_RunsBootstrappedScript_WithSamePreambleShape()
+    {
+        // Same bootstrap shape as PreDeploy/PostDeploy: preamble + content,
+        // written to a temp file, fed to the engine, tracked for cleanup.
+        WriteConventionScript("echo deploy failed");
+        var engine = new StubScriptEngine(exitCode: 0);
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+        ctx.Variables!.Set("FailureContext", "rolling back");
+
+        await new DeployFailedConventionStep(engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        engine.Captured.ShouldNotBeNull();
+        engine.Captured!.ScriptPath.ShouldNotBe(Path.Combine(_workDir, "DeployFailed.sh"));
+        var bootstrapped = File.ReadAllText(engine.Captured.ScriptPath);
+        bootstrapped.ShouldContain("export FailureContext=",
+            customMessage: "DeployFailed MUST see the same variable scope as the main script — operators rely on it to read deploy state.");
+        bootstrapped.ShouldContain("echo deploy failed");
+
+        ctx.TemporaryFiles.ShouldContain(engine.Captured.ScriptPath,
+            customMessage: "Bootstrapped DeployFailed file MUST be cleaned up after the deploy.");
+    }
+
+    [Fact]
+    public async Task Execute_OutputVariables_MergeBackIntoContextVariableSet()
+    {
+        // DeployFailed can compute values that downstream cleanup steps /
+        // log analytics need (e.g. RollbackTraceId). Output vars MUST flow
+        // back, same contract as ConventionScriptStep + ExecuteScriptWithEngine.
+        WriteConventionScript("echo x");
+
+        var engine = new StubScriptEngine(
+            exitCode: 0,
+            outputVariables: new[] { new OutputVariable("RollbackTraceId", "abc-123", IsSensitive: false) });
+
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+
+        await new DeployFailedConventionStep(engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.Variables!.Get("RollbackTraceId").ShouldBe("abc-123");
+    }
+
+    // ── Re-failure semantics ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_HookItselfFails_DoesNotThrow_PreservesOriginalCause()
+    {
+        // CRITICAL: if DeployFailed.sh itself exits non-zero, the step MUST
+        // log + swallow. Throwing again would either replace the original
+        // execution failure (lost forensics) or stack into an
+        // AggregateException that's harder to debug.
+        WriteConventionScript("exit 1");
+        var engine = new StubScriptEngine(exitCode: 5);
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+
+        await Should.NotThrowAsync(() =>
+            new DeployFailedConventionStep(engine).ExecuteAsync(ctx, CancellationToken.None));
+    }
+
+    // ── Defensive ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullScriptEngine_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new DeployFailedConventionStep(null!));
+    }
+
+    [Fact]
+    public async Task Execute_WorkingDirNullAtRuntime_ThrowsClearly()
+    {
+        // IsEnabled would have caught this, but defensive against direct
+        // ExecuteAsync invocations (in tests, in future pipeline reshuffles).
+        WriteConventionScript("x");
+        var ctx = BuildContext(executionFailed: true, exitCode: null);
+        ctx.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new DeployFailedConventionStep(new StubScriptEngine()).ExecuteAsync(ctx, CancellationToken.None));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private void WriteConventionScript(string contents)
+        => File.WriteAllText(Path.Combine(_workDir, "DeployFailed.sh"), contents);
+
+    private RunScriptCommandContext BuildContext(bool executionFailed, int? exitCode)
+    {
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = new VariableSet(),
+            ExecutionFailed = executionFailed,
+            ScriptResult = exitCode is null ? null : new ScriptExecutionResult(exitCode.Value)
+        };
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Pipeline/FailureAwarePipelineTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Pipeline/FailureAwarePipelineTests.cs
@@ -1,0 +1,127 @@
+using Shouldly;
+using Squid.Calamari.Pipeline;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Pipeline;
+
+/// <summary>
+/// Pins the contract between <see cref="ExecutionPipeline{TContext}"/> and
+/// <see cref="IFailureAwareExecutionContext"/>: when any non-cleanup step
+/// throws, the pipeline sets <c>ExecutionFailed = true</c> on the context
+/// before propagating the exception. Cleanup-phase steps then read this to
+/// decide whether to fire.
+/// </summary>
+public sealed class FailureAwarePipelineTests
+{
+    [Fact]
+    public async Task NormalRun_NoExceptions_FlagStaysFalse()
+    {
+        var ctx = new FlagContext();
+        var pipeline = new ExecutionPipeline<FlagContext>(new IExecutionStep<FlagContext>[]
+        {
+            new NoopStep()
+        });
+
+        await pipeline.ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.ExecutionFailed.ShouldBeFalse(
+            customMessage: "Normal pipeline run with no exceptions MUST leave ExecutionFailed=false.");
+    }
+
+    [Fact]
+    public async Task NormalStepThrows_FlagSetBeforeRethrow()
+    {
+        var ctx = new FlagContext();
+        var pipeline = new ExecutionPipeline<FlagContext>(new IExecutionStep<FlagContext>[]
+        {
+            new ThrowingStep("kaboom")
+        });
+
+        // Pipeline rethrows the captured exception — that's expected.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            pipeline.ExecuteAsync(ctx, CancellationToken.None));
+        ex.Message.ShouldBe("kaboom");
+
+        ctx.ExecutionFailed.ShouldBeTrue(
+            customMessage: "An exception in a normal-phase step MUST set ExecutionFailed=true so " +
+                           "IAlwaysRunExecutionStep implementations can read it during cleanup.");
+    }
+
+    [Fact]
+    public async Task AlwaysRunStep_ReadsFlag_RunsAfterFailingStep()
+    {
+        // Combined contract test — failure-aware cleanup step sees the flag.
+        var ctx = new FlagContext();
+        var observer = new FlagObserverAlwaysRun();
+        var pipeline = new ExecutionPipeline<FlagContext>(new IExecutionStep<FlagContext>[]
+        {
+            new ThrowingStep("upstream failure"),
+            observer
+        });
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            pipeline.ExecuteAsync(ctx, CancellationToken.None));
+
+        observer.ObservedFlagWhenRunning.ShouldBeTrue(
+            customMessage: "Cleanup-phase IAlwaysRun step MUST observe ExecutionFailed=true after an " +
+                           "upstream normal-phase step threw. Without this signal, DeployFailed-style " +
+                           "conditional cleanup hooks can't tell success from failure.");
+    }
+
+    [Fact]
+    public async Task ContextWithoutFailureAware_NotAffected_BackCompat()
+    {
+        // The interface is opt-in; legacy contexts that don't implement it
+        // MUST keep their existing behaviour (pipeline doesn't blow up
+        // trying to set a flag on a context that doesn't expose one).
+        var ctx = new LegacyContext();
+        var pipeline = new ExecutionPipeline<LegacyContext>(new IExecutionStep<LegacyContext>[]
+        {
+            new LegacyThrowingStep()
+        });
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            pipeline.ExecuteAsync(ctx, CancellationToken.None));
+
+        // Nothing else to assert — the lack of a runtime crash IS the test.
+    }
+
+    // ── Test stubs ──────────────────────────────────────────────────────────
+
+    private sealed class FlagContext : IFailureAwareExecutionContext
+    {
+        public bool ExecutionFailed { get; set; }
+    }
+
+    private sealed class LegacyContext { /* no IFailureAware */ }
+
+    private sealed class NoopStep : ExecutionStep<FlagContext>
+    {
+        public override Task ExecuteAsync(FlagContext context, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingStep : ExecutionStep<FlagContext>
+    {
+        private readonly string _message;
+        public ThrowingStep(string message) { _message = message; }
+        public override Task ExecuteAsync(FlagContext context, CancellationToken ct)
+            => throw new InvalidOperationException(_message);
+    }
+
+    private sealed class LegacyThrowingStep : ExecutionStep<LegacyContext>
+    {
+        public override Task ExecuteAsync(LegacyContext context, CancellationToken ct)
+            => throw new InvalidOperationException("legacy boom");
+    }
+
+    private sealed class FlagObserverAlwaysRun : IAlwaysRunExecutionStep<FlagContext>
+    {
+        public bool ObservedFlagWhenRunning { get; private set; }
+        public bool IsEnabled(FlagContext context) => true;
+        public Task ExecuteAsync(FlagContext context, CancellationToken ct)
+        {
+            ObservedFlagWhenRunning = context.ExecutionFailed;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the deferred convention from G1.5 (#370). Operator drops `DeployFailed.sh` in the package; Calamari runs it ONLY when the deploy actually failed.

## What's in the box

| Layer | File |
|---|---|
| New opt-in interface | `src/Squid.Calamari/Pipeline/IFailureAwareExecutionContext.cs` |
| Pipeline sets the flag | `src/Squid.Calamari/Pipeline/ExecutionPipeline.cs` (catch block) |
| Context implements interface | `src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs` |
| Step | `src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs` (new) |
| Wire literal | `ConventionScriptNames.DeployFailed = "DeployFailed"` |
| Pipeline wiring | `RunScriptCommand.cs` (cleanup phase, before CleanupTemporaryFiles) |
| Tests | `FailureAwarePipelineTests.cs` (4) + `DeployFailedConventionStepTests.cs` (13) |

## Predicate truth table

| Script exists? | ExecutionFailed flag | Main exit code | Fires? |
|---|---|---|---|
| No | — | — | No |
| Yes | false | 0 / null | **No** (pinned) |
| Yes | true | — | Yes |
| Yes | false | non-zero | Yes |

## Key design choices

- **No re-throw on hook failure** — if `DeployFailed.sh` itself fails, log structured warning + swallow. Original execution failure stays the canonical cause for forensics. Matches Octopus.
- **Output vars merge** into `context.Variables` — symmetric with PreDeploy/PostDeploy/main contract.
- **Cleanup-phase order** — runs BEFORE `CleanupTemporaryFilesStep`, so the script can read the extracted+bootstrapped temp files.
- **Opt-in interface pattern** — non-implementing contexts unaffected. Same lightweight extension as `IPathBasedExecutionContext`.

## Test plan

- [x] Squid.Calamari.Tests: 335/335 (was 318; +17 new)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Solution build: 0 errors
- [x] Wire literal pinned: `ConventionScriptNames.DeployFailed = "DeployFailed"`
- [x] Pre-merge audit GREEN on 6/6 invariants
- [ ] Staging: real `.nupkg` with `DeployFailed.sh` + intentionally-failing main script

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing wire literals | Unchanged |
| Standalone-script deploys (no DeployFailed.sh) | Zero impact — IsEnabled returns false |
| Successful deploys with DeployFailed.sh shipped | Zero impact — IsEnabled returns false (CRITICAL — pinned by `IsEnabled_ScriptPresent_NoFailure_ReturnsFalse`) |
| ExecutionPipeline contract with non-FailureAware contexts | Unchanged (pinned by `ContextWithoutFailureAware_NotAffected_BackCompat`) |
| SquidWeb | Untouched — file-based convention, no UI wire literal |