### PR TITLE
Add .7z package extraction via SharpCompress

### DIFF
--- a/src/Squid.Calamari/Commands/Package/ArchiveSafety.cs
+++ b/src/Squid.Calamari/Commands/Package/ArchiveSafety.cs
@@ -5,7 +5,7 @@ namespace Squid.Calamari.Commands.Package;
 /// <summary>
 /// Shared hostile-archive defence primitives used by every
 /// <see cref="IPackageExtractor"/>. Each format-specific extractor (zip /
-/// tar / tar.gz / future 7z / wim) hits the SAME safety story, so the
+/// tar / tar.gz / 7z / future wim) hits the SAME safety story, so the
 /// rules live here once.
 ///
 /// <para>Three independent defences a malicious archive must clear:

--- a/src/Squid.Calamari/Commands/Package/PackageExtractorRegistry.cs
+++ b/src/Squid.Calamari/Commands/Package/PackageExtractorRegistry.cs
@@ -10,8 +10,8 @@ namespace Squid.Calamari.Commands.Package;
 ///         <c>.tar.gz</c> / <c>.tgz</c> compound suffix.</item>
 ///   <item><see cref="ZipPackageExtractor"/> — <c>.zip</c> / <c>.nupkg</c>.</item>
 ///   <item><see cref="TarPackageExtractor"/> — plain <c>.tar</c>.</item>
-///   <item><see cref="SevenZipUnsupportedExtractor"/> — recognised but
-///         deliberately failing extractor for <c>.7z</c> (deferred dep).</item>
+///   <item><see cref="SevenZipPackageExtractor"/> — <c>.7z</c> via
+///         SharpCompress (managed, no external 7z binary).</item>
 /// </list>
 ///
 /// <para>If none match, <see cref="Resolve"/> returns null — caller
@@ -26,7 +26,7 @@ internal static class PackageExtractorRegistry
         new TarGzPackageExtractor(),
         new ZipPackageExtractor(),
         new TarPackageExtractor(),
-        new SevenZipUnsupportedExtractor()
+        new SevenZipPackageExtractor()
     };
 
     /// <summary>List of file-extension-style strings the dispatcher
@@ -38,7 +38,8 @@ internal static class PackageExtractorRegistry
         ".nupkg",
         ".tar",
         ".tar.gz",
-        ".tgz"
+        ".tgz",
+        ".7z"
     };
 
     public static IPackageExtractor? Resolve(string archivePath)

