### PR TITLE
Add Calamari script timeout and localize K8s namespace resolution

### DIFF
--- a/src/Squid.Calamari/Execution/Processes/ProcessRunner.cs
+++ b/src/Squid.Calamari/Execution/Processes/ProcessRunner.cs
@@ -1,14 +1,36 @@
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using Squid.Calamari.Execution.Output;
 
 namespace Squid.Calamari.Execution.Processes;
 
 public sealed class ProcessRunner : IProcessRunner
 {
-    public async Task<ProcessResult> ExecuteAsync(
-        ProcessInvocation invocation,
-        IProcessOutputSink outputSink,
-        CancellationToken ct)
+    /// <summary>
+    /// Optional wall-clock ceiling for a single Calamari child process, in whole minutes.
+    /// Unset / non-numeric / non-positive => no Calamari-local timeout (the process runs
+    /// until it exits or the caller's <see cref="CancellationToken"/> fires — the historical
+    /// behaviour, preserved so long-running deployments are never killed by default).
+    ///
+    /// <para>Set to a positive integer to have the runner terminate a child that overruns,
+    /// so a hung script (one blocked on stdin, a <c>kubectl</c> that never returns, etc.)
+    /// can't pin the work directory or the calling thread forever. Resolved at call time so
+    /// operators can change it between deployments without restarting the agent.</para>
+    /// </summary>
+    public const string ScriptTimeoutMinutesEnvVar = "SQUID_CALAMARI_SCRIPT_TIMEOUT_MINUTES";
+
+    /// <summary>
+    /// Exit code returned when a process is killed for exceeding the timeout. Mirrors the
+    /// coreutils <c>timeout</c> convention (124) so logs and downstream tooling read it as
+    /// "terminated for overrunning its deadline", not a script-authored failure.
+    /// </summary>
+    internal const int TimeoutExitCode = 124;
+
+    public Task<ProcessResult> ExecuteAsync(ProcessInvocation invocation, IProcessOutputSink outputSink, CancellationToken ct)
+        => ExecuteAsync(invocation, outputSink, ResolveTimeout(), ct);
+
+    internal async Task<ProcessResult> ExecuteAsync(ProcessInvocation invocation, IProcessOutputSink outputSink, TimeSpan? timeout, CancellationToken ct)
     {
         using var process = CreateProcess(invocation);
 
@@ -28,9 +50,83 @@ public sealed class ProcessRunner : IProcessRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
+        return timeout is { } limit
+            ? await WaitWithTimeoutAsync(process, invocation, outputSink, limit, ct).ConfigureAwait(false)
+            : await WaitAsync(process, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<ProcessResult> WaitAsync(Process process, CancellationToken ct)
+    {
         await process.WaitForExitAsync(ct).ConfigureAwait(false);
 
         return new ProcessResult(process.ExitCode);
+    }
+
+    private static async Task<ProcessResult> WaitWithTimeoutAsync(
+        Process process, ProcessInvocation invocation, IProcessOutputSink outputSink, TimeSpan timeout, CancellationToken ct)
+    {
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
+
+            return new ProcessResult(process.ExitCode);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            KillProcessTree(process);
+
+            await WaitForExitBestEffortAsync(process).ConfigureAwait(false);
+
+            outputSink.WriteStderr(
+                $"Process '{invocation.Executable}' exceeded the {timeout.TotalMinutes:0.##}-minute Calamari script timeout and was terminated. " +
+                $"Adjust or disable it via the {ScriptTimeoutMinutesEnvVar} environment variable.");
+
+            return new ProcessResult(TimeoutExitCode);
+        }
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited between the HasExited check and the kill — nothing to terminate.
+        }
+        catch (Win32Exception)
+        {
+            // OS refused the kill (already dying / insufficient rights) — best-effort only.
+        }
+    }
+
+    private static async Task WaitForExitBestEffortAsync(Process process)
+    {
+        try
+        {
+            await process.WaitForExitAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // Tree didn't fully reap within the grace window; we've done our best.
+        }
+    }
+
+    internal static TimeSpan? ResolveTimeout()
+        => ParseTimeoutMinutes(Environment.GetEnvironmentVariable(ScriptTimeoutMinutesEnvVar));
+
+    internal static TimeSpan? ParseTimeoutMinutes(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes)) return null;
+        if (minutes <= 0) return null;
+
+        return TimeSpan.FromMinutes(minutes);
     }
 
     private static Process CreateProcess(ProcessInvocation invocation)

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
@@ -432,27 +432,20 @@ public sealed partial class ExecuteStepsPhase
 
         var packageReferences = BuildPackageReferences(actionName);
 
