### PR TITLE
PowerShell-on-Linux: multi-shell Calamari pipeline

### DIFF
--- a/src/Squid.Calamari/Commands/RunScriptCommand.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommand.cs
@@ -75,7 +75,7 @@ public class RunScriptCommand
             // script starts the application (e.g. database migrations,
             // permission fixes, cache invalidation).
             new ConventionScriptStep(ConventionScriptNames.PreDeploy, scriptEngine),
-            new WriteBootstrappedBashScriptStep(),
+            new WriteBootstrappedScriptStep(),
             new ExecuteScriptWithEngineStep(scriptEngine),
             // G1.5 — PostDeploy convention hook. Runs only when the package
             // ships a `PostDeploy.sh` file. Smoke tests, cache warm-up,

--- a/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
@@ -23,6 +23,13 @@ internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVar
 
     public string? BootstrappedScriptPath { get; set; }
 
+    /// <summary>PR-4: detected from <c>ScriptPath</c>'s extension by
+    /// <c>WriteBootstrappedScriptStep</c>. Consumed by
+    /// <c>ExecuteScriptWithEngineStep</c> to dispatch to the right
+    /// <see cref="Scripting.IScriptExecutor"/>. Default Bash matches
+    /// existing behaviour for scripts without a recognised extension.</summary>
+    public ScriptSyntax DetectedScriptSyntax { get; set; } = ScriptSyntax.Bash;
+
     public ScriptExecutionResult? ScriptResult { get; set; }
 
     public CommandExecutionResult? CommandResult { get; set; }
@@ -37,7 +44,14 @@ internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVar
     public bool ExecutionFailed { get; set; }
 }
 
-internal sealed class WriteBootstrappedBashScriptStep : ExecutionStep<RunScriptCommandContext>
+/// <summary>
+/// PR-4: syntax-aware bootstrap. Picks bash or PowerShell preamble +
+/// matching temp-file extension based on <see cref="ScriptSyntaxDetector"/>
+/// applied to <c>context.ScriptPath</c>. Back-compat: scripts without a
+/// <c>.ps1</c> / <c>.psm1</c> extension default to bash — every existing
+/// operator deploy hits the original code path unchanged.
+/// </summary>
+internal sealed class WriteBootstrappedScriptStep : ExecutionStep<RunScriptCommandContext>
 {
     public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
@@ -48,16 +62,24 @@ internal sealed class WriteBootstrappedBashScriptStep : ExecutionStep<RunScriptC
         if (context.Variables == null)
             throw new InvalidOperationException("Variables have not been loaded.");
 
+        var syntax = ScriptSyntaxDetector.DetectFromPath(context.ScriptPath);
+
         var originalScript = File.ReadAllText(context.ScriptPath);
-        var preamble = VariableBootstrapper.GeneratePreamble(context.Variables);
+        var preamble = syntax switch
+        {
+            ScriptSyntax.PowerShell => PowerShellVariableBootstrapper.GeneratePreamble(context.Variables),
+            _ => VariableBootstrapper.GeneratePreamble(context.Variables)
+        };
         var bootstrappedScript = preamble + originalScript;
 
+        var extension = syntax == ScriptSyntax.PowerShell ? ".ps1" : ".sh";
         var bootstrappedPath = Path.Combine(
             context.WorkingDirectory,
-            $".squid-bootstrapped-{Guid.NewGuid():N}.sh");
+            $".squid-bootstrapped-{Guid.NewGuid():N}{extension}");
         File.WriteAllText(bootstrappedPath, bootstrappedScript);
 
         context.BootstrappedScriptPath = bootstrappedPath;
+        context.DetectedScriptSyntax = syntax;
         context.TemporaryFiles.Add(bootstrappedPath);
         return Task.CompletedTask;
     }
@@ -87,7 +109,10 @@ internal sealed class ExecuteScriptWithEngineStep : ExecutionStep<RunScriptComma
                 {
                     ScriptPath = context.BootstrappedScriptPath,
                     WorkingDirectory = context.WorkingDirectory,
-                    Syntax = ScriptSyntax.Bash,
+                    // PR-4: dispatch by what the bootstrap step detected, not
+                    // hardcoded Bash. Default Bash is preserved for any script
+                    // without a recognised PS extension.
+                    Syntax = context.DetectedScriptSyntax,
                     OutputProcessor = outputProcessor
                 },
                 ct)

