### PR TITLE
Python script runner (multi-shell Calamari)

### DIFF
--- a/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
+++ b/src/Squid.Calamari/Commands/RunScriptCommandPipeline.cs
@@ -79,11 +79,17 @@ internal sealed class WriteBootstrappedScriptStep : ExecutionStep<RunScriptComma
         var preamble = syntax switch
         {
             ScriptSyntax.PowerShell => PowerShellVariableBootstrapper.GeneratePreamble(context.Variables),
+            ScriptSyntax.Python => PythonVariableBootstrapper.GeneratePreamble(context.Variables),
             _ => VariableBootstrapper.GeneratePreamble(context.Variables)
         };
         var bootstrappedScript = preamble + originalScript;
 
-        var extension = syntax == ScriptSyntax.PowerShell ? ".ps1" : ".sh";
+        var extension = syntax switch
+        {
+            ScriptSyntax.PowerShell => ".ps1",
+            ScriptSyntax.Python => ".py",
+            _ => ".sh"
+        };
         var bootstrappedPath = Path.Combine(
             context.WorkingDirectory,
             $".squid-bootstrapped-{Guid.NewGuid():N}{extension}");

--- a/src/Squid.Calamari/Execution/PythonScriptExecutor.cs
+++ b/src/Squid.Calamari/Execution/PythonScriptExecutor.cs
@@ -1,0 +1,101 @@
+using Squid.Calamari.Execution.Output;
+using Squid.Calamari.Execution.Processes;
+
+namespace Squid.Calamari.Execution;
+
+/// <summary>
+/// PR-10 — executes a Python script file, streaming stdout/stderr through
+/// <see cref="ScriptOutputProcessor"/>. Sibling of
+/// <see cref="BashScriptExecutor"/> + <see cref="PowerShellScriptExecutor"/>.
+///
+/// <para><b>Interpreter resolution</b>: prefers <c>python3</c> (the
+/// unambiguous Python-3 launcher on Linux / macOS), falls back to
+/// <c>python</c> (Windows installs + some minimal containers expose only
+/// <c>python</c>). Returns a clear "Python not installed" error when
+/// neither is on PATH — no silent fallthrough to bash.</para>
+///
+/// <para><b>Arguments</b>: <c>-u</c> (unbuffered stdout/stderr so the
+/// captured-log layer streams output in real time instead of after the
+/// process exits) + the script path.</para>
+/// </summary>
+public class PythonScriptExecutor
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly Func<string?> _pythonResolver;
+
+    public PythonScriptExecutor()
+        : this(new ProcessRunner(), ResolvePythonBinary)
+    {
+    }
+
+    public PythonScriptExecutor(IProcessRunner processRunner)
+        : this(processRunner, ResolvePythonBinary)
+    {
+    }
+
+    internal PythonScriptExecutor(IProcessRunner processRunner, Func<string?> pythonResolver)
+    {
+        _processRunner = processRunner;
+        _pythonResolver = pythonResolver;
+    }
+
+    public async Task<int> ExecuteAsync(
+        string scriptPath,
+        string workDir,
+        ScriptOutputProcessor outputProcessor,
+        CancellationToken ct)
+    {
+        var binary = _pythonResolver()
+                     ?? throw new InvalidOperationException(
+                         "Python executor: neither 'python3' nor 'python' was found on PATH. " +
+                         "Install Python 3 (https://www.python.org/downloads/) on this agent OR run the " +
+                         "script as bash by renaming it to .sh.");
+
+        var invocation = new ProcessInvocation(
+            executable: binary,
+            arguments: ["-u", scriptPath],
+            workingDirectory: workDir);
+
+        var result = await _processRunner.ExecuteAsync(invocation, outputProcessor.OutputSink, ct)
+            .ConfigureAwait(false);
+
+        return result.ExitCode;
+    }
+
+    /// <summary>
+    /// Find python3 / python on PATH. python3 first (unambiguous Python-3),
+    /// then python (Windows / minimal-container fallback). Returns the
+    /// absolute path of the first found, or null.
+    /// </summary>
+    public static string? ResolvePythonBinary()
+    {
+        var py3 = FindOnPath(OperatingSystem.IsWindows() ? "python3.exe" : "python3");
+        if (py3 is not null) return py3;
+
+        var py = FindOnPath(OperatingSystem.IsWindows() ? "python.exe" : "python");
+        return py;
+    }
+
+    private static string? FindOnPath(string executableName)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVar)) return null;
+
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+
+        foreach (var dir in pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(dir, executableName);
+                if (File.Exists(candidate)) return candidate;
+            }
+            catch (ArgumentException)
+            {
+                // Invalid path chars in a PATH segment — skip silently.
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Squid.Calamari/Scripting/PythonScriptExecutorAdapter.cs
+++ b/src/Squid.Calamari/Scripting/PythonScriptExecutorAdapter.cs
@@ -1,0 +1,38 @@
+using Squid.Calamari.Execution;
+
+namespace Squid.Calamari.Scripting;
+
+/// <summary>
+/// PR-10 — <see cref="IScriptExecutor"/> adapter for Python. Sibling of
+/// <see cref="BashScriptExecutorAdapter"/> + <see cref="PowerShellScriptExecutorAdapter"/>.
+/// Registered in <see cref="ScriptEngine"/>'s default constructor; engine
+/// dispatches by <see cref="ScriptExecutionRequest.Syntax"/>.
+/// </summary>
+public sealed class PythonScriptExecutorAdapter : IScriptExecutor
+{
+    private readonly PythonScriptExecutor _executor;
+
+    public PythonScriptExecutorAdapter()
+        : this(new PythonScriptExecutor())
+    {
+    }
+
+    public PythonScriptExecutorAdapter(PythonScriptExecutor executor)
+    {
+        _executor = executor;
+    }
+
+    public bool CanExecute(ScriptSyntax syntax) => syntax == ScriptSyntax.Python;
+
+    public async Task<ScriptExecutionResult> ExecuteAsync(ScriptExecutionRequest request, CancellationToken ct)
+    {
+        var exitCode = await _executor.ExecuteAsync(
+                request.ScriptPath,
+                request.WorkingDirectory,
+                request.OutputProcessor,
+                ct)
+            .ConfigureAwait(false);
+
+        return new ScriptExecutionResult(exitCode, request.OutputProcessor.OutputVariables);
+    }
+}

--- a/src/Squid.Calamari/Scripting/ScriptEngine.cs
+++ b/src/Squid.Calamari/Scripting/ScriptEngine.cs
@@ -7,7 +7,7 @@ public sealed class ScriptEngine : IScriptEngine
 
     public ScriptEngine()
         : this(
-            [new BashScriptExecutorAdapter(), new PowerShellScriptExecutorAdapter()],
+            [new BashScriptExecutorAdapter(), new PowerShellScriptExecutorAdapter(), new PythonScriptExecutorAdapter()],
             [new EnsureScriptFileExistsDecorator()])
     {
     }

--- a/src/Squid.Calamari/Scripting/ScriptSyntax.cs
+++ b/src/Squid.Calamari/Scripting/ScriptSyntax.cs
@@ -4,4 +4,5 @@ public enum ScriptSyntax
 {
     Bash = 1,
     PowerShell = 2,
+    Python = 3,
 }

--- a/src/Squid.Calamari/Scripting/ScriptSyntaxDetector.cs
+++ b/src/Squid.Calamari/Scripting/ScriptSyntaxDetector.cs
@@ -28,6 +28,7 @@ public static class ScriptSyntaxDetector
         {
             ".ps1" => ScriptSyntax.PowerShell,
             ".psm1" => ScriptSyntax.PowerShell,
+            ".py" => ScriptSyntax.Python,
             // .sh and everything else → bash (default + back-compat).
             _ => ScriptSyntax.Bash
         };

--- a/src/Squid.Calamari/Variables/PythonVariableBootstrapper.cs
+++ b/src/Squid.Calamari/Variables/PythonVariableBootstrapper.cs
@@ -1,0 +1,75 @@
+using System.Text;
+
+namespace Squid.Calamari.Variables;
+
+/// <summary>
+/// PR-10 — Python counterpart to <see cref="VariableBootstrapper"/> (bash)
+/// and <see cref="PowerShellVariableBootstrapper"/> (PS). Generates an
+/// <c>os.environ['VAR'] = '...'</c> preamble so an operator's Python script
+/// reads variables via <c>os.environ</c> / <c>os.getenv</c> — same
+/// environment-variable injection model as bash <c>export</c> and PS
+/// <c>$env:</c>.
+///
+/// <para><b>Value escaping</b>: each value is emitted as a single-quoted
+/// Python string literal. Python single-quoted literals interpret backslash
+/// escapes, so we escape (in order) <c>\</c> → <c>\\</c>, <c>'</c> →
+/// <c>\'</c>, newline → <c>\n</c>, CR → <c>\r</c>, tab → <c>\t</c>. This is
+/// lossless (Python re-expands the escapes to the exact original bytes) AND
+/// readable (operator debugging the bootstrapped script sees real text, not
+/// base64). PEM keys / multi-line values round-trip correctly via the
+/// <c>\n</c> escape.</para>
+///
+/// <para><b>Name sanitisation</b>: identical to the bash / PS bootstrappers
+/// (<c>.</c> / <c>-</c> / <c>/</c> → <c>_</c>) so the SAME operator variable
+/// name resolves under any of the three shells without renaming.</para>
+/// </summary>
+public static class PythonVariableBootstrapper
+{
+    public static string GeneratePreamble(IEnumerable<KeyValuePair<string, string>> variables)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Squid: inject deployment variables into os.environ for the operator script.");
+        sb.AppendLine("import os");
+        sb.AppendLine();
+
+        foreach (var (name, value) in variables)
+        {
+            if (!IsValidPythonEnvName(name))
+                continue;
+
+            var envName = SanitizeName(name);
+            var escaped = EscapeSingleQuoted(value ?? string.Empty);
+
+            sb.AppendLine($"os.environ['{envName}'] = '{escaped}'");
+        }
+
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static bool IsValidPythonEnvName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        var sanitized = SanitizeName(name);
+        if (sanitized.Length == 0) return false;
+        if (char.IsDigit(sanitized[0])) return false;
+        return sanitized.All(c => char.IsLetterOrDigit(c) || c == '_');
+    }
+
+    private static string SanitizeName(string name)
+        => name.Replace('.', '_').Replace('-', '_').Replace('/', '_');
+
+    /// <summary>
+    /// Escape for a Python single-quoted string literal. Backslash FIRST
+    /// (so we don't double-escape the escapes we add after), then quote +
+    /// the whitespace controls Python interprets as escapes.
+    /// </summary>
+    private static string EscapeSingleQuoted(string value)
+        => value
+            .Replace("\\", "\\\\")
+            .Replace("'", "\\'")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r")
+            .Replace("\t", "\\t");
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/WriteBootstrappedScriptStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/WriteBootstrappedScriptStepTests.cs
@@ -73,6 +73,26 @@ public sealed class WriteBootstrappedScriptStepTests : IDisposable
     }
 
     [Fact]
