### PR TITLE
Enforce deployment capability suitability (off/warn/strict)

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Filtering/StepRoleMatcher.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Filtering/StepRoleMatcher.cs
@@ -1,0 +1,51 @@
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.Core.Services.DeploymentExecution.Filtering;
+
+/// <summary>
+/// Single source of truth for "which targets does a step run on?" — the
+/// step-role → machine match used by BOTH the planner (preview) and the
+/// executor's runtime target resolution. Having one implementation guarantees
+/// the machines a preview reports as matched are EXACTLY the machines the
+/// deployment actually runs on; there is no second, drift-prone matcher.
+///
+/// <para><b>Rules</b>: a step's required roles come from its
+/// <see cref="SpecialVariables.Step.TargetRoles"/> property (comma-separated).
+/// An absent / blank / whitespace-only value means the step is unscoped and
+/// matches every candidate target. Otherwise a target matches when its roles
+/// overlap the required roles (case-insensitive).</para>
+/// </summary>
+public static class StepRoleMatcher
+{
+    /// <summary>
+    /// The roles a step requires of a target, ordered + case-insensitive.
+    /// Empty means "unscoped — matches all targets".
+    /// </summary>
+    public static IReadOnlyList<string> RequiredRoles(DeploymentStepDto step)
+    {
+        var rolesProperty = step.Properties?
+            .FirstOrDefault(p => p.PropertyName == SpecialVariables.Step.TargetRoles);
+
+        if (rolesProperty == null || string.IsNullOrWhiteSpace(rolesProperty.PropertyValue))
+            return Array.Empty<string>();
+
+        return DeploymentTargetFinder.ParseCsvRoles(rolesProperty.PropertyValue)
+            .OrderBy(role => role, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Whether a target whose roles are <paramref name="machineRoles"/> matches a
+    /// step requiring <paramref name="requiredRoles"/>. Empty required roles match
+    /// everything; otherwise the sets must overlap (case-insensitive).
+    /// </summary>
+    public static bool Matches(IReadOnlyCollection<string> requiredRoles, IEnumerable<string> machineRoles)
+    {
+        if (requiredRoles.Count == 0) return true;
+
+        var roleSet = new HashSet<string>(requiredRoles, StringComparer.OrdinalIgnoreCase);
+
+        return machineRoles.Any(roleSet.Contains);
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Filtering/TargetStepMatcher.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Filtering/TargetStepMatcher.cs
@@ -1,22 +1,22 @@
-using Squid.Message.Constants;
 using Squid.Message.Models.Deployments.Process;
 
 namespace Squid.Core.Services.DeploymentExecution.Filtering;
 
 public static class TargetStepMatcher
 {
+    /// <summary>
+    /// Runtime fallback used only when no plan exists for a step. Delegates to
+    /// <see cref="StepRoleMatcher"/> — the SAME role match the planner uses — so
+    /// even this path can never diverge from what a preview would compute (e.g.
+    /// it now treats a whitespace-only roles value as unscoped, matching the
+    /// planner, instead of matching zero targets).
+    /// </summary>
     public static List<DeploymentTargetContext> FindMatchingTargetsForStep(DeploymentStepDto step, List<DeploymentTargetContext> allTargets)
     {
-        var stepRolesProperty = step.Properties?
-            .FirstOrDefault(p => p.PropertyName == SpecialVariables.Step.TargetRoles);
-
-        if (stepRolesProperty == null || string.IsNullOrEmpty(stepRolesProperty.PropertyValue))
-            return allTargets;
-
-        var stepRoles = DeploymentTargetFinder.ParseCsvRoles(stepRolesProperty.PropertyValue);
+        var requiredRoles = StepRoleMatcher.RequiredRoles(step);
 
         return allTargets
-            .Where(tc => DeploymentTargetFinder.ParseRoles(tc.Machine.Roles).Overlaps(stepRoles))
+            .Where(tc => StepRoleMatcher.Matches(requiredRoles, DeploymentTargetFinder.ParseRoles(tc.Machine.Roles)))
             .ToList();
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
@@ -11,7 +11,9 @@ using Squid.Core.Services.DeploymentExecution.Variables;
 using Squid.Message.Constants;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Hardening;
 
 namespace Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
 
@@ -142,7 +144,15 @@ public sealed partial class ExecuteStepsPhase
             ? string.Join("; ", dispatch.Validation.Violations.Select(v => v.Message))
             : "dispatch blocked by capability validation";
 
-        Log.Warning("[Deploy] Action {ActionName} skipped on {MachineName}: {Message}", action.Name, tc.Machine.Name, message);
+        // Capability enforcement (Rule 11). Strict already failed pre-flight in
+        // PlanDeploymentPhase, so here we only distinguish off (quiet, debug) from
+        // warn (the default — a visible warning naming the strict/off escape
+        // hatch). Both still skip the incompatible dispatch + emit the deploy-log
+        // event, so warn reproduces the prior behaviour exactly (non-breaking).
+        if (CapabilityEnforcement.ResolveMode() == EnforcementMode.Off)
+            Log.Debug("[Deploy] Action {ActionName} skipped on {MachineName} (capability mismatch, enforcement=off): {Message}", action.Name, tc.Machine.Name, message);
+        else
+            Log.Warning("[Deploy] Action {ActionName} skipped on {MachineName}: {Message}. Set {EnvVar}=strict to fail the deployment instead, or =off to silence.", action.Name, tc.Machine.Name, message, CapabilityEnforcement.EnvVar);
 
         await lifecycle.EmitAsync(new ActionCapabilityFilteredEvent(new DeploymentEventContext
         {

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6a_PlanDeploymentPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6a_PlanDeploymentPhase.cs
@@ -1,4 +1,7 @@
 using Squid.Core.Services.DeploymentExecution.Planning;
+using Squid.Core.Services.DeploymentExecution.Planning.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Hardening;
 
 namespace Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
 
@@ -51,6 +54,30 @@ public sealed class PlanDeploymentPhase(IDeploymentPlanner planner) : IDeploymen
         var request = BuildPlanRequest(ctx);
 
         ctx.Plan = await planner.PlanAsync(request, ct).ConfigureAwait(false);
+
+        EnforceCapabilityStrict(ctx.Plan);
+    }
+
+    /// <summary>
+    /// Capability enforcement (Rule 11), strict mode only: fail the deployment
+    /// PRE-FLIGHT (before any step runs) when the plan contains a known
+    /// capability mismatch. Scoped to <see cref="PlanBlockingReasonCodes.CapabilityViolation"/>
+    /// — other blockers (no matching targets, unresolved transport) are a
+    /// separate concern and never escalated by this toggle. off/warn never throw
+    /// here; they let <see cref="ExecuteStepsPhase"/> skip the incompatible
+    /// (action × target) at dispatch time.
+    /// </summary>
+    private static void EnforceCapabilityStrict(DeploymentPlan plan)
+    {
+        if (CapabilityEnforcement.ResolveMode() != EnforcementMode.Strict) return;
+
+        var capabilityBlockers = plan.BlockingReasons
+            .Where(b => b.Code == PlanBlockingReasonCodes.CapabilityViolation)
+            .ToList();
+
+        if (capabilityBlockers.Count == 0) return;
+
+        throw new DeploymentPlanValidationException(plan with { BlockingReasons = capabilityBlockers });
     }
 
     private static bool ShouldSkip(DeploymentTaskContext ctx)

--- a/src/Squid.Core/Services/DeploymentExecution/Planning/DeploymentPlanner.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Planning/DeploymentPlanner.cs
@@ -416,30 +416,16 @@ public sealed class DeploymentPlanner : IDeploymentPlanner
 
     // ---------- required-roles helpers ----------------------------------
 
+    // Delegates to StepRoleMatcher — the SINGLE source of truth shared with the
+    // executor's runtime target resolution, so preview-matched targets are
+    // exactly the machines the deployment runs on.
     private static List<string> ExtractRequiredRoles(DeploymentStepDto step)
-    {
-        var rolesProperty = step.Properties?
-            .FirstOrDefault(p => p.PropertyName == SpecialVariables.Step.TargetRoles);
-
-        if (rolesProperty == null || string.IsNullOrWhiteSpace(rolesProperty.PropertyValue))
-            return new List<string>();
-
-        return DeploymentTargetFinder.ParseCsvRoles(rolesProperty.PropertyValue)
-            .OrderBy(role => role, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
+        => StepRoleMatcher.RequiredRoles(step).ToList();
 
     private static List<PlannedTarget> FilterTargetsByRoles(IReadOnlyList<PlannedTarget> candidates, List<string> requiredRoles)
-    {
-        if (requiredRoles.Count == 0)
-            return candidates.ToList();
-
-        var roleSet = new HashSet<string>(requiredRoles, StringComparer.OrdinalIgnoreCase);
-
-        return candidates
-            .Where(t => t.Roles.Any(r => roleSet.Contains(r)))
+        => candidates
+            .Where(t => StepRoleMatcher.Matches(requiredRoles, t.Roles))
             .ToList();
-    }
 
     // ---------- step-skipped factory -----------------------------------
 

--- a/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityEnforcement.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Validation/CapabilityEnforcement.cs
@@ -1,0 +1,40 @@
+using Squid.Message.Hardening;
+
+namespace Squid.Core.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Three-mode enforcement (global CLAUDE.md Rule 11) for deployment
+/// capability/suitability mismatches — when the planner KNOWS a target cannot
+/// run an action (unsupported script syntax, action type, required feature, or
+/// OS/role capability slot), based on the target's advertised capabilities.
+///
+/// <list type="bullet">
+///   <item><b>off</b> — skip the incompatible (action × target) silently
+///         (debug-level only). The legacy "graceful filter" with no log noise.</item>
+///   <item><b>warn</b> (DEFAULT) — skip it AND emit a structured warning naming
+///         the missing capability + how to switch to strict. This reproduces
+///         today's behaviour exactly, so the default is non-breaking.</item>
+///   <item><b>strict</b> — fail the deployment PRE-FLIGHT (before any step runs)
+///         when a capability mismatch is detected, so a mis-targeted action is a
+///         hard error rather than a silent skip.</item>
+/// </list>
+///
+/// <para><b>Cold cache stays optimistic-allow in every mode</b>: if a target has
+/// advertised no capabilities yet (no health check landed), the planner cannot
+/// prove incompatibility, so the dispatch is allowed and any real mismatch
+/// surfaces at runtime — the same outcome a capability-unaware server gives.
+/// Enforcement only ever acts on a KNOWN (warm-cache) mismatch.</para>
+///
+/// <para>Scope: this toggle governs capability suitability only. Target-selection
+/// concerns (no matching targets for a role, unresolved transport) are separate
+/// and unaffected.</para>
+/// </summary>
+public static class CapabilityEnforcement
+{
+    /// <summary>Operator escape hatch (Rule 8). Pinned by a unit test.</summary>
+    public const string EnvVar = "SQUID_CAPABILITY_ENFORCEMENT";
+
+    /// <summary>Resolve the current mode from <see cref="EnvVar"/>; defaults to
+    /// <see cref="EnforcementMode.Warn"/> when unset/blank/unrecognised.</summary>
+    public static EnforcementMode ResolveMode() => EnforcementModeReader.Read(EnvVar);
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Filtering/StepRoleMatcherTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Filtering/StepRoleMatcherTests.cs
@@ -1,0 +1,81 @@
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Filtering;
+
+/// <summary>
+/// Unit tests for <see cref="StepRoleMatcher"/> — the SINGLE role match shared
+/// by the planner (preview) and the executor's runtime target resolution. Pins
+/// the rules that keep preview-matched targets identical to the machines a
+/// deployment actually runs on, including the whitespace-roles edge that the two
+/// old (duplicated) matchers used to disagree on.
+/// </summary>
+public class StepRoleMatcherTests
+{
+    [Fact]
+    public void NoRolesProperty_IsUnscoped_MatchesAnyTarget()
+    {
+        var required = StepRoleMatcher.RequiredRoles(Step(roles: null));
+
+        required.ShouldBeEmpty();
+        StepRoleMatcher.Matches(required, new[] { "web" }).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankOrWhitespaceRoles_IsUnscoped_MatchesAnyTarget(string roles)
+    {
+        // The old TargetStepMatcher treated whitespace-only as "match NOTHING";
+        // the planner treated it as "match ALL". Unified to ALL (unscoped).
+        var required = StepRoleMatcher.RequiredRoles(Step(roles));
+
+        required.ShouldBeEmpty();
+        StepRoleMatcher.Matches(required, new[] { "web" }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OverlappingRole_Matches()
+    {
+        var required = StepRoleMatcher.RequiredRoles(Step("web,db"));
+
+        StepRoleMatcher.Matches(required, new[] { "db", "cache" }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NoOverlap_DoesNotMatch()
+    {
+        var required = StepRoleMatcher.RequiredRoles(Step("web"));
+
+        StepRoleMatcher.Matches(required, new[] { "db" }).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RoleMatch_IsCaseInsensitive()
+    {
+        var required = StepRoleMatcher.RequiredRoles(Step("Web-Server"));
+
+        StepRoleMatcher.Matches(required, new[] { "WEB-SERVER" }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ScopedStep_TargetWithNoRoles_DoesNotMatch()
+        => StepRoleMatcher.Matches(new[] { "web" }, System.Array.Empty<string>()).ShouldBeFalse();
+
+    [Fact]
+    public void UnscopedStep_TargetWithNoRoles_StillMatches()
+        => StepRoleMatcher.Matches(System.Array.Empty<string>(), System.Array.Empty<string>()).ShouldBeTrue();
+
+    private static DeploymentStepDto Step(string roles) => new()
+    {
+        Id = 1,
+        Name = "step",
+        Properties = roles == null
+            ? new List<DeploymentStepPropertyDto>()
+            : new List<DeploymentStepPropertyDto>
+            {
+                new() { StepId = 1, PropertyName = SpecialVariables.Step.TargetRoles, PropertyValue = roles }
+            }
+    };
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Validation/CapabilityEnforcementTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Validation/CapabilityEnforcementTests.cs
@@ -1,0 +1,53 @@
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Hardening;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Serialises every test that mutates the process-wide
+/// <c>SQUID_CAPABILITY_ENFORCEMENT</c> env var, so parallel collections can't
+/// observe each other's overrides.
+/// </summary>
+[CollectionDefinition("CapabilityEnforcementEnv", DisableParallelization = true)]
+public class CapabilityEnforcementEnvCollection { }
+
+/// <summary>
+/// Rule 11 pinning for <see cref="CapabilityEnforcement"/>: the env-var name
+/// (Rule 8) and the off/warn/strict parse + the non-breaking default (warn).
+/// </summary>
+[Collection("CapabilityEnforcementEnv")]
+public class CapabilityEnforcementTests
+{
+    [Fact]
+    public void EnvVar_ConstantNamePinned()
+        // Renaming this breaks every operator who pinned strict/off via env.
+        => CapabilityEnforcement.EnvVar.ShouldBe("SQUID_CAPABILITY_ENFORCEMENT");
+
+    [Fact]
+    public void ResolveMode_Unset_DefaultsToWarn()
+        => WithEnv(null, () => CapabilityEnforcement.ResolveMode().ShouldBe(EnforcementMode.Warn,
+            customMessage: "Default MUST be Warn so the feature is non-breaking on upgrade (skip + warn, as today)."));
+
+    [Theory]
+    [InlineData("off", EnforcementMode.Off)]
+    [InlineData("warn", EnforcementMode.Warn)]
+    [InlineData("strict", EnforcementMode.Strict)]
+    [InlineData("STRICT", EnforcementMode.Strict)]
+    [InlineData("garbage", EnforcementMode.Warn)]
+    public void ResolveMode_ParsesEnvVar(string value, EnforcementMode expected)
+        => WithEnv(value, () => CapabilityEnforcement.ResolveMode().ShouldBe(expected));
+
+    private static void WithEnv(string value, System.Action body)
+    {
+        var original = System.Environment.GetEnvironmentVariable(CapabilityEnforcement.EnvVar);
+        try
+        {
+            System.Environment.SetEnvironmentVariable(CapabilityEnforcement.EnvVar, value);
+            body();
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable(CapabilityEnforcement.EnvVar, original);
+        }
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Validation/PlanDeploymentPhaseCapabilityStrictTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Validation/PlanDeploymentPhaseCapabilityStrictTests.cs
@@ -1,0 +1,87 @@
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
+using Squid.Core.Services.DeploymentExecution.Planning;
+using Squid.Core.Services.DeploymentExecution.Planning.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Snapshots;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Validation;
+
+/// <summary>
+/// Rule 11 behavioural matrix for strict capability enforcement at plan time.
+/// strict fails the deployment PRE-FLIGHT on a capability mismatch; off/warn/
+/// default never throw (they let the executor skip the dispatch). Scoped to
+/// CapabilityViolation — other blockers (no matching targets) are not escalated.
+/// Shares the serial env collection so the env-var override can't race.
+/// </summary>
+[Collection("CapabilityEnforcementEnv")]
+public class PlanDeploymentPhaseCapabilityStrictTests
+{
+    [Fact]
+    public Task Strict_WithCapabilityBlocker_ThrowsPreFlight()
+        => WithEnv("strict", () =>
+            Should.ThrowAsync<DeploymentPlanValidationException>(() => Run(PlanWith(PlanBlockingReasonCodes.CapabilityViolation))));
+
+    [Theory]
+    [InlineData(null)]    // unset → default warn
+    [InlineData("warn")]
+    [InlineData("off")]
+    public Task NonStrict_WithCapabilityBlocker_DoesNotThrow(string mode)
+        => WithEnv(mode, () =>
+            Should.NotThrowAsync(() => Run(PlanWith(PlanBlockingReasonCodes.CapabilityViolation))));
+
+    [Fact]
+    public Task Strict_WithOnlyNonCapabilityBlocker_DoesNotThrow()
+        // A no-matching-targets blocker is a separate concern from capability
+        // suitability — strict capability enforcement must NOT escalate it.
+        => WithEnv("strict", () =>
+            Should.NotThrowAsync(() => Run(PlanWith(PlanBlockingReasonCodes.NoMatchingTargets))));
+
+    private static Task Run(DeploymentPlan plan)
+    {
+        var planner = new Mock<IDeploymentPlanner>();
+        planner.Setup(p => p.PlanAsync(It.IsAny<DeploymentPlanRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(plan);
+
+        return new PlanDeploymentPhase(planner.Object).ExecuteAsync(BuildContext(), CancellationToken.None);
+    }
+
+    private static DeploymentPlan PlanWith(string blockerCode) => new()
+    {
+        Mode = PlanMode.Preview,
+        ReleaseId = 1,
+        EnvironmentId = 2,
+        DeploymentProcessSnapshotId = 3,
+        BlockingReasons = new[]
+        {
+            new PlanBlockingReason { Code = blockerCode, Message = "incompatible", MachineId = 1, MachineName = "linux-1" }
+        }
+    };
+
+    private static DeploymentTaskContext BuildContext() => new()
+    {
+        ServerTaskId = 1,
+        Deployment = new Deployment { Id = 1, EnvironmentId = 2, ChannelId = 3 },
+        Release = new Squid.Core.Persistence.Entities.Deployments.Release { Id = 1, Version = "1.0.0" },
+        ProcessSnapshot = new DeploymentProcessSnapshotDto { Id = 3 },
+        Steps = new List<DeploymentStepDto> { new() { Id = 1, Name = "s", Properties = new(), Actions = new() } },
+        Variables = new List<VariableDto>(),
+        AllTargetsContext = new List<DeploymentTargetContext>()
+    };
+
+    private static async Task WithEnv(string value, Func<Task> body)
+    {
+        var original = System.Environment.GetEnvironmentVariable(CapabilityEnforcement.EnvVar);
+        try
+        {
+            System.Environment.SetEnvironmentVariable(CapabilityEnforcement.EnvVar, value);
+            await body();
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable(CapabilityEnforcement.EnvVar, original);
+        }
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.Services.DeploymentExecution.Planning.Exceptions;
@@ -179,6 +180,37 @@ public class DeploymentPlannerTests
         planned.MatchedTargets.Count.ShouldBe(1);
         planned.MatchedTargets[0].MachineId.ShouldBe(1);
         planned.Dispatches.Count.ShouldBe(1);
+    }
+
+    // ---------- preview == runtime target consistency -------------------
+
+    [Theory]
+    [InlineData("web")]      // scoped: only web targets
+    [InlineData("web,db")]   // scoped: multiple roles
+    [InlineData(null)]       // unscoped: matches all
+    [InlineData("   ")]      // whitespace-only roles → unscoped (the edge the two old matchers disagreed on)
+    public async Task PreviewMatchedTargets_EqualExecutorRuntimeMatch(string roles)
+    {
+        // The machines a preview reports as matched MUST be exactly the machines
+        // the executor's runtime resolution selects — they now share StepRoleMatcher.
+        var step = BuildStep(id: 10, order: 1, name: "Deploy", roles: roles);
+        step.Actions.Add(BuildAction(id: 100, order: 1, actionType: SpecialVariables.ActionTypes.Script, name: "Run"));
+
+        var targets = new List<DeploymentTargetContext>
+        {
+            BuildTargetContext(1, "web-1", "web", CommunicationStyle.KubernetesApi),
+            BuildTargetContext(2, "db-1", "db", CommunicationStyle.KubernetesApi),
+            BuildTargetContext(3, "web-2", "web", CommunicationStyle.KubernetesApi)
+        };
+
+        var plan = await BuildPlanner().PlanAsync(BuildRequest(PlanMode.Preview, [step], targets), CancellationToken.None);
+        var previewMatched = plan.Steps.Single().MatchedTargets.Select(t => t.MachineId).OrderBy(id => id).ToList();
+
+        var runtimeMatched = TargetStepMatcher.FindMatchingTargetsForStep(step, targets)
+            .Select(tc => tc.Machine.Id).OrderBy(id => id).ToList();
+
+        runtimeMatched.ShouldBe(previewMatched,
+            customMessage: "Preview-matched machines MUST equal the executor's runtime match — one source of truth (StepRoleMatcher).");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **Three-mode capability enforcement** (`SQUID_CAPABILITY_ENFORCEMENT`, default `warn` — Rule 11): a target known to be unable to run an action (script syntax, action type, required feature, OS/role slot) now surfaces at **plan time** instead of only failing at runtime.
  - `strict` — fail the deployment **pre-flight** (before any step runs) on a capability mismatch.
  - `warn` (default) — skip the incompatible `(action × target)` with a structured warning. **Identical to prior behaviour → non-breaking.**
  - `off` — skip silently.
  - Cold-cache (target hasn't advertised capabilities yet) stays **optimistic-allow** in every mode — we can't prove incompatibility, so we let runtime decide. Scoped to capability blockers only; no-matching-targets / unresolved-transport are a separate concern and unaffected.
- **Preview == runtime, guaranteed**: unify step→target role matching into one `StepRoleMatcher` shared by the planner (preview) and the executor's runtime resolution, so the machines a preview reports as matched are exactly the machines the deployment runs on. Removes the duplicate fallback matcher whose whitespace-only-roles handling could diverge.

This **exceeds Octopus**: Octopus has no pre-flight capability gate at all (incompatibility only fails at runtime in Calamari) and defers role→machine binding to runtime (preview and reality can differ). Here capability suitability is graded + enforced, and preview is the single source of truth for both the UI and execution.

## Test plan

- [x] Unit: `StepRoleMatcher` matrix (scoped / unscoped / whitespace / case-insensitive / overlap)
- [x] Unit: **preview/runtime consistency** theory — planner `MatchedTargets` == executor `TargetStepMatcher` for the same scenario (incl. the whitespace edge)
- [x] Unit: enforcement matrix at plan time — `strict` throws on a capability blocker; `warn`/`off`/default don't; `strict` does **not** throw on a non-capability (no-targets) blocker; env-var name pinned (Rule 8); default = warn (non-breaking)
- [x] Full unit suite green (5681); full solution builds clean (0 errors)