--- a/src/Squid.Calamari/Commands/Package/SevenZipPackageExtractor.cs
+++ b/src/Squid.Calamari/Commands/Package/SevenZipPackageExtractor.cs
@@ -1,0 +1,102 @@
+using SharpCompress.Archives.SevenZip;
+
+namespace Squid.Calamari.Commands.Package;
+
+/// <summary>
+/// PR-11 — <c>.7z</c> archive extractor backed by <c>SharpCompress</c>
+/// (managed, no external <c>7z</c> binary). Same hostile-archive defence
+/// as <see cref="ZipPackageExtractor"/> / <see cref="TarPackageExtractor"/>:
+/// zip-slip rejection, per-entry + total-archive size caps, fail-closed —
+/// all via the shared <see cref="ArchiveSafety"/> primitives so every
+/// format hits one identical safety story.
+///
+/// <para><b>Size cap is pre-decompression</b>: SharpCompress exposes each
+/// entry's uncompressed <see cref="SharpCompress.Archives.SevenZip.SevenZipArchiveEntry.Size"/>
+/// from the 7z header BEFORE the entry stream is opened, so a zip-bomb
+/// entry is rejected by <see cref="ArchiveSafety.CheckPerEntryCap"/> without
+/// ever being decompressed to disk. (Matches the declared-size model the
+/// zip + tar extractors use — consistent across formats.)</para>
+///
+/// <para><b>Untrusted input</b>: SharpCompress surfaces corrupt / truncated
+/// archives as <see cref="IOException"/> (incl. <c>EndOfStreamException</c>)
+/// or <see cref="InvalidOperationException"/>, and encrypted archives as
+/// <see cref="System.Security.Cryptography.CryptographicException"/>. All
+/// are caught and converted to a structured failure — extraction is an
+/// untrusted-input boundary, so a malformed package halts the deploy with
+/// a clear reason instead of crashing the pipeline.</para>
+/// </summary>
+internal sealed class SevenZipPackageExtractor : IPackageExtractor
+{
+    public bool CanHandle(string archivePath)
+        => string.Equals(Path.GetExtension(archivePath), ".7z", StringComparison.OrdinalIgnoreCase);
+
+    public ExtractResult Extract(string archivePath, string destinationDir)
+    {
+        if (!File.Exists(archivePath))
+            return ExtractResult.Failure($"Archive '{archivePath}' does not exist.");
+
+        Directory.CreateDirectory(destinationDir);
+        var canonicalDest = ArchiveSafety.EnsureTrailingSeparator(destinationDir);
+
+        try
+        {
+            using var stream = File.OpenRead(archivePath);
+            using var archive = SevenZipArchive.Open(stream);
+            return ExtractEntries(archive, canonicalDest);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+               or InvalidOperationException
+               or UnauthorizedAccessException
+               or System.Security.Cryptography.CryptographicException)
+        {
+            return ExtractResult.Failure(
+                $"7z archive '{archivePath}' could not be extracted (corrupt, truncated, or encrypted): {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static ExtractResult ExtractEntries(SevenZipArchive archive, string canonicalDest)
+    {
+        int filesExtracted = 0;
+        long totalBytesWritten = 0;
+
+        foreach (var entry in archive.Entries)
+        {
+            // Malformed headers can yield a null/empty key — skip rather than NRE.
+            if (string.IsNullOrEmpty(entry.Key)) continue;
+
+            var entryPath = ArchiveSafety.ResolveSafeEntryPath(entry.Key, canonicalDest);
+            if (entryPath is null)
+                return ExtractResult.Failure($"Entry '{entry.Key}' would escape the destination directory (7z-slip). Aborted.");
+
+            if (entry.IsDirectory)
+            {
+                Directory.CreateDirectory(entryPath);
+                continue;
+            }
+
+            if (entry.Size < 0)
+                return ExtractResult.Failure($"Entry '{entry.Key}' has negative size {entry.Size} — malformed 7z header.");
+
+            var perEntryFailure = ArchiveSafety.CheckPerEntryCap(entry.Key, entry.Size);
+            if (perEntryFailure is not null) return perEntryFailure;
+
+            var totalFailure = ArchiveSafety.CheckTotalCap(entry.Key, totalBytesWritten + entry.Size);
+            if (totalFailure is not null) return totalFailure;
+
+            var parentDir = Path.GetDirectoryName(entryPath);
+            if (!string.IsNullOrEmpty(parentDir)) Directory.CreateDirectory(parentDir);
+
+            // Overwrite-on-collision matches the zip + tar extractors — a
+            // re-deploy with the same archive lands cleanly.
+            using (var entryStream = entry.OpenEntryStream())
+            using (var output = File.Create(entryPath))
+                entryStream.CopyTo(output);
+
+            filesExtracted++;
+            totalBytesWritten += entry.Size;
+        }
+
+        return ExtractResult.Success(filesExtracted, totalBytesWritten);
+    }
+}

--- a/src/Squid.Calamari/Commands/Package/TarPackageExtractor.cs
+++ b/src/Squid.Calamari/Commands/Package/TarPackageExtractor.cs
@@ -177,22 +177,3 @@ internal sealed class TarGzPackageExtractor : IPackageExtractor
         }
     }
 }
-
-/// <summary>
-/// PR-2 — placeholder for <c>.7z</c>. Native .NET has NO 7z support;
-/// SharpCompress would be a new NuGet dep. Deferred until operator demand
-/// justifies the dependency footprint on the agent. This extractor
-/// matches the extension so the dispatcher hits it (instead of silently
-/// not-found-ing) and returns a CLEAR not-supported message rather than
-/// crashing.
-/// </summary>
-internal sealed class SevenZipUnsupportedExtractor : IPackageExtractor
-{
-    public bool CanHandle(string archivePath)
-        => string.Equals(Path.GetExtension(archivePath), ".7z", StringComparison.OrdinalIgnoreCase);
-
-    public ExtractResult Extract(string archivePath, string destinationDir)
-        => ExtractResult.Failure(
-            $"7z archive '{archivePath}' is recognised but not supported in Squid.Calamari yet. " +
-            "Convert to .zip / .nupkg / .tar / .tar.gz, or file a feature request to add SharpCompress.");
-}

