### PR TITLE
A3: structured StepOutcome surfaced through CommandExecutionResult

### DIFF
--- a/src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs
+++ b/src/Squid.Calamari/Commands/Configuration/ConfigurationTransformsStep.cs
@@ -66,6 +66,8 @@ public static class ConfigurationTransformsVariableNames
 /// </summary>
 internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptCommandContext>
 {
+    public const string StepName = "ConfigurationTransforms";
+
     public override bool IsEnabled(RunScriptCommandContext context)
     {
         if (context.Variables is null) return false;
@@ -77,6 +79,7 @@ internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptComma
 
     public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -90,6 +93,7 @@ internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptComma
         {
             Console.WriteLine(
                 $"ConfigurationTransforms: working dir '{context.WorkingDirectory}' does not exist; skipping.");
+            context.StepOutcomes.Add(StepOutcome.Skipped(StepName, "Working directory does not exist") with { DurationMs = sw.ElapsedMilliseconds });
             return Task.CompletedTask;
         }
 
@@ -112,6 +116,12 @@ internal sealed class ConfigurationTransformsStep : ExecutionStep<RunScriptComma
         Console.WriteLine(
             $"ConfigurationTransforms: applied {applied} transform(s), {failed} failure(s). " +
             "Operator can grep the deploy log for 'ConfigurationTransforms:' lines to see per-pair outcomes.");
+
+        context.StepOutcomes.Add(StepOutcome.Success(StepName, new Dictionary<string, long>
+        {
+            ["TransformsApplied"] = applied,
+            ["TransformsFailed"] = failed
+        }) with { DurationMs = sw.ElapsedMilliseconds });
 
         return Task.CompletedTask;
     }

--- a/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
@@ -74,6 +74,7 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
 
     public override async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -123,6 +124,12 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
                 "Deploy aborted — fix the hook or remove the script from the package.");
 
         Console.WriteLine($"{_conventionName}: completed successfully.");
+
+        context.StepOutcomes.Add(StepOutcome.Success(_conventionName, new Dictionary<string, long>
+        {
+            ["ExitCode"] = result.ExitCode,
+            ["OutputVariablesCount"] = result.OutputVariables.Count
+        }) with { DurationMs = sw.ElapsedMilliseconds });
     }
 
     /// <summary>

--- a/src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs
@@ -64,6 +64,7 @@ internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunSc
 
     public async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -116,9 +117,16 @@ internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunSc
             Console.Error.WriteLine(
                 $"::warning::{ConventionName}: hook exited with code {result.ExitCode}. " +
                 "Original deploy failure is preserved.");
+            context.StepOutcomes.Add(StepOutcome.Failed(ConventionName, $"Hook exited with code {result.ExitCode}; original deploy failure preserved.")
+                with { DurationMs = sw.ElapsedMilliseconds, Metrics = new Dictionary<string, long> { ["ExitCode"] = result.ExitCode } });
             return;
         }
 
         Console.WriteLine($"{ConventionName}: completed successfully.");
+        context.StepOutcomes.Add(StepOutcome.Success(ConventionName, new Dictionary<string, long>
+        {
+            ["ExitCode"] = result.ExitCode,
+            ["OutputVariablesCount"] = result.OutputVariables.Count
+        }) with { DurationMs = sw.ElapsedMilliseconds });
     }
 }

