### PR TITLE
Multi-shell convention hooks (PreDeploy.ps1 / PostDeploy.ps1 / DeployFailed.ps1)

### DIFF
--- a/src/Squid.Calamari/Commands/Conventions/ConventionBootstrap.cs
+++ b/src/Squid.Calamari/Commands/Conventions/ConventionBootstrap.cs
@@ -1,0 +1,48 @@
+using Squid.Calamari.Commands;
+using Squid.Calamari.Scripting;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.Conventions;
+
+/// <summary>
+/// PR-7 — shared bootstrap helper for convention scripts. Generates the
+/// syntax-appropriate variable preamble (bash <c>export</c> or PowerShell
+/// <c>$env:</c>) and writes the bootstrapped temp file with the matching
+/// extension, so a convention hook sees the same variable scope as the
+/// operator's main script regardless of shell.
+///
+/// <para>Shared between <see cref="ConventionScriptStep"/> (Pre/Post) and
+/// <see cref="DeployFailedConventionStep"/> so the bootstrap shape can't
+/// drift between the normal-phase and cleanup-phase hooks.</para>
+/// </summary>
+internal static class ConventionBootstrap
+{
+    /// <summary>
+    /// Read the convention script, prepend the syntax-appropriate variable
+    /// preamble, write to a uniquely-named temp file in the working dir
+    /// with the matching extension. Returns the temp path (caller tracks
+    /// it for cleanup). Caller has already null-checked WorkingDirectory +
+    /// Variables.
+    /// </summary>
+    public static string WriteBootstrappedConventionScript(
+        RunScriptCommandContext context,
+        string conventionName,
+        ResolvedConvention resolved)
+    {
+        var originalScript = File.ReadAllText(resolved.Path);
+        var preamble = resolved.Syntax switch
+        {
+            ScriptSyntax.PowerShell => PowerShellVariableBootstrapper.GeneratePreamble(context.Variables!),
+            _ => VariableBootstrapper.GeneratePreamble(context.Variables!)
+        };
+        var bootstrappedScript = preamble + originalScript;
+
+        var extension = resolved.Syntax == ScriptSyntax.PowerShell ? ".ps1" : ".sh";
+        var bootstrappedPath = Path.Combine(
+            context.WorkingDirectory!,
+            $".squid-{conventionName.ToLowerInvariant()}-{Guid.NewGuid():N}{extension}");
+        File.WriteAllText(bootstrappedPath, bootstrappedScript);
+
+        return bootstrappedPath;
+    }
+}

--- a/src/Squid.Calamari/Commands/Conventions/ConventionScriptResolver.cs
+++ b/src/Squid.Calamari/Commands/Conventions/ConventionScriptResolver.cs
@@ -1,0 +1,53 @@
+using Squid.Calamari.Scripting;
+
+namespace Squid.Calamari.Commands.Conventions;
+
+/// <summary>
+/// PR-7 — multi-shell convention-script resolution. Operators can ship a
+/// convention as <c>PreDeploy.sh</c> (bash) OR <c>PreDeploy.ps1</c>
+/// (PowerShell). This resolver finds which exists and pairs it with the
+/// right <see cref="ScriptSyntax"/> so the calling step dispatches to the
+/// correct executor.
+///
+/// <para><b>Both-exist tie-break</b>: a cross-platform package may ship
+/// BOTH <c>PreDeploy.sh</c> and <c>PreDeploy.ps1</c>. We prefer the one
+/// matching the operator's MAIN script syntax (derived from the main
+/// script's extension via <see cref="ScriptSyntaxDetector"/>). Rationale:
+/// an operator deploying a PowerShell app wants the PowerShell convention;
+/// a bash app wants the bash convention. Deterministic + matches intuition
+/// + no OS-mocking needed in tests.</para>
+///
+/// <para><b>Back-compat</b>: a package shipping only <c>PreDeploy.sh</c>
+/// (every pre-PR-7 package) resolves to bash exactly as before. The .ps1
+/// probe is purely additive.</para>
+/// </summary>
+internal static class ConventionScriptResolver
+{
+    /// <summary>
+    /// Resolve a convention script in <paramref name="workingDir"/>.
+    /// Returns the absolute path + its syntax, or <see langword="null"/>
+    /// when no <c>{conventionName}.sh</c> / <c>.ps1</c> exists.
+    /// </summary>
+    public static ResolvedConvention? Resolve(string workingDir, string conventionName, ScriptSyntax preferredSyntax)
+    {
+        var psPath = Path.Combine(workingDir, $"{conventionName}.ps1");
+        var shPath = Path.Combine(workingDir, $"{conventionName}.sh");
+
+        var psExists = File.Exists(psPath);
+        var shExists = File.Exists(shPath);
+
+        if (!psExists && !shExists) return null;
+
+        // Both shipped → main script's syntax wins.
+        if (psExists && shExists)
+            return preferredSyntax == ScriptSyntax.PowerShell
+                ? new ResolvedConvention(psPath, ScriptSyntax.PowerShell)
+                : new ResolvedConvention(shPath, ScriptSyntax.Bash);
+
+        return psExists
+            ? new ResolvedConvention(psPath, ScriptSyntax.PowerShell)
+            : new ResolvedConvention(shPath, ScriptSyntax.Bash);
+    }
+}
+
+internal readonly record struct ResolvedConvention(string Path, ScriptSyntax Syntax);