+    public async Task PythonScript_GeneratesPyPreambleAndPyExtension()
+    {
+        var script = Path.Combine(_workDir, "deploy.py");
+        File.WriteAllText(script, "import os\nprint(os.environ['MyVar'])");
+
+        var ctx = BuildContext(script);
+        ctx.Variables!.Set("MyVar", "v");
+
+        await new WriteBootstrappedScriptStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        ctx.BootstrappedScriptPath!.ShouldEndWith(".py");
+        ctx.DetectedScriptSyntax.ShouldBe(ScriptSyntax.Python);
+
+        var bootstrapped = File.ReadAllText(ctx.BootstrappedScriptPath);
+        bootstrapped.ShouldContain("os.environ['MyVar'] = 'v'",
+            customMessage: "Python bootstrap MUST use os.environ injection — not bash export or PS $env:.");
+        bootstrapped.ShouldContain("print(os.environ['MyVar'])");
+    }
+
+    [Fact]
     public async Task ScriptWithoutExtension_DefaultsToBash_BackCompat()
     {
         // Existing operators ship script paths like `script-{guid}` (no

--- a/tests/Squid.Calamari.Tests/Calamari/Scripting/PythonScriptExecutorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Scripting/PythonScriptExecutorTests.cs
@@ -1,0 +1,91 @@
+using Shouldly;
+using Squid.Calamari.Execution;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Scripting;
+
+/// <summary>
+/// PR-10 — unit tests for <see cref="PythonScriptExecutor"/>. Drives the
+/// resolver + argument shape via injected seams without requiring Python
+/// on the test runner.
+/// </summary>
+public sealed class PythonScriptExecutorTests
+{
+    [Fact]
+    public void ResolvePythonBinary_NeitherInstalled_ReturnsNull()
+    {
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", "/nonexistent-segment");
+            PythonScriptExecutor.ResolvePythonBinary().ShouldBeNull();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoBinaryFound_ThrowsWithOperatorActionableMessage()
+    {
+        var executor = NewExecutor(new StubProcessRunner(), resolver: () => null);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            executor.ExecuteAsync("/tmp/x.py", "/tmp", new Squid.Calamari.Execution.ScriptOutputProcessor(), CancellationToken.None));
+
+        ex.Message.ShouldContain("python", Case.Insensitive);
+        ex.Message.ShouldContain("Install Python");
+        ex.Message.ShouldContain(".sh",
+            customMessage: "Error MUST mention the bash-fallback workaround.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BinaryResolved_InvokesWithUnbufferedFlagAndScriptPath()
+    {
+        var stub = new StubProcessRunner();
+        var executor = NewExecutor(stub, resolver: () => "/usr/bin/python3");
+
+        await executor.ExecuteAsync("/tmp/deploy.py", "/tmp", new Squid.Calamari.Execution.ScriptOutputProcessor(), CancellationToken.None);
+
+        stub.CapturedInvocation.ShouldNotBeNull();
+        stub.CapturedInvocation!.Executable.ShouldBe("/usr/bin/python3");
+        stub.CapturedInvocation.Arguments.ShouldBe(new[] { "-u", "/tmp/deploy.py" },
+            customMessage: "Python MUST run with -u (unbuffered) so logs stream, then the script path.");
+        stub.CapturedInvocation.WorkingDirectory.ShouldBe("/tmp");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesExitCode()
+    {
+        var stub = new StubProcessRunner { ExitCodeToReturn = 3 };
+        var executor = NewExecutor(stub, resolver: () => "/usr/bin/python3");
+
+        var exit = await executor.ExecuteAsync("/tmp/x.py", "/tmp", new Squid.Calamari.Execution.ScriptOutputProcessor(), CancellationToken.None);
+
+        exit.ShouldBe(3);
+    }
+
+    private static PythonScriptExecutor NewExecutor(Squid.Calamari.Execution.Processes.IProcessRunner runner, Func<string?> resolver)
+        => (PythonScriptExecutor)Activator.CreateInstance(
+            typeof(PythonScriptExecutor),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { runner, resolver },
+            culture: null)!;
+
+    private sealed class StubProcessRunner : Squid.Calamari.Execution.Processes.IProcessRunner
+    {
+        public int ExitCodeToReturn { get; set; } = 0;
+        public Squid.Calamari.Execution.Processes.ProcessInvocation? CapturedInvocation { get; private set; }
+
+        public Task<Squid.Calamari.Execution.Processes.ProcessResult> ExecuteAsync(
+            Squid.Calamari.Execution.Processes.ProcessInvocation invocation,
+            Squid.Calamari.Execution.Output.IProcessOutputSink outputSink,
+            CancellationToken ct)
+        {
+            CapturedInvocation = invocation;
+            return Task.FromResult(new Squid.Calamari.Execution.Processes.ProcessResult(ExitCodeToReturn));
+        }
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Scripting/ScriptSyntaxDetectorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Scripting/ScriptSyntaxDetectorTests.cs
@@ -16,6 +16,8 @@ public sealed class ScriptSyntaxDetectorTests
     [InlineData("/x/y.ps1", ScriptSyntax.PowerShell)]
     [InlineData("/x/y.PS1", ScriptSyntax.PowerShell)]
     [InlineData("/x/y.psm1", ScriptSyntax.PowerShell)]
+    [InlineData("/x/y.py", ScriptSyntax.Python)]
+    [InlineData("/x/y.PY", ScriptSyntax.Python)]
     [InlineData("/x/y.sh", ScriptSyntax.Bash)]
     [InlineData("/x/y.bash", ScriptSyntax.Bash)]
     [InlineData("/x/y", ScriptSyntax.Bash)]    // no extension → bash default

--- a/tests/Squid.Calamari.Tests/Calamari/Variables/PythonVariableBootstrapperTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Variables/PythonVariableBootstrapperTests.cs
@@ -1,0 +1,95 @@
+using Shouldly;
+using Squid.Calamari.Variables;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Variables;
+
+/// <summary>
+/// PR-10 — Python preamble shape. Mirrors the bash + PS bootstrapper test
+/// suites: os.environ assignment, name sanitiser parity, lossless value
+/// escaping (quotes / backslashes / newlines).
+/// </summary>
+public sealed class PythonVariableBootstrapperTests
+{
+    [Fact]
+    public void GeneratePreamble_ImportsOsAndAssignsEnviron()
+    {
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["MyVar"] = "hello" });
+
+        preamble.ShouldContain("import os");
+        preamble.ShouldContain("os.environ['MyVar'] = 'hello'",
+            customMessage: "Python bootstrap MUST set os.environ so the operator script reads via os.getenv / os.environ.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_SanitisesDotsHyphensSlashes_SameAsBashAndPs()
+    {
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string>
+            {
+                ["My.Dotted.Name"] = "v1",
+                ["My-Hyphen-Name"] = "v2",
+                ["My/Slash/Name"] = "v3"
+            });
+
+        preamble.ShouldContain("os.environ['My_Dotted_Name'] = 'v1'");
+        preamble.ShouldContain("os.environ['My_Hyphen_Name'] = 'v2'");
+        preamble.ShouldContain("os.environ['My_Slash_Name'] = 'v3'");
+    }
+
+    [Fact]
+    public void GeneratePreamble_SkipsNamesStartingWithDigit()
+    {
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["1stVar"] = "skipped", ["ValidVar"] = "kept" });
+
+        preamble.ShouldNotContain("1stVar", Case.Insensitive);
+        preamble.ShouldContain("ValidVar");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EscapesSingleQuoteAndBackslash()
+    {
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["Path"] = @"C:\it's\here" });
+
+        // Backslash → \\, single quote → \'. Python re-expands to C:\it's\here.
+        preamble.ShouldContain(@"os.environ['Path'] = 'C:\\it\'s\\here'",
+            customMessage: "Backslash + single-quote MUST be escaped for the Python single-quoted literal, losslessly.");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EscapesNewlinesAsBackslashN()
+    {
+        // PEM-key-style multi-line value. Python interprets \n in a single-
+        // quoted literal as a real newline, so this round-trips losslessly.
+        var pem = "-----BEGIN-----\nline1\nline2\n-----END-----";
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["Key"] = pem });
+
+        preamble.ShouldContain(@"os.environ['Key'] = '-----BEGIN-----\nline1\nline2\n-----END-----'",
+            customMessage: "Embedded newlines MUST become \\n escapes — single-line literal that Python expands back to the multi-line value.");
+        // The raw preamble line MUST NOT contain a literal newline inside the
+        // value (that would break the single-quoted string).
+        preamble.ShouldNotContain("'-----BEGIN-----\n");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EscapesTabAndCarriageReturn()
+    {
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(
+            new Dictionary<string, string> { ["V"] = "a\tb\rc" });
+
+        preamble.ShouldContain(@"os.environ['V'] = 'a\tb\rc'");
+    }
+
+    [Fact]
+    public void GeneratePreamble_EmptyVariableSet_StillImportsOs()
+    {
+        var preamble = PythonVariableBootstrapper.GeneratePreamble(new Dictionary<string, string>());
+
+        preamble.ShouldContain("import os");
+        preamble.ShouldNotContain("os.environ[");
+    }
+}


### PR DESCRIPTION
## Summary

Calamari can now execute Python scripts natively. Operator names the file `.py` → runs through the same `RunScriptCommand` pipeline as bash + PowerShell (extract, rewriters, conventions, variable injection).

Clean clone of the PR-4 (#374) PowerShell pattern. **Zero new NuGet deps** — `python3`/`python` resolved via PATH probe.

## What's in the box

| Layer | File |
|---|---|
| `ScriptSyntax.Python` | enum +1 value |
| Detector `.py` → Python | `ScriptSyntaxDetector.cs` |
| Executor (`python3` → `python` fallback, `-u`) | `PythonScriptExecutor.cs` (new) |
| Adapter (registered in ScriptEngine) | `PythonScriptExecutorAdapter.cs` (new) |
| Bootstrapper (`os.environ[...]`) | `PythonVariableBootstrapper.cs` (new) |
| Bootstrap step dispatch | `RunScriptCommandPipeline.cs` |

## Variable injection

`os.environ['VAR'] = 'value'` preamble. Same name sanitiser as bash/PS (`.`/`-`/`/` → `_`) so the **same** operator variable resolves under any shell. Lossless single-quote escaping (`\`→`\\`, `'`→`\'`, newline→`\n`, CR→`\r`, tab→`\t`) — multi-line PEM values round-trip + stay readable in the bootstrapped script.

## Known limitation (documented)

The preamble is prepended, so `from __future__ import ...` (must be statement #1) is unsupported — rare in deployment scripts; workaround is to drop it. Consistent with how bash/PS bootstrappers prepend.

## Test plan

- [x] Squid.Calamari.Tests: 518/518 (was 504; +14)
- [x] Build: 0 errors
- [x] PythonVariableBootstrapperTests (7): os.environ injection, name parity, escaping (quote/backslash/newline/tab/CR), empty set
- [x] PythonScriptExecutorTests (4): neither-binary → actionable error; `-u` + script-path argv; exit-code propagation
- [x] Detector + bootstrap-step `.py` dispatch
- [ ] Staging: real `.py` deploy reading `os.environ` variables

## Non-breaking guarantee

| Surface | Status |
|---|---|
| Bash + PowerShell paths | Unchanged |
| Wire literals | None added |
| `ScriptSyntax` enum | Additive (Python=3) |
| SquidWeb | Untouched |