-        // Resolve the target namespace with project-overrides-endpoint precedence AND
-        // template expansion. effectiveVariables lists project vars FIRST, then endpoint
-        // vars, so FirstOrDefault picks the project version when both exist. The raw
-        // value may contain `#{X}` templates (a real use-case: Namespace=#{Environment}-
-        // app expanding to "prod-app"), so we feed it through VariableExpander.
-        var rawTargetNamespace = effectiveVariables
-            .FirstOrDefault(v => v.Name == SpecialVariables.Kubernetes.Namespace)?.Value;
-        var resolvedTargetNamespace = string.IsNullOrEmpty(rawTargetNamespace)
-            ? rawTargetNamespace
-            : VariableExpander.ExpandString(rawTargetNamespace, prepared.VariableDictionary);
-
+        // The render context is transport-agnostic: it carries the effective variables and the
+        // variable dictionary, and each transport's renderer resolves whatever target-specific
+        // values it needs (e.g. the Kubernetes renderers read + expand their own namespace
+        // variable). The generic pipeline deliberately knows nothing about namespaces.
         var renderContext = new IntentRenderContext
         {
             Target = tc,
             Step = step,
             EffectiveVariables = effectiveVariables,
+            VariableDictionary = prepared.VariableDictionary,
             ServerTaskId = _ctx.ServerTaskId,
             ReleaseVersion = _ctx.Release?.Version,
             StepTimeout = stepTimeout,
-            PackageReferences = packageReferences,
-            TargetNamespace = resolvedTargetNamespace
+            PackageReferences = packageReferences
         };
 
         var renderer = intentRendererRegistry.Resolve(tc.CommunicationStyle, expandedIntent);

--- a/src/Squid.Core/Services/DeploymentExecution/Rendering/IntentRenderContext.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Rendering/IntentRenderContext.cs
@@ -1,5 +1,6 @@
 using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.VariableSubstitution;
 using Squid.Message.Models.Deployments.Process;
 using Squid.Message.Models.Deployments.Variable;
 
@@ -21,6 +22,15 @@ public sealed class IntentRenderContext
     /// <summary>Effective variables for this target/action (deployment vars + endpoint vars + action scope).</summary>
     public required IReadOnlyList<VariableDto> EffectiveVariables { get; init; }
 
+    /// <summary>
+    /// Variable dictionary for evaluating <c>#{...}</c> templates at render time. Built from the
+    /// same action-scoped variables as <see cref="EffectiveVariables"/> (plus package metadata).
+    /// Transports that resolve target-specific values from variable templates (e.g. a Kubernetes
+    /// namespace like <c>#{Environment}-app</c>) expand them through this dictionary, so the
+    /// generic pipeline never needs to know transport-specific variable names.
+    /// </summary>
+    public required VariableDictionary VariableDictionary { get; init; }
+
     /// <summary>Release version string, or <c>null</c> for a non-release-driven deployment.</summary>
     public string? ReleaseVersion { get; init; }
 
@@ -29,13 +39,6 @@ public sealed class IntentRenderContext
 
     /// <summary>Optional per-step wall-clock timeout; <c>null</c> means "transport default".</summary>
     public TimeSpan? StepTimeout { get; init; }
-
-    /// <summary>
-    /// Target namespace for the deployment action, resolved from endpoint variables.
-    /// Transports that support namespace isolation (e.g. Kubernetes) use this to
-    /// scope script execution. <c>null</c> when the transport has no namespace concept.
-    /// </summary>
-    public string? TargetNamespace { get; init; }
 
     /// <summary>
     /// Post-acquisition package references for this action, matched from acquired packages

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesAgentIntentRenderer.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesAgentIntentRenderer.cs
@@ -21,8 +21,9 @@ namespace Squid.Core.Services.DeploymentExecution.Kubernetes.Rendering;
 /// <para>Supported intents: <see cref="RunScriptIntent"/>, <see cref="KubernetesApplyIntent"/>,
 /// <see cref="HelmUpgradeIntent"/>, <see cref="KubernetesKustomizeIntent"/>.</para>
 ///