--- a/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/ConventionScriptStep.cs
@@ -68,8 +68,8 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
         if (string.IsNullOrEmpty(context.WorkingDirectory)) return false;
         if (context.Variables is null) return false;
 
-        var scriptPath = ResolveConventionScriptPath(context.WorkingDirectory);
-        return File.Exists(scriptPath);
+        return ConventionScriptResolver.Resolve(
+            context.WorkingDirectory, _conventionName, PreferredSyntax(context)) is not null;
     }
 
     public override async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
@@ -84,21 +84,16 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
             throw new InvalidOperationException(
                 $"{_conventionName}: variables have not been loaded.");
 
-        var scriptPath = ResolveConventionScriptPath(context.WorkingDirectory);
+        var resolved = ConventionScriptResolver.Resolve(
+                           context.WorkingDirectory, _conventionName, PreferredSyntax(context))
+                       ?? throw new InvalidOperationException(
+                           $"{_conventionName}: convention script vanished between IsEnabled and ExecuteAsync.");
 
-        // Generate the same export-VAR preamble used for the main script so
-        // operator's PreDeploy.sh / PostDeploy.sh see identical variable scope.
-        var originalScript = File.ReadAllText(scriptPath);
-        var preamble = VariableBootstrapper.GeneratePreamble(context.Variables);
-        var bootstrappedScript = preamble + originalScript;
-
-        var bootstrappedPath = Path.Combine(
-            context.WorkingDirectory,
-            $".squid-{_conventionName.ToLowerInvariant()}-{Guid.NewGuid():N}.sh");
-        File.WriteAllText(bootstrappedPath, bootstrappedScript);
+        var bootstrappedPath = ConventionBootstrap.WriteBootstrappedConventionScript(
+            context, _conventionName, resolved);
         context.TemporaryFiles.Add(bootstrappedPath);
 
-        Console.WriteLine($"{_conventionName}: running '{scriptPath}'.");
+        Console.WriteLine($"{_conventionName}: running '{resolved.Path}' ({resolved.Syntax}).");
 
         var outputProcessor = new ScriptOutputProcessor();
         var result = await _scriptEngine.ExecuteAsync(
@@ -106,7 +101,7 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
                 {
                     ScriptPath = bootstrappedPath,
                     WorkingDirectory = context.WorkingDirectory,
-                    Syntax = ScriptSyntax.Bash,
+                    Syntax = resolved.Syntax,
                     OutputProcessor = outputProcessor
                 },
                 ct)
@@ -120,7 +115,7 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
 
         if (result.ExitCode != 0)
             throw new InvalidOperationException(
-                $"{_conventionName}: hook script '{scriptPath}' exited with code {result.ExitCode}. " +
+                $"{_conventionName}: hook script '{resolved.Path}' exited with code {result.ExitCode}. " +
                 "Deploy aborted — fix the hook or remove the script from the package.");
 
         Console.WriteLine($"{_conventionName}: completed successfully.");
@@ -129,17 +124,13 @@ internal sealed class ConventionScriptStep : ExecutionStep<RunScriptCommandConte
         {
             ["ExitCode"] = result.ExitCode,
             ["OutputVariablesCount"] = result.OutputVariables.Count
-        }) with { DurationMs = sw.ElapsedMilliseconds });
+        }) with { DurationMs = sw.ElapsedMilliseconds, Message = $"Syntax={resolved.Syntax}" });
     }
 
