### PR TITLE
Resume in-flight scripts by ticket instead of re-dispatching

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.cs
@@ -75,6 +75,8 @@ public sealed partial class ExecuteStepsPhase(
 
         _currentBatchIndex = 0;
 
+        await EnsureCheckpointRowAsync(ct).ConfigureAwait(false);
+
         foreach (var batch in batches)
         {
             if (_ctx.ResumeFromBatchIndex.HasValue && _currentBatchIndex <= _ctx.ResumeFromBatchIndex.Value)
@@ -99,6 +101,23 @@ public sealed partial class ExecuteStepsPhase(
             _currentBatchIndex++;
         }
     }
+
+    /// <summary>
+    /// Resume-by-ticket: ensure a checkpoint row exists before any script is
+    /// dispatched, so in-flight tickets recorded mid-batch (by
+    /// <see cref="Squid.Core.Services.Deployments.Checkpoints.IInFlightScriptStore"/>)
+    /// have a row to land on — the first batch-boundary save happens only AFTER
+    /// batch 0's scripts have already been dispatched.
+    ///
+    /// <para><b>Insert-only-if-absent</b>: on resume the row already holds the
+    /// real prior state (loaded by <c>ResumeCheckpointPhase</c>) and MUST NOT be
+    /// clobbered. A fresh row carries <c>LastCompletedBatchIndex = -1</c> +
+    /// empty state, which makes resume re-run from batch 0 — identical to the
+    /// pre-existing "no row yet" behaviour, only now with the in-flight ledger
+    /// available for re-attach.</para>
+    /// </summary>
+    private async Task EnsureCheckpointRowAsync(CancellationToken ct)
+        => await checkpointService.EnsureExistsAsync(_ctx.ServerTaskId, _ctx.Deployment?.Id ?? 0, ct).ConfigureAwait(false);
 
     /// <summary>
     /// Maximum attempts for <see cref="PersistCheckpointAsync"/> before
@@ -166,8 +185,9 @@ public sealed partial class ExecuteStepsPhase(
             LastCompletedBatchIndex = batchIndex,
             FailureEncountered = _ctx.FailureEncountered,
             OutputVariablesJson = outputVariablesJson,
-            BatchStatesJson = batchStatesJson,
-            InFlightScriptsJson = "{}"
+            BatchStatesJson = batchStatesJson
+            // InFlightScriptsJson is owned by IInFlightScriptStore and deliberately
+            // left untouched here — see DeploymentCheckpointService.SaveAsync.
         };
 
         var delay = CheckpointPersistInitialDelay;

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -5,7 +5,9 @@ using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Script.Files;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.Deployments.Checkpoints;
 using Squid.Core.Settings.Halibut;
+using Squid.Message.Constants;
 using Squid.Message.Contracts.Tentacle;
 
 namespace Squid.Core.Services.DeploymentExecution.Tentacle;
@@ -32,6 +34,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
     private readonly IHalibutScriptObserver _observer;
     private readonly IMachineCircuitBreakerRegistry _breakerRegistry;
     private readonly IMachineRuntimeCapabilitiesCache _capabilitiesCache;
+    private readonly IInFlightScriptStore _inFlightStore;
     private readonly TimeSpan _defaultScriptTimeout;
 
     public HalibutMachineExecutionStrategy(
@@ -40,13 +43,15 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         IHalibutScriptObserver observer,
         HalibutSetting halibutSetting,
         IMachineCircuitBreakerRegistry breakerRegistry = null,
-        IMachineRuntimeCapabilitiesCache capabilitiesCache = null)
+        IMachineRuntimeCapabilitiesCache capabilitiesCache = null,
+        IInFlightScriptStore inFlightStore = null)
     {
         _halibutClientFactory = halibutClientFactory;
         _payloadBuilder = payloadBuilder;
         _observer = observer;
         _breakerRegistry = breakerRegistry;
         _capabilitiesCache = capabilitiesCache;
+        _inFlightStore = inFlightStore;
         _defaultScriptTimeout = TimeSpan.FromMinutes(Math.Max(1, halibutSetting.Polling.ScriptTimeoutMinutes));
     }
 
