### PR TITLE
A2 followup: .properties / .ini structured-config format

### DIFF
--- a/src/Squid.Calamari/Commands/StructuredConfig/PropertiesConfigFormat.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/PropertiesConfigFormat.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using Squid.Calamari.Variables;
+
+namespace Squid.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-9 — line-oriented <c>.properties</c> / <c>.ini</c> branch of the
+/// structured-config format dispatch. Java-stack operators ship
+/// <c>application.properties</c> (Spring Boot) or <c>.ini</c> files; this
+/// rewrites leaf values whose computed key-path matches a variable.
+///
+/// <para><b>Path computation</b>:
+/// <list type="bullet">
+///   <item><c>.properties</c>: the key IS the path
+///         (<c>logging.level.root=INFO</c> → path <c>logging.level.root</c>).
+///         Both dot and colon variable forms match via
+///         <see cref="ConfigVariableLookup"/>.</item>
+///   <item><c>.ini</c>: <c>[section]</c> headers prefix the key
+///         (<c>[database] url=...</c> → path <c>database.url</c>). Section-
+///         scoped keys disambiguate same-named keys across sections.</item>
+/// </list></para>
+///
+/// <para><b>Format preservation</b>: rewrites ONLY the value span of a
+/// matched line — comments (<c>#</c> / <c>!</c> / <c>;</c>), blank lines,
+/// section headers, key order, and the original delimiter + spacing
+/// (<c>key = value</c> vs <c>key=value</c>) all survive byte-for-byte.
+/// Line-based, no round-trip through a typed model.</para>
+///
+/// <para><b>Line-continuation limitation</b>: a value ending with a
+/// backslash (<c>key=part1\</c>) is a Java multi-line value. To avoid
+/// corrupting the continuation, such a key is SKIPPED (left intact) rather
+/// than partially rewritten. Deployment .properties almost never use
+/// continuation; documented + pinned so the behaviour is explicit.</para>
+/// </summary>
+internal sealed class PropertiesConfigFormat : IStructuredConfigFormat
+{
+    private static readonly string[] Extensions = { ".properties", ".ini" };
+
+    public string FormatName => "Properties";
+
+    public bool CanHandle(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+        return Extensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public StructuredConfigReplaceResult Replace(string content, VariableSet variables)
+    {
+        ArgumentNullException.ThrowIfNull(variables);
+        if (string.IsNullOrEmpty(content))
+            return StructuredConfigReplaceResult.Success(content, 0);
+
+        // Preserve the original line endings by splitting on \n and keeping
+        // the structure; we re-join with \n. To preserve \r\n we detect and
+        // restore per-line below.
+        var lines = content.Split('\n');
+        var replacedCount = 0;
+        var section = string.Empty;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            // Carry the \r if the original used CRLF — strip for parsing,
+            // re-append on write so the file's EOL style round-trips.
+            var raw = lines[i];
+            var hasCr = raw.EndsWith('\r');
+            var line = hasCr ? raw[..^1] : raw;
+
+            var rewritten = RewriteLine(line, variables, ref section, ref replacedCount);
+
+            lines[i] = hasCr ? rewritten + '\r' : rewritten;
+        }
+
+        return StructuredConfigReplaceResult.Success(string.Join('\n', lines), replacedCount);
+    }
+
+    private static string RewriteLine(string line, VariableSet variables, ref string section, ref int replacedCount)
+    {
+        var trimmedStart = line.TrimStart();
+
+        // Comment or blank → unchanged. # and ! are Java-properties comments;
+        // ; is the INI comment convention. All preserved.
+        if (trimmedStart.Length == 0
+            || trimmedStart[0] is '#' or '!' or ';')
+            return line;
+
+        // INI section header [name] → track + emit unchanged.
+        if (trimmedStart.StartsWith('[') && trimmedStart.TrimEnd().EndsWith(']'))
+        {
+            var inner = trimmedStart.TrimEnd();
+            section = inner[1..^1].Trim();
+            return line;
+        }
+
+        // Find the first key/value delimiter (= or :). No delimiter → key-only
+        // or malformed line; leave unchanged.
+        var delimIndex = IndexOfDelimiter(line);
+        if (delimIndex < 0) return line;
+
+        var key = line[..delimIndex].Trim();
+        if (key.Length == 0) return line;
+
+        var path = section.Length == 0 ? key : $"{section}.{key}";
+
+        var valuePart = line[(delimIndex + 1)..];
+
+        // Line-continuation guard — don't partially rewrite a multi-line value.
+        if (valuePart.TrimEnd().EndsWith('\\')) return line;
+
+        if (!ConfigVariableLookup.TryFind(variables, path, out var newValue)) return line;
+
+        // Preserve everything up to + including the delimiter, plus the
+        // leading whitespace of the original value, then substitute.
+        var leadingWs = valuePart.Length - valuePart.TrimStart().Length;
+        var prefix = line[..(delimIndex + 1)] + valuePart[..leadingWs];
+
+        replacedCount++;
+        return prefix + newValue;
+    }
+
+    /// <summary>First <c>=</c> or <c>:</c>, whichever comes first. Java
+    /// properties accept both as key/value separators.</summary>
+    private static int IndexOfDelimiter(string line)
+    {
+        var eq = line.IndexOf('=');
+        var colon = line.IndexOf(':');
+
+        if (eq < 0) return colon;
+        if (colon < 0) return eq;
+        return Math.Min(eq, colon);
+    }
+}

