### PR TITLE
Route PowerShell through Calamari (opt-in via env flag)

### DIFF
--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -1219,7 +1219,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
                 .FirstOrDefault(f => string.Equals(Path.GetFileName(f.Name), "sensitiveVariables.json", StringComparison.Ordinal))
                 ?.EncryptionPassword;
 
-            return StartCalamariProcess(workDir, variablesPath, sensitiveVariablesPath, sensitivePassword, command.Arguments);
+            return StartCalamariProcess(workDir, variablesPath, sensitiveVariablesPath, sensitivePassword, command.ScriptSyntax, command.Arguments);
         }
 
         return command.ScriptSyntax switch
@@ -1258,7 +1258,48 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
     /// <c>Progress=Running</c> but the Calamari child had already crashed).
     /// Pinned by <c>IsCalamariCompatible_*</c> tests.</para>
     /// </summary>
-    internal static bool IsCalamariCompatible(ScriptType syntax) => syntax == ScriptType.Bash;
+    /// <summary>
+    /// Opt-in env var (Rule 8). When set to a truthy value, PowerShell
+    /// scripts ALSO route through Calamari (gaining the full rewriter +
+    /// convention pipeline). Default OFF preserves the conservative
+    /// bash-only routing — zero behaviour change for every existing agent.
+    ///
+    /// <para><b>Why opt-in, not default-on</b>: server-side PowerShell-
+    /// emitting paths (IISDeployScriptBuilder, WindowsTentacleUpgradeStrategy)
+    /// already inline variables into the script body via $SquidParameters,
+    /// so Calamari's bootstrap adds nothing for them — and routing them
+    /// through the extra Calamari child process changes the process tree /
+    /// cancellation / output-capture path. Operators with CUSTOM PowerShell
+    /// package deploys (who want SubstituteInFiles / ConfigurationTransforms /
+    /// conventions applied) opt in explicitly + reversibly.</para>
+    ///
+    /// <para>Pinned by <c>CalamariPowerShellEnvVar_ConstantNamePinned</c>.</para>
+    /// </summary>
+    public const string CalamariPowerShellEnvVar = "SQUID_TENTACLE_CALAMARI_POWERSHELL";
+
+    /// <summary>
+    /// Calamari routing predicate. Bash always qualifies. PowerShell
+    /// qualifies ONLY when <see cref="CalamariPowerShellEnvVar"/> is set to
+    /// a truthy value (1 / true / yes / on, case-insensitive) — the PR-4
+    /// PowerShell-aware bootstrap + the per-syntax <c>--script=</c> path
+    /// (PR-8) are the prerequisites that make this safe; the env gate keeps
+    /// it opt-in so the default agent behaviour is unchanged.
+    /// </summary>
+    internal static bool IsCalamariCompatible(ScriptType syntax) => syntax switch
+    {
+        ScriptType.Bash => true,
+        ScriptType.PowerShell => IsCalamariPowerShellEnabled(),
+        _ => false
+    };
+
+    /// <summary>Parse the opt-in env flag. Truthy = 1 / true / yes / on
+    /// (case-insensitive). Anything else (incl. unset) = false.</summary>
+    internal static bool IsCalamariPowerShellEnabled()
+    {
+        var raw = Environment.GetEnvironmentVariable(CalamariPowerShellEnvVar);
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+        return raw.Trim().ToLowerInvariant() is "1" or "true" or "yes" or "on";
+    }
 
     /// <summary>
     /// dispatches to the platform-resolved
@@ -1280,7 +1321,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
     }
 
     private static Process StartCalamariProcess(
-        string workDir, string variablesPath, string sensitiveVariablesPath, string? sensitivePassword, string[] arguments)
+        string workDir, string variablesPath, string sensitiveVariablesPath, string? sensitivePassword, ScriptType syntax, string[] arguments)
     {
         var psi = BuildCalamariProcessStartInfo(
             workDir,
@@ -1288,6 +1329,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
             sensitiveVariablesPath,
             sensitivePassword,
             sensitiveCiphertextExists: File.Exists(sensitiveVariablesPath),
+            syntax,
             arguments);
 
         var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
@@ -1307,6 +1349,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         string sensitiveVariablesPath,
         string? sensitivePassword,
         bool sensitiveCiphertextExists,
+        ScriptType syntax,
         string[] arguments)
     {
         var psi = new ProcessStartInfo
@@ -1322,7 +1365,12 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         };
 
         psi.ArgumentList.Add("run-script");
