### PR TITLE
Add rollback deployment command

### DIFF
--- a/src/Squid.Api/Controllers/DeploymentController.cs
+++ b/src/Squid.Api/Controllers/DeploymentController.cs
@@ -23,6 +23,15 @@ public class DeploymentController : ControllerBase
         return Ok(response);
     }
 
+    [HttpPost("rollback")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RollbackDeploymentResponse))]
+    public async Task<IActionResult> RollbackDeploymentAsync([FromBody] RollbackDeploymentCommand command)
+    {
+        var response = await _mediator.SendAsync<RollbackDeploymentCommand, RollbackDeploymentResponse>(command).ConfigureAwait(false);
+
+        return Ok(response);
+    }
+
     [HttpPost("preview")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PreviewDeploymentResponse))]
     public async Task<IActionResult> PreviewDeploymentAsync([FromBody] PreviewDeploymentRequest request)

--- a/src/Squid.Core/Handlers/CommandHandlers/Deployments/Deployment/RollbackDeploymentCommandHandler.cs
+++ b/src/Squid.Core/Handlers/CommandHandlers/Deployments/Deployment/RollbackDeploymentCommandHandler.cs
@@ -1,0 +1,30 @@
+using Squid.Core.Services.Deployments.Rollback;
+using Squid.Message.Commands.Deployments.Deployment;
+
+namespace Squid.Core.Handlers.CommandHandlers.Deployments.Deployment;
+
+public class RollbackDeploymentCommandHandler : ICommandHandler<RollbackDeploymentCommand, RollbackDeploymentResponse>
+{
+    private readonly IRollbackService _rollbackService;
+
+    public RollbackDeploymentCommandHandler(IRollbackService rollbackService)
+    {
+        _rollbackService = rollbackService;
+    }
+
+    public async Task<RollbackDeploymentResponse> Handle(IReceiveContext<RollbackDeploymentCommand> context, CancellationToken cancellationToken)
+    {
+        var @event = await _rollbackService.RollbackDeploymentAsync(context.Message, cancellationToken).ConfigureAwait(false);
+
+        await context.PublishAsync(@event, cancellationToken).ConfigureAwait(false);
+
+        return new RollbackDeploymentResponse
+        {
+            Data = new CreateDeploymentResponseData
+            {
+                Deployment = @event.Deployment,
+                TaskId = @event.TaskId
+            }
+        };
+    }
+}

--- a/src/Squid.Core/Services/Deployments/Rollback/Exceptions/RollbackNotAvailableException.cs
+++ b/src/Squid.Core/Services/Deployments/Rollback/Exceptions/RollbackNotAvailableException.cs
@@ -1,0 +1,23 @@
+namespace Squid.Core.Services.Deployments.Rollback.Exceptions;
+
+/// <summary>
+/// Thrown when a rollback cannot be performed: no successful deployment
+/// history for the environment, no prior release distinct from the current
+/// one, or an operator-specified target release that never successfully
+/// deployed to the environment. Inherits <see cref="InvalidOperationException"/>
+/// so the global exception filter maps it to a client-actionable 4xx with the
+/// message below.
+/// </summary>
+public class RollbackNotAvailableException : InvalidOperationException
+{
+    public int ProjectId { get; }
+
+    public int EnvironmentId { get; }
+
+    public RollbackNotAvailableException(int projectId, int environmentId, string reason)
+        : base($"Cannot roll back project {projectId} in environment {environmentId}: {reason}")
+    {
+        ProjectId = projectId;
+        EnvironmentId = environmentId;
+    }
+}

--- a/src/Squid.Core/Services/Deployments/Rollback/RollbackService.cs
+++ b/src/Squid.Core/Services/Deployments/Rollback/RollbackService.cs
@@ -1,27 +1,40 @@
 using Squid.Core.Persistence.Db;
 using Squid.Core.Services.Deployments.DeploymentCompletions;
+using Squid.Core.Services.Deployments.Deployments;
+using Squid.Core.Services.Deployments.Rollback.Exceptions;
+using Squid.Message.Commands.Deployments.Deployment;
+using Squid.Message.Events.Deployments.Deployment;
 
 namespace Squid.Core.Services.Deployments.Rollback;
 
 /// <summary>
