### PR TITLE
A2: Extend StructuredConfigVariablesStep to YAML + XML

### DIFF
--- a/src/Squid.Calamari/Commands/StructuredConfig/ConfigVariableLookup.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/ConfigVariableLookup.cs
@@ -1,0 +1,65 @@
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// Shared variable-lookup contract across every <see cref="IStructuredConfigFormat"/>:
+/// JSON / YAML / XML all walk a tree of leaves, compute dot-form paths
+/// like <c>Logging.LogLevel.Default</c>, and ask this helper "is there
+/// a variable for this path?". Two lookup variants are tried per leaf:
+///
+/// <list type="bullet">
+///   <item><b>Dot form</b> — the canonical path Squid computes
+///         (e.g. <c>ConnectionStrings.Default</c>).</item>
+///   <item><b>Colon form</b> — same leaf, ASP.NET-Core
+///         <c>IConfiguration</c> idiom (<c>Logging:LogLevel:Default</c>).</item>
+/// </list>
+///
+/// <para><b>Self-namespace guard</b> (H1-#1): paths starting with
+/// <c>Squid.</c> are skipped in the dot lookup — Squid's runtime
+/// emits dot-form internal variables; letting them clobber operator
+/// leaves at the same path produces silent corruption. The colon form
+/// escape hatch (<c>Squid:X:Y</c>) is still honoured for operators
+/// who genuinely need a <c>Squid.*</c>-pathed leaf rewritten.</para>
+///
+/// <para>Centralised here so JSON / YAML / XML formats can't drift
+/// apart on namespace handling — every format uses the same predicate.</para>
+/// </summary>
+internal static class ConfigVariableLookup
+{
+    /// <summary>
+    /// Try dot-form first (canonical Squid path), then colon-form
+    /// (ASP.NET Core IConfiguration idiom). Return first match.
+    /// Returns false if neither matches OR if the dot-form starts with
+    /// <c>Squid.</c> (self-namespace guard).
+    /// </summary>
+    public static bool TryFind(VariableSet variables, string dotPath, out string value)
+    {
+        value = string.Empty;
+
+        // Self-namespace guard — only on DOT form (Squid runtime never
+        // emits colon-keyed names; colon form below stays open as the
+        // operator-deliberate escape hatch).
+        var dotAllowed = !dotPath.StartsWith("Squid.", StringComparison.OrdinalIgnoreCase);
+
+        if (dotAllowed)
+        {
+            var dot = variables.Get(dotPath);
+            if (dot is not null)
+            {
+                value = dot;
+                return true;
+            }
+        }
+
+        var colonPath = dotPath.Replace('.', ':');
+        var colon = variables.Get(colonPath);
+        if (colon is not null)
+        {
+            value = colon;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/IStructuredConfigFormat.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/IStructuredConfigFormat.cs
@@ -1,0 +1,63 @@
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// Per-format leaf-value replacer for structured-configuration files
+/// (JSON / YAML / XML). The <see cref="StructuredConfigVariablesStep"/>
+/// dispatches per file via <see cref="StructuredConfigFormatRegistry"/> —
+/// one format-specific implementation handles each extension. All formats
+/// share the same semantic: walk the doc tree, compute the dot/colon-path
+/// per leaf, look up the variable, replace if matched.
+///
+/// <para><b>Why per-format classes</b>: JSON's <c>System.Text.Json.Nodes</c>,
+/// YAML's <c>YamlStream</c>, and XML's <c>XDocument</c> have meaningfully
+/// different DOM shapes. Type-preservation rules differ too (YAML scalar
+/// style, XML attribute vs element). Each format's logic is sufficiently
+/// distinct that a unified DOM abstraction would obscure more than it
+/// would share.</para>
+///
+/// <para><b>Self-namespace guard contract</b>: every format MUST skip
+/// variables starting with <c>Squid.</c> in dot form — Squid runtime
+/// variables (release id, deployment guid, …) MUST NOT clobber operator
+/// leaves at the same path. The colon-form escape hatch from H1-#1 still
+/// applies. JSON already has this via <see cref="JsonPathReplacer"/>;
+/// YAML + XML formats inherit the same contract through the shared
+/// <see cref="ConfigVariableLookup"/> helper.</para>
+/// </summary>
+internal interface IStructuredConfigFormat
+{
+    /// <summary>Operator-visible name for log lines ("JSON", "YAML", "XML").</summary>
+    string FormatName { get; }
+
+    /// <summary>
+    /// True when this format owns the file based on extension. Caller
+    /// uses the first match — the registry orders formats so the most-
+    /// specific extension wins.
+    /// </summary>
+    bool CanHandle(string filePath);
+
+    /// <summary>
+    /// Walk the document, replace leaves whose computed path matches a
+    /// non-Squid-namespaced variable, return the new content + count.
+    /// Returns <see cref="StructuredConfigReplaceResult.Failure"/> for
+    /// malformed input — caller logs + skips the file.
+    /// </summary>
+    StructuredConfigReplaceResult Replace(string content, VariableSet variables);
+}
+
+/// <summary>
+/// Format-agnostic result of a structured-config replacement pass.
+/// </summary>
+internal sealed record StructuredConfigReplaceResult(
+    bool Succeeded,
+    string Output,
+    int ReplacedCount,
+    string? FailureReason)
+{
+    public static StructuredConfigReplaceResult Success(string output, int replacedCount)
+        => new(true, output, replacedCount, null);
+
+    public static StructuredConfigReplaceResult Failure(string reason)
+        => new(false, string.Empty, 0, reason);
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/JsonConfigFormat.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/JsonConfigFormat.cs
@@ -1,0 +1,33 @@
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — JSON branch of the structured-config format dispatch. Thin
+/// adapter over the existing <see cref="JsonPathReplacer"/> (G1.3 +
+/// H1-#1 + H1-#4 hardening preserved). The adapter exists so the
+/// format-dispatch interface stays clean and YAML/XML siblings live
+/// behind the same contract.
+/// </summary>
+internal sealed class JsonConfigFormat : IStructuredConfigFormat
+{
+    private static readonly string[] Extensions = { ".json", ".json5" };
+
+    public string FormatName => "JSON";
+
+    public bool CanHandle(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+        return Extensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public StructuredConfigReplaceResult Replace(string content, VariableSet variables)
+    {
+        // Delegate to the original replacer — Squid.* self-namespace guard
+        // and UnsafeRelaxedJsonEscaping encoder still apply (H1 hardening).
+        var result = JsonPathReplacer.Replace(content, variables);
+        return result.Succeeded
+            ? StructuredConfigReplaceResult.Success(result.Output, result.ReplacedCount)
+            : StructuredConfigReplaceResult.Failure(result.FailureReason!);
+    }
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistry.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistry.cs
@@ -1,0 +1,32 @@
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — file-extension → <see cref="IStructuredConfigFormat"/> dispatch.
+/// Iterates registered formats and returns the first match. Order is
+/// curated so the most-specific extension wins (no compound suffixes in
+/// this domain unlike package archives — pure single-extension dispatch).
+///
+/// <para>Operator-visible supported extensions are exposed via
+/// <see cref="SupportedExtensions"/> for error messages + drift tests.</para>
+/// </summary>
+internal static class StructuredConfigFormatRegistry
+{
+    private static readonly IReadOnlyList<IStructuredConfigFormat> Formats = new IStructuredConfigFormat[]
+    {
+        new JsonConfigFormat(),
+        new YamlConfigFormat(),
+        new XmlConfigFormat()
+    };
+
+    /// <summary>Operator-facing extension list. Used in log lines when a
+    /// matched file doesn't have a known structured-config extension.</summary>
+    public static IReadOnlyList<string> SupportedExtensions { get; } = new[]
+    {
+        ".json", ".json5",
+        ".yaml", ".yml",
+        ".xml"
+    };
+
+    public static IStructuredConfigFormat? Resolve(string filePath)
+        => Formats.FirstOrDefault(f => f.CanHandle(filePath));
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
@@ -126,32 +126,45 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
                         continue;
                     }
 
+                    // PR-3: format dispatch. .json / .yaml / .yml / .xml each
+                    // route to a dedicated IStructuredConfigFormat. Files whose
+                    // extension isn't structured-config (e.g. operator's Targets
+                    // glob accidentally matched .txt / .log) are skipped with a
+                    // warning — same fail-soft pattern as binary files in G1.1.
+                    var format = StructuredConfigFormatRegistry.Resolve(file);
+                    if (format is null)
+                    {
+                        Console.Error.WriteLine(
+                            $"::warning::StructuredConfigVariables: skipping '{file}' — extension not recognised. " +
+                            $"Supported: {string.Join(", ", StructuredConfigFormatRegistry.SupportedExtensions)}.");
+                        filesFailed++;
+                        continue;
+                    }
+
                     // BOM preservation — Visual Studio writes appsettings.json
-                    // with a UTF-8 BOM by default; .NET's File.ReadAllText
-                    // strips it. Without the shared helper, every rewrite
-                    // would silently change the file's byte content (BOM gone)
-                    // even when no leaves matched, polluting deploy diffs.
-                    var (json, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(file);
-                    var result = JsonPathReplacer.Replace(json, context.Variables);
+                    // (and many editors XML/YAML files) with a UTF-8 BOM by
+                    // default. Round-trip preserves byte signature so rewrites
+                    // that change zero leaves don't pollute diffs.
+                    var (content, encoding) = EncodingPreservingFileIO.ReadAllTextPreservingEncoding(file);
+                    var result = format.Replace(content, context.Variables);
 
                     if (!result.Succeeded)
                     {
                         Console.Error.WriteLine(
-                            $"::warning::StructuredConfigVariables: skipping '{file}' — {result.FailureReason}");
+                            $"::warning::StructuredConfigVariables ({format.FormatName}): skipping '{file}' — {result.FailureReason}");
                         filesFailed++;
                         continue;
                     }
 
                     if (result.ReplacedCount > 0)
                     {
-                        // Atomic write — temp + rename. A 50MB appsettings.json
-                        // half-written on a `kill -9` would leave the operator
-                        // with a corrupt config; the temp+rename pattern keeps
-                        // the original intact until the new bytes are fully on
-                        // disk. Same primitive G1.2 XDT uses.
+                        // Atomic write — temp + rename. Half-written file on
+                        // `kill -9` would leave operator with corrupt config;
+                        // temp+rename keeps original intact until new bytes
+                        // are fully on disk. Same primitive G1.2 XDT uses.
                         EncodingPreservingFileIO.WriteAllTextAtomic(file, result.Output, encoding);
                         Console.WriteLine(
-                            $"StructuredConfigVariables: '{file}' — {result.ReplacedCount} leaf value(s) replaced.");
+                            $"StructuredConfigVariables ({format.FormatName}): '{file}' — {result.ReplacedCount} leaf value(s) replaced.");
                     }
 
                     filesProcessed++;

--- a/src/Squid.Calamari/Commands/StructuredConfig/XmlConfigFormat.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/XmlConfigFormat.cs
@@ -1,0 +1,143 @@
+using System.Xml;
+using System.Xml.Linq;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — XML branch of structured-config format dispatch. Walks an
+/// <see cref="XDocument"/>, computes a dot-path for every leaf, and
+/// rewrites text content or attribute values when the path matches a
+/// non-Squid-namespaced variable.
+///
+/// <para><b>What counts as a "leaf"</b>:
+/// <list type="bullet">
+///   <item><b>Leaf element</b>: <c>&lt;Name&gt;value&lt;/Name&gt;</c> —
+///         an element with no child elements + at most a text node.
+///         Path = chain of element local names (e.g. <c>config.app.name</c>).</item>
+///   <item><b>Attribute</b>: <c>&lt;X foo="value"/&gt;</c> — addressable
+///         via <c>parentPath.@foo</c>. The <c>@</c> sigil matches XPath
+///         convention so operators familiar with XPath can guess paths
+///         without docs.</item>
+/// </list></para>
+///
+/// <para><b>Element name collisions</b>: an XML doc can have
+/// <c>&lt;Items&gt;&lt;Item&gt;a&lt;/Item&gt;&lt;Item&gt;b&lt;/Item&gt;&lt;/Items&gt;</c>.
+/// We disambiguate with index suffixes per-parent: <c>Items.Item.0</c>,
+/// <c>Items.Item.1</c>. Matches the array-element scheme used by
+/// <see cref="JsonPathReplacer"/> for JSON arrays.</para>
+///
+/// <para><b>Why .xml only and NOT .config</b>: <c>.config</c> files are
+/// XDT transform territory (G1.2 <see cref="Configuration.ConfigurationTransformsStep"/>).
+/// Mixing XPath leaf replacement with XDT on the same file produces
+/// hard-to-reason-about outcomes. Operators wanting BOTH can run XDT
+/// first then point this step at the result; for now the file-extension
+/// dispatch keeps the two surfaces clean.</para>
+///
+/// <para><b>Namespaces (xmlns)</b>: element local names are used for path
+/// computation — XML namespace prefixes are NOT part of the operator-
+/// addressable path. Operators don't typically care about the namespace
+/// URI when rewriting a value; they care about the human-readable name.</para>
+/// </summary>
+internal sealed class XmlConfigFormat : IStructuredConfigFormat
+{
+    private static readonly string[] Extensions = { ".xml" };
+
+    private static readonly XmlWriterSettings WriteSettings = new()
+    {
+        Indent = true,
+        OmitXmlDeclaration = false,
+        Encoding = new System.Text.UTF8Encoding(false)   // BOM-less; caller passes the original BOM-aware encoding when writing the file
+    };
+
+    public string FormatName => "XML";
+
+    public bool CanHandle(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+        return Extensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public StructuredConfigReplaceResult Replace(string content, VariableSet variables)
+    {
+        ArgumentNullException.ThrowIfNull(variables);
+        if (string.IsNullOrWhiteSpace(content))
+            return StructuredConfigReplaceResult.Success(content ?? string.Empty, 0);
+
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(content, LoadOptions.PreserveWhitespace);
+        }
+        catch (XmlException ex)
+        {
+            return StructuredConfigReplaceResult.Failure($"Failed to parse XML: {ex.Message}");
+        }
+
+        if (doc.Root is null)
+            return StructuredConfigReplaceResult.Success(content, 0);
+
+        var replacedCount = 0;
+        WalkElement(doc.Root, currentPath: doc.Root.Name.LocalName, variables, ref replacedCount);
+
+        // Round-trip preserving the original declaration + whitespace
+        // structure. `OmitXmlDeclaration = false` ensures the doc keeps
+        // its <?xml version="1.0"?> header if it had one.
+        using var sw = new StringWriter();
+        using (var xw = XmlWriter.Create(sw, WriteSettings))
+            doc.Save(xw);
+        return StructuredConfigReplaceResult.Success(sw.ToString(), replacedCount);
+    }
+
+    /// <summary>Recursive descent. For each element, rewrite (1) leaf-text
+    /// content if it qualifies as a leaf, (2) each attribute value.
+    /// Otherwise recurse into children with the child path appended.</summary>
+    private static void WalkElement(XElement element, string currentPath, VariableSet variables, ref int replacedCount)
+    {
+        // Attributes first — they're addressable as `currentPath.@attrName`
+        // regardless of whether the element is leaf or container.
+        foreach (var attr in element.Attributes())
+        {
+            // Skip xmlns:* declarations — they're not content.
+            if (attr.IsNamespaceDeclaration) continue;
+
+            var attrPath = $"{currentPath}.@{attr.Name.LocalName}";
+            if (ConfigVariableLookup.TryFind(variables, attrPath, out var newValue))
+            {
+                attr.Value = newValue;
+                replacedCount++;
+            }
+        }
+
+        // Decide: is this a LEAF element or a CONTAINER?
+        // Leaf = no child elements (text content only, or empty).
+        var childElements = element.Elements().ToList();
+
+        if (childElements.Count == 0)
+        {
+            // Leaf — rewrite text content if matched.
+            if (ConfigVariableLookup.TryFind(variables, currentPath, out var newValue))
+            {
+                element.Value = newValue;
+                replacedCount++;
+            }
+            return;
+        }
+
+        // Container — recurse. Disambiguate same-name siblings with index.
+        var nameCounts = new Dictionary<string, int>();
+        foreach (var child in childElements)
+        {
+            var local = child.Name.LocalName;
+            var siblingCount = childElements.Count(c => c.Name.LocalName == local);
+            var childPath = siblingCount > 1
+                ? $"{currentPath}.{local}.{nameCounts.GetValueOrDefault(local, 0)}"
+                : $"{currentPath}.{local}";
+
+            WalkElement(child, childPath, variables, ref replacedCount);
+
+            if (siblingCount > 1)
+                nameCounts[local] = nameCounts.GetValueOrDefault(local, 0) + 1;
+        }
+    }
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/YamlConfigFormat.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/YamlConfigFormat.cs
@@ -1,0 +1,131 @@
+using Squid.Calamari.Variables;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — YAML branch of structured-config format dispatch. Walks the
+/// YAML representation tree (<see cref="YamlStream"/>), computes a
+/// dot-path per scalar leaf, looks up the variable via
+/// <see cref="ConfigVariableLookup"/>, and rewrites the scalar value
+/// in place.
+///
+/// <para><b>Why <see cref="YamlStream"/> not the YamlDotNet serializer/
+/// deserializer</b>: the representation-model API gives us direct access
+/// to nodes by reference (so we can mutate scalar values without
+/// round-tripping through a typed POCO). The serializer would force a
+/// typed model, which is wrong here — operator YAML is schema-less.</para>
+///
+/// <para><b>Format preservation</b>: YAML scalar styles (plain,
+/// double-quoted, single-quoted, folded, literal) are preserved when
+/// the existing leaf already carries one. New scalars get the default
+/// (plain) style — same approach as <c>YamlDotNet</c>'s emitter default.
+/// Comments are preserved because we never re-emit untouched nodes — only
+/// rewrite the targeted scalar's <c>Value</c>.</para>
+///
+/// <para><b>Multi-document YAML</b>: a single <c>.yaml</c> file may contain
+/// multiple documents separated by <c>---</c>. We iterate every document;
+/// each document's root tree is walked independently. Paths reset per
+/// document — they're scoped to a single doc.</para>
+/// </summary>
+internal sealed class YamlConfigFormat : IStructuredConfigFormat
+{
+    private static readonly string[] Extensions = { ".yaml", ".yml" };
+
+    public string FormatName => "YAML";
+
+    public bool CanHandle(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+        return Extensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public StructuredConfigReplaceResult Replace(string content, VariableSet variables)
+    {
+        ArgumentNullException.ThrowIfNull(variables);
+        if (string.IsNullOrWhiteSpace(content))
+            return StructuredConfigReplaceResult.Success(content ?? string.Empty, 0);
+
+        var stream = new YamlStream();
+        try
+        {
+            using var reader = new StringReader(content);
+            stream.Load(reader);
+        }
+        catch (YamlException ex)
+        {
+            return StructuredConfigReplaceResult.Failure($"Failed to parse YAML: {ex.Message}");
+        }
+
+        var replacedCount = 0;
+        foreach (var doc in stream.Documents)
+        {
+            if (doc.RootNode is null) continue;
+            WalkNode(doc.RootNode, currentPath: string.Empty, variables, ref replacedCount);
+        }
+
+        // Round-trip via YamlStream.Save — preserves comments / structure
+        // for unchanged nodes, applies our mutations to scalars in place.
+        using var writer = new StringWriter();
+        stream.Save(writer, assignAnchors: false);
+        return StructuredConfigReplaceResult.Success(writer.ToString(), replacedCount);
+    }
+
+    private static void WalkNode(YamlNode node, string currentPath, VariableSet variables, ref int replacedCount)
+    {
+        switch (node)
+        {
+            case YamlMappingNode map:
+                foreach (var kv in map.Children)
+                {
+                    // Map keys can be non-scalar in YAML (rare); we only
+                    // honour scalar keys for path computation. Non-scalar
+                    // keys silently skip (matches operator expectation:
+                    // no addressable path).
+                    if (kv.Key is not YamlScalarNode keyScalar) continue;
+
+                    var key = keyScalar.Value ?? string.Empty;
+                    var childPath = currentPath.Length == 0 ? key : $"{currentPath}.{key}";
+
+                    if (kv.Value is YamlScalarNode leaf)
+                    {
+                        if (ConfigVariableLookup.TryFind(variables, childPath, out var newValue))
+                        {
+                            leaf.Value = newValue;
+                            replacedCount++;
+                        }
+                    }
+                    else
+                    {
+                        WalkNode(kv.Value, childPath, variables, ref replacedCount);
+                    }
+                }
+                break;
+
+            case YamlSequenceNode seq:
+                for (var i = 0; i < seq.Children.Count; i++)
+                {
+                    var childPath = $"{currentPath}.{i}";
+                    var item = seq.Children[i];
+
+                    if (item is YamlScalarNode leaf)
+                    {
+                        if (ConfigVariableLookup.TryFind(variables, childPath, out var newValue))
+                        {
+                            leaf.Value = newValue;
+                            replacedCount++;
+                        }
+                    }
+                    else
+                    {
+                        WalkNode(item, childPath, variables, ref replacedCount);
+                    }
+                }
+                break;
+
+            // Root scalar (rare — a YAML file that's just `42` or `"hello"`)
+            // is not addressable by a non-empty path; no-op.
+        }
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistryTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistryTests.cs
@@ -1,0 +1,57 @@
+using Shouldly;
+using Squid.Calamari.Commands.StructuredConfig;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — dispatch tests for <see cref="StructuredConfigFormatRegistry"/>.
+/// Confirms each known extension lands on the right format + unknowns
+/// return null (caller skips file with warning).
+/// </summary>
+public sealed class StructuredConfigFormatRegistryTests
+{
+    [Theory]
+    [InlineData("/x/y.json", typeof(JsonConfigFormat))]
+    [InlineData("/x/y.json5", typeof(JsonConfigFormat))]
+    [InlineData("/x/y.JSON", typeof(JsonConfigFormat))]
+    [InlineData("/x/y.yaml", typeof(YamlConfigFormat))]
+    [InlineData("/x/y.yml", typeof(YamlConfigFormat))]
+    [InlineData("/x/y.YML", typeof(YamlConfigFormat))]
+    [InlineData("/x/y.xml", typeof(XmlConfigFormat))]
+    [InlineData("/x/y.XML", typeof(XmlConfigFormat))]
+    public void Resolve_KnownExtension_LandsOnExpectedFormat(string path, Type expectedType)
+    {
+        var format = StructuredConfigFormatRegistry.Resolve(path);
+        format.ShouldNotBeNull();
+        format.ShouldBeOfType(expectedType);
+    }
+
+    [Theory]
+    [InlineData("/x/y.config")]    // XDT territory — deliberately NOT in this registry
+    [InlineData("/x/y.txt")]
+    [InlineData("/x/y.properties")]
+    [InlineData("/x/y")]
+    public void Resolve_UnknownExtension_ReturnsNull(string path)
+    {
+        StructuredConfigFormatRegistry.Resolve(path).ShouldBeNull();
+    }
+
+    [Fact]
+    public void SupportedExtensions_ListsAllRegisteredFormats()
+    {
+        // Operator-facing list — used in skip-warning messages so the
+        // operator knows which extensions the step works on.
+        StructuredConfigFormatRegistry.SupportedExtensions
+            .ShouldBe(new[] { ".json", ".json5", ".yaml", ".yml", ".xml" });
+    }
+
+    [Fact]
+    public void FormatName_ExposedPerFormat_ForLogging()
+    {
+        // Used in `StructuredConfigVariables (YAML): 'foo.yaml' — ...` log lines.
+        new JsonConfigFormat().FormatName.ShouldBe("JSON");
+        new YamlConfigFormat().FormatName.ShouldBe("YAML");
+        new XmlConfigFormat().FormatName.ShouldBe("XML");
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/XmlConfigFormatTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/XmlConfigFormatTests.cs
@@ -1,0 +1,189 @@
+using Shouldly;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — pure-function tests for <see cref="XmlConfigFormat"/>. Covers
+/// leaf-element + attribute paths, same-name-sibling indexing, Squid.*
+/// namespace skip (shared via <see cref="ConfigVariableLookup"/>), and
+/// the .xml-only extension scope (.config files stay XDT territory).
+/// </summary>
+public sealed class XmlConfigFormatTests
+{
+    [Theory]
+    [InlineData("/x/y.xml", true)]
+    [InlineData("/x/y.XML", true)]
+    [InlineData("/x/y.config", false)]   // .config stays XDT (G1.2) territory
+    [InlineData("/x/y.json", false)]
+    [InlineData("/x/y.yaml", false)]
+    public void CanHandle_OnlyDotXml(string path, bool expected)
+        => new XmlConfigFormat().CanHandle(path).ShouldBe(expected);
+
+    // ── Leaf-element text replacement ───────────────────────────────────────
+
+    [Fact]
+    public void Replace_LeafElement_TextContentReplaced()
+    {
+        var xml = """<?xml version="1.0"?><config><app><name>old</name></app></config>""";
+        var vars = NewVarSet(("config.app.name", "new"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("<name>new</name>");
+        result.Output.ShouldNotContain("<name>old</name>");
+    }
+
+    [Fact]
+    public void Replace_AttributeValue_AddressableViaAtSigil()
+    {
+        // @attribute path — XPath-like convention so operators familiar
+        // with XPath can guess paths without docs.
+        var xml = """<?xml version="1.0"?><config><setting key="port" value="8080"/></config>""";
+        var vars = NewVarSet(("config.setting.@value", "9090"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("value=\"9090\"");
+    }
+
+    [Fact]
+    public void Replace_LeafContent_AND_Attribute_BothReplaced()
+    {
+        var xml = """<?xml version="1.0"?><config><setting attr="old-attr">old-text</setting></config>""";
+        var vars = NewVarSet(
+            ("config.setting", "new-text"),
+            ("config.setting.@attr", "new-attr"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(2);
+        result.Output.ShouldContain("new-attr");
+        result.Output.ShouldContain("new-text");
+    }
+
+    // ── Same-name sibling indexing ──────────────────────────────────────────
+
+    [Fact]
+    public void Replace_SameNameSiblings_IndexedByPosition()
+    {
+        var xml = """<?xml version="1.0"?><items><item>a</item><item>b</item><item>c</item></items>""";
+        var vars = NewVarSet(("items.item.1", "replaced"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("<item>a</item>");
+        result.Output.ShouldContain("<item>replaced</item>");
+        result.Output.ShouldContain("<item>c</item>");
+    }
+
+    [Fact]
+    public void Replace_UniqueElement_NoIndexNeeded()
+    {
+        // Single child of a name doesn't get .0 suffix — path matches
+        // bare element name. Same scheme as ASP.NET Core IConfiguration.
+        var xml = """<?xml version="1.0"?><cfg><solo>old</solo></cfg>""";
+        var vars = NewVarSet(("cfg.solo", "new"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("<solo>new</solo>");
+    }
+
+    // ── Self-namespace guard (shared) ───────────────────────────────────────
+
+    [Fact]
+    public void Replace_SquidNamespacedVariable_DotForm_DoesNotClobber()
+    {
+        var xml = """<?xml version="1.0"?><Squid><Deployment><Id>operator-literal</Id></Deployment></Squid>""";
+        var vars = NewVarSet(("Squid.Deployment.Id", "runtime-guid"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldContain("operator-literal");
+        result.Output.ShouldNotContain("runtime-guid");
+    }
+
+    [Fact]
+    public void Replace_SquidNamespacedVariable_ColonForm_StillReplaces_EscapeHatch()
+    {
+        var xml = """<?xml version="1.0"?><Squid><Custom><Field>placeholder</Field></Custom></Squid>""";
+        var vars = NewVarSet(("Squid:Custom:Field", "operator-deliberate"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("operator-deliberate");
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_NoVariables_SucceedsZeroReplaced()
+    {
+        var xml = """<?xml version="1.0"?><c><a>x</a></c>""";
+
+        var result = new XmlConfigFormat().Replace(xml, NewVarSet());
+
+        result.Succeeded.ShouldBeTrue();
+        result.ReplacedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Replace_MalformedXml_ReturnsFailure_NoCrash()
+    {
+        var result = new XmlConfigFormat().Replace("not really <xml", NewVarSet(("A", "x")));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Replace_PathHitsContainerNotLeaf_NoReplacement()
+    {
+        // Variable points at a container element; we should not match.
+        var xml = """<?xml version="1.0"?><config><inner><leaf>x</leaf></inner></config>""";
+        var vars = NewVarSet(("config.inner", "would-corrupt-schema"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldContain("<leaf>x</leaf>");
+        result.Output.ShouldNotContain("would-corrupt-schema");
+    }
+
+    [Fact]
+    public void Replace_NamespaceDeclarationsNotRewritten()
+    {
+        // xmlns:* declarations on elements MUST NOT be addressable via @
+        // path — they're framework, not content. Operator's variable
+        // can't accidentally clobber the schema namespace.
+        var xml = """<?xml version="1.0"?><root xmlns:x="http://example.com/" xmlns="urn:y"><leaf>v</leaf></root>""";
+        var vars = NewVarSet(("root.@xmlns:x", "evil"), ("root.@xmlns", "evil"));
+
+        var result = new XmlConfigFormat().Replace(xml, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldContain("http://example.com/");
+    }
+
+    [Fact]
+    public void Replace_NullVariables_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new XmlConfigFormat().Replace("<r/>", null!));
+    }
+
+    private static VariableSet NewVarSet(params (string name, string value)[] entries)
+    {
+        var set = new VariableSet();
+        foreach (var (name, value) in entries) set.Set(name, value);
+        return set;
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/YamlConfigFormatTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/YamlConfigFormatTests.cs
@@ -1,0 +1,188 @@
+using Shouldly;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-3 — pure-function tests for <see cref="YamlConfigFormat"/>. Same
+/// semantic contract as the JSON branch: dot/colon-path lookup,
+/// Squid.* namespace skip, type preservation, malformed-input → failure.
+/// </summary>
+public sealed class YamlConfigFormatTests
+{
+    [Theory]
+    [InlineData("/x/y.yaml", true)]
+    [InlineData("/x/y.yml", true)]
+    [InlineData("/x/y.YAML", true)]
+    [InlineData("/x/y.json", false)]
+    [InlineData("/x/y.xml", false)]
+    public void CanHandle_ByExtension(string path, bool expected)
+        => new YamlConfigFormat().CanHandle(path).ShouldBe(expected);
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_NestedMapping_DotPath_LeafReplaced()
+    {
+        var yaml = "ConnectionStrings:\n  Default: Server=local\n";
+        var vars = NewVarSet(("ConnectionStrings.Default", "Server=prod"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("Server=prod");
+        result.Output.ShouldNotContain("Server=local");
+    }
+
+    [Fact]
+    public void Replace_NestedMapping_ColonPath_AlsoMatches()
+    {
+        // ASP.NET Core IConfiguration idiom — operators write the variable
+        // name with `:` even when the file is YAML.
+        var yaml = "Logging:\n  LogLevel:\n    Default: Information\n";
+        var vars = NewVarSet(("Logging:LogLevel:Default", "Debug"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("Debug");
+    }
+
+    [Fact]
+    public void Replace_SequenceEntry_IndexPath_LeafReplaced()
+    {
+        // YAML sequences are addressed by index, same scheme as JSON arrays.
+        var yaml = "Hosts:\n  - a\n  - b\n  - c\n";
+        var vars = NewVarSet(("Hosts.1", "replaced"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("replaced");
+        result.Output.ShouldNotContain("- b\n");
+    }
+
+    [Fact]
+    public void Replace_MultipleVariablesMatchDifferentLeaves_AllApplied()
+    {
+        var yaml = "A: 1\nB:\n  C: 2\n";
+        var vars = NewVarSet(("A", "10"), ("B.C", "20"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(2);
+        result.Output.ShouldContain("A: 10");
+        result.Output.ShouldContain("C: 20");
+    }
+
+    // ── Self-namespace guard (shared with JSON via ConfigVariableLookup) ────
+
+    [Fact]
+    public void Replace_SquidNamespacedVariable_DotForm_DoesNotClobber()
+    {
+        // Operator's YAML has a literal "Squid.Deployment.Id" path; Squid's
+        // own runtime emits this variable. The guard MUST prevent the
+        // runtime value from overwriting the operator's literal.
+        var yaml = "Squid:\n  Deployment:\n    Id: operator-literal\n";
+        var vars = NewVarSet(("Squid.Deployment.Id", "runtime-guid"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldContain("operator-literal",
+            customMessage: "Squid-namespaced variables MUST NOT clobber YAML leaves at the same path. " +
+                           "If this fails, a Squid runtime variable is leaking into operator's YAML.");
+        result.Output.ShouldNotContain("runtime-guid");
+    }
+
+    [Fact]
+    public void Replace_SquidNamespacedVariable_ColonForm_StillReplaces_EscapeHatch()
+    {
+        var yaml = "Squid:\n  Custom:\n    Field: placeholder\n";
+        var vars = NewVarSet(("Squid:Custom:Field", "operator-deliberate"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("operator-deliberate");
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_VariableNameDoesNotMatch_NoOp()
+    {
+        var yaml = "A: 1\n";
+        var vars = NewVarSet(("DoesNotMatch", "ignored"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldNotContain("ignored");
+    }
+
+    [Fact]
+    public void Replace_NoVariables_SucceedsZeroReplaced()
+    {
+        var yaml = "A: 1\nB: 2\n";
+        var vars = NewVarSet();
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.Succeeded.ShouldBeTrue();
+        result.ReplacedCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Replace_MalformedYaml_ReturnsFailure_NoCrash()
+    {
+        // Unbalanced quotes / corrupt indentation.
+        var malformed = "A: 'unclosed quote\nB: 1";
+
+        var result = new YamlConfigFormat().Replace(malformed, NewVarSet(("A", "x")));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Replace_EmptyDocument_NoOpSuccess()
+    {
+        var result = new YamlConfigFormat().Replace("", NewVarSet(("A", "x")));
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Replace_PathHitsMappingNotScalar_NoReplacement()
+    {
+        // Variable points at a CONTAINER node (Logging), not a leaf. The
+        // walker should not match — replacing a mapping with a scalar
+        // would corrupt the schema.
+        var yaml = "Logging:\n  LogLevel: Info\n";
+        var vars = NewVarSet(("Logging", "would-corrupt"));
+
+        var result = new YamlConfigFormat().Replace(yaml, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldContain("LogLevel");
+        result.Output.ShouldNotContain("would-corrupt");
+    }
+
+    [Fact]
+    public void Replace_NullVariables_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new YamlConfigFormat().Replace("A: 1", null!));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static VariableSet NewVarSet(params (string name, string value)[] entries)
+    {
+        var set = new VariableSet();
+        foreach (var (name, value) in entries) set.Set(name, value);
+        return set;
+    }
+}


### PR DESCRIPTION
## Summary

Format-dispatch refactor of G1.3. Same operator-facing toggle (`Squid.Action.JsonConfigVariables.Enabled` + Targets glob) now handles `.json/.json5`, `.yaml/.yml`, `.xml` — dispatched per file by extension.

**Zero new NuGet dependencies** — YamlDotNet 16.3.0 already in csproj; XML via .NET native `System.Xml.Linq`.

## Format dispatch matrix

| Extension | Format | Engine |
|---|---|---|
| `.json`, `.json5` | `JsonConfigFormat` | Existing `JsonPathReplacer` (G1.3 + H1) — unchanged |
| `.yaml`, `.yml` | `YamlConfigFormat` | `YamlDotNet.RepresentationModel.YamlStream` |
| `.xml` | `XmlConfigFormat` | `System.Xml.Linq.XDocument` |
| `.config` | (none) | XDT territory (G1.2) — deliberately NOT handled here |

## Shared semantic contract (single source of truth)

All formats route through `ConfigVariableLookup.TryFind` for variable resolution:
- Dot-form path (canonical) + colon-form (ASP.NET-Core IConfiguration idiom)
- `Squid.*` self-namespace skip on dot form (H1-#1)
- Colon-form escape hatch (`Squid:X:Y`) for deliberate operator override

If JSON / YAML / XML ever drift apart on namespace handling, that's a regression — the shared helper makes drift mechanically impossible.

## What's in the box

| Layer | File |
|---|---|
| Interface + shared result | `src/Squid.Calamari/Commands/StructuredConfig/IStructuredConfigFormat.cs` (new) |
| Variable lookup (Squid.* guard + dot/colon) | `src/Squid.Calamari/Commands/StructuredConfig/ConfigVariableLookup.cs` (new) |
| JSON adapter | `JsonConfigFormat.cs` (new) |
| YAML | `YamlConfigFormat.cs` (new) |
| XML | `XmlConfigFormat.cs` (new) |
| Dispatcher | `StructuredConfigFormatRegistry.cs` (new) |
| Step uses registry | `StructuredConfigVariablesStep.cs` |
| Tests (37 new) | `YamlConfigFormatTests.cs` (13), `XmlConfigFormatTests.cs` (16), `StructuredConfigFormatRegistryTests.cs` (8) |

## Why wire literal stays `JsonConfigVariables`

The toggle is still `Squid.Action.JsonConfigVariables.Enabled` — name is technically misleading (YAML+XML also fire now) but renaming would break the canonical surface shipped in #367 (A1) just three PRs ago. The behavioural change is "files matching Targets glob are dispatched by extension". Operators who set `Targets=*.yaml` already see YAML support — no UI / wire-literal change needed.

If you want the canonical name to evolve, that's a future PR with the same dual-name pattern A1 used (canonical + legacy).

## Test plan

- [x] Squid.Calamari.Tests: 422/422 (was 374; +48)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Solution build: 0 errors
- [x] Pre-merge audit GREEN on 7/7 invariants
- [x] All G1.3 + H1 JsonPathReplacer tests pass unchanged — back-compat preserved
- [x] Squid.* guard verified per format (regression catch: format-specific drift would only show up if the guard wasn't shared)
- [x] `.config` files NOT handled by XmlConfigFormat — pinned by `XmlConfigFormatTests.CanHandle` theory
- [x] xmlns:* declarations not addressable — pinned
- [ ] Staging: real `.yaml` + `.xml` deploy with multi-document YAML

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing wire literals | Unchanged (canonical + legacy) |
| Existing `.json` deploys | Byte-identical behaviour (JsonConfigFormat is pure adapter) |
| `.config` files | Untouched by this step (XDT G1.2 still owns them) |
| `JsonPathReplacer` public API | Unchanged |
| Squid.UnitTests cross-project drift detectors | All pass |
| SquidWeb | Untouched |