### PR TITLE
Add rollback-target resolver over the deployment journal

### DIFF
--- a/src/Squid.Core/Services/Deployments/DeploymentCompletions/DeploymentCompletionDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/DeploymentCompletions/DeploymentCompletionDataProvider.cs
@@ -1,6 +1,10 @@
 using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Rollback;
 using Squid.Core.Services.Deployments.ServerTask;
+// 'Release' alone binds to the sibling Services.Deployments.Release namespace
+// from this file's scope, so alias the entity explicitly for the journal join.
+using ReleaseEntity = Squid.Core.Persistence.Entities.Deployments.Release;
 
 namespace Squid.Core.Services.Deployments.DeploymentCompletions;
 
@@ -11,6 +15,16 @@ public interface IDeploymentCompletionDataProvider : IScopedDependency
     Task<List<DeploymentCompletion>> GetDeploymentCompletionsByDeploymentIdAsync(int deploymentId, CancellationToken cancellationToken = default);
 
     Task<List<DeploymentCompletion>> GetLatestSuccessfulCompletionsAsync(int? projectId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// PR-12 — successful deployments of releases to a single environment,
+    /// newest-first, as the rollback journal. Joins the completion journal to
+    /// <see cref="Deployment"/> (for project/environment/release) and
+    /// <see cref="Release"/> (for the version string). Ordered by
+    /// <see cref="DeploymentCompletion.CompletedTime"/> descending so
+    /// <see cref="RollbackTargetSelector"/> can pick the prior distinct release.
+    /// </summary>
+    Task<List<RollbackReleaseHistoryEntry>> GetSuccessfulReleaseHistoryAsync(int projectId, int environmentId, CancellationToken cancellationToken = default);
 
     Task DeleteByDeploymentIdsAsync(List<int> deploymentIds, CancellationToken cancellationToken = default);
 }