@@ -168,12 +173,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
             TargetNamespace = request.TargetNamespace
         };
 
-        var startResponse = await scriptClient.StartScriptAsync(command).ConfigureAwait(false);
-
-        Log.Information("[Deploy] Starting packaged YAML deployment on agent {MachineName} with ticket {Ticket}",
-            request.Machine.Name, scriptTicket);
-
-        return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, scriptTicket, scriptTimeout, ct, request.Masker, startResponse, endpoint).ConfigureAwait(false);
+        return await DispatchOrReattachAsync(request, scriptClient, endpoint, scriptTicket, command, scriptTimeout, ct).ConfigureAwait(false);
     }
 
     private async Task<ScriptExecutionResult> ExecuteDirectScriptViaHalibutAsync(
@@ -205,13 +205,111 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
             TargetNamespace = request.TargetNamespace
         };
 
+        return await DispatchOrReattachAsync(request, scriptClient, endpoint, scriptTicket, command, scriptTimeout, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Dispatch a script to the agent and observe it to completion — or, on a
+    /// resumed deployment, re-attach to a still-running script from a prior
+    /// (crashed) run instead of launching a duplicate. The in-flight ScriptTicket
+    /// is recorded right after <c>StartScript</c> and cleared once observation
+    /// completes, so a server crash mid-script leaves a durable pointer the next
+    /// run can re-attach to.
+    /// </summary>
+    private async Task<ScriptExecutionResult> DispatchOrReattachAsync(
+        ScriptExecutionRequest request, IAsyncScriptService scriptClient, ServiceEndPoint endpoint,
+        ScriptTicket scriptTicket, StartScriptCommand command, TimeSpan scriptTimeout, CancellationToken ct)
+    {
+        var reattached = await TryReattachAsync(request, scriptClient, endpoint, scriptTimeout, ct).ConfigureAwait(false);
+        if (reattached != null) return reattached;
+
         var startResponse = await scriptClient.StartScriptAsync(command).ConfigureAwait(false);
 
-        Log.Information("[Deploy] Starting direct script on agent {MachineName} with ticket {Ticket}",
+        if (_inFlightStore != null)
+            await _inFlightStore.RecordDispatchedAsync(request.ServerTaskId, request.Machine.Id, scriptTicket.TaskId, ct).ConfigureAwait(false);
+
+        Log.Information("[Deploy] Dispatching script to agent {MachineName} with ticket {Ticket}",
             request.Machine.Name, scriptTicket);
 
-        return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, scriptTicket, scriptTimeout, ct, request.Masker, startResponse, endpoint).ConfigureAwait(false);
+        try
+        {
+            return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, scriptTicket, scriptTimeout, ct, request.Masker, startResponse, endpoint).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_inFlightStore != null)
+                await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+        }
     }