--- a/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistry.cs
+++ b/src/Squid.Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistry.cs
@@ -15,7 +15,8 @@ internal static class StructuredConfigFormatRegistry
     {
         new JsonConfigFormat(),
         new YamlConfigFormat(),
-        new XmlConfigFormat()
+        new XmlConfigFormat(),
+        new PropertiesConfigFormat()
     };
 
     /// <summary>Operator-facing extension list. Used in log lines when a
@@ -24,7 +25,8 @@ internal static class StructuredConfigFormatRegistry
     {
         ".json", ".json5",
         ".yaml", ".yml",
-        ".xml"
+        ".xml",
+        ".properties", ".ini"
     };
 
     public static IStructuredConfigFormat? Resolve(string filePath)

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/PropertiesConfigFormatTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/PropertiesConfigFormatTests.cs
@@ -1,0 +1,221 @@
+using Shouldly;
+using Squid.Calamari.Commands.StructuredConfig;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.StructuredConfig;
+
+/// <summary>
+/// PR-9 — pure-function tests for <see cref="PropertiesConfigFormat"/>.
+/// Java-properties + INI line-oriented rewrite: key-path lookup, INI
+/// section prefixing, format preservation (comments / order / spacing /
+/// EOL), Squid.* guard, line-continuation skip.
+/// </summary>
+public sealed class PropertiesConfigFormatTests
+{
+    [Theory]
+    [InlineData("/x/y.properties", true)]
+    [InlineData("/x/y.PROPERTIES", true)]
+    [InlineData("/x/y.ini", true)]
+    [InlineData("/x/y.json", false)]
+    [InlineData("/x/y.yaml", false)]
+    public void CanHandle_ByExtension(string path, bool expected)
+        => new PropertiesConfigFormat().CanHandle(path).ShouldBe(expected);
+
+    // ── .properties happy path ──────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_DottedKey_ValueReplaced()
+    {
+        var props = "logging.level.root=INFO\n";
+        var vars = NewVarSet(("logging.level.root", "DEBUG"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("logging.level.root=DEBUG");
+        result.Output.ShouldNotContain("INFO");
+    }
+
+    [Fact]
+    public void Replace_ColonDelimiter_AlsoSupported()
+    {
+        // Java properties accept key:value too.
+        var props = "database.url : jdbc:old\n";
+
+        // Note: the FIRST colon is the delimiter, so the key is "database.url"
+        // and the value is " jdbc:old". Operator variable matches the key path.
+        var vars = NewVarSet(("database.url", "jdbc:new"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("jdbc:new");
+    }
+
+    [Fact]
+    public void Replace_ColonPathVariable_MatchesDottedKey()
+    {
+        // Operator writes the variable in ASP.NET-Core colon idiom; the file
+        // key is dotted. ConfigVariableLookup bridges them.
+        var props = "Logging.LogLevel.Default=Information\n";
+        var vars = NewVarSet(("Logging:LogLevel:Default", "Debug"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("=Debug");
+    }
+
+    [Fact]
+    public void Replace_PreservesSpacingAroundDelimiter()
+    {
+        var props = "my.key = oldvalue\n";
+        var vars = NewVarSet(("my.key", "newvalue"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.Output.ShouldBe("my.key = newvalue\n",
+            customMessage: "Spacing around the delimiter MUST be preserved — only the value text changes.");
+    }
+
+    // ── INI section prefixing ───────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_IniSection_PrefixesKeyPath()
+    {
+        var ini = "[database]\nurl=old\n[logging]\nlevel=INFO\n";
+        var vars = NewVarSet(("database.url", "newurl"), ("logging.level", "DEBUG"));
+
+        var result = new PropertiesConfigFormat().Replace(ini, vars);
+
+        result.ReplacedCount.ShouldBe(2);
+        result.Output.ShouldContain("url=newurl");
+        result.Output.ShouldContain("level=DEBUG");
+        result.Output.ShouldContain("[database]");    // section headers preserved
+        result.Output.ShouldContain("[logging]");
+    }
+
+    [Fact]
+    public void Replace_IniSameKeyDifferentSections_DisambiguatedByPath()
+    {
+        var ini = "[a]\nport=1\n[b]\nport=2\n";
+        var vars = NewVarSet(("b.port", "9090"));
+
+        var result = new PropertiesConfigFormat().Replace(ini, vars);
+
+        result.ReplacedCount.ShouldBe(1);
+        result.Output.ShouldContain("[a]\nport=1");    // a.port untouched
+        result.Output.ShouldContain("port=9090");      // b.port replaced
+    }
+
+    // ── Format preservation ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_PreservesCommentsAndBlankLinesAndOrder()
+    {
+        var props = "# header comment\n\nfirst.key=a\n! bang comment\nsecond.key=b\n";
+        var vars = NewVarSet(("second.key", "B"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.Output.ShouldBe("# header comment\n\nfirst.key=a\n! bang comment\nsecond.key=B\n",
+            customMessage: "Comments (# and !), blank lines, key order, and unmatched keys MUST all be byte-preserved.");
+    }
+
+    [Fact]
+    public void Replace_PreservesCrlfEol()
+    {
+        var props = "a.b=old\r\nc.d=keep\r\n";
+        var vars = NewVarSet(("a.b", "new"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.Output.ShouldBe("a.b=new\r\nc.d=keep\r\n",
+            customMessage: "CRLF line endings MUST round-trip — Windows-authored .properties files keep their EOL style.");
+    }
+
+    [Fact]
+    public void Replace_SemicolonComment_Preserved()
+    {
+        var ini = "; ini-style comment\nkey=old\n";
+        var vars = NewVarSet(("key", "new"));
+
+        var result = new PropertiesConfigFormat().Replace(ini, vars);
+
+        result.Output.ShouldContain("; ini-style comment");
+        result.Output.ShouldContain("key=new");
+    }
+
+    // ── Squid.* guard (shared) ──────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_SquidNamespacedKey_DotForm_DoesNotClobber()
+    {
+        var props = "Squid.Deployment.Id=operator-literal\n";
+        var vars = NewVarSet(("Squid.Deployment.Id", "runtime-guid"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldContain("operator-literal");
+        result.Output.ShouldNotContain("runtime-guid");
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Replace_NoMatch_NoOp()
+    {
+        var props = "a.b=1\n";
+        var result = new PropertiesConfigFormat().Replace(props, NewVarSet(("x.y", "z")));
+        result.ReplacedCount.ShouldBe(0);
+        result.Output.ShouldBe("a.b=1\n");
+    }
+
+    [Fact]
+    public void Replace_KeyOnlyLineNoDelimiter_Untouched()
+    {
+        var props = "justakey\nreal.key=v\n";
+        var result = new PropertiesConfigFormat().Replace(props, NewVarSet(("real.key", "w")));
+        result.Output.ShouldContain("justakey");
+        result.Output.ShouldContain("real.key=w");
+    }
+
+    [Fact]
+    public void Replace_LineContinuation_SkippedToAvoidCorruption()
+    {
+        // A value ending with backslash is a Java multi-line value. We MUST
+        // NOT partially rewrite it — leave the key intact.
+        var props = "multi.key=part1\\\n  part2\nsimple.key=old\n";
+        var vars = NewVarSet(("multi.key", "REPLACED"), ("simple.key", "new"));
+
+        var result = new PropertiesConfigFormat().Replace(props, vars);
+
+        result.Output.ShouldContain("multi.key=part1\\",
+            customMessage: "Line-continuation values MUST be skipped (left intact) to avoid corrupting the continuation.");
+        result.Output.ShouldNotContain("REPLACED");
+        result.Output.ShouldContain("simple.key=new",
+            customMessage: "Non-continuation keys in the same file still get replaced.");
+    }
+
+    [Fact]
+    public void Replace_Empty_NoOpSuccess()
+    {
+        new PropertiesConfigFormat().Replace("", NewVarSet(("a", "b")))
+            .Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Replace_NullVariables_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new PropertiesConfigFormat().Replace("a=b", null!));
+    }
+
+    private static VariableSet NewVarSet(params (string name, string value)[] entries)
+    {
+        var set = new VariableSet();
+        foreach (var (name, value) in entries) set.Set(name, value);
+        return set;
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistryTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/StructuredConfig/StructuredConfigFormatRegistryTests.cs
@@ -20,6 +20,9 @@ public sealed class StructuredConfigFormatRegistryTests
     [InlineData("/x/y.YML", typeof(YamlConfigFormat))]
     [InlineData("/x/y.xml", typeof(XmlConfigFormat))]
     [InlineData("/x/y.XML", typeof(XmlConfigFormat))]
+    [InlineData("/x/y.properties", typeof(PropertiesConfigFormat))]
+    [InlineData("/x/y.ini", typeof(PropertiesConfigFormat))]
+    [InlineData("/x/y.PROPERTIES", typeof(PropertiesConfigFormat))]
     public void Resolve_KnownExtension_LandsOnExpectedFormat(string path, Type expectedType)
     {
         var format = StructuredConfigFormatRegistry.Resolve(path);
@@ -30,7 +33,7 @@ public sealed class StructuredConfigFormatRegistryTests
     [Theory]
     [InlineData("/x/y.config")]    // XDT territory — deliberately NOT in this registry
     [InlineData("/x/y.txt")]
-    [InlineData("/x/y.properties")]
+    [InlineData("/x/y.toml")]      // TOML not supported yet
     [InlineData("/x/y")]
     public void Resolve_UnknownExtension_ReturnsNull(string path)
     {
@@ -43,7 +46,7 @@ public sealed class StructuredConfigFormatRegistryTests
         // Operator-facing list — used in skip-warning messages so the
         // operator knows which extensions the step works on.
         StructuredConfigFormatRegistry.SupportedExtensions
-            .ShouldBe(new[] { ".json", ".json5", ".yaml", ".yml", ".xml" });
+            .ShouldBe(new[] { ".json", ".json5", ".yaml", ".yml", ".xml", ".properties", ".ini" });
     }
 
     [Fact]
@@ -53,5 +56,6 @@ public sealed class StructuredConfigFormatRegistryTests
         new JsonConfigFormat().FormatName.ShouldBe("JSON");
         new YamlConfigFormat().FormatName.ShouldBe("YAML");
         new XmlConfigFormat().FormatName.ShouldBe("XML");
+        new PropertiesConfigFormat().FormatName.ShouldBe("Properties");
     }
 }


### PR DESCRIPTION
## Summary

Adds `PropertiesConfigFormat` to the PR-3 (#373) format dispatch. Java-stack operators (Spring Boot `application.properties`) + INI users get leaf replacement on the same `Squid.Action.JsonConfigVariables` toggle, routed by file extension.

**Zero new NuGet deps. Zero wire-literal changes.**

## Path computation

| File | Path rule |
|---|---|
| `.properties` | key IS the dot-path: `logging.level.root=INFO` → `logging.level.root`. Both `=` and `:` delimiters |
| `.ini` | `[section]` prefixes the key: `[database] url=` → `database.url` |

## Format preservation (line-oriented, no DOM round-trip)

Rewrites ONLY the matched value span:
- Comments (`#` / `!` / `;`), blank lines, key order, unmatched keys → byte-preserved
- Delimiter + spacing (`key = value`) → preserved
- CRLF vs LF → round-tripped per-line
- **Line-continuation** values (`key=part1\`) → SKIPPED (left intact) to avoid corrupting Java multi-line values — documented + pinned

Shares `ConfigVariableLookup` with JSON/YAML/XML → identical `Squid.*` self-namespace guard + dot/colon dual-form lookup.

## Test plan

- [x] Squid.Calamari.Tests: 504/504 (was 481; +23)
- [x] Squid.UnitTests: 5625/5625 (unchanged)
- [x] Build: 0 errors
- [x] 21 PropertiesConfigFormat tests: dotted/colon keys, INI sections + same-key disambiguation, comment/order/spacing/CRLF preservation, Squid.* guard, line-continuation skip
- [x] Registry dispatch + SupportedExtensions pin updated
- [ ] Staging: real Spring Boot `application.properties` deploy

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Wire literals | Unchanged — same toggle, extension dispatch |
| Existing JSON/YAML/XML config deploys | Unchanged |
| `.config` (XDT) files | Still not handled here (G1.2 owns them) |
| SquidWeb | Untouched |