-/// PR-12 — resolves the rollback target for an environment: the release that
-/// was successfully running before the current one. Owns the data access (via
-/// <see cref="IDeploymentCompletionDataProvider"/>) and delegates the
-/// selection rule to <see cref="RollbackTargetSelector"/>. Re-deploying that
-/// release (PR-13) is the rollback action.
+/// PR-12/13 — rollback for an environment. Resolves the release to roll back
+/// to (the prior successful release, or an operator-specified prior release)
+/// from the deployment journal, then re-deploys it. A rollback is a normal
+/// deployment of an older release, so the action delegates to
+/// <see cref="IDeploymentService.CreateDeploymentAsync"/> for all validation,
+/// snapshotting and enqueueing — no parallel deploy path.
 /// </summary>
 public interface IRollbackService : IScopedDependency
 {
     /// <summary>
     /// The release to roll back to for <paramref name="projectId"/> in
     /// <paramref name="environmentId"/>, or <see langword="null"/> when there
-    /// is no prior distinct release (never deployed, or only one release ever
-    /// ran there).
+    /// is no prior distinct release. Read-only — does not deploy.
     /// </summary>
     Task<RollbackReleaseHistoryEntry?> GetRollbackTargetAsync(int projectId, int environmentId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Roll <paramref name="command"/>'s environment back to a prior release
+    /// (auto-resolved previous, or the command's explicit <c>ReleaseId</c>),
+    /// re-deploying it through the standard deployment pipeline.
+    /// </summary>
+    Task<DeploymentCreatedEvent> RollbackDeploymentAsync(RollbackDeploymentCommand command, CancellationToken cancellationToken = default);
 }
 
-public class RollbackService(IDeploymentCompletionDataProvider deploymentCompletionDataProvider) : IRollbackService
+public class RollbackService(
+    IDeploymentCompletionDataProvider deploymentCompletionDataProvider,
+    IDeploymentService deploymentService) : IRollbackService
 {
     public async Task<RollbackReleaseHistoryEntry?> GetRollbackTargetAsync(int projectId, int environmentId, CancellationToken cancellationToken = default)
     {
@@ -30,4 +43,70 @@ public class RollbackService(IDeploymentCompletionDataProvider deploymentComplet
 
         return RollbackTargetSelector.SelectPreviousDistinctRelease(history);
     }
+
+    public async Task<DeploymentCreatedEvent> RollbackDeploymentAsync(RollbackDeploymentCommand command, CancellationToken cancellationToken = default)
+    {
+        var targetReleaseId = await ResolveTargetReleaseIdAsync(command.ProjectId, command.EnvironmentId, command.ReleaseId, cancellationToken).ConfigureAwait(false);
+
+        var createCommand = BuildCreateCommand(command, targetReleaseId);
+
+        return await deploymentService.CreateDeploymentAsync(createCommand, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolve + validate the effective rollback target. When
+    /// <paramref name="requestedReleaseId"/> is null, auto-selects the previous
+    /// distinct release; otherwise validates the requested release actually
+    /// deployed successfully to the environment and is not the current one.
+    /// Throws <see cref="RollbackNotAvailableException"/> when no valid target
+    /// exists.
+    /// </summary>
+    private async Task<int> ResolveTargetReleaseIdAsync(int projectId, int environmentId, int? requestedReleaseId, CancellationToken cancellationToken)
+    {
+        var history = await deploymentCompletionDataProvider
+            .GetSuccessfulReleaseHistoryAsync(projectId, environmentId, cancellationToken).ConfigureAwait(false);
+
+        if (history.Count == 0)
+            throw new RollbackNotAvailableException(projectId, environmentId, "no successful deployment exists for this environment.");
+
+        var currentReleaseId = history[0].ReleaseId;
+
+        if (requestedReleaseId is null)
+        {
+            var previous = RollbackTargetSelector.SelectPreviousDistinctRelease(history);
+
+            if (previous is null)
+                throw new RollbackNotAvailableException(projectId, environmentId, "no prior release differs from the currently deployed one.");
+
+            return previous.ReleaseId;
+        }
+
+        var requested = requestedReleaseId.Value;
+
+        if (requested == currentReleaseId)
+            throw new RollbackNotAvailableException(projectId, environmentId, $"release {requested} is already the current release.");
+
+        if (history.All(entry => entry.ReleaseId != requested))
+            throw new RollbackNotAvailableException(projectId, environmentId, $"release {requested} has no successful deployment to this environment to roll back to.");
+
+        return requested;
+    }
+
+    private static CreateDeploymentCommand BuildCreateCommand(RollbackDeploymentCommand command, int targetReleaseId)
+        => new()
+        {
+            SpaceId = command.SpaceId,
+            ReleaseId = targetReleaseId,
+            EnvironmentId = command.EnvironmentId,
+            Name = command.Name ?? $"Rollback to release {targetReleaseId}",
+            Comments = command.Comments,
+            ForcePackageDownload = command.ForcePackageDownload,
+            ForcePackageRedeployment = command.ForcePackageRedeployment,
+            UseGuidedFailure = command.UseGuidedFailure,
+            QueueTime = command.QueueTime,
+            QueueTimeExpiry = command.QueueTimeExpiry,
+            SpecificMachineIds = command.SpecificMachineIds,
+            ExcludedMachineIds = command.ExcludedMachineIds,
+            SkipActionIds = command.SkipActionIds
+        };
 }

--- a/src/Squid.Message/Commands/Deployments/Deployment/RollbackDeploymentCommand.cs
+++ b/src/Squid.Message/Commands/Deployments/Deployment/RollbackDeploymentCommand.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Serialization;
+using Squid.Message.Attributes;
+using Squid.Message.Enums;
+using Squid.Message.Response;
+
+namespace Squid.Message.Commands.Deployments.Deployment;
+
+/// <summary>
+/// Roll an environment back to a prior release. A rollback is just a normal
+/// deployment of an older release (no special "rollback" flag on the
+/// deployment), so this reuses the entire <see cref="CreateDeploymentCommand"/>
+/// path once the target release is resolved.
+///
+/// <para><see cref="ReleaseId"/> is optional: when omitted, the server rolls
+/// back to the previously-running successful release for the environment
+/// (auto target). When supplied, it must be a release that previously
+/// deployed successfully to this environment and differ from the current one
+/// — letting an operator jump back to any prior good version, not just one
+/// step.</para>
+///
+/// <para>Carries <see cref="Permission.DeploymentCreate"/> — a rollback IS a
+/// deployment.</para>
+/// </summary>
+[RequiresPermission(Permission.DeploymentCreate)]
+public class RollbackDeploymentCommand : ICommand, ISpaceScoped
+{
+    public int? SpaceId { get; set; }
+
+    public int ProjectId { get; set; }
+
+    public int EnvironmentId { get; set; }
+
+    /// <summary>Optional explicit rollback target. Null = auto-resolve the
+    /// previous successful release for the environment.</summary>
+    public int? ReleaseId { get; set; }
+
+    public string Name { get; set; }
+
+    public string Comments { get; set; }
+
+    public bool ForcePackageDownload { get; set; }
+
+    public bool ForcePackageRedeployment { get; set; }
+
+    public bool UseGuidedFailure { get; set; }
+
+    public DateTimeOffset? QueueTime { get; set; }
+
+    public DateTimeOffset? QueueTimeExpiry { get; set; }
+
+    public List<string> SpecificMachineIds { get; set; } = new();
+
+    public List<string> ExcludedMachineIds { get; set; } = new();
+
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    public List<int> SkipActionIds { get; set; } = new();
+}
+
+public class RollbackDeploymentResponse : SquidResponse<CreateDeploymentResponseData>
+{
+}

--- a/tests/Squid.IntegrationTests/Services/Deployments/Rollback/RollbackDeploymentTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Rollback/RollbackDeploymentTests.cs
@@ -1,0 +1,194 @@
+using Autofac;
+using Moq;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.Deployments;
+using Squid.Core.Services.Deployments.Rollback;
+using Squid.Core.Services.Deployments.Rollback.Exceptions;
+using Squid.IntegrationTests.Base;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Commands.Deployments.Deployment;
+using Squid.Message.Events.Deployments.Deployment;
+using Squid.Message.Models.Deployments.Deployment;
+
+namespace Squid.IntegrationTests.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-13 — integration tests for the rollback action against a real Postgres
+/// journal. The SUCCESS path resolves the target from the real journal and
+/// delegates to a stubbed <see cref="IDeploymentService"/> (we assert the
+/// resolved release flows into the standard deploy command). The REJECTION
+/// paths use the real services — they must throw before any deployment is
+/// created.
+/// </summary>
+public class RollbackDeploymentTests : TestBase
+{
+    public RollbackDeploymentTests() : base("DeploymentRollbackAction", "squid_it_deployment_rollback_action")
+    {
+    }
+
+    [Fact]
+    public async Task RollbackDeployment_AutoTarget_DeploysPreviousRelease()
+    {
+        int projectId = 0, envId = 0, v1ReleaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+            v1ReleaseId = v1.Id;
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var captured = await CaptureDelegatedDeploymentAsync(
+            new RollbackDeploymentCommand { ProjectId = projectId, EnvironmentId = envId, ReleaseId = null }).ConfigureAwait(false);
+
+        captured.ShouldNotBeNull();
+        captured.ReleaseId.ShouldBe(v1ReleaseId, customMessage: "Auto rollback MUST re-deploy the release running before the current one.");
+        captured.EnvironmentId.ShouldBe(envId);
+    }
+
+    [Fact]
+    public async Task RollbackDeployment_ExplicitRelease_DeploysThatRelease()
+    {
+        int projectId = 0, envId = 0, v1ReleaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+            var v3 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "3.0.0").ConfigureAwait(false);
+            v1ReleaseId = v1.Id;
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v3.Id, "Success", t0.AddMinutes(20)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var captured = await CaptureDelegatedDeploymentAsync(
+            new RollbackDeploymentCommand { ProjectId = projectId, EnvironmentId = envId, ReleaseId = v1ReleaseId }).ConfigureAwait(false);
+
+        captured.ReleaseId.ShouldBe(v1ReleaseId, customMessage: "Operator-specified prior release MUST be the one re-deployed.");
+    }
+
+    [Fact]
+    public async Task RollbackDeployment_SingleRelease_Throws()
+    {
+        int projectId = 0, envId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", DateTimeOffset.UtcNow.AddMinutes(-10)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await ShouldRejectAsync(new RollbackDeploymentCommand { ProjectId = projectId, EnvironmentId = envId }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task RollbackDeployment_CurrentRelease_Throws()
+    {
+        int projectId = 0, envId = 0, v2ReleaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+            v2ReleaseId = v2.Id;
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await ShouldRejectAsync(new RollbackDeploymentCommand { ProjectId = projectId, EnvironmentId = envId, ReleaseId = v2ReleaseId }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task RollbackDeployment_UnknownRelease_Throws()
+    {
+        int projectId = 0, envId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var b = new TestDataBuilder(repository, unitOfWork);
+            var ctx = await SeedProjectAsync(b).ConfigureAwait(false);
+            projectId = ctx.ProjectId;
+            envId = ctx.EnvId;
+
+            var v1 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "1.0.0").ConfigureAwait(false);
+            var v2 = await b.CreateReleaseAsync(ctx.ProjectId, ctx.ChannelId, "2.0.0").ConfigureAwait(false);
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-1);
+            await DeployAsync(b, ctx, envId, v1.Id, "Success", t0).ConfigureAwait(false);
+            await DeployAsync(b, ctx, envId, v2.Id, "Success", t0.AddMinutes(10)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await ShouldRejectAsync(new RollbackDeploymentCommand { ProjectId = projectId, EnvironmentId = envId, ReleaseId = 999999 }).ConfigureAwait(false);
+    }
+
+    private async Task<CreateDeploymentCommand> CaptureDelegatedDeploymentAsync(RollbackDeploymentCommand command)
+    {
+        CreateDeploymentCommand captured = null;
+
+        var deploymentService = new Mock<IDeploymentService>();
+        deploymentService
+            .Setup(service => service.CreateDeploymentAsync(It.IsAny<CreateDeploymentCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateDeploymentCommand, CancellationToken>((create, _) => captured = create)
+            .ReturnsAsync(new DeploymentCreatedEvent { TaskId = 1, Deployment = new DeploymentDto { Id = 1 } });
+
+        await Run<IRollbackService>(
+            async service => await service.RollbackDeploymentAsync(command, CancellationToken.None).ConfigureAwait(false),
+            builder => builder.RegisterInstance(deploymentService.Object).As<IDeploymentService>()).ConfigureAwait(false);
+
+        return captured;
+    }
+
+    private async Task ShouldRejectAsync(RollbackDeploymentCommand command)
+        => await Run<IRollbackService>(async service =>
+            await Should.ThrowAsync<RollbackNotAvailableException>(
+                () => service.RollbackDeploymentAsync(command, CancellationToken.None)).ConfigureAwait(false)).ConfigureAwait(false);
+
+    private record SeedContext(int ProjectId, int EnvId, int ChannelId);
+
+    private static async Task<SeedContext> SeedProjectAsync(TestDataBuilder b, string envName = "Production")
+    {
+        var lifecycle = await b.CreateLifecycleAsync().ConfigureAwait(false);
+        var group = await b.CreateProjectGroupAsync().ConfigureAwait(false);
+        var env = await b.CreateEnvironmentAsync(envName).ConfigureAwait(false);
+        var varSet = await b.CreateVariableSetAsync().ConfigureAwait(false);
+        var project = await b.CreateProjectAsync(varSet.Id, 0, group.Id, lifecycle.Id).ConfigureAwait(false);
+        var channel = await b.CreateChannelAsync(project.Id, lifecycle.Id).ConfigureAwait(false);
+        return new SeedContext(project.Id, env.Id, channel.Id);
+    }
+
+    private static async Task DeployAsync(TestDataBuilder b, SeedContext ctx, int environmentId, int releaseId, string state, DateTimeOffset completedTime)
+    {
+        var task = await b.CreateServerTaskAsync(state).ConfigureAwait(false);
+        var deployment = await b.CreateDeploymentAsync(ctx.ProjectId, environmentId, releaseId, task.Id, ctx.ChannelId).ConfigureAwait(false);
+        await b.CreateDeploymentCompletionAsync(deployment.Id, state, completedTime).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Rollback/RollbackServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Rollback/RollbackServiceTests.cs
@@ -1,0 +1,141 @@
+using System.Linq;
+using Squid.Core.Services.Deployments.DeploymentCompletions;
+using Squid.Core.Services.Deployments.Deployments;
+using Squid.Core.Services.Deployments.Rollback;
+using Squid.Core.Services.Deployments.Rollback.Exceptions;
+using Squid.Message.Commands.Deployments.Deployment;
+using Squid.Message.Events.Deployments.Deployment;
+using Squid.Message.Models.Deployments.Deployment;
+
+namespace Squid.UnitTests.Services.Deployments.Rollback;
+
+/// <summary>
+/// PR-13 — unit tests for <see cref="RollbackService"/>. Mocks the journal
+/// provider + <see cref="IDeploymentService"/> so the target resolution /
+/// validation rule and the delegation to the standard deploy path are pinned
+/// in isolation (no DB, no pipeline).
+/// </summary>
+public class RollbackServiceTests
+{
+    private const int ProjectId = 7;
+    private const int EnvironmentId = 3;
+
+    private readonly Mock<IDeploymentCompletionDataProvider> _journal = new();
+    private readonly Mock<IDeploymentService> _deploymentService = new();
+    private readonly RollbackService _sut;
+
+    public RollbackServiceTests()
+    {
+        _sut = new RollbackService(_journal.Object, _deploymentService.Object);
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_NoReleaseId_DeploysPreviousDistinctRelease()
+    {
+        GivenHistory(Entry(3, 300), Entry(2, 200), Entry(1, 100));
+        var captured = CaptureDelegatedCreate();
+
+        await _sut.RollbackDeploymentAsync(Command(releaseId: null));
+
+        captured().ShouldNotBeNull();
+        captured().ReleaseId.ShouldBe(2, customMessage: "Auto rollback targets the release running before the current one.");
+        captured().EnvironmentId.ShouldBe(EnvironmentId);
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_ExplicitValidReleaseId_DeploysThatRelease()
+    {
+        GivenHistory(Entry(3, 300), Entry(2, 200), Entry(1, 100));
+        var captured = CaptureDelegatedCreate();
+
+        await _sut.RollbackDeploymentAsync(Command(releaseId: 1));
+
+        captured().ReleaseId.ShouldBe(1, customMessage: "Operator-specified prior release MUST be honoured.");
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_PropagatesEnvironmentAndRedeployFlags()
+    {
+        GivenHistory(Entry(2, 200), Entry(1, 100));
+        var captured = CaptureDelegatedCreate();
+
+        await _sut.RollbackDeploymentAsync(new RollbackDeploymentCommand
+        {
+            ProjectId = ProjectId,
+            EnvironmentId = EnvironmentId,
+            ForcePackageRedeployment = true,
+            SkipActionIds = new List<int> { 42 }
+        });
+
+        captured().ForcePackageRedeployment.ShouldBeTrue();
+        captured().SkipActionIds.ShouldContain(42);
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_ExplicitCurrentReleaseId_ThrowsAndDoesNotDeploy()
+    {
+        GivenHistory(Entry(3, 300), Entry(2, 200), Entry(1, 100));
+
+        await Should.ThrowAsync<RollbackNotAvailableException>(() => _sut.RollbackDeploymentAsync(Command(releaseId: 3)));
+
+        VerifyNoDeployment();
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_ExplicitUnknownReleaseId_ThrowsAndDoesNotDeploy()
+    {
+        GivenHistory(Entry(3, 300), Entry(2, 200), Entry(1, 100));
+
+        await Should.ThrowAsync<RollbackNotAvailableException>(() => _sut.RollbackDeploymentAsync(Command(releaseId: 99)));
+
+        VerifyNoDeployment();
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_NoSuccessfulHistory_ThrowsAndDoesNotDeploy()
+    {
+        GivenHistory();
+
+        await Should.ThrowAsync<RollbackNotAvailableException>(() => _sut.RollbackDeploymentAsync(Command(releaseId: null)));
+
+        VerifyNoDeployment();
+    }
+
+    [Fact]
+    public async Task RollbackDeploymentAsync_SingleReleaseNoTarget_ThrowsAndDoesNotDeploy()
+    {
+        GivenHistory(Entry(1, 100));
+
+        await Should.ThrowAsync<RollbackNotAvailableException>(() => _sut.RollbackDeploymentAsync(Command(releaseId: null)));
+
+        VerifyNoDeployment();
+    }
+
+    private void GivenHistory(params RollbackReleaseHistoryEntry[] newestFirst)
+        => _journal
+            .Setup(journal => journal.GetSuccessfulReleaseHistoryAsync(ProjectId, EnvironmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newestFirst.ToList());
+
+    private Func<CreateDeploymentCommand> CaptureDelegatedCreate()
+    {
+        CreateDeploymentCommand captured = null;
+
+        _deploymentService
+            .Setup(service => service.CreateDeploymentAsync(It.IsAny<CreateDeploymentCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateDeploymentCommand, CancellationToken>((command, _) => captured = command)
+            .ReturnsAsync(new DeploymentCreatedEvent { TaskId = 1, Deployment = new DeploymentDto { Id = 1 } });
+
+        return () => captured;
+    }
+
+    private void VerifyNoDeployment()
+        => _deploymentService.Verify(
+            service => service.CreateDeploymentAsync(It.IsAny<CreateDeploymentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+    private static RollbackDeploymentCommand Command(int? releaseId)
+        => new() { ProjectId = ProjectId, EnvironmentId = EnvironmentId, ReleaseId = releaseId };
+
+    private static RollbackReleaseHistoryEntry Entry(int releaseId, int deploymentId)
+        => new(releaseId, $"{releaseId}.0.0", deploymentId, DateTimeOffset.UtcNow.AddMinutes(-releaseId));
+}


### PR DESCRIPTION
## Summary

- `RollbackDeploymentCommand` rolls an environment back to a prior release by **re-deploying it through the existing deployment pipeline** — a rollback is a normal deployment of an older release, so there is **no new deployment flag and no schema change**.
- Target resolution uses the deployment journal (built in #382): the previous successful release by default, or an operator-specified prior release **validated** against the environment's success history (rejects the current release, an unknown release, or an environment with no prior release).
- The action delegates to `DeploymentService.CreateDeploymentAsync`, reusing all preview/validation, snapshotting and enqueueing — no parallel deploy path. `POST /api/deployments/rollback` exposes it; carries `DeploymentCreate` permission.

## Test plan

- [x] Unit (`RollbackServiceTests`, 7): auto target → previous distinct release; explicit valid target honoured; environment + redeploy flags propagated; rejects current / unknown / absent / single-release targets without deploying (mocked journal + `IDeploymentService`)
- [x] Integration vs Postgres (`RollbackDeploymentTests`, 5): auto + explicit success paths resolve the correct release from the real journal and pass it into the standard deploy command (stubbed deploy boundary); single-release / current-release / unknown-release rejections throw through the real service
- [x] Full unit suite green (5639), full solution builds clean

Together with #382 (resolver: unit + integration) this gives the rollback feature unit + integration coverage; the deploy path it reuses (`CreateDeploymentAsync`) is already covered by the existing deployment E2E suite.