--- a/src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs
+++ b/src/Squid.Calamari/Commands/Package/ExtractPackageStep.cs
@@ -45,6 +45,8 @@ public static class PackageVariableNames
 /// </summary>
 internal sealed class ExtractPackageStep : ExecutionStep<RunScriptCommandContext>
 {
+    public const string StepName = "ExtractPackage";
+
     public override bool IsEnabled(RunScriptCommandContext context)
     {
         if (context.Variables is null) return false;
@@ -56,6 +58,7 @@ internal sealed class ExtractPackageStep : ExecutionStep<RunScriptCommandContext
 
     public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -87,6 +90,13 @@ internal sealed class ExtractPackageStep : ExecutionStep<RunScriptCommandContext
         Console.WriteLine(
             $"ExtractPackage: '{archivePath}' → '{context.WorkingDirectory}' " +
             $"({result.FilesExtracted:N0} file(s), {result.TotalBytesWritten:N0} bytes).");
+
+        // PR-5: structured outcome for UI / analytics consumers.
+        context.StepOutcomes.Add(StepOutcome.Success(StepName, new Dictionary<string, long>
+        {
+            ["FilesExtracted"] = result.FilesExtracted,
+            ["TotalBytesWritten"] = result.TotalBytesWritten
+        }) with { DurationMs = sw.ElapsedMilliseconds, Message = $"From '{archivePath}'" });
 
         return Task.CompletedTask;
     }

--- a/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
@@ -5,7 +5,7 @@ using Squid.Calamari.Variables;
 
 namespace Squid.Calamari.Commands;
 
-internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVariableLoadingExecutionContext, ITemporaryFileTrackingExecutionContext, IFailureAwareExecutionContext
+internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVariableLoadingExecutionContext, ITemporaryFileTrackingExecutionContext, IFailureAwareExecutionContext, IStepOutcomeAwareContext
 {
     public required string ScriptPath { get; init; }
 
@@ -42,6 +42,14 @@ internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVar
     /// hook (G1.5 followup) to fire only on failure paths. Default false.
     /// </summary>
     public bool ExecutionFailed { get; set; }
+
+    /// <summary>
+    /// PR-5 — structured per-step outcomes. Each rewriter / extract /
+    /// convention / main-script step appends one entry as it finishes.
+    /// Surfaced on <c>CommandExecutionResult.StepOutcomes</c> for caller-
+    /// side analytics / UI display.
+    /// </summary>
+    public ICollection<StepOutcome> StepOutcomes { get; } = new List<StepOutcome>();
 }
 
 /// <summary>
@@ -53,8 +61,11 @@ internal sealed class RunScriptCommandContext : IPathBasedExecutionContext, IVar
 /// </summary>
 internal sealed class WriteBootstrappedScriptStep : ExecutionStep<RunScriptCommandContext>
 {
+    public const string StepName = "WriteBootstrappedScript";
+
     public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -81,12 +92,22 @@ internal sealed class WriteBootstrappedScriptStep : ExecutionStep<RunScriptComma
         context.BootstrappedScriptPath = bootstrappedPath;
         context.DetectedScriptSyntax = syntax;
         context.TemporaryFiles.Add(bootstrappedPath);
+
+        context.StepOutcomes.Add(StepOutcome.Success(StepName, new Dictionary<string, long>
+        {
+            ["VariablesExported"] = context.Variables.Count,
+            ["OriginalScriptBytes"] = originalScript.Length,
+            ["BootstrappedScriptBytes"] = bootstrappedScript.Length
+        }) with { DurationMs = sw.ElapsedMilliseconds, Message = $"Syntax={syntax}" });
+
         return Task.CompletedTask;
     }
 }
 
 internal sealed class ExecuteScriptWithEngineStep : ExecutionStep<RunScriptCommandContext>
 {
+    public const string StepName = "ExecuteMainScript";
+
     private readonly IScriptEngine _scriptEngine;
 
     public ExecuteScriptWithEngineStep(IScriptEngine scriptEngine)
@@ -96,6 +117,8 @@ internal sealed class ExecuteScriptWithEngineStep : ExecutionStep<RunScriptComma
 
     public override async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
         if (string.IsNullOrEmpty(context.WorkingDirectory))
             throw new InvalidOperationException("Working directory has not been initialized.");
         if (string.IsNullOrEmpty(context.BootstrappedScriptPath))
@@ -117,6 +140,17 @@ internal sealed class ExecuteScriptWithEngineStep : ExecutionStep<RunScriptComma
                 },
                 ct)
             .ConfigureAwait(false);