-/// <para>Namespace resolution for <see cref="RunScriptIntent"/> reads
-/// <see cref="IntentRenderContext.TargetNamespace"/>; other intents carry namespace directly.</para>
+/// <para>Namespace resolution for <see cref="RunScriptIntent"/> reads the
+/// <c>Squid.Action.Kubernetes.Namespace</c> variable via
+/// <see cref="KubernetesTargetNamespaceResolver"/>; other intents carry namespace directly.</para>
 ///
 /// <para>Unsupported intents throw <see cref="IntentRenderingException"/>.</para>
 /// </summary>
@@ -51,8 +52,8 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
 
     private static ScriptExecutionRequest RenderRunScript(RunScriptIntent intent, IntentRenderContext context)
     {
-        var namespace_ = ResolveNamespace(context);
-        var wrappedBody = WrapBodyWithNamespace(intent.ScriptBody, intent.Syntax, namespace_);
+        var resolvedNamespace = KubernetesTargetNamespaceResolver.Resolve(context);
+        var wrappedBody = WrapBodyWithNamespace(intent.ScriptBody, intent.Syntax, DefaultNamespace(resolvedNamespace));
 
         return new ScriptExecutionRequest
         {
@@ -69,7 +70,7 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = intent.Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = resolvedNamespace,
             PackageReferences = context.PackageReferences.ToList()
         };
     }
@@ -81,7 +82,7 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
         var waitScript = KubernetesResourceWaitBuilder.BuildWaitScript(
             deploymentFiles.ToLegacyDictionary(), intent.ObjectStatusCheck, intent.StatusCheckTimeoutSeconds, intent.Namespace, intent.Syntax);
         var rawScript = applyScript + waitScript;
-        var wrappedScript = WrapBodyWithNamespace(rawScript, intent.Syntax, ResolveNamespaceForApply(intent.Namespace));
+        var wrappedScript = WrapBodyWithNamespace(rawScript, intent.Syntax, DefaultNamespace(intent.Namespace));
 
         return new ScriptExecutionRequest
         {
@@ -98,7 +99,7 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = intent.Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             DeploymentFiles = deploymentFiles,
             PackageReferences = context.PackageReferences.ToList()
         };
@@ -109,7 +110,7 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
     {
         var deploymentFiles = HelmUpgradeScriptBuilder.BuildDeploymentFiles(intent);
         var rawScript = HelmUpgradeScriptBuilder.Build(intent, intent.Syntax);
-        var namespace_ = ResolveNamespaceForApply(intent.Namespace);
+        var namespace_ = DefaultNamespace(intent.Namespace);
         var wrappedScript = WrapBodyWithNamespace(rawScript, intent.Syntax, namespace_);
 
         return new ScriptExecutionRequest
@@ -127,7 +128,7 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = ((ExecutionIntent)intent).Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             DeploymentFiles = deploymentFiles,
             PackageReferences = context.PackageReferences.ToList()
         };
@@ -136,7 +137,7 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
     private static ScriptExecutionRequest RenderKustomize(KubernetesKustomizeIntent intent, IntentRenderContext context)
     {
         var rawScript = KubernetesKustomizeScriptBuilder.Build(intent, intent.Syntax);
-        var namespace_ = ResolveNamespaceForApply(intent.Namespace);
+        var namespace_ = DefaultNamespace(intent.Namespace);
         var wrappedScript = WrapBodyWithNamespace(rawScript, intent.Syntax, namespace_);
 
         return new ScriptExecutionRequest
@@ -154,19 +155,14 @@ public sealed class KubernetesAgentIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = intent.Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             PackageReferences = context.PackageReferences.ToList()
         };
     }
 