-    /// <summary>
-    /// Resolve the absolute path of the convention script. Centralised so
-    /// the lookup logic is identical between <c>IsEnabled</c> and
-    /// <c>ExecuteAsync</c> — drift between them would mean "step enabled,
-    /// script vanished, race / mystery error mid-execute".
-    /// </summary>
-    private string ResolveConventionScriptPath(string workingDir)
-        => Path.Combine(workingDir, $"{_conventionName}.sh");
+    /// <summary>The main script's syntax — used to break ties when a
+    /// package ships BOTH a .sh and .ps1 variant of the convention.</summary>
+    private static ScriptSyntax PreferredSyntax(RunScriptCommandContext context)
+        => ScriptSyntaxDetector.DetectFromPath(context.ScriptPath);
 }
 
 /// <summary>

--- a/src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs
+++ b/src/Squid.Calamari/Commands/Conventions/DeployFailedConventionStep.cs
@@ -58,8 +58,8 @@ internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunSc
                          || (context.ScriptResult is not null && context.ScriptResult.ExitCode != 0);
         if (!hadFailure) return false;
 
-        var scriptPath = Path.Combine(context.WorkingDirectory, $"{ConventionName}.sh");
-        return File.Exists(scriptPath);
+        return ConventionScriptResolver.Resolve(
+            context.WorkingDirectory, ConventionName, PreferredSyntax(context)) is not null;
     }
 
     public async Task ExecuteAsync(RunScriptCommandContext context, CancellationToken ct)
@@ -74,22 +74,19 @@ internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunSc
             throw new InvalidOperationException(
                 $"{ConventionName}: variables have not been loaded.");
 
-        var scriptPath = Path.Combine(context.WorkingDirectory, $"{ConventionName}.sh");
+        var resolved = ConventionScriptResolver.Resolve(
+                           context.WorkingDirectory, ConventionName, PreferredSyntax(context))
+                       ?? throw new InvalidOperationException(
+                           $"{ConventionName}: convention script vanished between IsEnabled and ExecuteAsync.");
 
-        var originalScript = File.ReadAllText(scriptPath);
-        var preamble = VariableBootstrapper.GeneratePreamble(context.Variables);
-        var bootstrappedScript = preamble + originalScript;
-
-        var bootstrappedPath = Path.Combine(
-            context.WorkingDirectory,
-            $".squid-{ConventionName.ToLowerInvariant()}-{Guid.NewGuid():N}.sh");
-        File.WriteAllText(bootstrappedPath, bootstrappedScript);
+        var bootstrappedPath = ConventionBootstrap.WriteBootstrappedConventionScript(
+            context, ConventionName, resolved);
         context.TemporaryFiles.Add(bootstrappedPath);
 
         var failureSignal = context.ExecutionFailed
             ? "prior step exception"
             : $"main script exit code {context.ScriptResult?.ExitCode}";
-        Console.WriteLine($"{ConventionName}: deploy failed ({failureSignal}); running '{scriptPath}'.");
+        Console.WriteLine($"{ConventionName}: deploy failed ({failureSignal}); running '{resolved.Path}' ({resolved.Syntax}).");
 
         var outputProcessor = new ScriptOutputProcessor();
         var result = await _scriptEngine.ExecuteAsync(
@@ -97,7 +94,7 @@ internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunSc
                 {
                     ScriptPath = bootstrappedPath,
                     WorkingDirectory = context.WorkingDirectory,
-                    Syntax = ScriptSyntax.Bash,
+                    Syntax = resolved.Syntax,
                     OutputProcessor = outputProcessor
                 },
                 ct)
@@ -127,6 +124,11 @@ internal sealed class DeployFailedConventionStep : IAlwaysRunExecutionStep<RunSc
         {
             ["ExitCode"] = result.ExitCode,
             ["OutputVariablesCount"] = result.OutputVariables.Count
-        }) with { DurationMs = sw.ElapsedMilliseconds });
+        }) with { DurationMs = sw.ElapsedMilliseconds, Message = $"Syntax={resolved.Syntax}" });
     }
