### PR TITLE
Wire-literal single source of truth: CalamariWireVariables index

### DIFF
--- a/src/Squid.Calamari/Constants/CalamariWireVariables.cs
+++ b/src/Squid.Calamari/Constants/CalamariWireVariables.cs
@@ -1,0 +1,177 @@
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Commands.Conventions;
+using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.Package;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Commands.Substitution;
+
+namespace Squid.Calamari.Constants;
+
+/// <summary>
+/// **Operator-facing index of every wire literal Squid.Calamari recognises.**
+///
+/// <para>Whether you're setting variables in a deployment process, writing
+/// a custom handler that drives Calamari, or hunting down "what does this
+/// toggle do?" — this file is the single grep target. Every literal that
+/// flows from server → variables.json → Calamari step is referenced here
+/// with operator-facing documentation.</para>
+///
+/// <para><b>How this stays accurate</b>: each constant here is a compile-
+/// time alias of the originating per-feature <c>*VariableNames</c> class.
+/// Renaming the per-feature constant breaks the alias here at build time;
+/// renaming the literal value is caught by the drift-detector tests in
+/// <c>CalamariWireVariablesDriftTests</c>. Either way the rename surfaces
+/// as a test/build failure, not a silent runtime no-op.</para>
+///
+/// <para><b>Note on legacy literals</b>: where a feature has both a
+/// canonical (handler-agnostic) name AND a legacy IIS-prefixed name (the
+/// A1 generalization in #367), both are listed — canonical first, with a
+/// nested <c>Legacy</c> static class. Operators on existing IIS deploys
+/// continue to use the Legacy names; new handlers should emit the
+/// canonical names.</para>
+/// </summary>
+public static class CalamariWireVariables
+{
+    // ── G1.1 — Token substitution in operator-nominated files ───────────────
+
+    /// <summary>
+    /// `#{Token}` replacement (G1.1). Set <see cref="Enabled"/> = "True"
+    /// and list file globs in <see cref="TargetFiles"/> (newline-separated)
+    /// to have Calamari resolve <c>#{VariableName}</c> tokens to their
+    /// values in matching files.
+    /// </summary>
+    public static class SubstituteInFiles
+    {
+        /// <summary>"True" to run the step. Default OFF.</summary>
+        public const string Enabled = SubstituteInFilesVariableNames.Enabled;
+
+        /// <summary>Newline-separated file globs (relative to working dir),
+        /// e.g. <c>web.config\nappsettings*.json</c>.</summary>
+        public const string TargetFiles = SubstituteInFilesVariableNames.TargetFiles;
+
+        /// <summary>"True" to fail the deploy when any token in target files
+        /// can't be resolved. Default OFF (lenient — unresolved tokens stay
+        /// as literal placeholders).</summary>
+        public const string ShouldFailOnUnresolved = SubstituteInFilesVariableNames.ShouldFailOnUnresolved;
+
+        /// <summary>Legacy IIS-handler-specific literals (pre-A1). Existing
+        /// IIS deployment definitions emit these; new handlers should emit
+        /// the canonical names above.</summary>
+        public static class Legacy
+        {
+            public const string Enabled = SubstituteInFilesVariableNames.Legacy.Enabled;
+            public const string TargetFiles = SubstituteInFilesVariableNames.Legacy.TargetFiles;
+        }
+    }
+
+    // ── G1.2 — XDT transforms on *.config files ─────────────────────────────
+
+    /// <summary>
+    /// XDT (web.{Env}.config) transforms on *.config files (G1.2). Set
+    /// <see cref="Enabled"/> = "True"; the step auto-pairs each <c>*.config</c>
+    /// with its <c>*.{EnvironmentName}.config</c> sibling AND
+    /// <c>*.Release.config</c>. Operator-supplied explicit pairs via
+    /// <see cref="AdditionalTransforms"/>.
+    /// </summary>
+    public static class ConfigurationTransforms
+    {
+        public const string Enabled = ConfigurationTransformsVariableNames.Enabled;
+
+        /// <summary>Drives auto-pair discovery, e.g. <c>"Production"</c> →
+        /// applies <c>web.Production.config</c> to <c>web.config</c>.</summary>
+        public const string EnvironmentName = ConfigurationTransformsVariableNames.EnvironmentName;
+
+        /// <summary>Newline-separated <c>transform.config =&gt; base.config</c>
+        /// pairs for cases not covered by auto-pairing.</summary>
+        public const string AdditionalTransforms = ConfigurationTransformsVariableNames.AdditionalTransforms;
+
+        /// <summary>Legacy IIS-prefixed literals (pre-A1).</summary>
+        public static class Legacy
+        {
+            public const string Enabled = ConfigurationTransformsVariableNames.Legacy.Enabled;
+            public const string EnvironmentName = ConfigurationTransformsVariableNames.Legacy.EnvironmentName;
+            public const string AdditionalTransforms = ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms;
+        }
+    }
+
+    // ── G1.3 + PR-3 — Structured-config leaf replacement (JSON / YAML / XML) ─
+
+    /// <summary>
+    /// Leaf-value replacement on operator-nominated structured-config files
+    /// (G1.3 + PR-3). Originally JSON-only; now dispatches by file extension
+    /// to JSON / YAML / XML format handlers via the same toggle + targets.
+    /// Operator's variable names with dot or colon (ASP.NET-Core IConfiguration
+    /// idiom) match leaves at corresponding paths.
+    /// </summary>
+    public static class JsonConfigVariables
+    {
+        /// <summary>"True" to enable. Same toggle drives JSON, YAML, and
+        /// XML branches — dispatch happens per file by extension.</summary>
+        public const string Enabled = StructuredConfigVariableNames.Enabled;
+
+        /// <summary>Newline-separated file globs. <c>.json/.json5</c>
+        /// dispatches to JSON, <c>.yaml/.yml</c> to YAML, <c>.xml</c> to
+        /// XML. Other extensions skip with a structured warning.</summary>
+        public const string Targets = StructuredConfigVariableNames.Targets;
+
+        /// <summary>Legacy IIS-prefixed names (pre-A1). Operator deploys
+        /// from before the rename still emit these; new handlers use the
+        /// canonical names above.</summary>
+        public static class Legacy
+        {
+            public const string Enabled = StructuredConfigVariableNames.Legacy.Enabled;
+            public const string Targets = StructuredConfigVariableNames.Legacy.Targets;
+        }
+    }
+
+    // ── G1.4 — Package extraction (.zip / .nupkg / .tar / .tar.gz / .tgz) ───
+
+    /// <summary>
+    /// Package extraction (G1.4 + PR-2 multi-format). When
+    /// <see cref="OriginalPath"/> points at a supported archive, Calamari
+    /// extracts it into the working directory BEFORE rewriters run, so
+    /// rewriters operate on extracted files.
+    /// </summary>
+    public static class Package
+    {
+        /// <summary>Absolute path on disk to the package file. Empty / unset
+        /// → no extraction (standalone-script deploys).</summary>
+        public const string OriginalPath = PackageVariableNames.OriginalPath;
+    }
+
+    // ── G1.5 + PR-1 — Convention hook script filenames ──────────────────────
+
+    /// <summary>
+    /// Convention hooks (G1.5 + PR-1). NOT wire literals — file-system
+    /// conventions. Operator drops a script with one of these stems in
+    /// the package; on extract, Calamari finds it and runs it at the
+    /// appropriate pipeline phase.
+    /// </summary>
+    public static class Conventions
+    {
+        /// <summary>Runs after extract + rewriters, before main script.</summary>
+        public const string PreDeployFilename = ConventionScriptNames.PreDeploy;
+
+        /// <summary>Runs after main script, before cleanup.</summary>
+        public const string PostDeployFilename = ConventionScriptNames.PostDeploy;
+
+        /// <summary>Runs in cleanup phase ONLY when the deploy failed
+        /// (prior step exception OR non-zero main-script exit code).</summary>
+        public const string DeployFailedFilename = ConventionScriptNames.DeployFailed;
+    }
+
+    // ── Hardening env vars (Rule 8 escape hatches) ──────────────────────────
+
+    /// <summary>
+    /// Operator escape-hatch environment variables (Rule 8). Set on the
+    /// agent's process environment; read at deploy time.
+    /// </summary>
+    public static class Hardening
+    {
+        /// <summary>Override the 50 MB per-file size cap applied uniformly
+        /// across SubstituteInFiles / ConfigurationTransforms /
+        /// StructuredConfig / ExtractPackage. Total archive cap is 10× this.
+        /// Default 50.</summary>
+        public const string MaxFileSizeMBEnvVar = EncodingPreservingFileIO.MaxFileSizeMBEnvVar;
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Constants/CalamariWireVariablesDriftTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Constants/CalamariWireVariablesDriftTests.cs
@@ -1,0 +1,155 @@
+using Shouldly;
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Commands.Conventions;
+using Squid.Calamari.Commands.Configuration;
+using Squid.Calamari.Commands.Package;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Commands.Substitution;
+using Squid.Calamari.Constants;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Constants;
+
+/// <summary>
+/// PR-6 — drift detectors for <see cref="CalamariWireVariables"/>. The
+/// SSOT is operator-facing; it MUST stay in sync with the per-feature
+/// originating constants. Two layers of pin:
+///
+/// <list type="number">
+///   <item><b>Alias integrity</b> — SSOT constant = originating constant.
+///         If a per-feature class renames its value, the SSOT silently
+///         picks it up via the compile-time alias; this test confirms
+///         the alias is still pointing at the right thing.</item>
+///   <item><b>Literal value</b> — pin the actual wire string. If both
+///         the per-feature constant AND the SSOT rename in lock-step,
+///         the alias-integrity test still passes; this third layer
+///         catches the coordinated rename so operators flipping the
+///         variable name in their orchestrator config don't silently
+///         break.</item>
+/// </list>
+///
+/// <para>Every wire literal Calamari recognizes is pinned here.
+/// Operators wanting the canonical "what variables can I set?" list
+/// read <see cref="CalamariWireVariables"/>; this test file is the
+/// machine-enforced version of that documentation.</para>
+/// </summary>
+public sealed class CalamariWireVariablesDriftTests
+{
+    // ── SubstituteInFiles (G1.1) ────────────────────────────────────────────
+
+    [Fact]
+    public void SubstituteInFiles_AliasIntegrity()
+    {
+        CalamariWireVariables.SubstituteInFiles.Enabled.ShouldBe(SubstituteInFilesVariableNames.Enabled);
+        CalamariWireVariables.SubstituteInFiles.TargetFiles.ShouldBe(SubstituteInFilesVariableNames.TargetFiles);
+        CalamariWireVariables.SubstituteInFiles.ShouldFailOnUnresolved.ShouldBe(SubstituteInFilesVariableNames.ShouldFailOnUnresolved);
+        CalamariWireVariables.SubstituteInFiles.Legacy.Enabled.ShouldBe(SubstituteInFilesVariableNames.Legacy.Enabled);
+        CalamariWireVariables.SubstituteInFiles.Legacy.TargetFiles.ShouldBe(SubstituteInFilesVariableNames.Legacy.TargetFiles);
+    }
+
+    [Fact]
+    public void SubstituteInFiles_LiteralValues()
+    {
+        CalamariWireVariables.SubstituteInFiles.Enabled.ShouldBe("Squid.Action.SubstituteInFiles.Enabled");
+        CalamariWireVariables.SubstituteInFiles.TargetFiles.ShouldBe("Squid.Action.SubstituteInFiles.TargetFiles");
+        CalamariWireVariables.SubstituteInFiles.ShouldFailOnUnresolved.ShouldBe("Squid.Action.SubstituteInFiles.ShouldFailDeploymentOnSubstitutionFails");
+        CalamariWireVariables.SubstituteInFiles.Legacy.Enabled.ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.Enabled");
+        CalamariWireVariables.SubstituteInFiles.Legacy.TargetFiles.ShouldBe("Squid.Action.IISWebSite.SubstituteInFiles.TargetFiles");
+    }
+
+    // ── ConfigurationTransforms (G1.2) ──────────────────────────────────────
+
+    [Fact]
+    public void ConfigurationTransforms_AliasIntegrity()
+    {
+        CalamariWireVariables.ConfigurationTransforms.Enabled.ShouldBe(ConfigurationTransformsVariableNames.Enabled);
+        CalamariWireVariables.ConfigurationTransforms.EnvironmentName.ShouldBe(ConfigurationTransformsVariableNames.EnvironmentName);
+        CalamariWireVariables.ConfigurationTransforms.AdditionalTransforms.ShouldBe(ConfigurationTransformsVariableNames.AdditionalTransforms);
+        CalamariWireVariables.ConfigurationTransforms.Legacy.Enabled.ShouldBe(ConfigurationTransformsVariableNames.Legacy.Enabled);
+        CalamariWireVariables.ConfigurationTransforms.Legacy.EnvironmentName.ShouldBe(ConfigurationTransformsVariableNames.Legacy.EnvironmentName);
+        CalamariWireVariables.ConfigurationTransforms.Legacy.AdditionalTransforms.ShouldBe(ConfigurationTransformsVariableNames.Legacy.AdditionalTransforms);
+    }
+
+    [Fact]
+    public void ConfigurationTransforms_LiteralValues()
+    {
+        CalamariWireVariables.ConfigurationTransforms.Enabled.ShouldBe("Squid.Action.ConfigurationTransforms.Enabled");
+        CalamariWireVariables.ConfigurationTransforms.EnvironmentName.ShouldBe("Squid.Action.ConfigurationTransforms.EnvironmentName");
+        CalamariWireVariables.ConfigurationTransforms.AdditionalTransforms.ShouldBe("Squid.Action.ConfigurationTransforms.AdditionalTransforms");
+        CalamariWireVariables.ConfigurationTransforms.Legacy.Enabled.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.Enabled");
+        CalamariWireVariables.ConfigurationTransforms.Legacy.EnvironmentName.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.EnvironmentName");
+        CalamariWireVariables.ConfigurationTransforms.Legacy.AdditionalTransforms.ShouldBe("Squid.Action.IISWebSite.ConfigurationTransforms.AdditionalTransforms");
+    }
+
+    // ── JsonConfigVariables (G1.3 + PR-3 multi-format) ──────────────────────
+
+    [Fact]
+    public void JsonConfigVariables_AliasIntegrity()
+    {
+        CalamariWireVariables.JsonConfigVariables.Enabled.ShouldBe(StructuredConfigVariableNames.Enabled);
+        CalamariWireVariables.JsonConfigVariables.Targets.ShouldBe(StructuredConfigVariableNames.Targets);
+        CalamariWireVariables.JsonConfigVariables.Legacy.Enabled.ShouldBe(StructuredConfigVariableNames.Legacy.Enabled);
+        CalamariWireVariables.JsonConfigVariables.Legacy.Targets.ShouldBe(StructuredConfigVariableNames.Legacy.Targets);
+    }
+
+    [Fact]
+    public void JsonConfigVariables_LiteralValues()
+    {
+        CalamariWireVariables.JsonConfigVariables.Enabled.ShouldBe("Squid.Action.JsonConfigVariables.Enabled");
+        CalamariWireVariables.JsonConfigVariables.Targets.ShouldBe("Squid.Action.JsonConfigVariables.Targets");
+        CalamariWireVariables.JsonConfigVariables.Legacy.Enabled.ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Enabled");
+        CalamariWireVariables.JsonConfigVariables.Legacy.Targets.ShouldBe("Squid.Action.IISWebSite.StructuredConfigurationVariables.Targets");
+    }
+
+    // ── Package (G1.4) ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Package_OriginalPath_PinnedAtCanonical()
+    {
+        CalamariWireVariables.Package.OriginalPath.ShouldBe(PackageVariableNames.OriginalPath);
+        CalamariWireVariables.Package.OriginalPath.ShouldBe("Squid.Action.Package.OriginalPath");
+    }
+
+    // ── Convention hook filenames (G1.5 + PR-1) ─────────────────────────────
+
+    [Fact]
+    public void Conventions_FilenamesPinned()
+    {
+        CalamariWireVariables.Conventions.PreDeployFilename.ShouldBe(ConventionScriptNames.PreDeploy);
+        CalamariWireVariables.Conventions.PostDeployFilename.ShouldBe(ConventionScriptNames.PostDeploy);
+        CalamariWireVariables.Conventions.DeployFailedFilename.ShouldBe(ConventionScriptNames.DeployFailed);
+
+        // These are operator-facing FILE STEMS, not wire literals — operators
+        // ship a `PreDeploy.sh` file in their package. Pinning the literal
+        // value here means renaming the stem is a deliberate test edit.
+        CalamariWireVariables.Conventions.PreDeployFilename.ShouldBe("PreDeploy");
+        CalamariWireVariables.Conventions.PostDeployFilename.ShouldBe("PostDeploy");
+        CalamariWireVariables.Conventions.DeployFailedFilename.ShouldBe("DeployFailed");
+    }
+
+    // ── Hardening env vars (T3) ─────────────────────────────────────────────
+
+    [Fact]
+    public void Hardening_MaxFileSizeMBEnvVar_Pinned()
+    {
+        CalamariWireVariables.Hardening.MaxFileSizeMBEnvVar.ShouldBe(EncodingPreservingFileIO.MaxFileSizeMBEnvVar);
+        CalamariWireVariables.Hardening.MaxFileSizeMBEnvVar.ShouldBe("SQUID_CALAMARI_REWRITER_MAX_FILE_SIZE_MB");
+    }
+
+    // ── Distinctness — canonical vs legacy ──────────────────────────────────
+
+    [Fact]
+    public void CanonicalAndLegacy_AreDistinctAcrossAllFeatures()
+    {
+        // Pin that canonical and legacy literals don't accidentally collide.
+        // If a future refactor flattens them to the same string, the dual-
+        // read fallback in the steps degrades to a single-read silently.
+        CalamariWireVariables.SubstituteInFiles.Enabled.ShouldNotBe(CalamariWireVariables.SubstituteInFiles.Legacy.Enabled);
+        CalamariWireVariables.SubstituteInFiles.TargetFiles.ShouldNotBe(CalamariWireVariables.SubstituteInFiles.Legacy.TargetFiles);
+        CalamariWireVariables.ConfigurationTransforms.Enabled.ShouldNotBe(CalamariWireVariables.ConfigurationTransforms.Legacy.Enabled);
+        CalamariWireVariables.ConfigurationTransforms.EnvironmentName.ShouldNotBe(CalamariWireVariables.ConfigurationTransforms.Legacy.EnvironmentName);
+        CalamariWireVariables.ConfigurationTransforms.AdditionalTransforms.ShouldNotBe(CalamariWireVariables.ConfigurationTransforms.Legacy.AdditionalTransforms);
+        CalamariWireVariables.JsonConfigVariables.Enabled.ShouldNotBe(CalamariWireVariables.JsonConfigVariables.Legacy.Enabled);
+        CalamariWireVariables.JsonConfigVariables.Targets.ShouldNotBe(CalamariWireVariables.JsonConfigVariables.Legacy.Targets);
+    }
+}


### PR DESCRIPTION
## Summary

Operator-facing aggregator of every wire literal Squid.Calamari recognises. Operators grep ONE file (`CalamariWireVariables.cs`) to discover every toggle / glob / convention filename / env var. Modeled after Octopus's `SpecialVariables.cs` (1208-line single index).

Per-feature `*VariableNames` classes keep ownership of their constants; the SSOT re-exports them via compile-time aliases.

## What's in the box

| Layer | File |
|---|---|
| SSOT index | `src/Squid.Calamari/Constants/CalamariWireVariables.cs` (new) |
| Drift detector tests (10) | `tests/Squid.Calamari.Tests/Calamari/Constants/CalamariWireVariablesDriftTests.cs` (new) |

## Grouped by feature

| Inner class | What it indexes |
|---|---|
| `SubstituteInFiles` (G1.1) | Canonical + nested `Legacy` IIS-prefixed |
| `ConfigurationTransforms` (G1.2) | Canonical + nested `Legacy` |
| `JsonConfigVariables` (G1.3 + PR-3) | Canonical + nested `Legacy`. Same toggle drives JSON / YAML / XML per file extension. |
| `Package` (G1.4) | `OriginalPath` (canonical-only) |
| `Conventions` (G1.5 + PR-1) | `PreDeployFilename` / `PostDeployFilename` / `DeployFailedFilename` (file-system conventions) |
| `Hardening` (T3) | `MaxFileSizeMBEnvVar` |

## How drift stays caught

1. **Compile-time alias** — each SSOT constant `= OriginatingClass.Const`. Renaming the originating const breaks the alias at build time.
2. **Drift detector tests** — pin both alias integrity (SSOT == origin) AND literal value (SSOT == `"Squid.Action.X.Y"`). Coordinated renames on both sides still surface as a deliberate test edit.

## Test plan

- [x] Squid.Calamari.Tests: 473/473 (was 463; +10)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Solution build: 0 errors
- [x] Pre-merge audit GREEN on 6/6 invariants
- [x] Purely additive — `git diff main` only shows new files, no modifications to existing code

## Non-breaking guarantee

| Surface | Status |
|---|---|
| All existing `*VariableNames` classes | Unchanged |
| Step files | Untouched |
| Registries | Untouched |
| Production behavior | Identical (SSOT contains only `public const string` aliases) |
| SquidWeb | Untouched |