-    private static string ResolveNamespace(IntentRenderContext context)
+    private static string DefaultNamespace(string? namespace_)
     {
-        return string.IsNullOrWhiteSpace(context.TargetNamespace) ? KubernetesDefaultValues.Namespace : context.TargetNamespace;
-    }
-
-    private static string ResolveNamespaceForApply(string intentNamespace)
-    {
-        return string.IsNullOrWhiteSpace(intentNamespace) ? KubernetesDefaultValues.Namespace : intentNamespace;
+        return string.IsNullOrWhiteSpace(namespace_) ? KubernetesDefaultValues.Namespace : namespace_;
     }
 
     private static string WrapBodyWithNamespace(string scriptBody, ScriptSyntax syntax, string namespace_)

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesApiIntentRenderer.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesApiIntentRenderer.cs
@@ -70,7 +70,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = intent.Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             PackageReferences = context.PackageReferences.ToList()
         };
     }
@@ -107,7 +107,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = intent.Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             DeploymentFiles = deploymentFiles,
             PackageReferences = context.PackageReferences.ToList()
         };
@@ -135,7 +135,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = ((ExecutionIntent)intent).Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             DeploymentFiles = deploymentFiles,
             PackageReferences = context.PackageReferences.ToList()
         };
@@ -161,7 +161,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
             ServerTaskId = context.ServerTaskId,
             ReleaseVersion = context.ReleaseVersion,
             Timeout = intent.Timeout ?? context.StepTimeout,
-            TargetNamespace = context.TargetNamespace,
+            TargetNamespace = KubernetesTargetNamespaceResolver.Resolve(context),
             PackageReferences = context.PackageReferences.ToList()
         };
     }

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesTargetNamespaceResolver.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesTargetNamespaceResolver.cs
@@ -1,0 +1,30 @@
+using Squid.Core.Services.DeploymentExecution.Rendering;
+using Squid.Core.Services.DeploymentExecution.Variables;
+using Squid.Message.Constants;
+
+namespace Squid.Core.Services.DeploymentExecution.Kubernetes.Rendering;
+
+/// <summary>
+/// Single source of truth for resolving the Kubernetes target namespace of an
+/// action at render time. Reads <see cref="SpecialVariables.Kubernetes.Namespace"/>
+/// from the render context's effective variables and expands any <c>#{...}</c>
+/// templates (e.g. <c>#{Environment}-app</c> → <c>prod-app</c>) via the context's
+/// variable dictionary.
+///
+/// <para>This lives in the Kubernetes transport so the <i>generic</i> render pipeline
+/// (<c>ExecuteStepsPhase</c>) never has to know the namespace variable name — only the
+/// transports that have a namespace concept read it. Returns the raw value (which may be
+/// <c>null</c> or empty) untouched when the variable is absent; callers decide the default.</para>
+/// </summary>
+internal static class KubernetesTargetNamespaceResolver
+{
+    public static string? Resolve(IntentRenderContext context)
+    {
+        var raw = context.EffectiveVariables
+            .FirstOrDefault(v => v.Name == SpecialVariables.Kubernetes.Namespace)?.Value;
+
+        return string.IsNullOrEmpty(raw)
+            ? raw
+            : VariableExpander.ExpandString(raw, context.VariableDictionary);
+    }
+}

--- a/tests/Squid.Calamari.Tests/Calamari/Execution/Processes/ProcessRunnerTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Execution/Processes/ProcessRunnerTests.cs
@@ -39,6 +39,68 @@ public class ProcessRunnerTests
         sink.Stdout.ShouldContain("works");
     }
 