+
+    /// <summary>
+    /// If a prior run recorded an in-flight ticket for this machine and the agent
+    /// still has a usable script for it, observe that script to completion and
+    /// return its result (no duplicate dispatch). Returns <see langword="null"/>
+    /// — meaning "dispatch fresh" — when there is no record, the probe fails, or
+    /// the agent has no usable script (<see cref="AgentHasUsableScript"/>). The
+    /// fresh-dispatch fallback is exactly today's behaviour, so re-attach can only
+    /// ever AVOID a duplicate, never change a deployment that wasn't resuming.
+    /// </summary>
+    private async Task<ScriptExecutionResult> TryReattachAsync(
+        ScriptExecutionRequest request, IAsyncScriptService scriptClient, ServiceEndPoint endpoint, TimeSpan scriptTimeout, CancellationToken ct)
+    {
+        if (_inFlightStore == null) return null;
+
+        var existingTicketId = await _inFlightStore.TryGetTicketAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(existingTicketId)) return null;
+
+        var existingTicket = new ScriptTicket(existingTicketId);
+
+        ScriptStatusResponse probe;
+        try
+        {
+            probe = await scriptClient.GetStatusAsync(new ScriptStatusRequest(existingTicket, 0)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Information(ex, "[Deploy] Re-attach probe failed for agent {MachineName} (ticket {Ticket}); dispatching fresh.",
+                request.Machine.Name, existingTicketId);
+            await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+            return null;
+        }
+
+        if (!AgentHasUsableScript(probe))
+        {
+            await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+            return null;
+        }
+
+        Log.Information("[Deploy] Re-attaching to in-flight script on agent {MachineName} (ticket {Ticket}, state {State}) after resume — skipping duplicate dispatch.",
+            request.Machine.Name, existingTicketId, probe.State);
+
+        try
+        {
+            return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, existingTicket, scriptTimeout, ct, request.Masker, probe, endpoint).ConfigureAwait(false);
+        }
+        finally
+        {
+            await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Whether a <c>GetStatus</c> probe shows the agent still holds the script,
+    /// so we re-attach instead of dispatching a duplicate. The Tentacle returns
+    /// <c>Complete + UnknownResult (-1)</c> for an UNKNOWN ticket — the single
+    /// "agent doesn't have it" signal — so ONLY that case dispatches fresh.
+    ///
+    /// <para>Every other state means the agent demonstrably holds the ticket and
+    /// MUST be re-attached to — including <see cref="ProcessState.Pending"/>: a
+    /// queued-but-not-started script left by the crashed run would otherwise run
+    /// <i>alongside</i> a fresh dispatch (new ticket), causing the exact
+    /// double-execution this feature prevents. A real script that genuinely
+    /// exited -1 collides with the sentinel and is conservatively re-dispatched
+    /// (today's behaviour) — an accepted rare edge.</para>
+    /// </summary>
+    internal static bool AgentHasUsableScript(ScriptStatusResponse probe)
+        => probe is not null
+           && !(probe.State == ProcessState.Complete && probe.ExitCode == ScriptExitCodes.UnknownResult);
 
     private static ScriptFile[] BuildDirectScriptFiles(
         DeploymentFileCollection deploymentFiles,

--- a/src/Squid.Core/Services/Deployments/Checkpoints/DeploymentCheckpointService.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/DeploymentCheckpointService.cs
@@ -9,6 +9,15 @@ public interface IDeploymentCheckpointService : IScopedDependency
 
     Task<DeploymentExecutionCheckpoint> LoadAsync(int serverTaskId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Insert an empty checkpoint row (LastCompletedBatchIndex = -1, empty state)
+    /// if none exists for the task — no-op when one already exists, so a resume
+    /// row is never overwritten. Lets the in-flight-script ledger
+    /// (<see cref="IInFlightScriptStore"/>) land tickets dispatched in the very
+    /// first batch, before the first batch-boundary save creates the row.
+    /// </summary>
+    Task EnsureExistsAsync(int serverTaskId, int deploymentId, CancellationToken ct = default);
+
     Task DeleteAsync(int serverTaskId, CancellationToken ct = default);
 }
 
@@ -22,7 +31,11 @@ public class DeploymentCheckpointService(IRepository repository, IUnitOfWork uni
                   .SetProperty(c => c.FailureEncountered, checkpoint.FailureEncountered)
                   .SetProperty(c => c.OutputVariablesJson, checkpoint.OutputVariablesJson)
                   .SetProperty(c => c.BatchStatesJson, checkpoint.BatchStatesJson ?? "{}")
-                  .SetProperty(c => c.InFlightScriptsJson, checkpoint.InFlightScriptsJson ?? "{}")
+                  // InFlightScriptsJson is intentionally NOT set here: it is owned
+                  // by IInFlightScriptStore, which records/clears tickets at script
+                  // dispatch/completion time (out of band with batch-boundary saves).
+                  // Overwriting it on every batch save would wipe in-flight tickets
+                  // dispatched mid-batch, defeating resume-by-ticket.
                   .SetProperty(c => c.LastModifiedDate, DateTimeOffset.UtcNow),
             ct).ConfigureAwait(false);
 
@@ -35,6 +48,27 @@ public class DeploymentCheckpointService(IRepository repository, IUnitOfWork uni
     public async Task<DeploymentExecutionCheckpoint> LoadAsync(int serverTaskId, CancellationToken ct = default)
     {
         return await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(c => c.ServerTaskId == serverTaskId).FirstOrDefaultAsync(ct).ConfigureAwait(false);
+    }
+
+    public async Task EnsureExistsAsync(int serverTaskId, int deploymentId, CancellationToken ct = default)
+    {
+        var exists = await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(c => c.ServerTaskId == serverTaskId)
+            .AnyAsync(ct).ConfigureAwait(false);
+
+        if (exists) return;
+
+        await repository.InsertAsync(new DeploymentExecutionCheckpoint
+        {
+            ServerTaskId = serverTaskId,
+            DeploymentId = deploymentId,
+            LastCompletedBatchIndex = -1,
+            FailureEncountered = false,
+            OutputVariablesJson = "[]",
+            BatchStatesJson = "{}",
+            InFlightScriptsJson = "{}"
+        }, ct).ConfigureAwait(false);
+
+        await unitOfWork.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(int serverTaskId, CancellationToken ct = default)

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+
+namespace Squid.Core.Services.Deployments.Checkpoints;
+
+/// <summary>
+/// Pure read/modify helpers for the deployment checkpoint's in-flight-scripts
+/// map — the JSON shape <c>{ "&lt;machineId&gt;": "&lt;scriptTicket&gt;" }</c> stored on
+/// <see cref="Persistence.Entities.Deployments.DeploymentExecutionCheckpoint.InFlightScriptsJson"/>.
+///
+/// <para>It records the ScriptTicket of a script dispatched to a Halibut agent
+/// but not yet observed to completion, so a resumed deployment can re-attach to
+/// a still-running script (probe the agent with the same ticket) instead of
+/// launching a duplicate. No I/O or locking here — the store layer owns
+/// persistence and the per-task write serialisation; this type is pure so the
+/// add/remove/lookup semantics are unit-testable in isolation.</para>
+/// </summary>
+public static class InFlightScriptMap
+{
+    /// <summary>Record (or overwrite) the in-flight ticket for a machine.</summary>
+    public static string Add(string json, int machineId, string scriptTicket)
+    {
+        var map = Parse(json);
+        map[machineId.ToString()] = scriptTicket;
+        return Serialize(map);
+    }
+
+    /// <summary>Drop a machine's in-flight ticket once its script is observed
+    /// to completion. Removing an absent machine is a no-op.</summary>
+    public static string Remove(string json, int machineId)
+    {
+        var map = Parse(json);
+        map.Remove(machineId.ToString());
+        return Serialize(map);
+    }
+
+    /// <summary>The recorded in-flight ticket for a machine, or
+    /// <see langword="null"/> if none.</summary>
+    public static string? TryGet(string json, int machineId)
+        => Parse(json).TryGetValue(machineId.ToString(), out var ticket) ? ticket : null;
+
+    private static Dictionary<string, string> Parse(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new();
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+        }
+        catch (JsonException)
+        {
+            // A malformed column (manual edit, partial write) must not crash the
+            // deploy — treat it as empty and let the executor re-dispatch fresh.
+            return new();
+        }
+    }
+
+    private static string Serialize(Dictionary<string, string> map) => JsonSerializer.Serialize(map);
+}

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+
+namespace Squid.Core.Services.Deployments.Checkpoints;
+
+/// <summary>
+/// Durable record of scripts dispatched to a Halibut agent but not yet observed
+/// to completion, persisted on the deployment checkpoint's
+/// <see cref="DeploymentExecutionCheckpoint.InFlightScriptsJson"/> column so a
+/// deployment resumed after a server crash can re-attach to a still-running
+/// script (probe the agent with the same ScriptTicket) instead of launching a
+/// duplicate.
+///
+/// <para><b>Concurrency</b>: a parallel batch dispatches to several targets at
+/// once, each recording its ticket. A single Hangfire worker owns a given
+/// deployment task, so all writes for one <c>serverTaskId</c> happen in one
+/// process — an in-process per-task lock serialises the read-modify-write of
+/// the shared JSON column. (Cross-process contention can't occur: task
+/// ownership is exclusive.)</para>
+///
+/// <para><b>Fail-safe</b>: if the checkpoint row does not exist yet, recording
+/// is silently skipped — the worst case is that resume re-dispatches (today's
+/// behaviour) rather than re-attaching. The executor creates the row before any
+/// dispatch, so this is only a defensive guard.</para>
+/// </summary>
+public interface IInFlightScriptStore : IScopedDependency
+{
+    Task RecordDispatchedAsync(int serverTaskId, int machineId, string scriptTicket, CancellationToken cancellationToken = default);
+
+    Task ClearAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default);
+
+    Task<string?> TryGetTicketAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default);
+}
+
+public sealed class InFlightScriptStore(IRepository repository) : IInFlightScriptStore
+{
+    private static readonly ConcurrentDictionary<int, SemaphoreSlim> TaskLocks = new();
+
+    public Task RecordDispatchedAsync(int serverTaskId, int machineId, string scriptTicket, CancellationToken cancellationToken = default)
+        => MutateAsync(serverTaskId, current => InFlightScriptMap.Add(current, machineId, scriptTicket), cancellationToken);
+
+    public Task ClearAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default)
+        => MutateAsync(serverTaskId, current => InFlightScriptMap.Remove(current, machineId), cancellationToken);
+
+    public async Task<string?> TryGetTicketAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default)
+    {
+        var row = await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(c => c.ServerTaskId == serverTaskId)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        return row == null ? null : InFlightScriptMap.TryGet(row.InFlightScriptsJson ?? "{}", machineId);
+    }
+
+    private async Task MutateAsync(int serverTaskId, Func<string, string> mutate, CancellationToken cancellationToken)
+    {
+        var gate = TaskLocks.GetOrAdd(serverTaskId, _ => new SemaphoreSlim(1, 1));
+
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var row = await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(c => c.ServerTaskId == serverTaskId)
+                .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+            if (row == null)
+            {
+                Log.Debug("[Deploy] No checkpoint row for task {ServerTaskId} while recording in-flight script — skipping (resume will re-dispatch).", serverTaskId);
+                return;
+            }
+
+            var updated = mutate(row.InFlightScriptsJson ?? "{}");
+
+            await repository.ExecuteUpdateAsync<DeploymentExecutionCheckpoint>(
+                c => c.ServerTaskId == serverTaskId,
+                s => s.SetProperty(c => c.InFlightScriptsJson, updated),
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+}

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Checkpoints;
+using Squid.IntegrationTests.Base;
+
+namespace Squid.IntegrationTests.Services.Deployments.Checkpoints;
+
+/// <summary>
+/// Resume-by-ticket — integration tests for <see cref="InFlightScriptStore"/>
+/// against a real Postgres checkpoint row. Covers record/clear/lookup, the
+/// clobber-fix (a batch-boundary save must NOT wipe in-flight tickets), the
+/// ensure-row helper, the no-row fail-safe, and concurrent record under the
+/// per-task lock.
+/// </summary>
+public class InFlightScriptStoreTests : TestBase
+{
+    public InFlightScriptStoreTests() : base("InFlightScriptStore", "squid_it_inflight_script")
+    {
+    }
+
+    [Fact]
+    public async Task EnsureExists_ThenRecordAndClear_RoundTrips()
+    {
+        const int taskId = 700001;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, machineId: 11, scriptTicket: "ticket-a")).ConfigureAwait(false);
+        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBe("ticket-a");
+
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, machineId: 11)).ConfigureAwait(false);
+        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Record_MultipleMachines_AreIndependent()
+    {
+        const int taskId = 700002;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 22, "ticket-b")).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, 11)).ConfigureAwait(false);
+
+        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBeNull();
+        (await GetTicketAsync(taskId, 22).ConfigureAwait(false)).ShouldBe("ticket-b",
+            customMessage: "Clearing one machine MUST NOT drop another machine's in-flight ticket.");
+    }
+
+    [Fact]
+    public async Task BatchCheckpointSave_DoesNotClobberInFlightTickets()
+    {
+        // The clobber-fix: DeploymentCheckpointService.SaveAsync (batch boundary)
+        // must no longer overwrite InFlightScriptsJson, or every batch save would
+        // wipe tickets dispatched mid-batch and defeat resume-by-ticket.
+        const int taskId = 700003;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+
+        // Simulate a batch-boundary checkpoint save (note its InFlightScriptsJson="{}").
+        await Run<IDeploymentCheckpointService>(svc => svc.SaveAsync(new DeploymentExecutionCheckpoint
+        {
+            ServerTaskId = taskId,
+            DeploymentId = 1,
+            LastCompletedBatchIndex = 0,
+            FailureEncountered = false,
+            OutputVariablesJson = "[]",
+            BatchStatesJson = "{}",
+            InFlightScriptsJson = "{}"
+        })).ConfigureAwait(false);
+
+        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBe("ticket-a",
+            customMessage: "A batch-boundary save MUST preserve in-flight tickets — InFlightScriptsJson is owned by the store.");
+
+        // And the batch save still updated its own column.
+        var row = await LoadAsync(taskId).ConfigureAwait(false);
+        row.LastCompletedBatchIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EnsureExists_IsIdempotent_AndDoesNotClobber()
+    {
+        const int taskId = 700004;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+
+        // A second EnsureExists (e.g. a resume re-entering the phase) must be a
+        // no-op — never reset the row or wipe the recorded ticket.
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBe("ticket-a");
+    }
+
+    [Fact]
+    public async Task Record_WithNoCheckpointRow_IsNoOp()
+    {
+        // Fail-safe: no checkpoint row yet → recording is skipped (resume just
+        // re-dispatches). Must not throw or create a row.
+        const int taskId = 700005;
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+
+        (await LoadAsync(taskId).ConfigureAwait(false)).ShouldBeNull();
+        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ConcurrentRecord_ForDistinctMachines_AllPersist()
+    {
+        // Parallel batch: many targets record at once. The per-task lock must
+        // serialise the read-modify-write so no ticket is lost.
+        const int taskId = 700006;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        var machineIds = Enumerable.Range(1, 25).ToList();
+
+        await Task.WhenAll(machineIds.Select(id =>
+            Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, id, $"ticket-{id}")))).ConfigureAwait(false);
+
+        foreach (var id in machineIds)
+            (await GetTicketAsync(taskId, id).ConfigureAwait(false)).ShouldBe($"ticket-{id}",
+                customMessage: $"Concurrent record lost machine {id}'s ticket — the per-task RMW lock is not serialising writes.");
+    }
+
+    private Task EnsureRowAsync(int taskId)
+        => Run<IDeploymentCheckpointService>(svc => svc.EnsureExistsAsync(taskId, deploymentId: 1));
+
+    private Task<string> GetTicketAsync(int taskId, int machineId)
+        => Run<IInFlightScriptStore, string>(s => s.TryGetTicketAsync(taskId, machineId));
+
+    private Task<DeploymentExecutionCheckpoint> LoadAsync(int taskId)
+        => Run<IDeploymentCheckpointService, DeploymentExecutionCheckpoint>(svc => svc.LoadAsync(taskId));
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/HalibutReattachDecisionTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/HalibutReattachDecisionTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Message.Constants;
+using Squid.Message.Contracts.Tentacle;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+/// <summary>
+/// Resume-by-ticket: pins <see cref="HalibutMachineExecutionStrategy.AgentHasUsableScript"/>,
+/// the decision that keeps re-attach non-breaking. On resume the strategy probes
+/// the agent's <c>GetStatus</c> for a recorded in-flight ticket; it re-attaches
+/// (observes the existing script) on any state EXCEPT <c>Complete + UnknownResult</c>,
+/// which is the Tentacle's "I don't have that ticket" signal and falls back to a
+/// fresh dispatch — today's behaviour.
+/// </summary>
+public class HalibutReattachDecisionTests
+{
+    [Fact]
+    public void Running_Reattaches()
+        => HalibutMachineExecutionStrategy.AgentHasUsableScript(Probe(ProcessState.Running, 0)).ShouldBeTrue();
+
+    [Fact]
+    public void Pending_Reattaches()
+        // A queued-but-not-started script left by the crashed run MUST be re-attached:
+        // a fresh dispatch (new ticket) would let the old queued script run too —
+        // the exact double-execution this feature prevents.
+        => HalibutMachineExecutionStrategy.AgentHasUsableScript(Probe(ProcessState.Pending, 0)).ShouldBeTrue();
+
+    [Theory]
+    [InlineData(0)]    // genuine success
+    [InlineData(5)]    // genuine non-zero failure
+    [InlineData(127)]  // command-not-found
+    public void CompleteWithRealExitCode_Reattaches(int exitCode)
+        => HalibutMachineExecutionStrategy.AgentHasUsableScript(Probe(ProcessState.Complete, exitCode)).ShouldBeTrue();
+
+    [Fact]
+    public void CompleteWithUnknownResult_DispatchesFresh()
+        => HalibutMachineExecutionStrategy.AgentHasUsableScript(Probe(ProcessState.Complete, ScriptExitCodes.UnknownResult))
+            .ShouldBeFalse(customMessage: "Complete + UnknownResult(-1) is the unknown-ticket signal — must fall back to fresh dispatch, never re-attach.");
+
+    [Fact]
+    public void NullProbe_DispatchesFresh()
+        => HalibutMachineExecutionStrategy.AgentHasUsableScript(null).ShouldBeFalse();
+
+    private static ScriptStatusResponse Probe(ProcessState state, int exitCode)
+        => new(new ScriptTicket("ticket"), state, exitCode, new List<ProcessOutput>(), 0);
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
@@ -1,0 +1,80 @@
+using Squid.Core.Services.Deployments.Checkpoints;
+
+namespace Squid.UnitTests.Services.Deployments.Checkpoints;
+
+/// <summary>
+/// Unit tests for <see cref="InFlightScriptMap"/> — the pure add/remove/lookup
+/// over the checkpoint's in-flight-scripts JSON. Pins round-trip correctness +
+/// the defensive empty/malformed handling the resume path relies on.
+/// </summary>
+public class InFlightScriptMapTests
+{
+    [Fact]
+    public void Add_OnEmpty_CreatesSingleEntry()
+    {
+        var json = InFlightScriptMap.Add("{}", machineId: 7, scriptTicket: "ticket-a");
+
+        InFlightScriptMap.TryGet(json, 7).ShouldBe("ticket-a");
+    }
+
+    [Fact]
+    public void Add_MultipleMachines_KeepsBoth()
+    {
+        var json = InFlightScriptMap.Add("{}", 7, "ticket-a");
+        json = InFlightScriptMap.Add(json, 9, "ticket-b");
+
+        InFlightScriptMap.TryGet(json, 7).ShouldBe("ticket-a");
+        InFlightScriptMap.TryGet(json, 9).ShouldBe("ticket-b");
+    }
+
+    [Fact]
+    public void Add_SameMachineTwice_OverwritesWithLatestTicket()
+    {
+        // A fresh dispatch (new Guid ticket) for the same machine replaces the
+        // prior in-flight ticket — the latest dispatch is the one to re-attach to.
+        var json = InFlightScriptMap.Add("{}", 7, "ticket-old");
+        json = InFlightScriptMap.Add(json, 7, "ticket-new");
+
+        InFlightScriptMap.TryGet(json, 7).ShouldBe("ticket-new");
+    }
+
+    [Fact]
+    public void Remove_DropsOnlyThatMachine()
+    {
+        var json = InFlightScriptMap.Add("{}", 7, "ticket-a");
+        json = InFlightScriptMap.Add(json, 9, "ticket-b");
+
+        json = InFlightScriptMap.Remove(json, 7);
+
+        InFlightScriptMap.TryGet(json, 7).ShouldBeNull();
+        InFlightScriptMap.TryGet(json, 9).ShouldBe("ticket-b");
+    }
+
+    [Fact]
+    public void Remove_AbsentMachine_IsNoOp()
+    {
+        var json = InFlightScriptMap.Add("{}", 7, "ticket-a");
+
+        var after = InFlightScriptMap.Remove(json, 999);
+
+        InFlightScriptMap.TryGet(after, 7).ShouldBe("ticket-a");
+    }
+
+    [Fact]
+    public void TryGet_AbsentMachine_ReturnsNull()
+        => InFlightScriptMap.TryGet("{}", 7).ShouldBeNull();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json at all")]
+    [InlineData("{ broken")]
+    public void EmptyOrMalformedJson_TreatedAsEmpty(string json)
+    {
+        // The resume path must never crash on a blank/corrupt column — it falls
+        // back to "no in-flight script", i.e. re-dispatch fresh.
+        InFlightScriptMap.TryGet(json, 7).ShouldBeNull();
+        InFlightScriptMap.Add(json, 7, "ticket-a").ShouldContain("ticket-a");
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the **double-execution window** when a server crash interrupts a deployment mid-script: on resume, the Halibut strategy re-attaches to the still-running agent script via its `ScriptTicket` instead of launching a duplicate. Matters most for non-idempotent installs on Halibut-backed targets (KubernetesAgent, Tentacle polling/listening).
- **No schema change** — reuses the previously-unused `DeploymentExecutionCheckpoint.InFlightScriptsJson` column (`{machineId: ticket}`). The strategy records the ticket right after `StartScript` and clears it once observed; `IInFlightScriptStore` serialises the per-task read-modify-write with an in-process lock (one Hangfire worker owns a task).
- **Non-breaking by construction** — re-attach happens only on a clear "agent still holds it" signal; the sole fall-back to a fresh dispatch is the Tentacle's `Complete + UnknownResult (-1)` "unknown ticket" reply, which is exactly today's behaviour. The store dependency is optional (null → no-op), so non-Halibut strategies and existing constructions are unaffected.
- Batch-boundary checkpoint saves no longer overwrite the ledger (clobber-fix), and the checkpoint row is created up-front (`EnsureExistsAsync`, insert-only) so first-batch tickets are durable; a fresh `-1` row re-runs batch 0 exactly as before.

## Test plan

- [x] Unit — `InFlightScriptMap` (11): add/remove/lookup round-trip, overwrite, blank/malformed JSON treated as empty
- [x] Unit — `AgentHasUsableScript` decision matrix (7): Running/Pending/Complete-real → re-attach; **Pending re-attaches to avoid the queued-script double-exec**; `Complete + UnknownResult` / null → fresh dispatch
- [x] Integration vs Postgres — `InFlightScriptStore` (6): record/clear round-trip, machines independent, **batch save does not clobber in-flight**, idempotent `EnsureExists`, no-row fail-safe, **concurrent record under the per-task lock**
- [x] Full unit suite green (5650), existing integration checkpoint tests green (14), full solution builds clean
- [ ] Follow-up: full crash → resume → re-attach E2E (real Halibut agent + simulated server restart)

Implements roadmap item #1 from the post-1.8.3 deployment-architecture review.