-        psi.ArgumentList.Add("--script=script.sh");
+        // PR-8: per-syntax script path. Bash → script.sh, PowerShell →
+        // script.ps1 — matches what WriteScriptFile already wrote to disk
+        // (ScriptFileNameFor). Calamari's PR-4 ScriptSyntaxDetector picks the
+        // executor from this extension. The hardcoded "script.sh" here was
+        // the co-dependent reason PowerShell couldn't route through Calamari.
+        psi.ArgumentList.Add($"--script={ScriptFileNameFor(syntax)}");
         psi.ArgumentList.Add($"--variables={variablesPath}");
 
         if (sensitiveCiphertextExists && !string.IsNullOrEmpty(sensitivePassword))

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
@@ -39,61 +39,111 @@ namespace Squid.Tentacle.Tests.ScriptExecution;
 /// </summary>
 public sealed class CalamariRoutingTests
 {
-    // ── IsCalamariCompatible — exhaustive truth table ───────────────────────────
+    // ── IsCalamariCompatible — truth table (PR-8: PowerShell now env-gated) ─────
 
     [Theory]
-    [InlineData(ScriptType.Bash, true)]                // ONLY syntax Calamari handles today
-    [InlineData(ScriptType.PowerShell, false)]         // PR #353 bug fix — must NOT route to Calamari
-    [InlineData(ScriptType.Python, false)]             // Calamari has no Python pipeline
+    [InlineData(ScriptType.Bash, true)]                // always routes to Calamari
+    [InlineData(ScriptType.PowerShell, false)]         // default OFF — env flag not set
+    [InlineData(ScriptType.Python, false)]             // Calamari has no Python pipeline (this PR)
     [InlineData(ScriptType.CSharp, false)]             // Calamari has no C# pipeline
     [InlineData(ScriptType.FSharp, false)]             // Calamari has no F# pipeline
-    public void IsCalamariCompatible_ReturnsTrueOnlyForBash(ScriptType syntax, bool expected)
+    public void IsCalamariCompatible_DefaultEnv_TrueOnlyForBash(ScriptType syntax, bool expected)
     {
+        // Default agent environment (flag unset). PowerShell stays FALSE —
+        // identical to pre-PR-8 behaviour. Back-compat pin.
+        Environment.SetEnvironmentVariable(LocalScriptService.CalamariPowerShellEnvVar, null);
         LocalScriptService.IsCalamariCompatible(syntax).ShouldBe(expected);
     }
 
-    [Fact]
-    public void IsCalamariCompatible_PowerShell_ExplicitlyFalse_RegressionPin()
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("TRUE")]
+    [InlineData("yes")]
+    [InlineData("on")]
+    public void IsCalamariCompatible_PowerShell_TrueWhenEnvFlagSet(string truthy)
     {
-        // The operator-reported failure mode was caused by this returning TRUE.
-        // A future refactor that flips it back without ALSO adding
-        // WriteBootstrappedPowerShellScriptStep to Calamari AND a per-syntax
-        // --script=... path in BuildCalamariProcessStartInfo would re-introduce
-        // the FileNotFoundException + UnknownResult crash. This standalone Fact
-        // exists so the failure message names the operator-visible symptom
-        // (not just "expected false but was true") if anyone widens the rule
-        // without checking the downstream prerequisites.
-        LocalScriptService.IsCalamariCompatible(ScriptType.PowerShell)
-            .ShouldBeFalse(
-                customMessage: "Routing PowerShell through Calamari crashes the child process " +
-                               "with FileNotFoundException ('script.sh' vs 'script.ps1' mismatch) " +
-                               "and surfaces as 'Unknown result (ticket or process not found) (exit code -1)' " +
-                               "to the operator. See LocalScriptService.IsCalamariCompatible docstring for " +
-                               "the full prerequisite list before flipping this back.");
+        Environment.SetEnvironmentVariable(LocalScriptService.CalamariPowerShellEnvVar, truthy);
+        try
+        {
+            LocalScriptService.IsCalamariCompatible(ScriptType.PowerShell).ShouldBeTrue(
+                customMessage: $"With {LocalScriptService.CalamariPowerShellEnvVar}={truthy}, PowerShell MUST route through Calamari " +
+                               "(opt-in). PR-4 added the PS-aware bootstrap; PR-8 added the per-syntax --script path.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(LocalScriptService.CalamariPowerShellEnvVar, null);
+        }
     }
 
-    // ── BuildCalamariProcessStartInfo — Bash-only argv contract ────────────────
+    [Theory]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("no")]
+    [InlineData("disabled")]
+    [InlineData("garbage")]
+    public void IsCalamariCompatible_PowerShell_FalseWhenEnvFlagFalsy(string falsy)
+    {
+        // Anything non-truthy keeps the conservative default. Bash is
+        // never affected by the flag.
+        Environment.SetEnvironmentVariable(LocalScriptService.CalamariPowerShellEnvVar, falsy);
+        try
+        {
+            LocalScriptService.IsCalamariCompatible(ScriptType.PowerShell).ShouldBeFalse();
+            LocalScriptService.IsCalamariCompatible(ScriptType.Bash).ShouldBeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(LocalScriptService.CalamariPowerShellEnvVar, null);
+        }
+    }
 
     [Fact]