+    [Fact]
+    public void ScriptTimeoutMinutesEnvVar_ConstantNamePinned()
+    {
+        // Renaming this breaks every operator who pinned a Calamari script timeout via env.
+        ProcessRunner.ScriptTimeoutMinutesEnvVar.ShouldBe("SQUID_CALAMARI_SCRIPT_TIMEOUT_MINUTES");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("1.5")]
+    [InlineData("0")]
+    [InlineData("-5")]
+    public void ParseTimeoutMinutes_UnsetInvalidOrNonPositive_ReturnsNull(string raw)
+    {
+        // Fail-open to "no timeout" — preserves the historical infinite-wait behaviour.
+        ProcessRunner.ParseTimeoutMinutes(raw).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("5", 5)]
+    [InlineData("  10  ", 10)]
+    [InlineData("120", 120)]
+    public void ParseTimeoutMinutes_PositiveInteger_ReturnsMinutes(string raw, int expectedMinutes)
+    {
+        ProcessRunner.ParseTimeoutMinutes(raw).ShouldBe(TimeSpan.FromMinutes(expectedMinutes));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ProcessExceedsTimeout_KilledWithTimeoutExitCodeAndStderr()
+    {
+        var runner = new ProcessRunner();
+        var sink = new RecordingSink();
+        var invocation = new ProcessInvocation(
+            executable: "bash",
+            arguments: ["-c", "sleep 30"],
+            workingDirectory: Directory.GetCurrentDirectory());
+
+        var result = await runner.ExecuteAsync(invocation, sink, TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        result.ExitCode.ShouldBe(124);
+        result.Succeeded.ShouldBeFalse();
+        string.Join("\n", sink.Stderr).ShouldContain("SQUID_CALAMARI_SCRIPT_TIMEOUT_MINUTES");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ProcessFinishesWithinTimeout_ReturnsRealExitCode()
+    {
+        var runner = new ProcessRunner();
+        var sink = new RecordingSink();
+        var invocation = new ProcessInvocation(
+            executable: "bash",
+            arguments: ["-c", "exit 3"],
+            workingDirectory: Directory.GetCurrentDirectory());
+
+        var result = await runner.ExecuteAsync(invocation, sink, TimeSpan.FromMinutes(2), CancellationToken.None);
+
+        result.ExitCode.ShouldBe(3);
+    }
+
     private sealed class RecordingSink : IProcessOutputSink
     {
         public List<string> Stdout { get; } = new();

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleIntentRendererTests.cs
@@ -6,6 +6,7 @@ using Squid.Core.Services.DeploymentExecution.Rendering.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Tentacle.Rendering;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Process;
@@ -157,6 +158,7 @@ public class TentacleIntentRendererTests
             },
             Step = new DeploymentStepDto { Name = "step-1" },
             EffectiveVariables = new List<VariableDto>(),
+            VariableDictionary = VariableDictionaryFactory.Create(new List<VariableDto>()),
             ServerTaskId = 42,
             ReleaseVersion = "1.0.0",
             StepTimeout = stepTimeout

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Rendering/ServerIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Rendering/ServerIntentRendererTests.cs
@@ -6,6 +6,7 @@ using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Rendering;
 using Squid.Core.Services.DeploymentExecution.Rendering.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Process;
@@ -258,6 +259,7 @@ public class ServerIntentRendererTests
             },
             Step = new DeploymentStepDto { Name = "step-1" },
             EffectiveVariables = variables ?? new List<VariableDto>(),
+            VariableDictionary = VariableDictionaryFactory.Create(variables ?? new List<VariableDto>()),
             ServerTaskId = serverTaskId,
             ReleaseVersion = releaseVersion,
             StepTimeout = stepTimeout,

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesAgentIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesAgentIntentRendererTests.cs
@@ -10,6 +10,8 @@ using Squid.Core.Services.DeploymentExecution.Rendering.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Script.Files;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
+using Squid.Message.Constants;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Machine;
@@ -173,6 +175,25 @@ public class KubernetesAgentIntentRendererTests
         var rendered = await _renderer.RenderAsync(intent, NewContext(targetNamespace: "production"), CancellationToken.None);
 
         rendered.TargetNamespace.ShouldBe("production");
+    }
+
+    [Fact]
+    public async Task RenderAsync_RunScriptIntent_NamespaceVariableTemplate_ExpandedBeforeWrappingAndRequest()
+    {
+        // The namespace variable carries a #{...} template; the renderer must read the
+        // Squid.Action.Kubernetes.Namespace variable AND expand it through the dictionary
+        // (this logic used to live in the generic ExecuteStepsPhase).
+        var intent = NewRunScriptIntent(scriptBody: "echo hi", syntax: ScriptSyntax.Bash);
+        var variables = new List<VariableDto>
+        {
+            new() { Name = "Environment", Value = "prod" },
+            new() { Name = SpecialVariables.Kubernetes.Namespace, Value = "#{Environment}-app" }
+        };
+
+        var rendered = await _renderer.RenderAsync(intent, NewContext(variables: variables), CancellationToken.None);
+
+        rendered.ScriptBody.ShouldContain("--namespace=\"prod-app\"");
+        rendered.TargetNamespace.ShouldBe("prod-app");
     }
 
     [Fact]
@@ -993,6 +1014,8 @@ public class KubernetesAgentIntentRendererTests
         List<PackageAcquisitionResult>? packageReferences = null,
         string? targetNamespace = null)
     {
+        var effective = WithTargetNamespace(variables ?? new List<VariableDto>(), targetNamespace);
+
         return new IntentRenderContext
         {
             Target = target ?? new DeploymentTargetContext
@@ -1002,12 +1025,25 @@ public class KubernetesAgentIntentRendererTests
                 EndpointContext = new EndpointContext()
             },
             Step = new DeploymentStepDto { Name = "step-1" },
-            EffectiveVariables = variables ?? new List<VariableDto>(),
+            EffectiveVariables = effective,
+            VariableDictionary = VariableDictionaryFactory.Create(effective),
             ServerTaskId = serverTaskId,
             ReleaseVersion = releaseVersion,
             StepTimeout = stepTimeout,
-            TargetNamespace = targetNamespace,
             PackageReferences = packageReferences ?? new List<PackageAcquisitionResult>()
+        };
+    }
+
+    // The namespace now travels as the Squid.Action.Kubernetes.Namespace variable (the
+    // renderer reads + expands it), so the helper injects it when a test asks for one.
+    private static List<VariableDto> WithTargetNamespace(List<VariableDto> variables, string? targetNamespace)
+    {
+        if (targetNamespace == null || variables.Any(v => v.Name == SpecialVariables.Kubernetes.Namespace))
+            return variables;
+
+        return new List<VariableDto>(variables)
+        {
+            new() { Name = SpecialVariables.Kubernetes.Namespace, Value = targetNamespace }
         };
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesApiIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesApiIntentRendererTests.cs
@@ -13,6 +13,7 @@ using Squid.Core.Services.DeploymentExecution.Rendering.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Script.Files;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
 using Squid.Message.Constants;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
@@ -96,6 +97,24 @@ public class KubernetesApiIntentRendererTests
         var rendered = await _renderer.RenderAsync(intent, NewContext(targetNamespace: "production"), CancellationToken.None);
 
         rendered.TargetNamespace.ShouldBe("production");
+    }
+
+    [Fact]
+    public async Task RenderAsync_RunScriptIntent_NamespaceVariableTemplate_ExpandedIntoRequest()
+    {
+        // The renderer reads the Squid.Action.Kubernetes.Namespace variable and expands its
+        // #{...} template through the dictionary (logic moved out of the generic pipeline).
+        SetupBuilder(returnValue: "wrapped");
+        var intent = NewRunScriptIntent(syntax: ScriptSyntax.Bash);
+        var variables = new List<VariableDto>
+        {
+            new() { Name = "Environment", Value = "prod" },
+            new() { Name = SpecialVariables.Kubernetes.Namespace, Value = "#{Environment}-app" }
+        };
+
+        var rendered = await _renderer.RenderAsync(intent, NewContext(variables: variables), CancellationToken.None);
+
+        rendered.TargetNamespace.ShouldBe("prod-app");
     }
 
     [Fact]