+
+        // PR-5: emit structured outcome. Status reflects exit code — non-zero
+        // is still a "ran successfully" outcome (the step didn't throw), the
+        // ExitCode metric carries the actual value for downstream consumers.
+        // Failure status is reserved for "the step itself raised" path which
+        // would never reach this line.
+        context.StepOutcomes.Add(StepOutcome.Success(StepName, new Dictionary<string, long>
+        {
+            ["ExitCode"] = context.ScriptResult.ExitCode,
+            ["OutputVariablesCount"] = context.ScriptResult.OutputVariables.Count
+        }) with { DurationMs = sw.ElapsedMilliseconds, Message = $"Syntax={context.DetectedScriptSyntax}" });
 
         // Symmetric with ConventionScriptStep — output variables the main
         // script set MUST flow into the shared variable set so PostDeploy
@@ -141,9 +175,13 @@ internal sealed class BuildRunScriptCommandResultStep : ExecutionStep<RunScriptC
         if (context.ScriptResult == null)
             throw new InvalidOperationException("Script result has not been produced.");
 
+        // PR-5: thread the accumulated step outcomes through to the caller.
+        // Snapshot-as-list so post-build mutations to context.StepOutcomes
+        // don't retroactively edit the result.
         context.CommandResult = new CommandExecutionResult(
             context.ScriptResult.ExitCode,
-            context.ScriptResult.OutputVariables);
+            context.ScriptResult.OutputVariables,
+            context.StepOutcomes.ToList());
 
         return Task.CompletedTask;
     }

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigVariablesStep.cs
@@ -69,6 +69,8 @@ public static class JsonConfigVariableNames
 /// </summary>
 internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCommandContext>
 {
+    public const string StepName = "StructuredConfigVariables";
+
     public override bool IsEnabled(RunScriptCommandContext context)
     {
         if (context.Variables is null) return false;
@@ -80,6 +82,7 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
 
     public override Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -92,7 +95,11 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
         // Canonical first, legacy fallback for the Targets glob list.
         var targetsRaw = context.Variables.Get(StructuredConfigVariableNames.Targets)
                          ?? context.Variables.Get(StructuredConfigVariableNames.Legacy.Targets);
-        if (string.IsNullOrWhiteSpace(targetsRaw)) return Task.CompletedTask;
+        if (string.IsNullOrWhiteSpace(targetsRaw))
+        {
+            context.StepOutcomes.Add(StepOutcome.Skipped(StepName, "Targets glob is empty") with { DurationMs = sw.ElapsedMilliseconds });
+            return Task.CompletedTask;
+        }
 
         var totalReplaced = 0;
         var filesProcessed = 0;
@@ -181,6 +188,13 @@ internal sealed class StructuredConfigVariablesStep : ExecutionStep<RunScriptCom
 
         Console.WriteLine(
             $"StructuredConfigVariables: processed {filesProcessed} file(s), {filesFailed} failure(s), {totalReplaced} total leaf replacement(s).");
+
+        context.StepOutcomes.Add(StepOutcome.Success(StepName, new Dictionary<string, long>
+        {
+            ["FilesProcessed"] = filesProcessed,
+            ["FilesFailed"] = filesFailed,
+            ["LeavesReplaced"] = totalReplaced
+        }) with { DurationMs = sw.ElapsedMilliseconds });
 
         return Task.CompletedTask;
     }

--- a/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
+++ b/src/Squid.Calamari/Commands/Substitution/SubstituteInFilesStep.cs
@@ -95,6 +95,8 @@ public static class SubstituteInFilesVariableNames
 
 internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandContext>
 {
+    public const string StepName = "SubstituteInFiles";
+
     /// <summary>Re-exported for backward-compat with the original test
     /// suite that referenced these on the step. The values point at the
     /// CANONICAL names — tests writing to these will exercise the
@@ -117,6 +119,7 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
 
     public override async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         ct.ThrowIfCancellationRequested();
 
         if (string.IsNullOrEmpty(context.WorkingDirectory))
@@ -205,6 +208,13 @@ internal sealed class SubstituteInFilesStep : ExecutionStep<RunScriptCommandCont
         Console.WriteLine(
             $"SubstituteInFiles: processed {filesProcessed} file(s), skipped {filesSkipped}. " +
             $"Unresolved tokens in {allUnresolved.Count} file(s).");
+
+        context.StepOutcomes.Add(StepOutcome.Success(StepName, new Dictionary<string, long>
+        {
+            ["FilesProcessed"] = filesProcessed,
+            ["FilesSkipped"] = filesSkipped,
+            ["FilesWithUnresolvedTokens"] = allUnresolved.Count
+        }) with { DurationMs = sw.ElapsedMilliseconds });
 
         if (failOnUnresolved && allUnresolved.Count > 0)
             throw new SubstituteInFilesException(allUnresolved);

--- a/src/Squid.Calamari/Execution/CommandExecutionResult.cs
+++ b/src/Squid.Calamari/Execution/CommandExecutionResult.cs
@@ -1,13 +1,18 @@
+using Squid.Calamari.Pipeline;
 using Squid.Calamari.ServiceMessages;
 
 namespace Squid.Calamari.Execution;
 
 public sealed class CommandExecutionResult
 {
-    public CommandExecutionResult(int exitCode, IReadOnlyList<OutputVariable>? outputVariables = null)
+    public CommandExecutionResult(
+        int exitCode,
+        IReadOnlyList<OutputVariable>? outputVariables = null,
+        IReadOnlyList<StepOutcome>? stepOutcomes = null)
     {
         ExitCode = exitCode;
         OutputVariables = outputVariables?.ToArray() ?? Array.Empty<OutputVariable>();
+        StepOutcomes = stepOutcomes?.ToArray() ?? Array.Empty<StepOutcome>();
     }
 
     public int ExitCode { get; }
@@ -15,4 +20,12 @@ public sealed class CommandExecutionResult
     public bool Succeeded => ExitCode == 0;
 
     public IReadOnlyList<OutputVariable> OutputVariables { get; }
+
+    /// <summary>
+    /// PR-5 — per-step structured outcomes emitted as the pipeline ran.
+    /// Ordered by execution sequence (the index reflects pipeline order).
+    /// Empty list for legacy callers / contexts that pre-date the
+    /// <see cref="IStepOutcomeAwareContext"/> interface.
+    /// </summary>
+    public IReadOnlyList<StepOutcome> StepOutcomes { get; }
 }

--- a/src/Squid.Calamari/Pipeline/StepOutcome.cs
+++ b/src/Squid.Calamari/Pipeline/StepOutcome.cs
@@ -1,0 +1,68 @@
+namespace Squid.Calamari.Pipeline;
+
+/// <summary>
+/// PR-5 — structured outcome record emitted by every rewriter / extract /
+/// convention step. Replaces unstructured <c>Console.WriteLine</c> "processed
+/// N files, M failures" log lines as the canonical surface that UIs / log
+/// analytics / future SDK callers query.
+///
+/// <para><b>Status truth table</b>:
+/// <list type="bullet">
+///   <item><see cref="StepStatus.Succeeded"/> — the step ran and finished
+///         normally. Metrics dict describes what it did (counts of files
+///         processed, leaves replaced, …).</item>
+///   <item><see cref="StepStatus.Skipped"/> — IsEnabled returned false OR
+///         the step short-circuited (no target glob, no convention file,
+///         etc.). Message names the reason in operator-friendly terms.</item>
+///   <item><see cref="StepStatus.Failed"/> — the step raised. Message
+///         carries the exception text. The pipeline still re-throws; this
+///         outcome is the post-mortem record.</item>
+/// </list></para>
+///
+/// <para><b>Stable contract</b>: this record is part of <see cref="Execution.CommandExecutionResult"/>
+/// which flows to whoever invoked Calamari (Tentacle, K8s agent, future
+/// Docker/cloud transports). Adding fields is fine; renaming or removing
+/// them is breaking.</para>
+/// </summary>
+public sealed record StepOutcome(
+    string StepName,
+    StepStatus Status,
+    string? Message,
+    IReadOnlyDictionary<string, long> Metrics,
+    long DurationMs)
+{
+    /// <summary>Convenience constructor for the most common case —
+    /// success with metrics, no message, duration filled in later.</summary>
+    public static StepOutcome Success(string stepName, IReadOnlyDictionary<string, long>? metrics = null)
+        => new(stepName, StepStatus.Succeeded, null, metrics ?? EmptyMetrics, 0);
+
+    public static StepOutcome Skipped(string stepName, string reason)
+        => new(stepName, StepStatus.Skipped, reason, EmptyMetrics, 0);
+
+    public static StepOutcome Failed(string stepName, string error)
+        => new(stepName, StepStatus.Failed, error, EmptyMetrics, 0);
+
+    private static readonly IReadOnlyDictionary<string, long> EmptyMetrics =
+        new Dictionary<string, long>();
+}
+
+public enum StepStatus
+{
+    Succeeded = 1,
+    Skipped = 2,
+    Failed = 3
+}
+
+/// <summary>
+/// PR-5 — opt-in marker. Contexts that expose a mutable list of
+/// <see cref="StepOutcome"/>s can be observed by the pipeline + steps.
+/// Same lightweight-extension pattern as
+/// <see cref="IPathBasedExecutionContext"/> / <see cref="IFailureAwareExecutionContext"/>.
+/// </summary>
+public interface IStepOutcomeAwareContext
+{
+    /// <summary>Outcomes appended in pipeline order. Empty when the
+    /// pipeline hasn't started yet; one entry per step that ran (or
+    /// raised). Consumer iterates this for analytics / display.</summary>
+    ICollection<StepOutcome> StepOutcomes { get; }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StepOutcomeEmissionTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StepOutcomeEmissionTests.cs
@@ -1,0 +1,190 @@
+using Shouldly;
+using Squid.Calamari.Commands;
+using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.Conventions;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Commands.Substitution;
+using Squid.Calamari.Pipeline;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands;
+
+/// <summary>
+/// PR-5 — pins that every G1.x pipeline step appends a structured
+/// <see cref="StepOutcome"/> to <c>context.StepOutcomes</c> when it
+/// completes. The outcome record is part of the
+/// <c>CommandExecutionResult.StepOutcomes</c> public contract — silent
+/// regression here would mean UI / log-analytics consumers stop seeing
+/// metrics for the affected step.
+/// </summary>
+public sealed class StepOutcomeEmissionTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public StepOutcomeEmissionTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"outcome-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task SubstituteInFilesStep_EmitsOutcome_WithFileCounts()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "a.txt"), "v=#{X}");
+
+        var ctx = BuildContext();
+        ctx.Variables!.Set(SubstituteInFilesVariableNames.Enabled, "True");
+        ctx.Variables.Set(SubstituteInFilesVariableNames.TargetFiles, "*.txt");
+        ctx.Variables.Set("X", "1");
+
+        await new SubstituteInFilesStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.StepName.ShouldBe(SubstituteInFilesStep.StepName);
+        outcome.Status.ShouldBe(StepStatus.Succeeded);
+        outcome.Metrics["FilesProcessed"].ShouldBe(1);
+        outcome.Metrics["FilesSkipped"].ShouldBe(0);
+        outcome.Metrics["FilesWithUnresolvedTokens"].ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ConfigurationTransformsStep_EmitsOutcome_WithAppliedAndFailedCounts()
+    {
+        // Stage a base + matching env transform so 1 apply lands.
+        File.WriteAllText(Path.Combine(_workDir, "web.config"),
+            "<?xml version=\"1.0\"?><configuration><appSettings><add key=\"x\" value=\"old\" /></appSettings></configuration>");
+        File.WriteAllText(Path.Combine(_workDir, "web.Production.config"),
+            "<?xml version=\"1.0\"?><configuration xmlns:xdt=\"http://schemas.microsoft.com/XML-Document-Transform\">" +
+            "<appSettings><add key=\"x\" value=\"new\" xdt:Transform=\"SetAttributes\" xdt:Locator=\"Match(key)\" /></appSettings></configuration>");
+
+        var ctx = BuildContext();
+        ctx.Variables!.Set(ConfigurationTransformsVariableNames.Enabled, "True");
+        ctx.Variables.Set(ConfigurationTransformsVariableNames.EnvironmentName, "Production");
+
+        await new ConfigurationTransformsStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.StepName.ShouldBe(ConfigurationTransformsStep.StepName);
+        outcome.Metrics["TransformsApplied"].ShouldBe(1);
+        outcome.Metrics["TransformsFailed"].ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task StructuredConfigStep_EmitsOutcome_WithReplacementCount()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "appsettings.json"), """{"K":"old"}""");
+
+        var ctx = BuildContext();
+        ctx.Variables!.Set(StructuredConfigVariableNames.Enabled, "True");
+        ctx.Variables.Set(StructuredConfigVariableNames.Targets, "appsettings.json");
+        ctx.Variables.Set("K", "new");
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.StepName.ShouldBe(StructuredConfigVariablesStep.StepName);
+        outcome.Metrics["FilesProcessed"].ShouldBe(1);
+        outcome.Metrics["LeavesReplaced"].ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task StructuredConfigStep_EmptyTargets_EmitsSkippedOutcome_NotSuccess()
+    {
+        // Empty Targets short-circuits in IsEnabled-passes case. MUST emit
+        // a Skipped outcome (not silently nothing) so UI shows "step ran,
+        // but skipped because operator didn't list any targets".
+        var ctx = BuildContext();
+        ctx.Variables!.Set(StructuredConfigVariableNames.Enabled, "True");
+        ctx.Variables.Set(StructuredConfigVariableNames.Targets, "");
+
+        await new StructuredConfigVariablesStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.Status.ShouldBe(StepStatus.Skipped);
+        outcome.Message.ShouldBe("Targets glob is empty");
+    }
+
+    [Fact]
+    public async Task ConventionScriptStep_EmitsOutcome_WhenHookRuns()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "echo hi");
+
+        var ctx = BuildContext();
+        var stubEngine = new Conventions.StubScriptEngine(exitCode: 0);
+
+        await new ConventionScriptStep(ConventionScriptNames.PreDeploy, stubEngine).ExecuteAsync(ctx, CancellationToken.None);
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.StepName.ShouldBe(ConventionScriptNames.PreDeploy);
+        outcome.Status.ShouldBe(StepStatus.Succeeded);
+        outcome.Metrics["ExitCode"].ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DeployFailedConventionStep_EmitsOutcome_WhenHookRunsCleanly()
+    {
+        // On a failure path, DeployFailed runs and emits an outcome.
+        File.WriteAllText(Path.Combine(_workDir, "DeployFailed.sh"), "echo cleanup");
+
+        var ctx = BuildContext();
+        ctx.ExecutionFailed = true;
+        var stubEngine = new Conventions.StubScriptEngine(exitCode: 0);
+
+        await new DeployFailedConventionStep(stubEngine).ExecuteAsync(ctx, CancellationToken.None);
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.StepName.ShouldBe(ConventionScriptNames.DeployFailed);
+        outcome.Status.ShouldBe(StepStatus.Succeeded);
+        outcome.Metrics["ExitCode"].ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DeployFailedConventionStep_HookItselfFails_EmitsFailedOutcome_StillNoThrow()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "DeployFailed.sh"), "exit 5");
+
+        var ctx = BuildContext();
+        ctx.ExecutionFailed = true;
+        var stubEngine = new Conventions.StubScriptEngine(exitCode: 5);
+
+        await Should.NotThrowAsync(() =>
+            new DeployFailedConventionStep(stubEngine).ExecuteAsync(ctx, CancellationToken.None));
+
+        var outcome = ctx.StepOutcomes.ShouldHaveSingleItem();
+        outcome.Status.ShouldBe(StepStatus.Failed,
+            customMessage: "DeployFailed hook failure MUST emit Failed status in the outcome — even though the step doesn't re-throw, the structured surface should record the failure for analytics.");
+        outcome.Metrics["ExitCode"].ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task ContextStepOutcomesList_StartsEmpty_PreservesAppendOrder()
+    {
+        // Defensive: pipeline state pinning. New context = empty list.
+        // Multiple step appends preserve insertion order.
+        var ctx = BuildContext();
+        ctx.StepOutcomes.ShouldBeEmpty();
+
+        ctx.StepOutcomes.Add(StepOutcome.Success("A"));
+        ctx.StepOutcomes.Add(StepOutcome.Skipped("B", "x"));
+        ctx.StepOutcomes.Add(StepOutcome.Success("C"));
+
+        ctx.StepOutcomes.Select(o => o.StepName).ShouldBe(new[] { "A", "B", "C" });
+    }
+
+    private RunScriptCommandContext BuildContext()
+    {
+        return new RunScriptCommandContext
+        {
+            ScriptPath = Path.Combine(_workDir, "script.sh"),
+            VariablesPath = Path.Combine(_workDir, "variables.json"),
+            WorkingDirectory = _workDir,
+            Variables = new VariableSet()
+        };
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Pipeline/StepOutcomeTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Pipeline/StepOutcomeTests.cs
@@ -1,0 +1,77 @@
+using Shouldly;
+using Squid.Calamari.Pipeline;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Pipeline;
+
+/// <summary>
+/// PR-5 — record-level tests for <see cref="StepOutcome"/>. Pins the
+/// public surface (status values, factory shape, default-empty metrics
+/// dict) that future UI / SDK consumers depend on.
+/// </summary>
+public sealed class StepOutcomeTests
+{
+    [Fact]
+    public void Success_FactoryProducesSucceededStatus()
+    {
+        var outcome = StepOutcome.Success("MyStep");
+        outcome.StepName.ShouldBe("MyStep");
+        outcome.Status.ShouldBe(StepStatus.Succeeded);
+        outcome.Message.ShouldBeNull();
+        outcome.Metrics.ShouldBeEmpty();
+        outcome.DurationMs.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Success_WithMetrics_AttachesMetricsDict()
+    {
+        var outcome = StepOutcome.Success("MyStep", new Dictionary<string, long>
+        {
+            ["FilesProcessed"] = 12,
+            ["Errors"] = 0
+        });
+
+        outcome.Metrics["FilesProcessed"].ShouldBe(12);
+        outcome.Metrics["Errors"].ShouldBe(0);
+    }
+
+    [Fact]
+    public void Skipped_FactoryNamesReason()
+    {
+        var outcome = StepOutcome.Skipped("MyStep", "Targets glob is empty");
+
+        outcome.Status.ShouldBe(StepStatus.Skipped);
+        outcome.Message.ShouldBe("Targets glob is empty");
+    }
+
+    [Fact]
+    public void Failed_FactoryNamesError()
+    {
+        var outcome = StepOutcome.Failed("MyStep", "Exception text");
+
+        outcome.Status.ShouldBe(StepStatus.Failed);
+        outcome.Message.ShouldBe("Exception text");
+    }
+
+    [Fact]
+    public void RecordEquality_SameValuesAreEqual()
+    {
+        // Pinning record-equality semantics — UI test harnesses can compare
+        // by value without needing custom equality. Pinned because someone
+        // changing this to a class would silently break test assertions.
+        var a = StepOutcome.Success("X");
+        var b = StepOutcome.Success("X");
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void StepStatus_EnumStableValues()
+    {
+        // Pinning enum values — these flow through CommandExecutionResult to
+        // downstream consumers. Changing them is binary-breaking for any
+        // serialised channel.
+        ((int)StepStatus.Succeeded).ShouldBe(1);
+        ((int)StepStatus.Skipped).ShouldBe(2);
+        ((int)StepStatus.Failed).ShouldBe(3);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a structured per-step outcome record alongside the existing free-form Console.WriteLine logs. Future UI dashboards / log analytics / SDK consumers can now read per-step metrics without parsing logs.

**Existing log lines preserved** — operators still grep them for human-readable summaries. The structured outcome is additive.

## What's in the box

| Layer | File |
|---|---|
| Record + enum + interface | `src/Squid.Calamari/Pipeline/StepOutcome.cs` (new) |
| Context implements interface | `src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs` |
| Result exposes list | `src/Squid.Calamari/Execution/CommandExecutionResult.cs` |
| Outcomes emitted by every step | 7 step files (Extract, SubstituteInFiles, ConfigurationTransforms, StructuredConfig, ConventionScript, DeployFailedConvention, ExecuteScriptWithEngine, WriteBootstrappedScript) |
| Tests | `StepOutcomeTests.cs` (6) + `StepOutcomeEmissionTests.cs` (8) |

## Per-step metrics emitted

| Step | Metrics keys |
|---|---|
| `ExtractPackage` | `FilesExtracted`, `TotalBytesWritten` |
| `SubstituteInFiles` | `FilesProcessed`, `FilesSkipped`, `FilesWithUnresolvedTokens` |
| `ConfigurationTransforms` | `TransformsApplied`, `TransformsFailed` |
| `StructuredConfigVariables` | `FilesProcessed`, `FilesFailed`, `LeavesReplaced` |
| `WriteBootstrappedScript` | `VariablesExported`, `OriginalScriptBytes`, `BootstrappedScriptBytes` |
| `ExecuteMainScript` | `ExitCode`, `OutputVariablesCount` |
| `PreDeploy` / `PostDeploy` / `DeployFailed` | `ExitCode`, `OutputVariablesCount` |

Every outcome carries `DurationMs` + `Status` (`Succeeded` / `Skipped` / `Failed`) + optional `Message`.

## Key design choices

- **Opt-in `IStepOutcomeAwareContext`** — same lightweight extension as `IPathBasedExecutionContext` / `IFailureAwareExecutionContext`. Existing callers unaffected.
- **`StepStatus` enum values pinned** (Succeeded=1, Skipped=2, Failed=3) — binary-stable for serialised channels.
- **Snapshot in `BuildRunScriptCommandResultStep`** — outcomes list copied (not aliased) into `CommandExecutionResult` so post-build mutations don't retroactively edit it.
- **`DeployFailed` non-zero exit emits `Status=Failed`** but still **doesn't re-throw** (preserves H1 semantics — original execution failure stays canonical). Failure now visible via the outcome surface for analytics.
- **Skipped status fires for short-circuits** (e.g. StructuredConfig with empty Targets glob) — UI shows "step ran, skipped" rather than the ambiguous absence-of-entry.

## Test plan

- [x] Squid.Calamari.Tests: 463/463 (was 449; +14)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Solution build: 0 errors
- [x] Record-level: factory shape + record equality + enum value stability
- [x] Per-step: each step emits exactly one outcome with the documented metric keys
- [x] Skipped status path covered (StructuredConfig empty-targets)
- [x] Failed status without re-throw (DeployFailed hook itself fails)

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Existing wire literals | Unchanged |
| Existing Console.WriteLine summary lines | Preserved (additive only) |
| `CommandExecutionResult` ctor | Additive `stepOutcomes` parameter with default `null` → empty list |
| Existing `RunScriptCommand.ExecuteAsync` callers | Get the new `StepOutcomes` property on the result; reading is optional |
| SquidWeb | Untouched |