-    public void BuildCalamariProcessStartInfo_HardcodesScriptSh_DocumentsBashOnlyContract()
+    public void CalamariPowerShellEnvVar_ConstantNamePinned()
     {
-        // Drift detector for the prerequisite call out in IsCalamariCompatible's
-        // docstring: Calamari's argv is hardcoded to --script=script.sh. If this
-        // EVER changes (e.g. someone adds per-syntax script paths), they MUST
-        // also widen IsCalamariCompatible — the two are co-dependent. Pinning the
-        // literal here makes any breaking refactor a test-time-visible decision.
+        // Rule 8 — operators pin this env var name in their agent config.
+        // Silent rename = silently-ignored opt-in.
+        LocalScriptService.CalamariPowerShellEnvVar.ShouldBe("SQUID_TENTACLE_CALAMARI_POWERSHELL");
+    }
+
+    // ── BuildCalamariProcessStartInfo — per-syntax --script path (PR-8) ─────────
+
+    [Fact]
+    public void BuildCalamariProcessStartInfo_Bash_UsesScriptSh()
+    {
         var psi = LocalScriptService.BuildCalamariProcessStartInfo(
             workDir: "/tmp/work",
             variablesPath: "/tmp/work/variables.json",
             sensitiveVariablesPath: "/tmp/work/sensitiveVariables.json",
             sensitivePassword: null,
             sensitiveCiphertextExists: false,
+            syntax: ScriptType.Bash,
             arguments: System.Array.Empty<string>());
 
         psi.ArgumentList.ShouldContain("--script=script.sh",
-            customMessage: "Calamari's --script= path is hardcoded to script.sh, which is why " +
-                           "IsCalamariCompatible must only return true for Bash. If you change this " +
-                           "to a per-syntax path (e.g. --script=<computed>), update IsCalamariCompatible " +
-                           "and the Calamari pipeline in the SAME PR — both halves are co-dependent.");
+            customMessage: "Bash MUST still use script.sh — back-compat with every existing bash deploy.");
+    }
+
+    [Fact]
+    public void BuildCalamariProcessStartInfo_PowerShell_UsesScriptPs1()
+    {
+        // PR-8 co-dependent fix: the per-syntax --script path. Without this,
+        // routing PS through Calamari would crash with FileNotFoundException
+        // (Tentacle wrote script.ps1, Calamari read script.sh). This pins the
+        // fix that makes the opt-in safe.
+        var psi = LocalScriptService.BuildCalamariProcessStartInfo(
+            workDir: "/tmp/work",
+            variablesPath: "/tmp/work/variables.json",
+            sensitiveVariablesPath: "/tmp/work/sensitiveVariables.json",
+            sensitivePassword: null,
+            sensitiveCiphertextExists: false,
+            syntax: ScriptType.PowerShell,
+            arguments: System.Array.Empty<string>());
+
+        psi.ArgumentList.ShouldContain("--script=script.ps1",
+            customMessage: "PowerShell MUST use script.ps1 — matches what WriteScriptFile wrote to disk. " +
+                           "The old hardcoded script.sh was why PS-through-Calamari crashed.");
+        psi.ArgumentList.ShouldNotContain("--script=script.sh");
     }
 }

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/SensitiveVariablePasswordTransportTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/SensitiveVariablePasswordTransportTests.cs
@@ -87,6 +87,7 @@ public sealed class SensitiveVariablePasswordTransportTests
             sensitiveVariablesPath: "/tmp/some-work/sensitiveVariables.json",
             sensitivePassword: "super-secret-pw",
             sensitiveCiphertextExists: true,