@@ -1213,6 +1232,8 @@ public class KubernetesApiIntentRendererTests
         List<PackageAcquisitionResult>? packageReferences = null,
         string? targetNamespace = null)
     {
+        var effective = WithTargetNamespace(variables ?? new List<VariableDto>(), targetNamespace);
+
         return new IntentRenderContext
         {
             Target = target ?? new DeploymentTargetContext
@@ -1222,12 +1243,25 @@ public class KubernetesApiIntentRendererTests
                 EndpointContext = new EndpointContext()
             },
             Step = new DeploymentStepDto { Name = "step-1" },
-            EffectiveVariables = variables ?? new List<VariableDto>(),
+            EffectiveVariables = effective,
+            VariableDictionary = VariableDictionaryFactory.Create(effective),
             ServerTaskId = serverTaskId,
             ReleaseVersion = releaseVersion,
             StepTimeout = stepTimeout,
-            TargetNamespace = targetNamespace,
             PackageReferences = packageReferences ?? new List<PackageAcquisitionResult>()
+        };
+    }
+
+    // The namespace now travels as the Squid.Action.Kubernetes.Namespace variable (the
+    // renderer reads + expands it), so the helper injects it when a test asks for one.
+    private static List<VariableDto> WithTargetNamespace(List<VariableDto> variables, string? targetNamespace)
+    {
+        if (targetNamespace == null || variables.Any(v => v.Name == SpecialVariables.Kubernetes.Namespace))
+            return variables;
+
+        return new List<VariableDto>(variables)
+        {
+            new() { Name = SpecialVariables.Kubernetes.Namespace, Value = targetNamespace }
         };
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesTargetNamespaceResolverTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesTargetNamespaceResolverTests.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Kubernetes.Rendering;
+using Squid.Core.Services.DeploymentExecution.Rendering;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.Deployments.Kubernetes;
+
+/// <summary>
+/// Unit coverage for the single source of truth that resolves a Kubernetes target
+/// namespace from action variables at render time. Pins the behaviour that moved
+/// out of the generic <c>ExecuteStepsPhase</c>: read
+/// <see cref="SpecialVariables.Kubernetes.Namespace"/>, expand <c>#{...}</c> templates,
+/// and honour project-overrides-endpoint precedence (first occurrence wins).
+/// </summary>
+public class KubernetesTargetNamespaceResolverTests
+{
+    [Fact]
+    public void Resolve_LiteralNamespaceVariable_ReturnedAsIs()
+    {
+        var context = ContextWith(new VariableDto { Name = SpecialVariables.Kubernetes.Namespace, Value = "production" });
+
+        KubernetesTargetNamespaceResolver.Resolve(context).ShouldBe("production");
+    }
+
+    [Fact]
+    public void Resolve_TemplateNamespaceVariable_ExpandedThroughDictionary()
+    {
+        var context = ContextWith(
+            new VariableDto { Name = "Environment", Value = "prod" },
+            new VariableDto { Name = SpecialVariables.Kubernetes.Namespace, Value = "#{Environment}-app" });
+
+        KubernetesTargetNamespaceResolver.Resolve(context).ShouldBe("prod-app");
+    }
+
+    [Fact]
+    public void Resolve_TwoNamespaceVariables_FirstWins()
+    {
+        // effectiveVariables lists project vars before endpoint vars, so the first
+        // occurrence is the project override — it must win.
+        var context = ContextWith(
+            new VariableDto { Name = SpecialVariables.Kubernetes.Namespace, Value = "project-ns" },
+            new VariableDto { Name = SpecialVariables.Kubernetes.Namespace, Value = "endpoint-ns" });
+
+        KubernetesTargetNamespaceResolver.Resolve(context).ShouldBe("project-ns");
+    }
+
+    [Fact]
+    public void Resolve_AbsentNamespaceVariable_ReturnsNull()
+    {
+        var context = ContextWith(new VariableDto { Name = "Unrelated", Value = "x" });
+
+        KubernetesTargetNamespaceResolver.Resolve(context).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_EmptyNamespaceVariable_ReturnsEmpty()
+    {
+        // Empty is returned untouched (no expansion attempt); the renderer decides the default.
+        var context = ContextWith(new VariableDto { Name = SpecialVariables.Kubernetes.Namespace, Value = "" });
+
+        KubernetesTargetNamespaceResolver.Resolve(context).ShouldBe("");
+    }
+
+    private static IntentRenderContext ContextWith(params VariableDto[] variables)
+    {
+        var list = variables.ToList();
+
+        return new IntentRenderContext
+        {
+            Target = new DeploymentTargetContext
+            {
+                Machine = new Machine { Id = 1, Name = "m1" },
+                CommunicationStyle = CommunicationStyle.KubernetesAgent,
+                EndpointContext = new EndpointContext()
+            },
+            Step = new DeploymentStepDto { Name = "step-1" },
+            EffectiveVariables = list,
+            VariableDictionary = VariableDictionaryFactory.Create(list)
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/OpenClaw/OpenClawIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/OpenClaw/OpenClawIntentRendererTests.cs
@@ -8,6 +8,7 @@ using Squid.Core.Services.DeploymentExecution.Rendering;
 using Squid.Core.Services.DeploymentExecution.Rendering.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
 using Squid.Message.Constants;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
@@ -329,6 +330,7 @@ public class OpenClawIntentRendererTests
             },
             Step = new DeploymentStepDto { Name = "step-1" },
             EffectiveVariables = variables ?? new List<VariableDto>(),
+            VariableDictionary = VariableDictionaryFactory.Create(variables ?? new List<VariableDto>()),
             ServerTaskId = serverTaskId,
             ReleaseVersion = releaseVersion,
             StepTimeout = stepTimeout

--- a/tests/Squid.UnitTests/Services/Deployments/Ssh/SshIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Ssh/SshIntentRendererTests.cs
@@ -8,6 +8,7 @@ using Squid.Core.Services.DeploymentExecution.Rendering.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Ssh.Rendering;
 using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Variables;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Execution;
 using Squid.Message.Models.Deployments.Process;
@@ -279,6 +280,7 @@ public class SshIntentRendererTests
             },
             Step = new DeploymentStepDto { Name = "step-1" },
             EffectiveVariables = variables ?? new List<VariableDto>(),
+            VariableDictionary = VariableDictionaryFactory.Create(variables ?? new List<VariableDto>()),
             ServerTaskId = serverTaskId,
             ReleaseVersion = releaseVersion,
             StepTimeout = stepTimeout,


### PR DESCRIPTION
## Summary

Two small correctness fixes that harden the execution path with **no wire, DB, enum, or interface changes**.

- **Calamari wall-clock timeout** (`ProcessRunner`): an opt-in `SQUID_CALAMARI_SCRIPT_TIMEOUT_MINUTES` env var, read at call time. Unset / non-numeric / non-positive preserves today's behaviour (wait until exit or caller cancellation), so long deployments are never killed by default. When set to a positive integer, an overrunning child is killed (whole process tree), the runner emits a clear stderr line naming the env var, and returns exit `124` — a hung script can no longer pin the work directory or the calling thread forever. `IProcessRunner` is unchanged.
- **K8s namespace genericity leak**: the transport-agnostic `ExecuteStepsPhase` no longer reads the Kubernetes-specific `Squid.Action.Kubernetes.Namespace` variable. The two Kubernetes intent renderers now resolve + expand it themselves via a shared `KubernetesTargetNamespaceResolver`, using the render context's variable dictionary. `IntentRenderContext` swaps the pre-resolved `TargetNamespace` string for a generic `VariableDictionary`. Project-overrides-endpoint precedence and `#{...}` template expansion are preserved exactly.

## Why non-breaking

- `IProcessRunner` signature unchanged; default `ExecuteAsync` path is byte-identical when the env var is unset.
- `ScriptExecutionRequest.TargetNamespace` and `StartScriptCommand.TargetNamespace` (the Halibut wire contract) are untouched — the agent still receives the same namespace.
- No enum / wire / DB / migration changes. The only constructors of `IntentRenderContext` are the pipeline and unit tests, both updated.

## Test plan

- [x] `ProcessRunnerTests`: env-var constant pinned (Rule 8), parse cases (unset/invalid/non-positive → no timeout; positive → minutes), kill-on-timeout returns 124 + stderr names the env var, finishes-within-timeout returns the real exit code.
- [x] `KubernetesTargetNamespaceResolverTests`: literal, `#{...}` template expansion, project-first precedence, absent → null, empty → empty.
- [x] `KubernetesApi`/`KubernetesAgent` renderer tests: new template-expansion cases; all existing namespace tests pass through the new variable path unchanged.
- [x] Full unit sweep: 5689 passed. Full Calamari suite: 545 passed. Full solution build: 0 errors.