@@ -51,6 +65,20 @@ public class DeploymentCompletionDataProvider(IRepository repository, IUnitOfWor
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
         return latestCompletions;
+    }
+
+    public async Task<List<RollbackReleaseHistoryEntry>> GetSuccessfulReleaseHistoryAsync(int projectId, int environmentId, CancellationToken cancellationToken = default)
+    {
+        var query = from completion in repository.QueryNoTracking<DeploymentCompletion>(dc => dc.State == TaskState.Success)
+                    join deployment in repository.QueryNoTracking<Deployment>()
+                        on completion.DeploymentId equals deployment.Id
+                    join release in repository.QueryNoTracking<ReleaseEntity>()
+                        on deployment.ReleaseId equals release.Id
+                    where deployment.ProjectId == projectId && deployment.EnvironmentId == environmentId
+                    orderby completion.CompletedTime descending
+                    select new RollbackReleaseHistoryEntry(release.Id, release.Version, deployment.Id, completion.CompletedTime);
+
+        return await query.ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteByDeploymentIdsAsync(List<int> deploymentIds, CancellationToken cancellationToken = default)

--- a/src/Squid.Core/Services/Deployments/Rollback/RollbackReleaseHistoryEntry.cs
+++ b/src/Squid.Core/Services/Deployments/Rollback/RollbackReleaseHistoryEntry.cs
@@ -1,0 +1,10 @@
+namespace Squid.Core.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-12 — one successful deployment of a release to a single environment, as
+/// read from the deployment journal (<c>DeploymentCompletion</c> joined to
+/// <c>Deployment</c> + <c>Release</c>). The resolver returns these ordered
+/// newest-first; <see cref="RollbackTargetSelector"/> consumes that ordering
+/// to pick the rollback target.
+/// </summary>
+public sealed record RollbackReleaseHistoryEntry(int ReleaseId, string ReleaseVersion, int DeploymentId, DateTimeOffset CompletedTime);

--- a/src/Squid.Core/Services/Deployments/Rollback/RollbackService.cs
+++ b/src/Squid.Core/Services/Deployments/Rollback/RollbackService.cs
@@ -1,0 +1,33 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.DeploymentCompletions;
+
+namespace Squid.Core.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-12 — resolves the rollback target for an environment: the release that
+/// was successfully running before the current one. Owns the data access (via
+/// <see cref="IDeploymentCompletionDataProvider"/>) and delegates the
+/// selection rule to <see cref="RollbackTargetSelector"/>. Re-deploying that
+/// release (PR-13) is the rollback action.
+/// </summary>
+public interface IRollbackService : IScopedDependency
+{
+    /// <summary>
+    /// The release to roll back to for <paramref name="projectId"/> in
+    /// <paramref name="environmentId"/>, or <see langword="null"/> when there
+    /// is no prior distinct release (never deployed, or only one release ever
+    /// ran there).
+    /// </summary>
+    Task<RollbackReleaseHistoryEntry?> GetRollbackTargetAsync(int projectId, int environmentId, CancellationToken cancellationToken = default);
+}
+
+public class RollbackService(IDeploymentCompletionDataProvider deploymentCompletionDataProvider) : IRollbackService
+{
+    public async Task<RollbackReleaseHistoryEntry?> GetRollbackTargetAsync(int projectId, int environmentId, CancellationToken cancellationToken = default)
+    {
+        var history = await deploymentCompletionDataProvider
+            .GetSuccessfulReleaseHistoryAsync(projectId, environmentId, cancellationToken).ConfigureAwait(false);
+
+        return RollbackTargetSelector.SelectPreviousDistinctRelease(history);
+    }
+}

--- a/src/Squid.Core/Services/Deployments/Rollback/RollbackTargetSelector.cs
+++ b/src/Squid.Core/Services/Deployments/Rollback/RollbackTargetSelector.cs
@@ -1,0 +1,34 @@
+namespace Squid.Core.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-12 — pure selection of the rollback target from an environment's
+/// successful-deployment history. No DB / I/O — driven entirely by the
+/// ordered list the resolver hands it, so the "which release do we roll back
+/// to?" rule is unit-testable in isolation.
+///
+/// <para><b>Rule</b>: "roll back" re-deploys the release that was successfully
+/// running BEFORE the current one — the most recent successful deployment
+/// whose release differs from the latest (current) release. This is robust to
+/// the same release being deployed several times in a row (those collapse to
+/// "current") and to a release being re-deployed after a newer one (we still
+/// roll back to whatever distinct release preceded the current state).</para>
+///
+/// <para>Returns <see langword="null"/> when there is no prior distinct
+/// release — the environment has never been deployed to, or has only ever run
+/// a single release. The caller surfaces that as "nothing to roll back to".</para>
+/// </summary>
+public static class RollbackTargetSelector
+{
+    public static RollbackReleaseHistoryEntry? SelectPreviousDistinctRelease(IReadOnlyList<RollbackReleaseHistoryEntry> historyNewestFirst)
+    {
+        if (historyNewestFirst is null || historyNewestFirst.Count == 0) return null;
+
+        var currentReleaseId = historyNewestFirst[0].ReleaseId;
+
+        foreach (var entry in historyNewestFirst)
+            if (entry.ReleaseId != currentReleaseId)
+                return entry;
+
+        return null;
+    }
+}

--- a/tests/Squid.IntegrationTests/Helpers/TestDataBuilder.cs
+++ b/tests/Squid.IntegrationTests/Helpers/TestDataBuilder.cs
@@ -456,13 +456,13 @@ public class TestDataBuilder
         return entity;
     }
 
