### PR TITLE
Harden in-flight ledger: bounded lock stripes + retried ensure-row

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.cs
@@ -117,7 +117,11 @@ public sealed partial class ExecuteStepsPhase(
     /// available for re-attach.</para>
     /// </summary>
     private async Task EnsureCheckpointRowAsync(CancellationToken ct)
-        => await checkpointService.EnsureExistsAsync(_ctx.ServerTaskId, _ctx.Deployment?.Id ?? 0, ct).ConfigureAwait(false);
+        => await RunCheckpointWriteWithRetryAsync(
+            () => checkpointService.EnsureExistsAsync(_ctx.ServerTaskId, _ctx.Deployment?.Id ?? 0, ct),
+            "ensure the checkpoint row exists",
+            "Resume-by-ticket is disabled for this run; a mid-script server restart will re-dispatch instead of re-attaching.",
+            ct).ConfigureAwait(false);
 
     /// <summary>
     /// Maximum attempts for <see cref="PersistCheckpointAsync"/> before
@@ -190,6 +194,28 @@ public sealed partial class ExecuteStepsPhase(
             // left untouched here — see DeploymentCheckpointService.SaveAsync.
         };
 
+        await RunCheckpointWriteWithRetryAsync(
+            () => checkpointService.SaveAsync(checkpoint, ct),
+            $"persist checkpoint at batch {batchIndex}",
+            "A server restart at this point will replay batches that completed in the current run — manual reconciliation may be needed.",
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Shared retry + exponential backoff for a checkpoint DB write — used by
+    /// both the batch-boundary persist and the up-front ensure-row. Up to
+    /// <see cref="CheckpointPersistMaxAttempts"/> attempts; transient DB blips
+    /// (connection drop, lock-wait) recover for free. On exhaustion it escalates
+    /// to <c>Log.Error</c> (so Error-threshold alerting catches it) and RETURNS —
+    /// the deploy keeps progressing, only the crash-recovery story is degraded.
+    /// Cancellation propagates immediately.
+    ///
+    /// <para>Before this was extracted, only the batch-boundary persist retried;
+    /// the ensure-row was a single un-retried write, so one transient blip could
+    /// silently disable resume-by-ticket for the whole run. Both now share this.</para>
+    /// </summary>
+    private async Task RunCheckpointWriteWithRetryAsync(Func<Task> write, string operation, string exhaustedGuidance, CancellationToken ct)
+    {
         var delay = CheckpointPersistInitialDelay;
         Exception lastException = null;
 
@@ -197,23 +223,19 @@ public sealed partial class ExecuteStepsPhase(
         {
             try
             {
-                await checkpointService.SaveAsync(checkpoint, ct).ConfigureAwait(false);
+                await write().ConfigureAwait(false);
                 return;
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
-                // Cancellation is not a checkpoint-persist failure. Surface
-                // it to the caller's CT path, which is already handled by
-                // the pipeline runner's cancel-vs-failure precedence.
                 throw;
             }
             catch (Exception ex) when (attempt < CheckpointPersistMaxAttempts)
             {
                 lastException = ex;
                 Log.Warning(ex,
-                    "[Deploy] Failed to persist checkpoint at batch {BatchIndex}, " +
-                    "attempt {Attempt}/{MaxAttempts}, retrying in {Delay}ms",
-                    batchIndex, attempt, CheckpointPersistMaxAttempts, delay.TotalMilliseconds);
+                    "[Deploy] Failed to {Operation}, attempt {Attempt}/{MaxAttempts}, retrying in {Delay}ms",
+                    operation, attempt, CheckpointPersistMaxAttempts, delay.TotalMilliseconds);
 
                 try
                 {
@@ -232,15 +254,9 @@ public sealed partial class ExecuteStepsPhase(
             }
         }
 
-        // All retries exhausted — escalate to Error (not Warning) so the
-        // failure surfaces in alerting configured at Error threshold.
-        // Continue execution; the deploy is still progressing, only the
-        // resume story for this batch is degraded.
         Log.Error(lastException,
-            "[Deploy] Failed to persist checkpoint at batch {BatchIndex} after {MaxAttempts} attempts. " +
-            "Deploy will continue, but a server restart at this point will replay batches that " +
-            "completed in the current run — manual reconciliation may be needed.",
-            batchIndex, CheckpointPersistMaxAttempts);
+            "[Deploy] Failed to {Operation} after {MaxAttempts} attempts. {Guidance}",
+            operation, CheckpointPersistMaxAttempts, exhaustedGuidance);
     }
 
     private string SerializeBatchStates()

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities.Deployments;
 
@@ -15,9 +14,12 @@ namespace Squid.Core.Services.Deployments.Checkpoints;
 /// <para><b>Concurrency</b>: a parallel batch dispatches to several targets at
 /// once, each recording its ticket. A single Hangfire worker owns a given
 /// deployment task, so all writes for one <c>serverTaskId</c> happen in one
-/// process — an in-process per-task lock serialises the read-modify-write of
-/// the shared JSON column. (Cross-process contention can't occur: task
-/// ownership is exclusive.)</para>
+/// process — a fixed set of lock stripes (keyed by <c>serverTaskId</c>)
+/// serialises the read-modify-write of the shared JSON column. Striping is
+/// bounded (no per-task growth over the server's lifetime); two tasks hashing
+/// to the same stripe serialise harmlessly, and a given task always maps to the
+/// same stripe so its own writes are always serialised. (Cross-process
+/// contention can't occur: task ownership is exclusive.)</para>
 ///
 /// <para><b>Fail-safe</b>: if the checkpoint row does not exist yet, recording
 /// is silently skipped — the worst case is that resume re-dispatches (today's
@@ -35,7 +37,16 @@ public interface IInFlightScriptStore : IScopedDependency
 
 public sealed class InFlightScriptStore(IRepository repository) : IInFlightScriptStore
 {
-    private static readonly ConcurrentDictionary<int, SemaphoreSlim> TaskLocks = new();
+    // Bounded lock stripes — one async gate per stripe, NOT one per task, so the
+    // set never grows over the server's lifetime. A task always maps to the same
+    // stripe (so its own RMW serialises); distinct tasks colliding on a stripe
+    // just serialise harmlessly.
+    private const int LockStripeCount = 64;
+
+    private static readonly SemaphoreSlim[] Stripes =
+        Enumerable.Range(0, LockStripeCount).Select(_ => new SemaphoreSlim(1, 1)).ToArray();
+
+    private static SemaphoreSlim LockFor(int serverTaskId) => Stripes[(uint)serverTaskId % LockStripeCount];
 
     public Task RecordDispatchedAsync(int serverTaskId, int machineId, string scriptTicket, CancellationToken cancellationToken = default)
         => MutateAsync(serverTaskId, current => InFlightScriptMap.Add(current, machineId, scriptTicket), cancellationToken);
@@ -53,7 +64,7 @@ public sealed class InFlightScriptStore(IRepository repository) : IInFlightScrip
 
     private async Task MutateAsync(int serverTaskId, Func<string, string> mutate, CancellationToken cancellationToken)
     {
-        var gate = TaskLocks.GetOrAdd(serverTaskId, _ => new SemaphoreSlim(1, 1));
+        var gate = LockFor(serverTaskId);
 
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
 

--- a/tests/Squid.UnitTests/Services/Deployments/Checkpoints/CheckpointPersistRetryTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Checkpoints/CheckpointPersistRetryTests.cs
@@ -168,6 +168,34 @@ public sealed class CheckpointPersistRetryTests
             customMessage: "Total retry should be well under 5s; longer indicates an unbounded backoff.");
     }
 
+    [Fact]
+    public async Task EnsureCheckpointRow_TransientFailureThenSuccess_Retries()
+    {
+        // M2: the up-front ensure-row write (resume-by-ticket substrate) must
+        // retry transient failures like the batch-boundary persist does — a
+        // single blip must not silently disable resume-by-ticket for the run.
+        var ensureAttempts = 0;
+
+        var checkpointService = new Mock<IDeploymentCheckpointService>();
+        checkpointService
+            .Setup(s => s.EnsureExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                ensureAttempts++;
+                if (ensureAttempts == 1)
+                    throw new InvalidOperationException("transient DB blip");
+                return Task.CompletedTask;
+            });
+        checkpointService
+            .Setup(s => s.SaveAsync(It.IsAny<DeploymentExecutionCheckpoint>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await DriveOneBatchAsync(checkpointService.Object);
+
+        ensureAttempts.ShouldBe(2,
+            customMessage: "EnsureCheckpointRowAsync must retry (1 fail + 1 success); fewer = no retry, more = over-retry.");
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
 
     /// <summary>


### PR DESCRIPTION
## Summary

Two non-blocking hardening follow-ups from the milestone 1.8.4 deep review of resume-by-ticket (#384):

- **M1 — bounded locking**: `InFlightScriptStore` used a `static ConcurrentDictionary<int, SemaphoreSlim>` keyed by `serverTaskId` that never evicted → one semaphore leaked per deployment task for the server's lifetime. Replaced with a fixed set of **lock stripes** (`serverTaskId % 64`): a task always maps to the same stripe (so its read-modify-write still serialises), distinct tasks colliding on a stripe serialise harmlessly, and the set is bounded.
- **M2 — retried ensure-row**: `EnsureCheckpointRowAsync` was a single un-retried write while the sibling `PersistCheckpointAsync` had a 3-attempt backoff — so one transient DB blip silently disabled resume-by-ticket for the whole run. Extracted the retry+backoff into a shared helper used by both.

Behaviour-preserving and non-breaking: per-task serialisation + persist-retry semantics are unchanged.

## Test plan

- [x] `CheckpointPersistRetry` suite green incl. new `EnsureCheckpointRow_TransientFailureThenSuccess_Retries` (M2)
- [x] `InFlightScriptStore` integration green incl. the 25-machine concurrent-record test (M1 striping preserves per-task serialisation)
- [x] Full unit suite green (5682); Squid.Core builds clean