--- a/src/Squid.Calamari/Squid.Calamari.csproj
+++ b/src/Squid.Calamari/Squid.Calamari.csproj
@@ -28,6 +28,16 @@
     warning when the assembly wasn't on the host).
     -->
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
+    <!--
+    PR-11 — SharpCompress: managed (pure-.NET) 7z reader. Picked over
+    shelling out to a `7z` CLI because (a) it works in minimal Linux
+    containers with no external binary, and (b) it lets the .7z path reuse
+    the SAME ArchiveSafety zip-slip / size-cap / fail-closed sandbox as the
+    zip + tar extractors, instead of carving a lawless exception for one
+    format. MIT-licensed, pure-managed, ~1.5 MB on disk; extraction-only need
+    (we never write 7z).
+    -->
+    <PackageReference Include="SharpCompress" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/ExtractPackageStepTests.cs
@@ -166,23 +166,19 @@ public sealed class ExtractPackageStepTests : IDisposable
     }
 
     [Fact]
-    public async Task Execute_SevenZipArchive_ThrowsWithDeferralExplanation()
+    public async Task Execute_SevenZipArchive_ExtractsIntoWorkingDir()
     {
-        // .7z is recognised by the dispatcher (so the operator gets a clear
-        // "not yet supported" message instead of "unknown format") but
-        // deliberately returns a failure result — no SharpCompress dep yet.
-        var sevenZ = Path.Combine(_archiveDir, "pkg.7z");
-        File.WriteAllText(sevenZ, "fake 7z bytes");
+        // PR-11: .7z is now extracted via SharpCompress (previously a deferral
+        // failure). Real py7zr-generated 7z bytes drive the production extractor
+        // end-to-end through the pipeline step.
+        var sevenZ = SevenZipTestFixtures.WriteToFile(
+            SevenZipTestFixtures.Happy, Path.Combine(_archiveDir, "pkg.7z"));
 
         var context = BuildContext(packagePath: sevenZ);
+        await new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None);
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
-            new ExtractPackageStep().ExecuteAsync(context, CancellationToken.None));
-
-        ex.Message.ShouldContain("7z");
-        ex.Message.ShouldContain("not supported",
-            customMessage: "Operator MUST see a clear deferral message naming alternatives, " +
-                           "not a generic 'unsupported extension' error (since the dispatcher DID recognise the format).");
+        File.ReadAllText(Path.Combine(_workDir, "readme.txt")).ShouldBe("hello from 7z");
+        File.ReadAllText(Path.Combine(_workDir, "bin", "app.dll")).ShouldBe("fake-binary-content");
     }
 
     // ── Failure surface ─────────────────────────────────────────────────────

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/PackageExtractorRegistryTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/PackageExtractorRegistryTests.cs
@@ -20,7 +20,8 @@ public sealed class PackageExtractorRegistryTests
     [InlineData("/x/y.tar.gz", typeof(TarGzPackageExtractor))]
     [InlineData("/x/y.tgz", typeof(TarGzPackageExtractor))]
     [InlineData("/x/y.TAR.GZ", typeof(TarGzPackageExtractor))]