-    public async Task<DeploymentCompletion> CreateDeploymentCompletionAsync(int deploymentId, string state = "Success")
+    public async Task<DeploymentCompletion> CreateDeploymentCompletionAsync(int deploymentId, string state = "Success", DateTimeOffset? completedTime = null)
     {
         var entity = new DeploymentCompletion
         {
             DeploymentId = deploymentId,
             State = state,
-            CompletedTime = DateTimeOffset.UtcNow,
+            CompletedTime = completedTime ?? DateTimeOffset.UtcNow,
             SpaceId = 1
         };
 

--- a/tests/Squid.IntegrationTests/Services/Deployments/Rollback/RollbackTargetResolutionTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Rollback/RollbackTargetResolutionTests.cs
@@ -1,0 +1,197 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.DeploymentCompletions;
+using Squid.Core.Services.Deployments.Rollback;
+using Squid.IntegrationTests.Base;
+using Squid.IntegrationTests.Helpers;
+
+namespace Squid.IntegrationTests.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-12 — integration tests for the rollback-target resolver against a real
+/// Postgres database. Seeds the deployment journal (Deployment +
+/// DeploymentCompletion) and asserts the resolver picks the prior distinct
+/// release, scoped to the environment and ignoring failed deployments.
+/// </summary>
+public class RollbackTargetResolutionTests : TestBase
+{
+    public RollbackTargetResolutionTests() : base("DeploymentRollback", "squid_it_deployment_rollback")
+    {
+    }
+
+    [Fact]
+    public async Task GetRollbackTarget_LinearReleaseHistory_ResolvesImmediatelyPrecedingRelease()
+    {
+        int projectId = 0, envId = 0, v2ReleaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+            var v3 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "3.0.0").ConfigureAwait(false);
+            v2ReleaseId = v2.Id;
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v3.Id, "Success", t0.AddMinutes(20)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var target = await ResolveTargetAsync(projectId, envId).ConfigureAwait(false);
+
+        target.ShouldNotBeNull();
+        target.ReleaseId.ShouldBe(v2ReleaseId);
+        target.ReleaseVersion.ShouldBe("2.0.0");
+    }
+
+    [Fact]
+    public async Task GetSuccessfulReleaseHistory_ReturnsNewestFirstWithVersions()
+    {
+        int projectId = 0, envId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        List<RollbackReleaseHistoryEntry> history = null;
+        await Run<IDeploymentCompletionDataProvider>(async provider =>
+            history = await provider.GetSuccessfulReleaseHistoryAsync(projectId, envId, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+
+        history.ShouldNotBeNull();
+        history.Count.ShouldBe(2);
+        history[0].ReleaseVersion.ShouldBe("2.0.0", customMessage: "Newest successful deployment MUST be first.");
+        history[1].ReleaseVersion.ShouldBe("1.0.0");
+    }
+
+    [Fact]
+    public async Task GetRollbackTarget_IgnoresOtherEnvironments()
+    {
+        int projectId = 0, envAId = 0, envBId = 0, v1ReleaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b, "Environment A").ConfigureAwait(false);
+            var envB = await b.CreateEnvironmentAsync("Environment B").ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envAId = ctx.EnvId;
+            envBId = envB.Id;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+            var v3 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "3.0.0").ConfigureAwait(false);
+            v1ReleaseId = v1.Id;
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envAId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envAId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+            // env B gets a LATER deployment of a different release — must not
+            // leak into env A's rollback resolution.
+            await DeployAsync(b, ctx, envBId, v3.Id, "Success", t0.AddMinutes(20)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var targetA = await ResolveTargetAsync(projectId, envAId).ConfigureAwait(false);
+        var targetB = await ResolveTargetAsync(projectId, envBId).ConfigureAwait(false);
+
+        targetA.ShouldNotBeNull();
+        targetA.ReleaseId.ShouldBe(v1ReleaseId,
+            customMessage: "Env A's previous release is 1.0.0; env B's later 3.0.0 deployment MUST NOT affect it.");
+        targetB.ShouldBeNull(customMessage: "Env B has only one release — nothing to roll back to.");
+    }
+
+    [Fact]
+    public async Task GetRollbackTarget_ExcludesFailedDeployments()
+    {
+        int projectId = 0, envId = 0, v1ReleaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+            var v3 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "3.0.0").ConfigureAwait(false);
+            v1ReleaseId = v1.Id;
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Failed", t0.AddMinutes(10)).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v3.Id, "Success", t0.AddMinutes(20)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var target = await ResolveTargetAsync(projectId, envId).ConfigureAwait(false);
+
+        // Successful history is v3 (current) then v1 — the failed v2 is skipped,
+        // so rollback targets 1.0.0, not the never-successful 2.0.0.
+        target.ShouldNotBeNull();
+        target.ReleaseId.ShouldBe(v1ReleaseId);
+        target.ReleaseVersion.ShouldBe("1.0.0");
+    }
+
+    [Fact]
+    public async Task GetRollbackTarget_SingleRelease_ReturnsNull()
+    {
+        int projectId = 0, envId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", DateTimeOffset.UtcNow.AddMinutes(-10)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var target = await ResolveTargetAsync(projectId, envId).ConfigureAwait(false);
+
+        target.ShouldBeNull();
+    }
+
+    private async Task<RollbackReleaseHistoryEntry> ResolveTargetAsync(int projectId, int environmentId)
+    {
+        RollbackReleaseHistoryEntry target = null;
+        await Run<IRollbackService>(async svc =>
+            target = await svc.GetRollbackTargetAsync(projectId, environmentId, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+        return target;
+    }
+
+    private record SeedContext(int ProjectId, int EnvId, int ChannelId);
+
+    private static async Task<SeedContext> SeedProjectAsync(TestDataBuilder b, string envName = "Production")
+    {
+        var lifecycle = await b.CreateLifecycleAsync().ConfigureAwait(false);
+        var group = await b.CreateProjectGroupAsync().ConfigureAwait(false);
+        var env = await b.CreateEnvironmentAsync(envName).ConfigureAwait(false);
+        var varSet = await b.CreateVariableSetAsync().ConfigureAwait(false);
+        var project = await b.CreateProjectAsync(varSet.Id, 0, group.Id, lifecycle.Id).ConfigureAwait(false);
+        var channel = await b.CreateChannelAsync(project.Id, lifecycle.Id).ConfigureAwait(false);
+        return new SeedContext(project.Id, env.Id, channel.Id);
+    }
+
+    private static async Task DeployAsync(TestDataBuilder b, SeedContext ctx, int environmentId, int releaseId, string state, DateTimeOffset completedTime)
+    {
+        var task = await b.CreateServerTaskAsync(state).ConfigureAwait(false);
+        var deployment = await b.CreateDeploymentAsync(ctx.ProjectId, environmentId, releaseId, task.Id, ctx.ChannelId).ConfigureAwait(false);
+        await b.CreateDeploymentCompletionAsync(deployment.Id, state, completedTime).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Rollback/RollbackTargetSelectorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Rollback/RollbackTargetSelectorTests.cs
@@ -1,0 +1,105 @@
+using Shouldly;
+using Squid.Core.Services.Deployments.Rollback;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-12 — unit tests for <see cref="RollbackTargetSelector"/>. Pins the
+/// "which release do we roll back to?" rule against every history shape the
+/// resolver can hand it.
+/// </summary>
+public sealed class RollbackTargetSelectorTests
+{
+    [Fact]
+    public void NoHistory_ReturnsNull()
+        => RollbackTargetSelector.SelectPreviousDistinctRelease(Array.Empty<RollbackReleaseHistoryEntry>())
+            .ShouldBeNull();
+
+    [Fact]
+    public void NullHistory_ReturnsNull()
+        => RollbackTargetSelector.SelectPreviousDistinctRelease(null!).ShouldBeNull();
+
+    [Fact]
+    public void SingleRelease_NothingToRollBackTo_ReturnsNull()
+    {
+        var history = new[] { Entry(releaseId: 5, version: "1.0.0", deploymentId: 100, minutesAgo: 0) };
+
+        RollbackTargetSelector.SelectPreviousDistinctRelease(history).ShouldBeNull();
+    }
+
+    [Fact]
+    public void SameReleaseDeployedRepeatedly_ReturnsNull()
+    {
+        // Re-deploying the SAME release several times is not a rollback target —
+        // there is no prior *distinct* release to go back to.
+        var history = new[]
+        {
+            Entry(releaseId: 5, version: "1.0.0", deploymentId: 102, minutesAgo: 0),
+            Entry(releaseId: 5, version: "1.0.0", deploymentId: 101, minutesAgo: 10),
+            Entry(releaseId: 5, version: "1.0.0", deploymentId: 100, minutesAgo: 20)
+        };
+
+        RollbackTargetSelector.SelectPreviousDistinctRelease(history).ShouldBeNull();
+    }
+
+    [Fact]
+    public void LinearHistory_ReturnsImmediatelyPrecedingRelease()
+    {
+        // v3 (current) <- v2 <- v1. Rolling back undoes the last change: v2.
+        var history = new[]
+        {
+            Entry(releaseId: 3, version: "3.0.0", deploymentId: 300, minutesAgo: 0),
+            Entry(releaseId: 2, version: "2.0.0", deploymentId: 200, minutesAgo: 10),
+            Entry(releaseId: 1, version: "1.0.0", deploymentId: 100, minutesAgo: 20)
+        };
+
+        var target = RollbackTargetSelector.SelectPreviousDistinctRelease(history);
+
+        target.ShouldNotBeNull();
+        target!.ReleaseId.ShouldBe(2);
+        target.ReleaseVersion.ShouldBe("2.0.0");
+        target.DeploymentId.ShouldBe(200,
+            customMessage: "Target MUST carry the deployment it came from so the caller can show 'roll back to the 2.0.0 you ran at HH:MM'.");
+    }
+
+    [Fact]
+    public void ReleaseReDeployedAfterNewer_RollsBackToTheDistinctPredecessor()
+    {
+        // Timeline: v1, then v2, then v1 again (current). The current release is
+        // v1; the distinct release preceding the current state is v2.
+        var history = new[]
+        {
+            Entry(releaseId: 1, version: "1.0.0", deploymentId: 103, minutesAgo: 0),
+            Entry(releaseId: 2, version: "2.0.0", deploymentId: 102, minutesAgo: 10),
+            Entry(releaseId: 1, version: "1.0.0", deploymentId: 101, minutesAgo: 20)
+        };
+
+        var target = RollbackTargetSelector.SelectPreviousDistinctRelease(history);
+
+        target!.ReleaseId.ShouldBe(2);
+        target.DeploymentId.ShouldBe(102);
+    }
+
+    [Fact]
+    public void PreviousReleaseDeployedMultipleTimes_ReturnsItsMostRecentDeployment()
+    {
+        // v2 (current) preceded by two v1 deployments. The target is the MOST
+        // RECENT v1 (deployment 101), not the older one (100).
+        var history = new[]
+        {
+            Entry(releaseId: 2, version: "2.0.0", deploymentId: 200, minutesAgo: 0),
+            Entry(releaseId: 1, version: "1.0.0", deploymentId: 101, minutesAgo: 10),
+            Entry(releaseId: 1, version: "1.0.0", deploymentId: 100, minutesAgo: 20)
+        };
+
+        var target = RollbackTargetSelector.SelectPreviousDistinctRelease(history);
+
+        target!.ReleaseId.ShouldBe(1);
+        target.DeploymentId.ShouldBe(101,
+            customMessage: "When the prior release was deployed multiple times, roll back to its most recent successful deployment.");
+    }
+
+    private static RollbackReleaseHistoryEntry Entry(int releaseId, string version, int deploymentId, int minutesAgo)
+        => new(releaseId, version, deploymentId, DateTimeOffset.UtcNow.AddMinutes(-minutesAgo));
+}


### PR DESCRIPTION
## Summary

- Resolve the release to roll back to for a `(project, environment)`: the most recent successfully-deployed release that *differs* from the current one.
- Reads the existing deployment-completion journal joined to `Deployment` + `Release` — **no schema change** — ordered newest-first, excluding failed deployments.
- Pure selection rule (`RollbackTargetSelector`) is separated from data access (`IRollbackService` → `IDeploymentCompletionDataProvider`), so the "which release?" logic is unit-testable in isolation.
- Foundation for the upcoming rollback command, which will re-dispatch the resolved release through the existing `DeploymentService.CreateDeploymentAsync` pipeline. Additive and non-breaking — nothing consumes it yet.

## Test plan

- [x] Unit (`RollbackTargetSelectorTests`, 7): empty/null history, single release, same release re-deployed, linear v1→v2→v3, release re-deployed after a newer one, prior release deployed multiple times (most-recent wins)
- [x] Integration vs Postgres (`RollbackTargetResolutionTests`, 5): linear history resolves the preceding release; journal query returns newest-first with versions; **environment isolation** (a later deploy to another environment is ignored); **failed deployments excluded**; single-release returns null
- [x] Full solution builds clean (0 errors)

E2E lands with the rollback **action** PR (seed prior releases → invoke rollback → assert the prior release re-deploys end-to-end), where there is a user-facing entry point to exercise.