+            syntax: ScriptType.Bash,
             arguments: Array.Empty<string>());
 
         psi.Environment[LocalScriptService.CalamariSensitivePasswordEnvVar].ShouldBe("super-secret-pw",
@@ -115,6 +116,7 @@ public sealed class SensitiveVariablePasswordTransportTests
             sensitiveVariablesPath: "/tmp/some-work/sensitiveVariables.json",
             sensitivePassword: null,
             sensitiveCiphertextExists: false,
+            syntax: ScriptType.Bash,
             arguments: Array.Empty<string>());
 
         psi.Environment.ContainsKey(LocalScriptService.CalamariSensitivePasswordEnvVar).ShouldBeFalse(
@@ -136,6 +138,7 @@ public sealed class SensitiveVariablePasswordTransportTests
             sensitiveVariablesPath: "/tmp/some-work/sensitiveVariables.json",
             sensitivePassword: "pw-without-ciphertext",
             sensitiveCiphertextExists: false,
+            syntax: ScriptType.Bash,
             arguments: Array.Empty<string>());
 
         psi.Environment.ContainsKey(LocalScriptService.CalamariSensitivePasswordEnvVar).ShouldBeFalse();
@@ -152,6 +155,7 @@ public sealed class SensitiveVariablePasswordTransportTests
             sensitiveVariablesPath: "/tmp/some-work/sensitiveVariables.json",
             sensitivePassword: null,
             sensitiveCiphertextExists: false,
+            syntax: ScriptType.Bash,
             arguments: new[] { "arg-one", "arg-two" });
 
         psi.ArgumentList.ShouldContain("--");


### PR DESCRIPTION
## Summary

Connects PR-4's capability (Calamari can run PowerShell) to the Tentacle routing decision. **Default OFF — zero behaviour change.** Operators with custom PowerShell package deploys opt in to gain the rewriter + convention pipeline for PS scripts.

## Two co-dependent changes (both required)

The prior `IsCalamariCompatible` docstring + drift test warned that flipping PowerShell routing needs BOTH halves:

1. **Gate** — `IsCalamariCompatible(PowerShell)` returns true only when `SQUID_TENTACLE_CALAMARI_POWERSHELL` is truthy (`1`/`true`/`yes`/`on`). Bash always qualifies. Default (unset) = PowerShell on the direct launcher, exactly as before.
2. **Per-syntax `--script` path** — `BuildCalamariProcessStartInfo` now emits `--script=script.ps1` for PowerShell (was hardcoded `script.sh`). This was the co-dependent crash cause: Tentacle wrote `script.ps1`, Calamari read `script.sh` → `FileNotFoundException`.

## Why opt-in (not default-on)

Server-side PS-emitting paths (IIS deploy, Windows upgrade) already inline variables via `$SquidParameters` and don't need Calamari's bootstrap; routing them through the extra Calamari child changes the process-tree / cancellation / output-capture path. The env gate keeps the default conservative + makes it reversible. Operators who want rewriters on their custom PS deploys flip the flag explicitly.

## Test plan

- [x] Tentacle.Tests: 1467/1467
- [x] Build: 0 errors
- [x] Default-env truth table — PowerShell stays FALSE (back-compat pin)
- [x] Truthy theory (5 cases) → PowerShell routes through Calamari
- [x] Falsy theory (6 cases) → stays off; bash never affected
- [x] `CalamariPowerShellEnvVar` constant pinned (Rule 8)
- [x] `--script=script.ps1` for PowerShell, `script.sh` for bash
- [ ] Staging: opt-in agent runs a custom `.ps1` package deploy through Calamari with SubstituteInFiles applied

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Default agent (flag unset) | **Identical** — PowerShell on direct launcher, bash on Calamari |
| Existing bash Calamari routing | `--script=script.sh` unchanged |
| IIS / upgrade PS paths | Unchanged unless operator sets the flag (then they route through Calamari, gaining nothing but losing nothing — variables already inlined) |
| `BuildCalamariProcessStartInfo` signature | Internal — only LocalScriptService + its tests; all call sites updated |
| SquidWeb | Untouched |