### PR TITLE
Multi-format package extraction (.tar, .tar.gz, .tgz)

### DIFF
--- a/src/Squid.Calamari/Commands/Package/ArchiveSafety.cs
+++ b/src/Squid.Calamari/Commands/Package/ArchiveSafety.cs
@@ -1,0 +1,115 @@
+using Squid.Calamari.Commands.Common;
+
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// Shared hostile-archive defence primitives used by every
+/// <see cref="IPackageExtractor"/>. Each format-specific extractor (zip /
+/// tar / tar.gz / future 7z / wim) hits the SAME safety story, so the
+/// rules live here once.
+///
+/// <para>Three independent defences a malicious archive must clear:
+/// <list type="number">
+///   <item><b>Zip-slip / absolute path</b>: entries with <c>..</c> escaping
+///         the destination, or absolute paths like <c>/etc/passwd</c> or
+///         <c>C:\Windows\...</c>. Resolved to canonical real path; rejected
+///         if not inside the destination. Per-format dispatch never sees
+///         the original entry name beyond the safety check.</item>
+///   <item><b>Per-entry size cap</b>: reuses the operator-tunable
+///         <see cref="EncodingPreservingFileIO.ResolveMaxFileSizeMB"/>
+///         (default 50 MB, env-var override). Lone huge file → reject.</item>
+///   <item><b>Total extracted size cap</b>: 10× per-entry. Catches zip-bomb
+///         pattern (many small entries summing to GB+).</item>
+///   <item><b>Fail-closed on any violation</b>: the whole extraction aborts.
+///         Partial extract would leave the rewriter pipeline operating on
+///         an inconsistent file-set — worse than failing fast.</item>
+/// </list></para>
+///
+/// <para><b>Why these primitives — not <c>ZipFile.ExtractToDirectory</c></b>:
+/// .NET's built-in extractor has a path-traversal check (since .NET Core 2.1)
+/// but doesn't honour our per-entry / total size caps, doesn't fail-closed
+/// uniformly across archive types, and doesn't expose the structured failure
+/// reason operators see in deploy logs.</para>
+/// </summary>
+internal static class ArchiveSafety
+{
+    /// <summary>10× per-entry. Picked to allow legitimate "big config +
+    /// many small files" packages while catching zip-bomb ratios that
+    /// hit 1000×+ in practice.</summary>
+    public const int TotalSizeCapMultiplier = 10;
+
+    /// <summary>Resolve per-entry cap from the shared env-var pathway.
+    /// Recomputed per call (no caching) — operators editing the env var
+    /// between deploys see the new value without restarting the agent.</summary>
+    public static long PerEntryCapBytes => EncodingPreservingFileIO.ResolveMaxFileSizeMB() * 1024L * 1024L;
+
+    /// <summary>10× per-entry. Tracked so log messages can name the
+    /// exact limit operators have to raise.</summary>
+    public static long TotalCapBytes => PerEntryCapBytes * TotalSizeCapMultiplier;
+
+    /// <summary>
+    /// Resolve an archive entry name to its absolute on-disk path AND verify
+    /// it stays inside <paramref name="canonicalDest"/>. Returns
+    /// <see langword="null"/> when the entry would escape (zip-slip, absolute
+    /// path, drive-letter, Windows UNC). Caller treats null as "abort this
+    /// extraction".
+    ///
+    /// <para><paramref name="canonicalDest"/> MUST already end with the
+    /// platform directory separator — caller guarantees this via
+    /// <see cref="EnsureTrailingSeparator"/>.</para>
+    /// </summary>
+    public static string? ResolveSafeEntryPath(string entryName, string canonicalDest)
+    {
+        // Normalise: archive entries (zip, tar) use forward slashes; on
+        // Windows the on-disk path uses backslash.
+        var normalised = entryName.Replace('/', Path.DirectorySeparatorChar);
+
+        // Reject absolute (`/`, `C:\`, UNC, drive-relative).
+        if (Path.IsPathRooted(normalised)) return null;
+
+        var combined = Path.Combine(canonicalDest, normalised);
+        var resolved = Path.GetFullPath(combined);
+
+        // Trailing-separator on canonicalDest prevents `/tmp/work-evil` from
+        // matching `/tmp/work` (prefix scan would otherwise allow alias attack).
+        // Case-insensitive matches Windows + macOS default; over-approximates
+        // on Linux ext4 (still safe — only widens rejection).
+        if (!resolved.StartsWith(canonicalDest, StringComparison.OrdinalIgnoreCase)) return null;
+
+        return resolved;
+    }
+
+    /// <summary>Canonicalise + add trailing separator so the prefix scan in
+    /// <see cref="ResolveSafeEntryPath"/> is segment-aligned. Idempotent.</summary>
+    public static string EnsureTrailingSeparator(string directory)
+    {
+        var canonical = Path.GetFullPath(directory);
+        return canonical.EndsWith(Path.DirectorySeparatorChar)
+            ? canonical
+            : canonical + Path.DirectorySeparatorChar;
+    }
+
+    /// <summary>Per-entry cap check. Returns a structured failure when
+    /// breached, naming the entry + size + cap + env-var to flip.</summary>
+    public static ExtractResult? CheckPerEntryCap(string entryName, long entryLength)
+    {
+        var cap = PerEntryCapBytes;
+        if (entryLength <= cap) return null;
+
+        return ExtractResult.Failure(
+            $"Entry '{entryName}' is {entryLength:N0} bytes, exceeds per-entry limit of {cap:N0} bytes. " +
+            $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+    }
+
+    /// <summary>Running-total cap check. Returns a structured failure when
+    /// breached, naming the entry at which the bomb was caught.</summary>
+    public static ExtractResult? CheckTotalCap(string entryName, long projectedTotal)
+    {
+        var cap = TotalCapBytes;
+        if (projectedTotal <= cap) return null;
+
+        return ExtractResult.Failure(
+            $"Total extracted size would exceed {cap:N0} bytes (suspected zip-bomb). " +
+            $"Aborted at entry '{entryName}'. Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+    }
+}

--- a/src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs
+++ b/src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs
@@ -45,12 +45,6 @@ public static class PackageVariableNames
 /// </summary>
 internal sealed class ExtractPackageStep : ExecutionStep<RunScriptCommandContext>
 {
-    /// <summary>Accepted archive extensions. Lower-cased for comparison.
-    /// nupkg is just a zip with a different filename suffix — same engine
-    /// handles both.</summary>
-    private static readonly HashSet<string> AllowedExtensions =
-        new(StringComparer.OrdinalIgnoreCase) { ".nupkg", ".zip" };
-
     public override bool IsEnabled(RunScriptCommandContext context)
     {
         if (context.Variables is null) return false;
@@ -73,13 +67,18 @@ internal sealed class ExtractPackageStep : ExecutionStep<RunScriptCommandContext
 
         var archivePath = context.Variables.Get(PackageVariableNames.OriginalPath)!.Trim();
 
-        var ext = Path.GetExtension(archivePath);
-        if (!AllowedExtensions.Contains(ext))
+        // PR-2: multi-format dispatch via the registry. .zip / .nupkg / .tar
+        // / .tar.gz / .tgz all flow through here, each format-specific
+        // extractor implementing the same IPackageExtractor contract +
+        // sharing the ArchiveSafety primitives.
+        var extractor = PackageExtractorRegistry.Resolve(archivePath);
+        if (extractor is null)
             throw new InvalidOperationException(
-                $"ExtractPackageStep: package '{archivePath}' has unsupported extension '{ext}'. " +
-                $"Supported: {string.Join(", ", AllowedExtensions)}. Skipping the extract step requires unsetting {PackageVariableNames.OriginalPath}.");
+                $"ExtractPackageStep: package '{archivePath}' has unsupported extension. " +
+                $"Supported: {string.Join(", ", PackageExtractorRegistry.SupportedExtensions)}. " +
+                $"Skipping the extract step requires unsetting {PackageVariableNames.OriginalPath}.");
 
-        var result = ZipExtractor.Extract(archivePath, context.WorkingDirectory);
+        var result = extractor.Extract(archivePath, context.WorkingDirectory);
 
         if (!result.Succeeded)
             throw new InvalidOperationException(

--- a/src/Squid.Calamari/Commands/Package/IPackageExtractor.cs
+++ b/src/Squid.Calamari/Commands/Package/IPackageExtractor.cs
@@ -1,0 +1,33 @@
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// Per-format archive extractor. The <see cref="ExtractPackageStep"/>
+/// resolves the right extractor by filename extension via
+/// <see cref="PackageExtractorRegistry"/>. Each implementation handles
+/// one archive format (zip/nupkg, tar, tar.gz, …) and shares the same
+/// hostile-archive defence story (zip-slip + size caps + fail-closed).
+///
+/// <para><b>Why per-format classes vs one big switch</b>: each format has
+/// a meaningfully different parse / stream / metadata model. Tar entries
+/// carry POSIX file modes that need separate handling from zip's external
+/// attributes; tar.gz needs an outer GZipStream wrapper around the tar
+/// reader; .7z needs an external library. Keeping them isolated lets
+/// each one own its own test surface + safety review.</para>
+/// </summary>
+internal interface IPackageExtractor
+{
+    /// <summary>
+    /// True if this extractor handles the archive's extension. Match by
+    /// suffix — multi-part extensions like <c>.tar.gz</c> are tried before
+    /// single-part <c>.gz</c> so dispatch lands on the most specific match.
+    /// </summary>
+    bool CanHandle(string archivePath);
+
+    /// <summary>
+    /// Extract <paramref name="archivePath"/> into <paramref name="destinationDir"/>.
+    /// Returns a structured result — does not throw for predictable failure
+    /// modes (zip-slip / oversize / malformed). Caller treats failure as
+    /// a halt-the-deploy signal.
+    /// </summary>
+    ExtractResult Extract(string archivePath, string destinationDir);
+}

--- a/src/Squid.Calamari/Commands/Package/PackageExtractorRegistry.cs
+++ b/src/Squid.Calamari/Commands/Package/PackageExtractorRegistry.cs
@@ -1,0 +1,46 @@
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// Multi-format archive dispatch (PR-2). Iterates registered
+/// <see cref="IPackageExtractor"/>s and returns the first one that
+/// <see cref="IPackageExtractor.CanHandle"/>s the archive — by filename
+/// extension. Order matters for multi-part extensions:
+/// <list type="number">
+///   <item><see cref="TarGzPackageExtractor"/> first — needs to match
+///         <c>.tar.gz</c> / <c>.tgz</c> compound suffix.</item>
+///   <item><see cref="ZipPackageExtractor"/> — <c>.zip</c> / <c>.nupkg</c>.</item>
+///   <item><see cref="TarPackageExtractor"/> — plain <c>.tar</c>.</item>
+///   <item><see cref="SevenZipUnsupportedExtractor"/> — recognised but
+///         deliberately failing extractor for <c>.7z</c> (deferred dep).</item>
+/// </list>
+///
+/// <para>If none match, <see cref="Resolve"/> returns null — caller
+/// (<see cref="ExtractPackageStep"/>) treats this as "unsupported
+/// extension" and throws with operator-actionable guidance.</para>
+/// </summary>
+internal static class PackageExtractorRegistry
+{
+    /// <summary>Ordered list — compound suffixes BEFORE single-part suffixes.</summary>
+    private static readonly IReadOnlyList<IPackageExtractor> Extractors = new IPackageExtractor[]
+    {
+        new TarGzPackageExtractor(),
+        new ZipPackageExtractor(),
+        new TarPackageExtractor(),
+        new SevenZipUnsupportedExtractor()
+    };
+
+    /// <summary>List of file-extension-style strings the dispatcher
+    /// recognises. Used in error messages so operators get a complete
+    /// "supported formats: …" list when they hit an unsupported extension.</summary>
+    public static IReadOnlyList<string> SupportedExtensions { get; } = new[]
+    {
+        ".zip",
+        ".nupkg",
+        ".tar",
+        ".tar.gz",
+        ".tgz"
+    };
+
+    public static IPackageExtractor? Resolve(string archivePath)
+        => Extractors.FirstOrDefault(e => e.CanHandle(archivePath));
+}

--- a/src/Squid.Calamari/Commands/Package/TarPackageExtractor.cs
+++ b/src/Squid.Calamari/Commands/Package/TarPackageExtractor.cs
@@ -1,0 +1,198 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// PR-2 — POSIX tar archive extractor. Handles plain <c>.tar</c> via
+/// <c>System.Formats.Tar.TarReader</c> (.NET 7+, no external dep). Same
+/// hostile-archive defence as <see cref="ZipPackageExtractor"/>: zip-slip
+/// rejection, per-entry + total-archive size caps, fail-closed.
+///
+/// <para><b>Symlinks &amp; device files</b>: tar can encode them via the
+/// entry's <see cref="TarEntryType"/>. We extract only regular files +
+/// directories; <c>SymbolicLink</c>, <c>HardLink</c>, <c>BlockDevice</c>,
+/// <c>CharacterDevice</c>, <c>Fifo</c> are SKIPPED with a structured
+/// console warning. Letting symlinks through would let a malicious tar
+/// plant a symlink pointing outside the working dir (the
+/// <see cref="Substitution.GlobMatcher"/> symlink sandbox catches OS-level
+/// follow attempts, but defence-in-depth says reject at extract time too).</para>
+///
+/// <para><b>Long path / PAX extension</b>: <c>TarReader</c> handles
+/// PAX/POSIX-1.2001 extended headers natively. Long paths that wouldn't
+/// fit the v7 100-byte name field still flow through correctly.</para>
+/// </summary>
+internal sealed class TarPackageExtractor : IPackageExtractor
+{
+    public bool CanHandle(string archivePath)
+        => string.Equals(Path.GetExtension(archivePath), ".tar", StringComparison.OrdinalIgnoreCase);
+
+    public ExtractResult Extract(string archivePath, string destinationDir)
+    {
+        if (!File.Exists(archivePath))
+            return ExtractResult.Failure($"Archive '{archivePath}' does not exist.");
+
+        Directory.CreateDirectory(destinationDir);
+        var canonicalDest = ArchiveSafety.EnsureTrailingSeparator(destinationDir);
+
+        try
+        {
+            using var stream = File.OpenRead(archivePath);
+            return ExtractTarStream(stream, canonicalDest, archivePath);
+        }
+        catch (IOException ex)
+        {
+            return ExtractResult.Failure($"Failed to read tar '{archivePath}': {ex.GetType().Name}: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ExtractResult.Failure($"Permission denied extracting '{archivePath}': {ex.Message}");
+        }
+    }
+
+    /// <summary>Stream-driven extraction loop — shared between plain .tar
+    /// and the tar.gz wrapper (<see cref="TarGzPackageExtractor"/>) which
+    /// reuses this code by passing a <c>GZipStream</c> over the archive.</summary>
+    internal static ExtractResult ExtractTarStream(Stream tarStream, string canonicalDest, string archiveLabelForLogs)
+    {
+        int filesExtracted = 0;
+        long totalBytesWritten = 0;
+
+        try
+        {
+            using var reader = new TarReader(tarStream, leaveOpen: true);
+
+            while (reader.GetNextEntry() is { } entry)
+            {
+                // Skip symlinks / hardlinks / devices — see class docs.
+                if (entry.EntryType is TarEntryType.SymbolicLink
+                                    or TarEntryType.HardLink
+                                    or TarEntryType.BlockDevice
+                                    or TarEntryType.CharacterDevice
+                                    or TarEntryType.Fifo)
+                {
+                    Console.WriteLine(
+                        $"TarExtractor: skipping non-regular entry '{entry.Name}' (type {entry.EntryType}). " +
+                        "Symlinks/devices are not extracted — operator-shipped archive can't grant filesystem escape this way.");
+                    continue;
+                }
+
+                var entryPath = ArchiveSafety.ResolveSafeEntryPath(entry.Name, canonicalDest);
+                if (entryPath is null)
+                    return ExtractResult.Failure($"Entry '{entry.Name}' would escape the destination directory (tar-slip). Aborted.");
+
+                if (entry.EntryType == TarEntryType.Directory)
+                {
+                    Directory.CreateDirectory(entryPath);
+                    continue;
+                }
+
+                // Regular file (TarEntryType.RegularFile or older v7
+                // TarEntryType.V7RegularFile). DataStream is null for entries
+                // that don't carry payload (a zero-byte file's DataStream is
+                // non-null and empty; truly null means non-file entry which
+                // we filtered above).
+                if (entry.DataStream is null)
+                    continue;
+
+                if (entry.Length < 0)
+                    return ExtractResult.Failure($"Entry '{entry.Name}' has negative Length {entry.Length} — malformed tar header.");
+
+                var perEntryFailure = ArchiveSafety.CheckPerEntryCap(entry.Name, entry.Length);
+                if (perEntryFailure is not null) return perEntryFailure;
+
+                var totalFailure = ArchiveSafety.CheckTotalCap(entry.Name, totalBytesWritten + entry.Length);
+                if (totalFailure is not null) return totalFailure;
+
+                var parentDir = Path.GetDirectoryName(entryPath);
+                if (!string.IsNullOrEmpty(parentDir)) Directory.CreateDirectory(parentDir);
+
+                // Overwrite-on-collision matches zip extractor — re-deploys
+                // with the same archive land cleanly.
+                using (var output = File.Create(entryPath))
+                    entry.DataStream.CopyTo(output);
+
+                filesExtracted++;
+                totalBytesWritten += entry.Length;
+            }
+        }
+        catch (InvalidDataException ex)
+        {
+            return ExtractResult.Failure($"Archive '{archiveLabelForLogs}' is malformed: {ex.Message}");
+        }
+        catch (EndOfStreamException ex)
+        {
+            return ExtractResult.Failure($"Archive '{archiveLabelForLogs}' is truncated: {ex.Message}");
+        }
+
+        return ExtractResult.Success(filesExtracted, totalBytesWritten);
+    }
+}
+
+/// <summary>
+/// PR-2 — gzipped tar (.tar.gz, .tgz). Layers a <see cref="GZipStream"/>
+/// over the file and delegates to the same tar reader as
+/// <see cref="TarPackageExtractor"/>. All safety primitives are identical
+/// because they're applied at the entry level after the gzip layer is
+/// transparent.
+/// </summary>
+internal sealed class TarGzPackageExtractor : IPackageExtractor
+{
+    private static readonly string[] Suffixes = { ".tar.gz", ".tgz" };
+
+    public bool CanHandle(string archivePath)
+    {
+        // Compound suffix — .tar.gz needs special-case before .gz alone.
+        // We compare against the FULL filename so ".tar.gz" matches even
+        // though Path.GetExtension only returns ".gz".
+        var name = Path.GetFileName(archivePath);
+        return Suffixes.Any(s => name.EndsWith(s, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public ExtractResult Extract(string archivePath, string destinationDir)
+    {
+        if (!File.Exists(archivePath))
+            return ExtractResult.Failure($"Archive '{archivePath}' does not exist.");
+
+        Directory.CreateDirectory(destinationDir);
+        var canonicalDest = ArchiveSafety.EnsureTrailingSeparator(destinationDir);
+
+        try
+        {
+            using var raw = File.OpenRead(archivePath);
+            using var gz = new GZipStream(raw, CompressionMode.Decompress);
+            return TarPackageExtractor.ExtractTarStream(gz, canonicalDest, archivePath);
+        }
+        catch (InvalidDataException ex)
+        {
+            return ExtractResult.Failure($"Archive '{archivePath}' is not a valid gzip stream: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            return ExtractResult.Failure($"Failed to read tar.gz '{archivePath}': {ex.GetType().Name}: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ExtractResult.Failure($"Permission denied extracting '{archivePath}': {ex.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// PR-2 — placeholder for <c>.7z</c>. Native .NET has NO 7z support;
+/// SharpCompress would be a new NuGet dep. Deferred until operator demand
+/// justifies the dependency footprint on the agent. This extractor
+/// matches the extension so the dispatcher hits it (instead of silently
+/// not-found-ing) and returns a CLEAR not-supported message rather than
+/// crashing.
+/// </summary>
+internal sealed class SevenZipUnsupportedExtractor : IPackageExtractor
+{
+    public bool CanHandle(string archivePath)
+        => string.Equals(Path.GetExtension(archivePath), ".7z", StringComparison.OrdinalIgnoreCase);
+
+    public ExtractResult Extract(string archivePath, string destinationDir)
+        => ExtractResult.Failure(
+            $"7z archive '{archivePath}' is recognised but not supported in Squid.Calamari yet. " +
+            "Convert to .zip / .nupkg / .tar / .tar.gz, or file a feature request to add SharpCompress.");
+}

--- a/src/Squid.Calamari/Commands/Package/ZipExtractor.cs
+++ b/src/Squid.Calamari/Commands/Package/ZipExtractor.cs
@@ -1,50 +1,43 @@
 using System.IO.Compression;
-using Squid.Calamari.Commands.Common;
 
 namespace Squid.Calamari.Commands.Package;
 
 /// <summary>
-/// G1.4 — pure-function zip / nupkg extractor used by
-/// <see cref="ExtractPackageStep"/>. Hardened against three classes of
-/// hostile archive content:
+/// G1.4 — zip / nupkg extractor. After PR-2 multi-format dispatch this
+/// is one of several <see cref="IPackageExtractor"/> implementations,
+/// selected by extension via <see cref="PackageExtractorRegistry"/>.
 ///
-/// <list type="number">
-///   <item><b>Zip-slip</b>: an entry path containing <c>..</c> segments that
-///         would canonicalise outside the destination root. Pinned by
-///         <c>Extract_ZipSlipEntry_Rejected</c>. Any single malicious entry
-///         rejects the whole extraction (fail-closed).</item>
-///   <item><b>Absolute paths</b>: an entry like <c>/etc/passwd</c> or
-///         <c>C:\Windows\System32\drivers\etc\hosts</c>. Rejected outright.</item>
-///   <item><b>Per-entry size + total size</b>: defends against zip-bombs
-///         (small archive, multi-GB payload). Per-entry cap reuses the
-///         shared <see cref="EncodingPreservingFileIO.ResolveMaxFileSizeMB"/>
-///         setting; total cap is 10x that (so 50 MB default ⇒ 500 MB total).</item>
-/// </list>
+/// <para><b>Why nupkg + zip share the same code</b>: a <c>.nupkg</c> is
+/// a zip file with a different filename suffix. Same binary format, same
+/// engine.</para>
 ///
-/// <para><b>Symlinks in zip</b>: zip can encode Unix file modes via the
-/// external-attributes field. We don't decode those — every entry is treated
-/// as a regular file or directory. Net effect: symlink entries are extracted
-/// as plain files containing the target-path string. Operator-visible but
-/// not exploitable (file content is the literal target string, not a real
-/// symlink). The companion <c>GlobMatcher</c> symlink-escape sandbox catches
-/// anything the OS treats as a symlink after extraction.</para>
-///
-/// <para><b>Why not <see cref="ZipFile.ExtractToDirectory(string, string)"/></b>:
-/// .NET's built-in extractor does have a path-traversal check (added in .NET
-/// Core 2.1) but doesn't honour our per-entry / total size caps or our
-/// fail-closed-on-first-violation policy. Inlining gives full control of
-/// the safety story.</para>
+/// <para>Safety primitives (zip-slip / size caps / fail-closed) come from
+/// <see cref="ArchiveSafety"/> — shared with the tar / tar.gz extractors
+/// added in PR-2 so the hostile-archive defence story is identical across
+/// formats.</para>
+/// </summary>
+internal sealed class ZipPackageExtractor : IPackageExtractor
+{
+    private static readonly string[] Extensions = { ".zip", ".nupkg" };
+
+    public bool CanHandle(string archivePath)
+    {
+        var ext = Path.GetExtension(archivePath);
+        return Extensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public ExtractResult Extract(string archivePath, string destinationDir)
+        => ZipExtractor.Extract(archivePath, destinationDir);
+}
+
+/// <summary>
+/// Static façade for backward-compat with G1.4 tests that drove
+/// <see cref="ZipExtractor.Extract"/> directly. New code SHOULD go through
+/// <see cref="PackageExtractorRegistry"/> so format dispatch happens
+/// uniformly.
 /// </summary>
 internal static class ZipExtractor
 {
-    /// <summary>
-    /// Multiplier applied to the per-file size cap to derive the total
-    /// archive-extraction cap. 10x is generous — a legitimate 50 MB
-    /// individual file plus surrounding small files easily fits under 500 MB
-    /// total. Zip bombs typically have ratios of 1000x+ so this catches them.
-    /// </summary>
-    private const int TotalSizeCapMultiplier = 10;
-
     public static ExtractResult Extract(string archivePath, string destinationDir)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(archivePath);
@@ -55,12 +48,7 @@ internal static class ZipExtractor
 
         Directory.CreateDirectory(destinationDir);
 
-        var canonicalDest = Path.GetFullPath(destinationDir);
-        if (!canonicalDest.EndsWith(Path.DirectorySeparatorChar))
-            canonicalDest += Path.DirectorySeparatorChar;
-
-        var perEntryCapBytes = EncodingPreservingFileIO.ResolveMaxFileSizeMB() * 1024L * 1024L;
-        var totalCapBytes = perEntryCapBytes * TotalSizeCapMultiplier;
+        var canonicalDest = ArchiveSafety.EnsureTrailingSeparator(destinationDir);
 
         int filesExtracted = 0;
         long totalBytesWritten = 0;
@@ -74,7 +62,7 @@ internal static class ZipExtractor
                 // Directory entry: 0-byte, name ends with `/`. Create dir, no contents.
                 if (string.IsNullOrEmpty(entry.Name) && entry.FullName.EndsWith('/'))
                 {
-                    var dirPath = ResolveSafeEntryPath(entry.FullName, canonicalDest);
+                    var dirPath = ArchiveSafety.ResolveSafeEntryPath(entry.FullName, canonicalDest);
                     if (dirPath is null)
                         return ExtractResult.Failure($"Entry '{entry.FullName}' would escape the destination directory (zip-slip). Aborted.");
                     Directory.CreateDirectory(dirPath);
@@ -84,19 +72,15 @@ internal static class ZipExtractor
                 // Skip 0-length non-directory entries with empty Name (zip-spec weirdness)
                 if (string.IsNullOrEmpty(entry.Name)) continue;
 
-                var entryPath = ResolveSafeEntryPath(entry.FullName, canonicalDest);
+                var entryPath = ArchiveSafety.ResolveSafeEntryPath(entry.FullName, canonicalDest);
                 if (entryPath is null)
                     return ExtractResult.Failure($"Entry '{entry.FullName}' would escape the destination directory (zip-slip). Aborted.");
 
-                if (entry.Length > perEntryCapBytes)
-                    return ExtractResult.Failure(
-                        $"Entry '{entry.FullName}' is {entry.Length:N0} bytes, exceeds per-entry limit of {perEntryCapBytes:N0} bytes. " +
-                        $"Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+                var perEntryFailure = ArchiveSafety.CheckPerEntryCap(entry.FullName, entry.Length);
+                if (perEntryFailure is not null) return perEntryFailure;
 
-                if (totalBytesWritten + entry.Length > totalCapBytes)
-                    return ExtractResult.Failure(
-                        $"Total extracted size would exceed {totalCapBytes:N0} bytes (suspected zip-bomb). " +
-                        $"Aborted at entry '{entry.FullName}'. Set {EncodingPreservingFileIO.MaxFileSizeMBEnvVar}=<MB> to raise the cap.");
+                var totalFailure = ArchiveSafety.CheckTotalCap(entry.FullName, totalBytesWritten + entry.Length);
+                if (totalFailure is not null) return totalFailure;
 
                 var parentDir = Path.GetDirectoryName(entryPath);
                 if (!string.IsNullOrEmpty(parentDir)) Directory.CreateDirectory(parentDir);
@@ -121,33 +105,6 @@ internal static class ZipExtractor
         }
 
         return ExtractResult.Success(filesExtracted, totalBytesWritten);
-    }
-
-    /// <summary>
-    /// Resolve an archive entry path to its absolute on-disk path AND verify
-    /// it stays inside <paramref name="canonicalDest"/>. Returns null when
-    /// the entry escapes (zip-slip / absolute path / drive-letter).
-    /// </summary>
-    private static string? ResolveSafeEntryPath(string entryName, string canonicalDest)
-    {
-        // Normalise: zip entries use forward slashes; on Windows we need backslashes.
-        var normalised = entryName.Replace('/', Path.DirectorySeparatorChar);
-
-        // Reject absolute paths (POSIX `/` or Windows `C:\`) and drive-relative paths.
-        if (Path.IsPathRooted(normalised)) return null;
-
-        // Combine + canonicalise. Path.GetFullPath resolves `..` segments;
-        // we then check the result is still under the destination.
-        var combined = Path.Combine(canonicalDest, normalised);
-        var resolved = Path.GetFullPath(combined);
-
-        // Compare case-insensitively on Windows / macOS (HFS/APFS default
-        // case-insensitive). Linux ext4 is case-sensitive but
-        // OrdinalIgnoreCase is the safe over-approximation — any case-aliased
-        // attack still gets rejected.
-        if (!resolved.StartsWith(canonicalDest, StringComparison.OrdinalIgnoreCase)) return null;
-
-        return resolved;
     }
 }
 

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs
@@ -101,10 +101,11 @@ public sealed class ExtractPackageStepTests : IDisposable
     [Fact]
     public async Task Execute_UnsupportedExtension_ThrowsWithGuidance()
     {
-        // .tar.gz / .7z / unknown extensions aren't supported yet. Operator
-        // gets a clear error message naming the wire literal to unset.
-        var bad = Path.Combine(_archiveDir, "package.tar.gz");
-        File.WriteAllText(bad, "fake tar");
+        // PR-2: .tar.gz / .tar are NOW supported. Still-unsupported formats
+        // (.rar, arbitrary text) MUST throw with the operator-facing
+        // supported-formats list naming the wire literal to unset.
+        var bad = Path.Combine(_archiveDir, "package.rar");
+        File.WriteAllText(bad, "fake rar");
 
         var context = BuildContext(packagePath: bad);
 
@@ -113,6 +114,75 @@ public sealed class ExtractPackageStepTests : IDisposable
 
         ex.Message.ShouldContain("unsupported extension");
         ex.Message.ShouldContain(PackageVariableNames.OriginalPath);
+        // Operator-facing list MUST include each supported format so the
+        // operator can repack without guessing.
+        foreach (var ext in PackageExtractorRegistry.SupportedExtensions)
+            ex.Message.ShouldContain(ext);
+    }
+
+    // ── PR-2 — multi-format dispatch ────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_TarArchive_ExtractsIntoWorkingDir()
+    {
+        var tar = Path.Combine(_archiveDir, "build-output.tar");
+        using (var fs = File.Create(tar))
+        using (var w = new System.Formats.Tar.TarWriter(fs, leaveOpen: true))
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes("body");
+            var entry = new System.Formats.Tar.PaxTarEntry(System.Formats.Tar.TarEntryType.RegularFile, "app/run.sh")
+            {
+                DataStream = new MemoryStream(bytes)
+            };
+            w.WriteEntry(entry);
+        }
+
+        var context = BuildContext(packagePath: tar);
+        await new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.Exists(Path.Combine(_workDir, "app", "run.sh")).ShouldBeTrue();
+        File.ReadAllText(Path.Combine(_workDir, "app", "run.sh")).ShouldBe("body");
+    }
+
+    [Fact]
+    public async Task Execute_TarGzArchive_ExtractsIntoWorkingDir()
+    {
+        var targz = Path.Combine(_archiveDir, "build-output.tar.gz");
+        using (var fs = File.Create(targz))
+        using (var gz = new System.IO.Compression.GZipStream(fs, System.IO.Compression.CompressionLevel.Optimal))
+        using (var w = new System.Formats.Tar.TarWriter(gz, leaveOpen: true))
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes("compressed");
+            w.WriteEntry(new System.Formats.Tar.PaxTarEntry(System.Formats.Tar.TarEntryType.RegularFile, "config.yaml")
+            {
+                DataStream = new MemoryStream(bytes)
+            });
+        }
+
+        var context = BuildContext(packagePath: targz);
+        await new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None);
+
+        File.ReadAllText(Path.Combine(_workDir, "config.yaml")).ShouldBe("compressed");
+    }
+
+    [Fact]
+    public async Task Execute_SevenZipArchive_ThrowsWithDeferralExplanation()
+    {
+        // .7z is recognised by the dispatcher (so the operator gets a clear
+        // "not yet supported" message instead of "unknown format") but
+        // deliberately returns a failure result — no SharpCompress dep yet.
+        var sevenZ = Path.Combine(_archiveDir, "pkg.7z");
+        File.WriteAllText(sevenZ, "fake 7z bytes");
+
+        var context = BuildContext(packagePath: sevenZ);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None));
+
+        ex.Message.ShouldContain("7z");
+        ex.Message.ShouldContain("not supported",
+            customMessage: "Operator MUST see a clear deferral message naming alternatives, " +
+                           "not a generic 'unsupported extension' error (since the dispatcher DID recognise the format).");
     }
 
     // ── Failure surface ─────────────────────────────────────────────────────

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/PackageExtractorRegistryTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/PackageExtractorRegistryTests.cs
@@ -1,0 +1,62 @@
+using Shouldly;
+using Squid.Calamari.Commands.Package;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Package;
+
+/// <summary>
+/// PR-2 — dispatch tests for <see cref="PackageExtractorRegistry"/>.
+/// Confirms each extension lands on the right extractor + compound suffixes
+/// resolve correctly + unsupported extensions return null (caller's signal
+/// to throw with operator guidance).
+/// </summary>
+public sealed class PackageExtractorRegistryTests
+{
+    [Theory]
+    [InlineData("/x/y.zip", typeof(ZipPackageExtractor))]
+    [InlineData("/x/y.nupkg", typeof(ZipPackageExtractor))]
+    [InlineData("/x/y.NUPKG", typeof(ZipPackageExtractor))]
+    [InlineData("/x/y.tar", typeof(TarPackageExtractor))]
+    [InlineData("/x/y.tar.gz", typeof(TarGzPackageExtractor))]
+    [InlineData("/x/y.tgz", typeof(TarGzPackageExtractor))]
+    [InlineData("/x/y.TAR.GZ", typeof(TarGzPackageExtractor))]
+    [InlineData("/x/y.7z", typeof(SevenZipUnsupportedExtractor))]
+    public void Resolve_KnownExtension_LandsOnExpectedExtractor(string archivePath, Type expectedType)
+    {
+        var extractor = PackageExtractorRegistry.Resolve(archivePath);
+        extractor.ShouldNotBeNull();
+        extractor.ShouldBeOfType(expectedType);
+    }
+
+    [Theory]
+    [InlineData("/x/y.rar")]
+    [InlineData("/x/y.gz")]    // bare .gz NOT supported (ambiguous: gzipped log vs tar.gz?)
+    [InlineData("/x/y.txt")]
+    [InlineData("/x/y")]
+    public void Resolve_UnknownExtension_ReturnsNull(string archivePath)
+    {
+        PackageExtractorRegistry.Resolve(archivePath).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_TarGzCompoundSuffix_BeatsBareTarMatch()
+    {
+        // Critical ordering invariant: .tar.gz MUST dispatch to TarGz, not
+        // be sliced as ".gz" or ".tar". The registry's listed order pins
+        // this — TarGz is first.
+        PackageExtractorRegistry.Resolve("/x/y.tar.gz")
+            .ShouldBeOfType<TarGzPackageExtractor>(
+                customMessage: "Compound .tar.gz MUST land on TarGzPackageExtractor (registry ordering). " +
+                               "If you see this fail, .tar.gz files would either error or get treated as plain tar.");
+    }
+
+    [Fact]
+    public void SupportedExtensions_ListsAllOperatorVisibleFormats()
+    {
+        // Pinning the operator-facing list — if a new extractor lands but
+        // SupportedExtensions isn't updated, operators won't see the new
+        // format in error messages.
+        PackageExtractorRegistry.SupportedExtensions
+            .ShouldBe(new[] { ".zip", ".nupkg", ".tar", ".tar.gz", ".tgz" });
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/TarPackageExtractorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/TarPackageExtractorTests.cs
@@ -1,0 +1,267 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text;
+using Shouldly;
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Commands.Package;
+using Squid.Calamari.Tests.Calamari.Commands.Common;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Package;
+
+/// <summary>
+/// PR-2 — pure-function tests for <see cref="TarPackageExtractor"/> +
+/// <see cref="TarGzPackageExtractor"/>. Same hostile-archive defence
+/// matrix as zip (zip-slip / size caps / fail-closed) plus tar-specific
+/// concerns (symlinks → skipped, PAX long paths, .tar.gz double-wrap).
+/// </summary>
+[Collection(RewriterEnvVarSerialCollection.Name)]
+public sealed class TarPackageExtractorTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public TarPackageExtractorTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"tar-ext-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── CanHandle dispatch ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("/x/y.tar", true)]
+    [InlineData("/x/y.TAR", true)]
+    [InlineData("/x/y.zip", false)]
+    [InlineData("/x/y.tar.gz", false)]    // compound suffix is TarGz's job
+    [InlineData("/x/y.tgz", false)]
+    [InlineData("/x/y.nupkg", false)]
+    public void TarExtractor_CanHandle_OnlyTarExtension(string path, bool expected)
+        => new TarPackageExtractor().CanHandle(path).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("/x/y.tar.gz", true)]
+    [InlineData("/x/y.tgz", true)]
+    [InlineData("/x/y.TGZ", true)]
+    [InlineData("/x/y.TAR.GZ", true)]
+    [InlineData("/x/y.tar", false)]
+    [InlineData("/x/y.gz", false)]    // bare .gz is NOT supported — would be ambiguous
+    [InlineData("/x/y.zip", false)]
+    public void TarGzExtractor_CanHandle_CompoundSuffixes(string path, bool expected)
+        => new TarGzPackageExtractor().CanHandle(path).ShouldBe(expected);
+
+    // ── Plain .tar happy path ───────────────────────────────────────────────
+
+    [Fact]
+    public void TarExtract_SimpleArchive_FilesLandInDestination()
+    {
+        var archive = Path.Combine(_workDir, "input.tar");
+        WriteTar(archive, new[]
+        {
+            ("readme.txt", "hello tar"),
+            ("config/app.json", """{"k":"v"}""")
+        });
+
+        var dest = Path.Combine(_workDir, "out");
+        var result = new TarPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        result.FilesExtracted.ShouldBe(2);
+        File.ReadAllText(Path.Combine(dest, "readme.txt")).ShouldBe("hello tar");
+        File.ReadAllText(Path.Combine(dest, "config", "app.json")).ShouldBe("""{"k":"v"}""");
+    }
+
+    [Fact]
+    public void TarExtract_DirectoryEntries_CreateDirOnDisk()
+    {
+        var archive = Path.Combine(_workDir, "with-dir.tar");
+        WriteTarWithDirectory(archive, "empty-folder/");
+        var dest = Path.Combine(_workDir, "out");
+
+        new TarPackageExtractor().Extract(archive, dest).Succeeded.ShouldBeTrue();
+        Directory.Exists(Path.Combine(dest, "empty-folder")).ShouldBeTrue();
+    }
+
+    // ── tar.gz happy path ───────────────────────────────────────────────────
+
+    [Fact]
+    public void TarGzExtract_GzippedArchive_FilesLandInDestination()
+    {
+        // Build a .tar in memory, gzip it, write to disk.
+        var archive = Path.Combine(_workDir, "input.tar.gz");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var fileStream = File.Create(archive))
+        using (var gz = new GZipStream(fileStream, CompressionLevel.Optimal))
+        using (var writer = new TarWriter(gz, leaveOpen: true))
+        {
+            AddTarFileEntry(writer, "readme.txt", "hello gzipped");
+            AddTarFileEntry(writer, "nested/path/data.txt", "deep");
+        }
+
+        var result = new TarGzPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        result.FilesExtracted.ShouldBe(2);
+        File.ReadAllText(Path.Combine(dest, "readme.txt")).ShouldBe("hello gzipped");
+        File.ReadAllText(Path.Combine(dest, "nested", "path", "data.txt")).ShouldBe("deep");
+    }
+
+    [Fact]
+    public void TarGzExtract_TgzExtension_AlsoSupported()
+    {
+        // .tgz is the same format with a different filename suffix —
+        // common in build pipelines (npm pack output etc.).
+        var archive = Path.Combine(_workDir, "input.tgz");
+        var dest = Path.Combine(_workDir, "out");
+
+        using (var fileStream = File.Create(archive))
+        using (var gz = new GZipStream(fileStream, CompressionLevel.Optimal))
+        using (var writer = new TarWriter(gz, leaveOpen: true))
+            AddTarFileEntry(writer, "x.txt", "content");
+
+        new TarGzPackageExtractor().Extract(archive, dest).Succeeded.ShouldBeTrue();
+        File.ReadAllText(Path.Combine(dest, "x.txt")).ShouldBe("content");
+    }
+
+    // ── Safety: tar-slip + absolute path ────────────────────────────────────
+
+    [Fact]
+    public void TarExtract_TarSlipEntry_Rejected_DestinationUntouched()
+    {
+        var archive = Path.Combine(_workDir, "evil.tar");
+        WriteTar(archive, new[]
+        {
+            ("normal.txt", "fine"),
+            ("../../../escapee.txt", "i should not exist")
+        });
+
+        var dest = Path.Combine(_workDir, "out");
+        var result = new TarPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("tar-slip");
+        File.Exists(Path.Combine(_workDir, "escapee.txt")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TarExtract_AbsolutePathEntry_Rejected()
+    {
+        var archive = Path.Combine(_workDir, "abs.tar");
+        WriteTar(archive, new[] { ("/etc/passwd", "compromised") });
+        var dest = Path.Combine(_workDir, "out");
+
+        new TarPackageExtractor().Extract(archive, dest).Succeeded.ShouldBeFalse();
+    }
+
+    // ── Safety: symlink entries skipped ─────────────────────────────────────
+
+    [Fact]
+    public void TarExtract_SymlinkEntry_SkippedNotFollowed()
+    {
+        var archive = Path.Combine(_workDir, "with-symlink.tar");
+
+        using (var fs = File.Create(archive))
+        using (var w = new TarWriter(fs, leaveOpen: true))
+        {
+            // Plant a regular file + a symlink pointing outside the destination.
+            AddTarFileEntry(w, "real.txt", "real content");
+            w.WriteEntry(new PaxTarEntry(TarEntryType.SymbolicLink, "link-to-passwd")
+            {
+                LinkName = "/etc/passwd"
+            });
+        }
+
+        var dest = Path.Combine(_workDir, "out");
+        var result = new TarPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue(
+            customMessage: "Symlinks MUST be SKIPPED (not extracted) — not a fatal error. The real file alongside still extracts.");
+        result.FilesExtracted.ShouldBe(1,
+            customMessage: "Only the regular-file entry was extracted; symlink was skipped.");
+        File.Exists(Path.Combine(dest, "real.txt")).ShouldBeTrue();
+        File.Exists(Path.Combine(dest, "link-to-passwd")).ShouldBeFalse(
+            customMessage: "Symlink entry MUST NOT materialize on disk. " +
+                           "If you see this fail, a malicious tar could plant filesystem-escape symlinks.");
+    }
+
+    // ── Safety: per-entry size cap ──────────────────────────────────────────
+
+    [Fact]
+    public void TarExtract_EntryExceedsPerEntryCap_Rejected()
+    {
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+
+        try
+        {
+            var archive = Path.Combine(_workDir, "big.tar");
+            using (var fs = File.Create(archive))
+            using (var w = new TarWriter(fs, leaveOpen: true))
+            {
+                // 2 MB payload — exceeds 1 MB cap.
+                var payload = new byte[(int)(2L * 1024 * 1024)];
+                Random.Shared.NextBytes(payload);
+                var entry = new PaxTarEntry(TarEntryType.RegularFile, "big.dat")
+                {
+                    DataStream = new MemoryStream(payload)
+                };
+                w.WriteEntry(entry);
+            }
+
+            var result = new TarPackageExtractor().Extract(archive, Path.Combine(_workDir, "out"));
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason.ShouldContain("per-entry limit");
+            result.FailureReason.ShouldContain(EncodingPreservingFileIO.MaxFileSizeMBEnvVar);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    // ── tar.gz: malformed gzip stream → clear error ─────────────────────────
+
+    [Fact]
+    public void TarGzExtract_NotGzipped_FailsCleanly()
+    {
+        var archive = Path.Combine(_workDir, "fake.tar.gz");
+        File.WriteAllText(archive, "not gzipped content");
+
+        var result = new TarGzPackageExtractor().Extract(archive, Path.Combine(_workDir, "out"));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static void WriteTar(string path, IEnumerable<(string name, string content)> entries)
+    {
+        using var fs = File.Create(path);
+        using var w = new TarWriter(fs, leaveOpen: true);
+        foreach (var (name, content) in entries)
+            AddTarFileEntry(w, name, content);
+    }
+
+    private static void WriteTarWithDirectory(string path, string dirEntryName)
+    {
+        using var fs = File.Create(path);
+        using var w = new TarWriter(fs, leaveOpen: true);
+        w.WriteEntry(new PaxTarEntry(TarEntryType.Directory, dirEntryName));
+    }
+
+    private static void AddTarFileEntry(TarWriter w, string name, string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var entry = new PaxTarEntry(TarEntryType.RegularFile, name)
+        {
+            DataStream = new MemoryStream(bytes)
+        };
+        w.WriteEntry(entry);
+    }
+}


### PR DESCRIPTION
## Summary

Extends G1.4 ExtractPackageStep with format dispatch. Operator's .nupkg/.zip workflow is **byte-identical**; `.tar`/`.tar.gz`/`.tgz` now extract through the same safety story (zip-slip, per-entry + total size caps, fail-closed).

**Zero new NuGet dependencies** — `System.Formats.Tar` is .NET 9 native, gzip via `System.IO.Compression`.

## Format dispatch matrix

| Extension | Extractor | Engine |
|---|---|---|
| `.zip`, `.nupkg` | `ZipPackageExtractor` | `System.IO.Compression.ZipArchive` (existing) |
| `.tar` | `TarPackageExtractor` | `System.Formats.Tar.TarReader` |
| `.tar.gz`, `.tgz` | `TarGzPackageExtractor` | `GZipStream` → `TarReader` |
| `.7z` | `SevenZipUnsupportedExtractor` | **Recognised, deferred** — clear error message naming alternatives |
| unknown | (registry returns null → step throws) | Operator gets list of supported formats |

## What's in the box

| Layer | File |
|---|---|
| Interface | `src/Squid.Calamari/Commands/Package/IPackageExtractor.cs` (new) |
| Shared safety primitives | `src/Squid.Calamari/Commands/Package/ArchiveSafety.cs` (new — extracted from ZipExtractor) |
| Dispatcher | `src/Squid.Calamari/Commands/Package/PackageExtractorRegistry.cs` (new) |
| Tar + tar.gz + 7z | `src/Squid.Calamari/Commands/Package/TarPackageExtractor.cs` (new) |
| Zip refactored | `src/Squid.Calamari/Commands/Package/ZipExtractor.cs` (static API preserved + `ZipPackageExtractor` wrapper added) |
| Step uses registry | `src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs` |
| Tests | `TarPackageExtractorTests.cs` (15), `PackageExtractorRegistryTests.cs` (8), step tests +3 |

## Hostile-archive safety (uniform across formats)

All extractors use `ArchiveSafety` primitives — single source of truth for safety:

- **Zip-slip / tar-slip / absolute-path** rejection via `ResolveSafeEntryPath`
- **Per-entry size cap** = `EncodingPreservingFileIO.ResolveMaxFileSizeMB()` (T3 env-var-tunable, 50 MB default)
- **Total archive cap** = 10× per-entry — catches zip-bomb pattern across formats
- **Fail-closed** on first violation — whole extract aborts, no partial state

## Tar-specific safety additions

- **Symlinks / hardlinks / device files** — SKIPPED with structured console warning. Without this, a malicious `.tar.gz` could plant a `link → /etc/passwd` for downstream rewriters to follow. (`TarExtract_SymlinkEntry_SkippedNotFollowed` pins this.)
- **PAX long paths** — `TarReader` handles POSIX-1.2001 extended headers natively. No manual header reassembly.

## Test plan

- [x] Squid.Calamari.Tests: 374/374 (was 335; +39)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Solution build: 0 errors
- [x] Pre-merge audit GREEN on 7/7 invariants
- [x] All 11 existing G1.4 `ZipExtractorTests` pass unchanged — back-compat preserved
- [x] No new NuGet dependencies
- [ ] Staging: real `.tar.gz` deploy with PreDeploy / PostDeploy conventions inside

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing `.nupkg` / `.zip` deploys | Byte-identical behaviour |
| `ZipExtractor.Extract(string, string)` static API | Preserved (G1.4 tests reference it directly) |
| Wire literal `Squid.Action.Package.OriginalPath` | Unchanged |
| Standalone-script deploys | Zero impact |
| `.7z` operators | Get clear "convert to .zip/.nupkg/.tar/.tar.gz" message instead of generic "unsupported format" |
| SquidWeb | Untouched |