--- a/src/Squid.Calamari/Execution/PowerShellScriptExecutor.cs
+++ b/src/Squid.Calamari/Execution/PowerShellScriptExecutor.cs
@@ -1,0 +1,113 @@
+using Squid.Calamari.Execution.Output;
+using Squid.Calamari.Execution.Processes;
+
+namespace Squid.Calamari.Execution;
+
+/// <summary>
+/// PR-4 — Executes a PowerShell script file, streaming stdout/stderr
+/// through <see cref="ScriptOutputProcessor"/>. Sibling of
+/// <see cref="BashScriptExecutor"/> for the bash branch.
+///
+/// <para><b>Executable resolution</b> — prefers <c>pwsh</c> (PowerShell
+/// 7+, cross-platform), falls back to <c>powershell.exe</c> on Windows
+/// (Windows PowerShell 5.1, always present on Win10+). Linux / macOS
+/// without <c>pwsh</c> get a clear "PowerShell not installed" error —
+/// no fallback (no <c>powershell.exe</c> exists outside Windows).</para>
+///
+/// <para><b>Arguments</b> match the established Squid pattern:
+/// <c>-NoProfile</c> (skip operator's profile.ps1, defends against
+/// machine-local env pollution) + <c>-NonInteractive</c> (refuse
+/// Read-Host prompts that would hang the deploy) + <c>-File &lt;path&gt;</c>.</para>
+/// </summary>
+public class PowerShellScriptExecutor
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly Func<string?> _pwshResolver;
+
+    public PowerShellScriptExecutor()
+        : this(new ProcessRunner(), ResolvePowerShellBinary)
+    {
+    }
+
+    public PowerShellScriptExecutor(IProcessRunner processRunner)
+        : this(processRunner, ResolvePowerShellBinary)
+    {
+    }
+
+    /// <summary>Test seam — lets tests inject the resolved binary path.</summary>
+    internal PowerShellScriptExecutor(IProcessRunner processRunner, Func<string?> pwshResolver)
+    {
+        _processRunner = processRunner;
+        _pwshResolver = pwshResolver;
+    }
+
+    public async Task<int> ExecuteAsync(
+        string scriptPath,
+        string workDir,
+        ScriptOutputProcessor outputProcessor,
+        CancellationToken ct)
+    {
+        var binary = _pwshResolver()
+                     ?? throw new InvalidOperationException(
+                         "PowerShell executor: neither 'pwsh' nor 'powershell.exe' (Windows-only fallback) was found on PATH. " +
+                         "Install PowerShell 7+ (https://aka.ms/install-powershell) on this agent OR run the script as bash by " +
+                         "renaming it to .sh.");
+
+        var invocation = new ProcessInvocation(
+            executable: binary,
+            arguments: ["-NoProfile", "-NonInteractive", "-File", scriptPath],
+            workingDirectory: workDir);
+
+        var result = await _processRunner.ExecuteAsync(invocation, outputProcessor.OutputSink, ct)
+            .ConfigureAwait(false);
+
+        return result.ExitCode;
+    }
+
+    /// <summary>
+    /// Find pwsh / powershell.exe on PATH. Returns the absolute path of
+    /// the first one found, or null if neither exists.
+    ///
+    /// <para>Probe order: <c>pwsh</c> first (cross-platform, modern),
+    /// then <c>powershell.exe</c> on Windows only (legacy 5.1 fallback —
+    /// always present on Win10+). This mirrors the 1.7.x Tentacle
+    /// fallback established in PR #352.</para>
+    /// </summary>
+    public static string? ResolvePowerShellBinary()
+    {
+        var pwsh = FindOnPath(OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh");
+        if (pwsh is not null) return pwsh;
+
+        if (OperatingSystem.IsWindows())
+        {
+            var legacy = FindOnPath("powershell.exe");
+            if (legacy is not null) return legacy;
+        }
+
+        return null;
+    }
+
+    private static string? FindOnPath(string executableName)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVar)) return null;
+
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+
+        foreach (var dir in pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(dir, executableName);
+                if (File.Exists(candidate)) return candidate;
+            }
+            catch (ArgumentException)
+            {
+                // Invalid path chars in PATH segment — skip silently. Operator
+                // has a corrupt PATH; we just don't find pwsh through that segment.
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Squid.Calamari/Scripting/PowerShellScriptExecutorAdapter.cs
+++ b/src/Squid.Calamari/Scripting/PowerShellScriptExecutorAdapter.cs
@@ -1,0 +1,38 @@
+using Squid.Calamari.Execution;
+
+namespace Squid.Calamari.Scripting;
+
+/// <summary>
+/// PR-4 — <see cref="IScriptExecutor"/> adapter for PowerShell. Sibling
+/// of <see cref="BashScriptExecutorAdapter"/>. Registered alongside the
+/// bash adapter in <see cref="ScriptEngine"/>'s default constructor;
+/// engine dispatches by <see cref="ScriptExecutionRequest.Syntax"/>.
+/// </summary>
+public sealed class PowerShellScriptExecutorAdapter : IScriptExecutor
+{
+    private readonly PowerShellScriptExecutor _executor;
+
+    public PowerShellScriptExecutorAdapter()
+        : this(new PowerShellScriptExecutor())
+    {
+    }
+
+    public PowerShellScriptExecutorAdapter(PowerShellScriptExecutor executor)
+    {
+        _executor = executor;
+    }
+
+    public bool CanExecute(ScriptSyntax syntax) => syntax == ScriptSyntax.PowerShell;
+
+    public async Task<ScriptExecutionResult> ExecuteAsync(ScriptExecutionRequest request, CancellationToken ct)
+    {
+        var exitCode = await _executor.ExecuteAsync(
+                request.ScriptPath,
+                request.WorkingDirectory,
+                request.OutputProcessor,
+                ct)
+            .ConfigureAwait(false);
+
+        return new ScriptExecutionResult(exitCode, request.OutputProcessor.OutputVariables);
+    }
+}

--- a/src/Squid.Calamari/Scripting/ScriptEngine.cs
+++ b/src/Squid.Calamari/Scripting/ScriptEngine.cs
@@ -7,7 +7,7 @@ public sealed class ScriptEngine : IScriptEngine
 
     public ScriptEngine()
         : this(
-            [new BashScriptExecutorAdapter()],
+            [new BashScriptExecutorAdapter(), new PowerShellScriptExecutorAdapter()],
             [new EnsureScriptFileExistsDecorator()])
     {
     }

--- a/src/Squid.Calamari/Scripting/ScriptSyntaxDetector.cs
+++ b/src/Squid.Calamari/Scripting/ScriptSyntaxDetector.cs
@@ -1,0 +1,35 @@
+namespace Squid.Calamari.Scripting;
+
+/// <summary>
+/// PR-4 — detect <see cref="ScriptSyntax"/> from a script's file
+/// extension. Operator-friendly: name your file <c>.ps1</c> for
+/// PowerShell, <c>.sh</c> (or anything else) for bash. No new wire
+/// literal needed — the extension IS the hint.
+///
+/// <para><b>Fallback to Bash</b> when the extension is unknown or empty.
+/// Existing operators who pass <c>script-{guid}.sh</c> (or no extension
+/// at all) keep the bash code path — back-compat with everything pre-PR-4.</para>
+/// </summary>
+public static class ScriptSyntaxDetector
+{
+    /// <summary>
+    /// Map file extension → syntax. Case-insensitive. Returns
+    /// <see cref="ScriptSyntax.Bash"/> for unknowns (preserves existing
+    /// bash-only behaviour).
+    /// </summary>
+    public static ScriptSyntax DetectFromPath(string scriptPath)
+    {
+        if (string.IsNullOrWhiteSpace(scriptPath)) return ScriptSyntax.Bash;
+
+        var ext = Path.GetExtension(scriptPath);
+        if (string.IsNullOrEmpty(ext)) return ScriptSyntax.Bash;
+
+        return ext.ToLowerInvariant() switch
+        {
+            ".ps1" => ScriptSyntax.PowerShell,
+            ".psm1" => ScriptSyntax.PowerShell,
+            // .sh and everything else → bash (default + back-compat).
+            _ => ScriptSyntax.Bash
+        };
+    }
+}

--- a/src/Squid.Calamari/Variables/PowerShellVariableBootstrapper.cs
+++ b/src/Squid.Calamari/Variables/PowerShellVariableBootstrapper.cs
@@ -1,0 +1,80 @@
+using System.Text;
+
+namespace Squid.Calamari.Variables;
+
+/// <summary>
+/// PR-4 — PowerShell counterpart to <see cref="VariableBootstrapper"/>.
+/// Generates a <c>$env:VAR = 'value'</c> preamble that injects variables
+/// into the PowerShell environment, so operator scripts see the same
+/// variable scope they'd see on bash.
+///
+/// <para><b>UTF-8 stdout pin</b>: prepended before the env-var block.
+/// On Windows, both <c>powershell.exe</c> and (some) <c>pwsh</c> hosts
+/// default <c>$OutputEncoding</c> + <c>[Console]::OutputEncoding</c> to
+/// the OEM codepage. Without this pin, non-ASCII chars (Chinese / emoji
+/// / curly quotes) get mangled before they hit the captured-log pipe.
+/// Same approach as the Tentacle-side <c>LocalScriptService.PowerShellUtf8Preamble</c>.</para>
+///
+/// <para><b>Variable-name sanitisation</b>: PowerShell env-var names
+/// accept letters, digits, underscores. We strip the same forbidden
+/// chars as the bash bootstrapper (<c>.</c>, <c>-</c>, <c>/</c>) so the
+/// SAME variable name resolves under either shell. Operator who switched
+/// from <c>.sh</c> to <c>.ps1</c> doesn't have to relearn naming.</para>
+///
+/// <para><b>Value escaping</b>: single-quoted PowerShell literals only
+/// need <c>'</c> escaped as <c>''</c>. Embedded newlines, dollars,
+/// backticks all survive literally — same lossless behaviour as the bash
+/// bootstrapper's single-quote wrapping after the B.6 audit.</para>
+/// </summary>
+public static class PowerShellVariableBootstrapper
+{
+    public static string GeneratePreamble(IEnumerable<KeyValuePair<string, string>> variables)
+    {
+        var sb = new StringBuilder();
+
+        // Force UTF-8 stdout BEFORE anything else runs — same line we use
+        // in the Tentacle script wrapper. Single line keeps the line-number
+        // shift small so error messages from operator scripts still point
+        // at meaningful lines (header + utf8 + var-count lines).
+        sb.AppendLine("# Squid: force UTF-8 stdout so non-ASCII chars (Chinese / emoji) round-trip through the captured-log layer.");
+        sb.AppendLine("$OutputEncoding=[System.Text.UTF8Encoding]::new($false);[Console]::OutputEncoding=$OutputEncoding");
+        sb.AppendLine();
+
+        foreach (var (name, value) in variables)
+        {
+            if (!IsValidPowerShellVariableName(name))
+                continue;
+
+            var envName = SanitizeName(name);
+            var escapedValue = EscapeSingleQuoted(value ?? string.Empty);
+
+            // $env:VAR = '...' — exposes to child processes; matches what
+            // `export VAR=...` does on bash.
+            sb.AppendLine($"$env:{envName} = '{escapedValue}'");
+        }
+
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static bool IsValidPowerShellVariableName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        var sanitized = SanitizeName(name);
+        if (sanitized.Length == 0) return false;
+        if (char.IsDigit(sanitized[0])) return false;
+        return sanitized.All(c => char.IsLetterOrDigit(c) || c == '_');
+    }
+
+    private static string SanitizeName(string name)
+        => name.Replace('.', '_').Replace('-', '_').Replace('/', '_');
+
+    /// <summary>
+    /// PowerShell single-quote literal escape: ONLY the single-quote needs
+    /// doubling (<c>'</c> → <c>''</c>). Everything else survives literally,
+    /// including <c>$</c>, <c>`</c>, embedded newlines, double quotes.
+    /// </summary>
+    private static string EscapeSingleQuoted(string value)
+        => value.Replace("'", "''");
+}

--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -1179,7 +1179,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         var sensitiveVariablesPath = Path.Combine(workDir, "sensitiveVariables.json");
 
         // Calamari can today only bootstrap BASH scripts — its pipeline contains
-        // exactly one writer step (<see cref="Squid.Calamari.Commands.WriteBootstrappedBashScriptStep"/>)
+        // exactly one writer step (<see cref="Squid.Calamari.Commands.WriteBootstrappedScriptStep"/>)
         // that does <c>File.ReadAllText("script.sh")</c> + prepends a Bash
         // <c>export VAR=...</c> preamble. There is NO <c>WriteBootstrappedPowerShellScriptStep</c>
         // and the Calamari CLI is hardcoded to <c>--script=script.sh</c> at the
@@ -1241,7 +1241,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
     ///
     /// <para>Today only <see cref="ScriptType.Bash"/> qualifies — Calamari's
     /// <c>RunScriptCommand</c> pipeline contains a single bootstrap step
-    /// (<c>WriteBootstrappedBashScriptStep</c>) that reads <c>script.sh</c> and
+    /// (<c>WriteBootstrappedScriptStep</c>) that reads <c>script.sh</c> and
     /// prepends a Bash <c>export VAR=...</c> preamble. There is intentionally
     /// NO <c>WriteBootstrappedPowerShellScriptStep</c>: every server-side
     /// PowerShell-emitting code path (<c>IISDeployScriptBuilder</c>,

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/WriteBootstrappedScriptStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/WriteBootstrappedScriptStepTests.cs
@@ -1,0 +1,125 @@
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Scripting;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands;
+
+/// <summary>
+/// PR-4 — syntax-aware bootstrap shape. .ps1 scripts get the PowerShell
+/// preamble + .ps1 temp file; everything else gets the bash preamble +
+/// .sh temp file. Pinned by extension dispatch via
+/// <see cref="ScriptSyntaxDetector"/>.
+/// </summary>
+public sealed class WriteBootstrappedScriptStepTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public WriteBootstrappedScriptStepTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"wbs-step-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task BashScript_GeneratesBashPreambleAndShExtension()
+    {
+        var script = Path.Combine(_workDir, "deploy.sh");
+        File.WriteAllText(script, "echo hi");
+
+        var ctx = BuildContext(script);
+        ctx.Variables!.Set("MyVar", "v");
+
+        await new WriteBootstrappedScriptStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.BootstrappedScriptPath.ShouldNotBeNull();
+        ctx.BootstrappedScriptPath!.ShouldEndWith(".sh");
+        ctx.DetectedScriptSyntax.ShouldBe(ScriptSyntax.Bash);
+
+        var bootstrapped = File.ReadAllText(ctx.BootstrappedScriptPath);
+        bootstrapped.ShouldContain("export MyVar=",
+            customMessage: "Bash bootstrap MUST use `export VAR=` syntax.");
+        bootstrapped.ShouldContain("echo hi");
+    }
+
+    [Fact]
+    public async Task PowerShellScript_GeneratesPsPreambleAndPs1Extension()
+    {
+        var script = Path.Combine(_workDir, "deploy.ps1");
+        File.WriteAllText(script, "Write-Output 'hi'");
+
+        var ctx = BuildContext(script);
+        ctx.Variables!.Set("MyVar", "v");
+
+        await new WriteBootstrappedScriptStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.BootstrappedScriptPath.ShouldNotBeNull();
+        ctx.BootstrappedScriptPath!.ShouldEndWith(".ps1");
+        ctx.DetectedScriptSyntax.ShouldBe(ScriptSyntax.PowerShell);
+
+        var bootstrapped = File.ReadAllText(ctx.BootstrappedScriptPath);
+        bootstrapped.ShouldContain("$env:MyVar = 'v'",
+            customMessage: "PowerShell bootstrap MUST use $env:VAR = 'value' syntax. " +
+                           "If you see `export VAR=` here, the syntax dispatch regressed.");
+        bootstrapped.ShouldContain("Write-Output 'hi'");
+        bootstrapped.ShouldContain("OutputEncoding",
+            customMessage: "PS bootstrap MUST include the UTF-8 stdout pin so non-ASCII chars round-trip.");
+    }
+
+    [Fact]
+    public async Task ScriptWithoutExtension_DefaultsToBash_BackCompat()
+    {
+        // Existing operators ship script paths like `script-{guid}` (no
+        // extension). Default MUST stay bash so nothing breaks.
+        var script = Path.Combine(_workDir, "no-ext-script");
+        File.WriteAllText(script, "echo hi");
+
+        var ctx = BuildContext(script);
+
+        await new WriteBootstrappedScriptStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.DetectedScriptSyntax.ShouldBe(ScriptSyntax.Bash);
+        ctx.BootstrappedScriptPath!.ShouldEndWith(".sh");
+    }
+
+    [Fact]
+    public async Task BootstrappedFile_TrackedAsTempForCleanup()
+    {
+        var script = Path.Combine(_workDir, "x.sh");
+        File.WriteAllText(script, "");
+        var ctx = BuildContext(script);
+
+        await new WriteBootstrappedScriptStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.TemporaryFiles.ShouldContain(ctx.BootstrappedScriptPath!,
+            customMessage: "Bootstrapped temp file MUST be tracked so CleanupTemporaryFilesStep removes it.");
+    }
+
+    [Fact]
+    public async Task WorkingDirNull_ThrowsClearly()
+    {
+        var ctx = BuildContext(Path.Combine(_workDir, "x.sh"));
+        ctx.WorkingDirectory = null;
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            new WriteBootstrappedScriptStep().ExecuteAsync(ctx, CancellationToken.None));
+    }
+
+    private RunScriptCommandContext BuildContext(string scriptPath)
+    {
+        File.WriteAllText(scriptPath, File.Exists(scriptPath) ? File.ReadAllText(scriptPath) : "");
+        return new RunScriptCommandContext
+        {
+            ScriptPath = scriptPath,
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = new VariableSet()
+        };
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Scripting/PowerShellScriptExecutorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Scripting/PowerShellScriptExecutorTests.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+using Squid.Calamari.Execution;
+using Squid.Calamari.Scripting;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Scripting;
+
+/// <summary>
+/// PR-4 — unit-level tests for <see cref="PowerShellScriptExecutor"/>.
+/// Drives the resolver + argument shape via injectable seams without
+/// requiring <c>pwsh</c> on the test runner (which would fail on CI hosts
+/// that don't have PS Core installed).
+/// </summary>
+public sealed class PowerShellScriptExecutorTests
+{
+    [Fact]
+    public void ResolvePowerShellBinary_NeitherInstalled_ReturnsNull()
+    {
+        // Pin the contract: when PATH contains neither pwsh nor powershell.exe,
+        // resolver returns null and the caller throws a clear error.
+        // (We can't easily "uninstall" pwsh for the test, so this test runs
+        // with a curated PATH set via env var.)
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", "/nonexistent-segment");
+            PowerShellScriptExecutor.ResolvePowerShellBinary().ShouldBeNull(
+                customMessage: "With no pwsh or powershell.exe on the PATH, resolver MUST return null. " +
+                               "Caller surfaces 'PowerShell not installed' error to operator.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoBinaryFound_ThrowsWithOperatorActionableMessage()
+    {
+        // Inject a null-resolver and verify the operator-facing error message
+        // names the install URL + the bash-fallback path.
+        var executor = new TestableExecutor(processRunner: new StubProcessRunner(), resolver: () => null);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            executor.RunAsync("/tmp/x.ps1", "/tmp", new Squid.Calamari.Execution.ScriptOutputProcessor(), CancellationToken.None));
+
+        ex.Message.ShouldContain("pwsh", Case.Insensitive);
+        ex.Message.ShouldContain("install",
+            customMessage: "Error MUST name how to install PowerShell — operator needs the next step, not just the diagnosis.");
+        ex.Message.ShouldContain(".sh",
+            customMessage: "Error MUST mention bash-fallback path so operator knows the workaround.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BinaryResolved_InvokesWithCorrectArguments()
+    {
+        // Pin the argument shape: -NoProfile -NonInteractive -File <path>.
+        // -NoProfile defends against operator's profile.ps1 polluting env;
+        // -NonInteractive refuses Read-Host prompts that would hang the deploy.
+        var stubProcess = new StubProcessRunner();
+        var executor = new TestableExecutor(processRunner: stubProcess, resolver: () => "/usr/bin/pwsh");
+
+        await executor.RunAsync("/tmp/script.ps1", "/tmp", new Squid.Calamari.Execution.ScriptOutputProcessor(), CancellationToken.None);
+
+        stubProcess.CapturedInvocation.ShouldNotBeNull();
+        stubProcess.CapturedInvocation!.Executable.ShouldBe("/usr/bin/pwsh");
+        stubProcess.CapturedInvocation.Arguments.ShouldBe(new[]
+        {
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            "/tmp/script.ps1"
+        });
+        stubProcess.CapturedInvocation.WorkingDirectory.ShouldBe("/tmp");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesExitCodeFromProcess()
+    {
+        var stubProcess = new StubProcessRunner { ExitCodeToReturn = 42 };
+        var executor = new TestableExecutor(processRunner: stubProcess, resolver: () => "/usr/bin/pwsh");
+
+        var exitCode = await executor.RunAsync("/tmp/x.ps1", "/tmp", new Squid.Calamari.Execution.ScriptOutputProcessor(), CancellationToken.None);
+
+        exitCode.ShouldBe(42);
+    }
+
+    // ── Test seam wrapping the internal ctor with the injected resolver ─────
+
+    private sealed class TestableExecutor
+    {
+        private readonly PowerShellScriptExecutor _inner;
+        public TestableExecutor(Squid.Calamari.Execution.Processes.IProcessRunner processRunner, Func<string?> resolver)
+        {
+            // Reach the internal constructor that accepts the resolver func.
+            _inner = (PowerShellScriptExecutor)Activator.CreateInstance(
+                typeof(PowerShellScriptExecutor),
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { processRunner, resolver },
+                culture: null)!;
+        }
+
+        public Task<int> RunAsync(string scriptPath, string workDir, Squid.Calamari.Execution.ScriptOutputProcessor processor, CancellationToken ct)
+            => _inner.ExecuteAsync(scriptPath, workDir, processor, ct);
+    }
+
+    /// <summary>Stub <see cref="Execution.Processes.IProcessRunner"/> that captures the invocation + returns a configurable exit code.</summary>
+    private sealed class StubProcessRunner : Squid.Calamari.Execution.Processes.IProcessRunner
+    {
+        public int ExitCodeToReturn { get; set; } = 0;
+        public Squid.Calamari.Execution.Processes.ProcessInvocation? CapturedInvocation { get; private set; }
+
+        public Task<Squid.Calamari.Execution.Processes.ProcessResult> ExecuteAsync(
+            Squid.Calamari.Execution.Processes.ProcessInvocation invocation,
+            Squid.Calamari.Execution.Output.IProcessOutputSink outputSink,
+            CancellationToken ct)
+        {
+            CapturedInvocation = invocation;
+            return Task.FromResult(new Squid.Calamari.Execution.Processes.ProcessResult(ExitCodeToReturn));
+        }
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Scripting/ScriptSyntaxDetectorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Scripting/ScriptSyntaxDetectorTests.cs
@@ -1,0 +1,34 @@
+using Shouldly;
+using Squid.Calamari.Scripting;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Scripting;
+
+/// <summary>
+/// PR-4 — extension → syntax mapping. Operator-facing contract: name the
+/// script <c>.ps1</c> for PowerShell, anything else (including .sh, .bash,
+/// or no extension) for bash. The detector MUST NOT introduce a new wire
+/// literal — the extension itself is the hint.
+/// </summary>
+public sealed class ScriptSyntaxDetectorTests
+{
+    [Theory]
+    [InlineData("/x/y.ps1", ScriptSyntax.PowerShell)]
+    [InlineData("/x/y.PS1", ScriptSyntax.PowerShell)]
+    [InlineData("/x/y.psm1", ScriptSyntax.PowerShell)]
+    [InlineData("/x/y.sh", ScriptSyntax.Bash)]
+    [InlineData("/x/y.bash", ScriptSyntax.Bash)]
+    [InlineData("/x/y", ScriptSyntax.Bash)]    // no extension → bash default
+    [InlineData("/x/y.unknown", ScriptSyntax.Bash)]
+    public void DetectFromPath_MapsExtensionToSyntax(string path, ScriptSyntax expected)
+        => ScriptSyntaxDetector.DetectFromPath(path).ShouldBe(expected);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DetectFromPath_NullOrEmpty_DefaultsToBash(string? path)
+        => ScriptSyntaxDetector.DetectFromPath(path!).ShouldBe(ScriptSyntax.Bash,
+            customMessage: "Empty / null script path MUST fall back to Bash — preserves existing operator behaviour " +
+                           "for callers that haven't set ScriptPath yet (defensive default).");
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Variables/PowerShellVariableBootstrapperTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Variables/PowerShellVariableBootstrapperTests.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Variables;
+
+/// <summary>
+/// PR-4 — PowerShell preamble shape. Mirrors
+/// <c>VariableBootstrapperTests</c> for the bash side; pins the env-var
+/// syntax, name sanitisation, value escaping, and the UTF-8 stdout pin.
+/// </summary>
+public sealed class PowerShellVariableBootstrapperTests
+{
+    [Fact]
+    public void GeneratePreamble_PinsUtf8StdoutBeforeVariables()
+    {
+        // Critical: chars from non-ASCII (Chinese / emoji) must round-trip.
+        // The UTF-8 pin MUST appear BEFORE the first `$env:` line so encoding
+        // is set before any output.
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["MyVar"] = "value" });
+
+        var utf8Index = preamble.IndexOf("[Console]::OutputEncoding", StringComparison.Ordinal);
+        var firstEnvIndex = preamble.IndexOf("$env:", StringComparison.Ordinal);
+
+        utf8Index.ShouldBeGreaterThanOrEqualTo(0,
+            customMessage: "UTF-8 OutputEncoding pin MUST appear in the preamble. " +
+                           "Without it, Windows hosts mangle non-ASCII chars in captured logs.");
+        utf8Index.ShouldBeLessThan(firstEnvIndex,
+            customMessage: "UTF-8 pin MUST appear BEFORE first variable export so encoding is set before any output.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EmitsEnvAssignment_SimpleNameAndValue()
+    {
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["MyVar"] = "hello" });
+
+        preamble.ShouldContain("$env:MyVar = 'hello'",
+            customMessage: "PS env-var assignment syntax. Operator's script reads $env:MyVar.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_SanitisesDotsHyphensSlashes_SameAsBash()
+    {
+        // Same sanitiser as bash bootstrapper — operator's variable name
+        // resolves under EITHER shell without renaming.
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string>
+            {
+                ["My.Dotted.Name"] = "v1",
+                ["My-Hyphen-Name"] = "v2",
+                ["My/Slash/Name"] = "v3"
+            });
+
+        preamble.ShouldContain("$env:My_Dotted_Name = 'v1'");
+        preamble.ShouldContain("$env:My_Hyphen_Name = 'v2'");
+        preamble.ShouldContain("$env:My_Slash_Name = 'v3'");
+    }
+
+    [Fact]
+    public void GeneratePreamble_SkipsNamesStartingWithDigit()
+    {
+        // PowerShell variable names can't start with digit (after sanitisation).
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string>
+            {
+                ["1stVar"] = "skipped",
+                ["ValidVar"] = "kept"
+            });
+
+        preamble.ShouldNotContain("1stVar", Case.Insensitive);
+        preamble.ShouldContain("ValidVar");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EscapesSingleQuoteByDoubling()
+    {
+        // PS single-quote literal: '' escapes to a literal single quote.
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["Password"] = "it's a secret" });
+
+        preamble.ShouldContain("$env:Password = 'it''s a secret'",
+            customMessage: "Single quote in operator value MUST be escaped by doubling " +
+                           "(PowerShell single-quote literal rule). Otherwise: parse error at deploy time.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_DoesNotEscapeDollarOrBacktick()
+    {
+        // Inside PS SINGLE-QUOTE literal, $ and ` are LITERAL. No escape needed.
+        // Pinning this so a future "let's be safe and escape everything" refactor
+        // doesn't break operator values containing `$foo` (e.g. cron syntax).
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["Cron"] = "$(date) `backtick`" });
+
+        preamble.ShouldContain("$env:Cron = '$(date) `backtick`'",
+            customMessage: "Single-quote PS literal does NOT interpret $ or backtick. " +
+                           "Operator's literal '$(date)' MUST survive through the preamble.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_PreservesEmbeddedNewlines()
+    {
+        // Multi-line values (e.g. PEM keys) MUST survive verbatim.
+        var multiline = "-----BEGIN-----\nline1\nline2\n-----END-----";
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["PrivateKey"] = multiline });
+
+        preamble.ShouldContain(multiline,
+            customMessage: "Embedded newlines in operator value MUST survive — same lossless behaviour as bash bootstrapper after B.6 audit.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EmptyVariableSet_StillEmitsUtf8Pin()
+    {
+        // No variables → preamble is just the UTF-8 pin. Empty preamble
+        // would let Windows host pick the OEM codepage default.
+        var preamble = PowerShellVariableBootstrapper.GeneratePreamble(new Dictionary<string, string>());
+
+        preamble.ShouldContain("[Console]::OutputEncoding");
+        preamble.ShouldNotContain("$env:");
+    }
+}

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
@@ -13,11 +13,11 @@ namespace Squid.Tentacle.Tests.ScriptExecution;
 /// <code>
 ///   Unhandled exception. System.IO.FileNotFoundException:
 ///     Could not find file 'C:\Windows\TEMP\squid-tentacle-{ticket}\script.sh'.
-///       at Squid.Calamari.Commands.WriteBootstrappedBashScriptStep.ExecuteAsync(...)
+///       at Squid.Calamari.Commands.WriteBootstrappedScriptStep.ExecuteAsync(...)
 /// </code>
 ///
 /// <para><b>Root cause</b>: Calamari's <c>RunScriptCommand</c> pipeline contains
-/// a SINGLE bootstrap step — <c>WriteBootstrappedBashScriptStep</c> — which does
+/// a SINGLE bootstrap step — <c>WriteBootstrappedScriptStep</c> — which does
 /// <c>File.ReadAllText("script.sh")</c>. The Tentacle CLI invocation hardcodes
 /// <c>--script=script.sh</c>. When the dispatched script is PowerShell, Tentacle
 /// writes <c>script.ps1</c> (right extension) but Calamari reads <c>script.sh</c>


### PR DESCRIPTION
## Summary

Calamari can now execute PowerShell scripts natively. Operator's `.ps1` main script flows through the same `RunScriptCommand` pipeline as `.sh` — same variable preamble, extract step, rewriters, convention hooks. PowerShell-on-Linux works through `pwsh`; Windows falls back to `powershell.exe` if pwsh isn't installed.

**Zero new NuGet dependencies.** `pwsh` / `powershell.exe` resolved at runtime via PATH probe (same pattern as 1.7.x #352 Tentacle fallback).

## Operator UX

Name your file by extension — the right shell runs it:

| Extension | Syntax | Executor |
|---|---|---|
| `.ps1`, `.psm1` | PowerShell | `pwsh` → fallback `powershell.exe` on Windows |
| `.sh`, no extension, anything else | Bash | `bash` (existing) |

No new wire literal. No operator opt-in. Same `Squid.Calamari run-script` invocation handles both.

## What's in the box

| Layer | File |
|---|---|
| Syntax detector | `src/Squid.Calamari/Scripting/ScriptSyntaxDetector.cs` (new) |
| PS executor | `src/Squid.Calamari/Execution/PowerShellScriptExecutor.cs` (new) |
| PS executor adapter | `src/Squid.Calamari/Scripting/PowerShellScriptExecutorAdapter.cs` (new) |
| PS bootstrapper | `src/Squid.Calamari/Variables/PowerShellVariableBootstrapper.cs` (new) |
| Syntax-aware bootstrap step | `src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs` — `WriteBootstrappedBashScriptStep` → `WriteBootstrappedScriptStep` |
| Engine registers both adapters | `src/Squid.Calamari/Scripting/ScriptEngine.cs` |
| Tests (27 new) | `ScriptSyntaxDetectorTests` + `PowerShellVariableBootstrapperTests` + `PowerShellScriptExecutorTests` + `WriteBootstrappedScriptStepTests` |

## Key parity decisions

- **Same variable-name sanitiser** as bash bootstrapper (`.`/`-`/`/` → `_`). Operator's `My.Var` resolves under either shell without renaming.
- **`-NoProfile -NonInteractive -File`** argument shape matches established Squid pattern in `SshExecutionStrategy` + `LocalProcessExecutionStrategy`.
- **UTF-8 stdout pin** before first `$env:` line — matches Tentacle's `LocalScriptService.PowerShellUtf8Preamble`. Without it Windows hosts mangle Chinese/emoji in captured logs.

## What's NOT in this PR (scoped out, separate follow-up)

- **Tentacle routing** is unchanged. `LocalScriptService.IsCalamariCompatible` still only returns true for Bash; PowerShell scripts dispatched through Tentacle still route via the direct launcher (PR #352 path). This PR adds Calamari's *capability* to handle PS; expanding Tentacle dispatch to USE it is a separate small PR.
- **PreDeploy.ps1 / PostDeploy.ps1 convention scripts** — convention scripts are still bash-only (file extension hard-coded in `ConventionScriptStep`). Multi-shell conventions are a separate follow-up.

## Test plan

- [x] Squid.Calamari.Tests: 449/449 (was 422; +27)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Solution build: 0 errors
- [x] Pre-merge audit GREEN on 8/8 invariants
- [x] Tentacle.Tests env-dependent failures unchanged from main baseline (Python/F#/K8s tests need installs locally)
- [ ] Staging: `.ps1` deploy with non-ASCII variable values (CJK + emoji) round-tripping through captured logs

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing `.sh` deploys | Byte-identical behaviour — `WriteBootstrappedScriptStep` picks Bash for everything without `.ps1`/`.psm1` |
| Existing scripts without extension | Default Bash (existing behaviour preserved) |
| Wire literals | Unchanged (zero new literals) |
| Tentacle dispatch routing | Unchanged — PS still goes through launcher, not Calamari |
| IIS PS1 deploy path | Unchanged — separate from Calamari |
| `WriteBootstrappedBashScriptStep` class name | Renamed to `WriteBootstrappedScriptStep` (internal class — only Calamari + 2 doc-strings in Tentacle updated) |
| SquidWeb | Untouched |