+
+    /// <summary>The main script's syntax — breaks ties when a package ships
+    /// both <c>DeployFailed.sh</c> and <c>DeployFailed.ps1</c>.</summary>
+    private static ScriptSyntax PreferredSyntax(RunScriptCommandContext context)
+        => ScriptSyntaxDetector.DetectFromPath(context.ScriptPath);
 }

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/ConventionScriptResolverTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/ConventionScriptResolverTests.cs
@@ -1,0 +1,100 @@
+using Shouldly;
+using Squid.Calamari.Commands.Conventions;
+using Squid.Calamari.Scripting;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Conventions;
+
+/// <summary>
+/// PR-7 — resolution tests for <see cref="ConventionScriptResolver"/>.
+/// Pins the multi-shell probe behaviour: .sh / .ps1 detection, the
+/// both-shipped tie-break (main script syntax wins), and the back-compat
+/// .sh-only path.
+/// </summary>
+public sealed class ConventionScriptResolverTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public ConventionScriptResolverTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"conv-resolve-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    [Fact]
+    public void Resolve_NeitherExists_ReturnsNull()
+    {
+        ConventionScriptResolver.Resolve(_workDir, "PreDeploy", ScriptSyntax.Bash)
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_OnlyShExists_ReturnsBash_BackCompat()
+    {
+        // Every pre-PR-7 package ships only .sh. MUST resolve to bash
+        // regardless of the main script's preferred syntax.
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "echo hi");
+
+        var resolved = ConventionScriptResolver.Resolve(_workDir, "PreDeploy", ScriptSyntax.PowerShell);
+
+        resolved.ShouldNotBeNull();
+        resolved!.Value.Syntax.ShouldBe(ScriptSyntax.Bash,
+            customMessage: ".sh-only package MUST resolve to bash even when the main script is PowerShell — " +
+                           "the file that exists wins; preference only breaks ties.");
+        resolved.Value.Path.ShouldEndWith("PreDeploy.sh");
+    }
+
+    [Fact]
+    public void Resolve_OnlyPs1Exists_ReturnsPowerShell()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.ps1"), "Write-Output hi");
+
+        var resolved = ConventionScriptResolver.Resolve(_workDir, "PreDeploy", ScriptSyntax.Bash);
+
+        resolved.ShouldNotBeNull();
+        resolved!.Value.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+        resolved.Value.Path.ShouldEndWith("PreDeploy.ps1");
+    }
+
+    [Fact]
+    public void Resolve_BothExist_PrefersPowerShell_WhenMainIsPowerShell()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "echo hi");
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.ps1"), "Write-Output hi");
+
+        var resolved = ConventionScriptResolver.Resolve(_workDir, "PreDeploy", ScriptSyntax.PowerShell);
+
+        resolved!.Value.Syntax.ShouldBe(ScriptSyntax.PowerShell,
+            customMessage: "When both convention variants ship, the one matching the MAIN script's syntax wins. " +
+                           "PowerShell main → PowerShell convention.");
+        resolved.Value.Path.ShouldEndWith("PreDeploy.ps1");
+    }
+
+    [Fact]
+    public void Resolve_BothExist_PrefersBash_WhenMainIsBash()
+    {
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "echo hi");
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.ps1"), "Write-Output hi");
+
+        var resolved = ConventionScriptResolver.Resolve(_workDir, "PreDeploy", ScriptSyntax.Bash);
+
+        resolved!.Value.Syntax.ShouldBe(ScriptSyntax.Bash,
+            customMessage: "Bash main → bash convention when both ship.");
+        resolved.Value.Path.ShouldEndWith("PreDeploy.sh");
+    }
+
+    [Fact]
+    public void Resolve_DifferentConventionName_DoesNotCrossMatch()
+    {
+        // PostDeploy.sh exists; asking for PreDeploy MUST return null.
+        File.WriteAllText(Path.Combine(_workDir, "PostDeploy.sh"), "echo hi");
+
+        ConventionScriptResolver.Resolve(_workDir, "PreDeploy", ScriptSyntax.Bash)
+            .ShouldBeNull();
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/ConventionScriptStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Conventions/ConventionScriptStepTests.cs
@@ -156,6 +156,47 @@ public sealed class ConventionScriptStepTests : IDisposable
     }
 
     [Fact]