-    [InlineData("/x/y.7z", typeof(SevenZipUnsupportedExtractor))]
+    [InlineData("/x/y.7z", typeof(SevenZipPackageExtractor))]
+    [InlineData("/x/y.7Z", typeof(SevenZipPackageExtractor))]
     public void Resolve_KnownExtension_LandsOnExpectedExtractor(string archivePath, Type expectedType)
     {
         var extractor = PackageExtractorRegistry.Resolve(archivePath);
@@ -57,6 +58,6 @@ public sealed class PackageExtractorRegistryTests
         // SupportedExtensions isn't updated, operators won't see the new
         // format in error messages.
         PackageExtractorRegistry.SupportedExtensions
-            .ShouldBe(new[] { ".zip", ".nupkg", ".tar", ".tar.gz", ".tgz" });
+            .ShouldBe(new[] { ".zip", ".nupkg", ".tar", ".tar.gz", ".tgz", ".7z" });
     }
 }

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/SevenZipPackageExtractorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/SevenZipPackageExtractorTests.cs
@@ -1,0 +1,161 @@
+using Shouldly;
+using Squid.Calamari.Commands.Common;
+using Squid.Calamari.Commands.Package;
+using Squid.Calamari.Tests.Calamari.Commands.Common;
+using Xunit;
+
+namespace Squid.Calamari.Tests.Calamari.Commands.Package;
+
+/// <summary>
+/// PR-11 — tests for <see cref="SevenZipPackageExtractor"/> (SharpCompress).
+/// Same hostile-archive defence matrix as the zip + tar extractors — 7z-slip
+/// rejection, per-entry size cap, fail-closed on malformed input — driven
+/// against REAL 7z bytes (see <see cref="SevenZipTestFixtures"/>).
+/// </summary>
+[Collection(RewriterEnvVarSerialCollection.Name)]
+public sealed class SevenZipPackageExtractorTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public SevenZipPackageExtractorTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), $"7z-ext-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workDir)) Directory.Delete(_workDir, recursive: true);
+    }
+
+    // ── CanHandle dispatch ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("/x/y.7z", true)]
+    [InlineData("/x/y.7Z", true)]
+    [InlineData("/x/y.zip", false)]
+    [InlineData("/x/y.tar", false)]
+    [InlineData("/x/y.tar.gz", false)]
+    [InlineData("/x/y.nupkg", false)]
+    public void CanHandle_OnlySevenZipExtension(string path, bool expected)
+        => new SevenZipPackageExtractor().CanHandle(path).ShouldBe(expected);
+
+    // ── Happy path ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_RealSevenZip_NestedFilesLandWithContent()
+    {
+        var archive = SevenZipTestFixtures.WriteToFile(SevenZipTestFixtures.Happy, Path.Combine(_workDir, "in.7z"));
+        var dest = Path.Combine(_workDir, "out");
+
+        var result = new SevenZipPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        result.FilesExtracted.ShouldBe(2);
+        result.TotalBytesWritten.ShouldBe(32);    // 13 + 19 bytes
+        File.ReadAllText(Path.Combine(dest, "readme.txt")).ShouldBe("hello from 7z");
+        File.ReadAllText(Path.Combine(dest, "bin", "app.dll")).ShouldBe("fake-binary-content");
+    }
+
+    [Fact]
+    public void Extract_ReExtract_OverwritesAndStillSucceeds()
+    {
+        // Re-deploy: same archive into a dir that already holds the files.
+        var archive = SevenZipTestFixtures.WriteToFile(SevenZipTestFixtures.Happy, Path.Combine(_workDir, "in.7z"));
+        var dest = Path.Combine(_workDir, "out");
+        Directory.CreateDirectory(dest);
+        File.WriteAllText(Path.Combine(dest, "readme.txt"), "stale");
+
+        new SevenZipPackageExtractor().Extract(archive, dest).Succeeded.ShouldBeTrue();
+        File.ReadAllText(Path.Combine(dest, "readme.txt")).ShouldBe("hello from 7z");
+    }
+
+    // ── Safety: 7z-slip rejection ───────────────────────────────────────────
+
+    [Fact]
+    public void Extract_SevenZipSlipEntry_Rejected_DestinationUntouched()
+    {
+        var archive = SevenZipTestFixtures.WriteToFile(SevenZipTestFixtures.Traversal, Path.Combine(_workDir, "evil.7z"));
+
+        // Nest the destination two levels deep so the fixture's `../../escape.txt`
+        // resolves to a path INSIDE _workDir — provably staged + cleaned up,
+        // no shared-temp pollution. The defence must still reject it.
+        var dest = Path.Combine(_workDir, "deep", "out");
+
+        var result = new SevenZipPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("7z-slip");
+        File.Exists(Path.Combine(_workDir, "escape.txt")).ShouldBeFalse(
+            customMessage: "Traversal entry MUST NOT materialize outside the destination. " +
+                           "If you see this fail, a malicious .7z could escape the working dir.");
+    }
+
+    // ── Safety: per-entry size cap (pre-decompression) ──────────────────────
+
+    [Fact]
+    public void Extract_EntryExceedsPerEntryCap_RejectedBeforeDecompression()
+    {
+        // big.bin declares 2 MiB uncompressed in its header; cap = 1 MB. The
+        // cap fires on the declared Size BEFORE the entry stream is opened, so
+        // the zip-bomb payload is never decompressed to disk.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, "1");
+        try
+        {
+            var archive = SevenZipTestFixtures.WriteToFile(SevenZipTestFixtures.Oversize, Path.Combine(_workDir, "bomb.7z"));
+
+            var result = new SevenZipPackageExtractor().Extract(archive, Path.Combine(_workDir, "out"));
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason.ShouldContain("per-entry limit");
+            result.FailureReason.ShouldContain(EncodingPreservingFileIO.MaxFileSizeMBEnvVar);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+        }
+    }
+
+    [Fact]
+    public void Extract_OversizeEntry_DefaultCap_ExtractsFine()
+    {
+        // Same fixture, default 50 MB cap (env unset) — 2 MiB is well under,
+        // so it extracts. Guards against an accidentally-too-low default.
+        Environment.SetEnvironmentVariable(EncodingPreservingFileIO.MaxFileSizeMBEnvVar, null);
+
+        var archive = SevenZipTestFixtures.WriteToFile(SevenZipTestFixtures.Oversize, Path.Combine(_workDir, "big.7z"));
+        var dest = Path.Combine(_workDir, "out");
+
+        var result = new SevenZipPackageExtractor().Extract(archive, dest);
+
+        result.Succeeded.ShouldBeTrue(customMessage: result.FailureReason);
+        new FileInfo(Path.Combine(dest, "big.bin")).Length.ShouldBe(2L * 1024 * 1024);
+    }
+
+    // ── Failure surface ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Extract_NonexistentArchive_ReturnsFailure()
+    {
+        var result = new SevenZipPackageExtractor().Extract(
+            Path.Combine(_workDir, "missing.7z"), Path.Combine(_workDir, "out"));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldContain("does not exist");
+    }
+
+    [Fact]
+    public void Extract_MalformedArchive_FailsCleanlyNoCrash()
+    {
+        // Garbage bytes — SharpCompress throws; the extractor MUST convert that
+        // to a structured failure, never let it bubble up and crash the deploy.
+        var archive = Path.Combine(_workDir, "broken.7z");
+        File.WriteAllText(archive, "not really a 7z file at all");
+
+        var result = new SevenZipPackageExtractor().Extract(archive, Path.Combine(_workDir, "out"));
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailureReason.ShouldNotBeNullOrEmpty();
+        result.FailureReason!.ShouldContain("could not be extracted");
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Commands/Package/SevenZipTestFixtures.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Commands/Package/SevenZipTestFixtures.cs
@@ -1,0 +1,41 @@
+namespace Squid.Calamari.Tests.Calamari.Commands.Package;
+
+/// <summary>
+/// PR-11 — pre-built <c>.7z</c> fixtures (base64) for the SharpCompress
+/// extractor tests.
+///
+/// <para><b>Why embedded base64 and not generated at test time</b>: 7z has
+/// no managed WRITER — SharpCompress (the production dep) only reads 7z, and
+/// the test runner is not assumed to have a <c>7z</c> CLI. So these archives
+/// were generated offline (py7zr 1.0.0, LZMA2 default) and embedded here.
+/// The tests decode them to a temp file and drive the REAL production
+/// extractor against REAL 7z bytes — high fidelity, zero runtime tooling
+/// dependency, runs identically on every dev box + CI.</para>
+///
+/// <para>The <see cref="Traversal"/> fixture deliberately contains a
+/// <c>../../escape.txt</c> entry — a hostile archive that standard 7z tooling
+/// REFUSES to create (py7zr's own path validator rejects it). It was built by
+/// bypassing that validator, so the extractor's zip-slip defence can be tested
+/// against a genuine malicious archive rather than a mock.</para>
+/// </summary>
+internal static class SevenZipTestFixtures
+{
+    /// <summary><c>readme.txt</c> = "hello from 7z", <c>bin/app.dll</c> = "fake-binary-content".</summary>
+    public const string Happy =
+        "N3q8ryccAASjuykwoAAAAAAAAAAVAAAAAAAAAJb+fA0BAB9oZWxsbyBmcm9tIDd6ZmFrZS1iaW5hcnktY29udGVudADgAIYAdF0AAIEzB64P0Es5PJ85EJxt+2pcRsiMI2VEGWxfJMkC53OZbK0MuohMV8sV1UVu1l7zcZTdNZ91Jq8ajotLCxB3PJKP8ZdmP3rChfIpPAa0svLe2zLLHHfp/GgzIj3ItX37IGvIzZTMrjFldLo50ctiATWqgwAAFwYkAQl8AAcLAQABISEBGAyAhwAA";
+
+    /// <summary><c>ok.txt</c> = "fine", <c>../../escape.txt</c> = "should-not-write" (zip-slip).</summary>
+    public const string Traversal =
+        "N3q8ryccAATNE3U3jAAAAAAAAAAVAAAAAAAAAKoR/qEBABNmaW5lc2hvdWxkLW5vdC13cml0ZQDgAIgAbF0AAIEzB64Pz4CuDA/Ual595dffeE/G8XzVUpxooJogMr7Qa9JaQ78gn+C2IDV7PruGaI1wLGxYqd5Y0xMrLMj5blEEpVBe4w9eyZ7f9zTUXaedbxQO1zwIaELLsJ6O1p7rJ2Lw55u2w3KkTczcABcGGAEJdAAHCwEAASEhARgMgIkAAA==";
+
+    /// <summary><c>big.bin</c> = 2 MiB of zeros (declared size 2,097,152) — trips a 1 MB per-entry cap.</summary>
+    public const string Oversize =
+        "N3q8ryccAAS8r/JI2gEAAAAAAAAVAAAAAAAAABsXDKz//xEBbF0AAG/9//+jt/9HPkgVcjlhUbiSKOajhgf57uQegtMvxTo8AUuxfsmKik0vow3Zf6bjjCMRU+BZGMV1iuJ3+LaUfwxqwN50SWTi6VxTsgTY90QMq18NbUbp5cN2iLeWV6y2TeFpHW/7S4gQbELLiD9cAI/QTq8mKJRxHz2PJOFwnqcjX+woy4XRlZiKfiqR8id19xnABphNmP3Yr9WQD8QlU/j1kTYxBaWw7m/BcE1HDNGREaqtYB26zrEnGFxZhulmUli+6XasWeTlWwUI+cfarfz7Uit0zR5bIEL53VM9+ClkCTuAyyps37U78MS9Ll+qDz5LZkKQEw7/EJP4cXhZ+AvN/5UoRg+p/Hze+5owLlbAj4Xzg4HAZcQlU/j1kTYxBaWw7m/BcE1HDNGREaqtYB26zrEnGFxZhulmUli+6XasWeTlWwUI+cfarfz7Uit0zR5bIEL53VM9+ClkCTuAyyps37U78MS8SCfmWIAA7QAFABymJPEAAOAAXABTXQAAgTMHrg/VOqJE1yTRz+P3ZNFayW/fgJpT3MF/s92ehqKhy0lzIvljFX6yU5lxibo7tCFnH5fyz+e01tAObcZGLC2l61IAgHGwCvcorz/yHwM2AAAXBoF/AQlbAAcLAQABISEBGAxdAAA=";
+
+    /// <summary>Decode a base64 fixture to <paramref name="path"/> and return the path.</summary>
+    public static string WriteToFile(string base64, string path)
+    {
+        File.WriteAllBytes(path, Convert.FromBase64String(base64));
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

- Add a SharpCompress-backed `.7z` extractor to Calamari's multi-format package pipeline, replacing the prior deferral stub that failed `.7z` with a "convert to another format" message.
- The `.7z` path reuses the shared `ArchiveSafety` sandbox — zip-slip rejection, per-entry + total size caps (enforced against the header-declared size **before** decompression, so a zip-bomb entry never hits disk), fail-closed on malformed/encrypted input.
- Non-breaking: a `.7z` package that previously errored now extracts; no wire-literal changes, no frontend impact. SharpCompress is MIT-licensed, pure-managed (~1.5 MB), chosen over shelling out to a `7z` CLI so it works in minimal Linux containers and keeps the uniform safety story across every format.

## Test plan

- [x] Unit: 13 dedicated `SevenZipPackageExtractorTests` + updated step/registry tests, driven against real py7zr-generated 7z bytes (embedded base64; 7z has no managed writer)
  - [x] Happy-path nested extraction (content + byte-count + dir creation) + idempotent re-extract
  - [x] Genuine traversal archive (`../../escape.txt`) rejected — destination untouched
  - [x] Zip-bomb-style oversize entry rejected pre-decompression; same fixture extracts under the default 50 MB cap
  - [x] Malformed bytes -> structured failure (no crash); nonexistent path -> failure
- [x] Full Calamari suite green (532/532)
- [x] Full solution builds clean (0 errors)