+    public async Task Execute_PreDeployPs1_DispatchesPowerShellSyntax_PsPreamble()
+    {
+        // PR-7: a PreDeploy.ps1 (no .sh sibling) MUST run with PowerShell
+        // syntax + the $env: preamble, regardless of the main script.
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.ps1"), "Write-Output \"hi $Greeting\"");
+
+        var engine = new StubScriptEngine(exitCode: 0);
+        var ctx = BuildContext();
+        ctx.Variables!.Set("Greeting", "world");
+
+        await new ConventionScriptStep(ConventionScriptNames.PreDeploy, engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        engine.Captured.ShouldNotBeNull();
+        engine.Captured!.Syntax.ShouldBe(ScriptSyntax.PowerShell,
+            customMessage: "PreDeploy.ps1 MUST dispatch with PowerShell syntax so the engine picks the PS executor.");
+        engine.Captured.ScriptPath.ShouldEndWith(".ps1",
+            customMessage: "Bootstrapped temp file for a PS convention MUST carry .ps1 so pwsh -File accepts it.");
+        var bootstrapped = File.ReadAllText(engine.Captured.ScriptPath);
+        bootstrapped.ShouldContain("$env:Greeting = 'world'",
+            customMessage: "PS convention MUST get the $env: preamble, not the bash export preamble.");
+        bootstrapped.ShouldContain("Write-Output \"hi $Greeting\"");
+    }
+
+    [Fact]
+    public async Task Execute_BothShVariants_MainBashWins_RunsShConvention()
+    {
+        // Cross-platform package ships both. Main script is .sh (default) →
+        // bash convention runs. Pins the tie-break wired through the step.
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.sh"), "echo from-sh");
+        File.WriteAllText(Path.Combine(_workDir, "PreDeploy.ps1"), "Write-Output from-ps");
+
+        var engine = new StubScriptEngine(exitCode: 0);
+        var ctx = BuildContext();    // ScriptPath ends with .sh → Bash preferred
+
+        await new ConventionScriptStep(ConventionScriptNames.PreDeploy, engine).ExecuteAsync(ctx, CancellationToken.None);
+
+        engine.Captured!.Syntax.ShouldBe(ScriptSyntax.Bash);
+        File.ReadAllText(engine.Captured.ScriptPath).ShouldContain("echo from-sh");
+    }
+
+    [Fact]
     public async Task Execute_PostDeploy_RunsWithSameBootstrapShape()
     {
         // PostDeploy is just another instance of the same class — confirm


### PR DESCRIPTION
## Summary

Extends PR-4 (#374) multi-shell support to convention hooks. Operators can ship a convention as `{name}.sh` (bash) OR `{name}.ps1` (PowerShell); Calamari finds which exists and dispatches to the matching executor + variable preamble.

## Resolution rules (`ConventionScriptResolver`)

| Files present | Resolves to |
|---|---|
| Neither | step skips (unchanged) |
| Only `.sh` | bash — **back-compat: every pre-PR-7 package** |
| Only `.ps1` | PowerShell |
| **Both** | the one matching the **main script's** syntax (from `context.ScriptPath`) — PowerShell app → PowerShell convention; bash app → bash convention |

Deterministic, intuitive, no OS-mocking in tests.

## What's in the box

| Layer | File |
|---|---|
| Resolver | `src/Squid.Calamari/Commands/Conventions/ConventionScriptResolver.cs` (new) |
| Shared bootstrap (Pre/Post + DeployFailed) | `src/Squid.Calamari/Commands/Conventions/ConventionBootstrap.cs` (new) |
| ConventionScriptStep updated | dispatch by resolved syntax |
| DeployFailedConventionStep updated | same |
| Tests | `ConventionScriptResolverTests.cs` (6) + ConventionScriptStepTests (+2) |

## Test plan

- [x] Squid.Calamari.Tests: 481/481 (was 473; +8)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Build: 0 errors
- [x] All 31 existing convention tests pass unchanged — back-compat
- [x] PreDeploy.ps1 → PowerShell syntax + `$env:` preamble + .ps1 temp extension
- [x] Both-variants tie-break: main-script syntax wins

## Non-breaking guarantee

| Surface | Status |
|---|---|
| `.sh`-only convention packages | Resolve to bash exactly as before |
| Wire literals / convention filenames | Unchanged (`PreDeploy`/`PostDeploy`/`DeployFailed` stems) |
| Pipeline order | Unchanged |
| SquidWeb | Untouched — file-based convention |