### PR TITLE
Add crash-resume re-attach integration tests

### DIFF
--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
@@ -1,0 +1,268 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Halibut;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.Deployments.Checkpoints;
+using Squid.IntegrationTests.Base;
+using Squid.Message.Constants;
+using Squid.Message.Contracts.Tentacle;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Variable;
+using Machine = Squid.Core.Persistence.Entities.Deployments.Machine;
+
+namespace Squid.IntegrationTests.Services.Deployments.Checkpoints;
+
+/// <summary>
+/// Resume-by-ticket — integration coverage for the crash-resume RE-ATTACH wiring in
+/// <see cref="HalibutMachineExecutionStrategy"/>. The unit tier
+/// (<c>HalibutReattachDecisionTests</c>) pins the <c>AgentHasUsableScript</c> decision and
+/// <c>InFlightScriptStoreTests</c> pins the DB-backed store; what neither covers is the
+/// end-to-end wiring: a ticket persisted by a prior (crashed) run is read back by a FRESH
+/// strategy instance, the agent is probed with that SAME ticket, and the script is observed
+/// to completion WITHOUT a duplicate <c>StartScript</c>.
+///
+/// <para><b>Why this gap mattered</b>: the full-pipeline resume E2E
+/// (<c>KubernetesResumeCheckpointE2ETests</c>) swaps in <c>CapturingExecutionStrategy</c>,
+/// which replaces <see cref="HalibutMachineExecutionStrategy"/> entirely — so
+/// <c>DispatchOrReattachAsync</c>/<c>TryReattachAsync</c> were never exercised by any
+/// pipeline test. This drives the REAL strategy + REAL observer + REAL DB-backed
+/// <see cref="IInFlightScriptStore"/>, mocking only the Halibut RPC transport (the agent),
+/// whose unknown-ticket contract is itself unit-pinned.</para>
+///
+/// <para><b>Tier</b>: integration (Rule 9) — real Postgres checkpoint row carries the ticket
+/// across a simulated restart (the strategy resolves a fresh store from a new DI scope that
+/// reads the same DB). The agent is a recording fake injected via a per-scope
+/// <see cref="IHalibutClientFactory"/> override (Rule 12 medium-mock: real prod class, mocked
+/// external dep covered elsewhere).</para>
+/// </summary>
+public class HalibutResumeReattachTests : TestBase
+{
+    public HalibutResumeReattachTests() : base("HalibutResumeReattach", "squid_it_reattach")
+    {
+    }
+
+    [Fact]
+    public async Task RecordedTicket_AgentHasCompleteScript_ReattachesWithoutDuplicateDispatch()
+    {
+        const int taskId = 810001, machineId = 11;
+        const string ticket = "reattach-ticket-complete";
+
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+        await RecordTicketAsync(taskId, machineId, ticket).ConfigureAwait(false);
+
+        var agent = new RecordingScriptService(
+            getStatusScript: new[] { (ProcessState.Complete, 0) },
+            completeResult: (ProcessState.Complete, 0));
+
+        var result = await ExecuteWithAgentAsync(taskId, machineId, agent).ConfigureAwait(false);
+
+        agent.StartScriptCalls.ShouldBe(0,
+            customMessage: "Re-attach MUST NOT dispatch a duplicate StartScript when the agent still holds the recorded ticket. " +
+                          "A non-zero count means the crashed run's script and a fresh dispatch both execute (the exact double-run this prevents).");
+        agent.ProbedTickets.ShouldContain(ticket);
+        result.Success.ShouldBeTrue();
+        result.ExitCode.ShouldBe(0);
+
+        (await GetTicketAsync(taskId, machineId).ConfigureAwait(false)).ShouldBeNull(
+            customMessage: "In-flight ticket MUST be cleared once the re-attached script completes, or the next run re-probes a dead ticket.");
+    }
+
+    [Fact]
+    public async Task RecordedTicket_AgentScriptStillRunning_ReattachesAndObservesToCompletion()
+    {
+        const int taskId = 810002, machineId = 12;
+        const string ticket = "reattach-ticket-running";
+
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+        await RecordTicketAsync(taskId, machineId, ticket).ConfigureAwait(false);
+
+        // Probe sees the script still Running; the observer's next poll sees it Complete.
+        var agent = new RecordingScriptService(
+            getStatusScript: new[] { (ProcessState.Running, 0), (ProcessState.Complete, 0) },
+            completeResult: (ProcessState.Complete, 0));
+
+        var result = await ExecuteWithAgentAsync(taskId, machineId, agent).ConfigureAwait(false);
+
+        agent.StartScriptCalls.ShouldBe(0,
+            customMessage: "A still-running script from a crashed run must be re-attached to, not re-dispatched.");
+        agent.ProbedTickets.ShouldAllBe(t => t == ticket,
+            customMessage: "Every status probe (initial + observer polls) must target the recorded ticket, never a fresh one.");
+        result.Success.ShouldBeTrue();
+
+        (await GetTicketAsync(taskId, machineId).ConfigureAwait(false)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RecordedTicket_AgentNoLongerHasScript_ClearsStaleAndDispatchesFresh()
+    {
+        const int taskId = 810003, machineId = 13;
+        const string staleTicket = "stale-ticket";
+
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+        await RecordTicketAsync(taskId, machineId, staleTicket).ConfigureAwait(false);
+
+        // The Tentacle returns Complete + UnknownResult(-1) for a ticket it doesn't have —
+        // the single "agent doesn't hold it" signal that must fall back to a fresh dispatch.
+        var agent = new RecordingScriptService(
+            getStatusScript: new[] { (ProcessState.Complete, ScriptExitCodes.UnknownResult), (ProcessState.Complete, 0) },
+            completeResult: (ProcessState.Complete, 0));
+
+        var result = await ExecuteWithAgentAsync(taskId, machineId, agent).ConfigureAwait(false);
+
+        agent.StartScriptCalls.ShouldBe(1,
+            customMessage: "A stale ticket (agent returns Complete+UnknownResult) MUST fall back to exactly one fresh dispatch.");
+        agent.StartedTickets.Single().ShouldNotBe(staleTicket,
+            customMessage: "The fresh dispatch must use a new ticket, not re-send the stale one.");
+        result.Success.ShouldBeTrue();
+
+        (await GetTicketAsync(taskId, machineId).ConfigureAwait(false)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task NoRecordedTicket_DispatchesFreshWithoutReattach()
+    {
+        const int taskId = 810004, machineId = 14;
+
+        // Checkpoint row exists (today's executor creates it before dispatch) but no
+        // in-flight ticket was recorded — there is nothing to re-attach to.
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        var agent = new RecordingScriptService(
+            getStatusScript: new[] { (ProcessState.Complete, 0) },
+            completeResult: (ProcessState.Complete, 0));
+
+        var result = await ExecuteWithAgentAsync(taskId, machineId, agent).ConfigureAwait(false);
+
+        agent.StartScriptCalls.ShouldBe(1,
+            customMessage: "With no recorded ticket the strategy must dispatch fresh — re-attach can only ever AVOID a duplicate.");
+        result.Success.ShouldBeTrue();
+    }
+
+    // ── Drive the real strategy with a fake agent (per-scope IHalibutClientFactory override) ──
+
+    private async Task<ScriptExecutionResult> ExecuteWithAgentAsync(int taskId, int machineId, RecordingScriptService agent)
+    {
+        ScriptExecutionResult result = null;
+
+        await Run<IEnumerable<IExecutionStrategy>>(
+            async strategies =>
+            {
+                var strategy = strategies.OfType<HalibutMachineExecutionStrategy>().Single();
+                result = await strategy.ExecuteScriptAsync(BuildRequest(taskId, machineId), CancellationToken.None).ConfigureAwait(false);
+            },
+            extraRegistration: b => b.RegisterInstance(new FixedHalibutClientFactory(agent)).As<IHalibutClientFactory>()).ConfigureAwait(false);
+
+        return result;
+    }
+
+    private static ScriptExecutionRequest BuildRequest(int taskId, int machineId) => new()
+    {
+        ExecutionMode = ExecutionMode.DirectScript,
+        ScriptBody = "echo resume-reattach",
+        Syntax = ScriptSyntax.Bash,
+        Variables = new List<VariableDto>(),
+        ServerTaskId = taskId,
+        StepName = "Step1",
+        ActionName = "Action1",
+        Machine = new Machine
+        {
+            Id = machineId,
+            Name = $"agent-{machineId}",
+            Endpoint = JsonSerializer.Serialize(new
+            {
+                CommunicationStyle = "KubernetesAgent",
+                SubscriptionId = $"sub-{machineId}",
+                Thumbprint = "AA11BB22CC33DD44"
+            })
+        }
+    };
+
+    // ── Helpers (mirror InFlightScriptStoreTests) ──
+
+    private Task EnsureRowAsync(int taskId)
+        => Run<IDeploymentCheckpointService>(svc => svc.EnsureExistsAsync(taskId, deploymentId: 1));
+
+    private Task RecordTicketAsync(int taskId, int machineId, string ticket)
+        => Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, machineId, ticket));
+
+    private Task<string> GetTicketAsync(int taskId, int machineId)
+        => Run<IInFlightScriptStore, string>(s => s.TryGetTicketAsync(taskId, machineId));
+
+    // ── Recording fake agent (the Halibut RPC counterpart) ──
+
+    private sealed class RecordingScriptService : IAsyncScriptService
+    {
+        private readonly Queue<(ProcessState State, int ExitCode)> _getStatusScript;
+        private readonly (ProcessState State, int ExitCode) _completeResult;
+
+        public RecordingScriptService(IEnumerable<(ProcessState, int)> getStatusScript, (ProcessState, int) completeResult)
+        {
+            _getStatusScript = new Queue<(ProcessState, int)>(getStatusScript);
+            _completeResult = completeResult;
+        }
+
+        public int StartScriptCalls { get; private set; }
+        public List<string> StartedTickets { get; } = new();
+        public List<string> ProbedTickets { get; } = new();
+
+        public Task<ScriptStatusResponse> StartScriptAsync(StartScriptCommand command)
+        {
+            StartScriptCalls++;
+            StartedTickets.Add(command.ScriptTicket.TaskId);
+            return Task.FromResult(Resp(command.ScriptTicket, ProcessState.Running, 0));
+        }
+
+        public Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request)
+        {
+            ProbedTickets.Add(request.Ticket.TaskId);
+            // Last scripted entry repeats so the observer's poll loop always terminates.
+            var (state, exit) = _getStatusScript.Count > 1 ? _getStatusScript.Dequeue() : _getStatusScript.Peek();
+            return Task.FromResult(Resp(request.Ticket, state, exit));
+        }
+
+        public Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command)
+            => Task.FromResult(Resp(command.Ticket, _completeResult.State, _completeResult.ExitCode));
+
+        public Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command)
+            => Task.FromResult(Resp(command.Ticket, ProcessState.Complete, 0));
+
+        private static ScriptStatusResponse Resp(ScriptTicket ticket, ProcessState state, int exitCode)
+            => new(ticket, state, exitCode, new List<ProcessOutput>(), 0);
+    }
+
+    private sealed class FixedHalibutClientFactory : IHalibutClientFactory
+    {
+        private readonly IAsyncScriptService _client;
+
+        public FixedHalibutClientFactory(IAsyncScriptService client) => _client = client;
+
+        public IAsyncScriptService CreateClient(ServiceEndPoint endpoint) => _client;
+
+        public IAsyncCapabilitiesService CreateCapabilitiesClient(ServiceEndPoint endpoint) => new NoOpCapabilitiesService();
+
+        public IAsyncClientFileTransferService CreateFileTransferClient(ServiceEndPoint endpoint) => new ThrowingFileTransferService();
+
+        private sealed class NoOpCapabilitiesService : IAsyncCapabilitiesService
+        {
+            public Task<CapabilitiesResponse> GetCapabilitiesAsync(CapabilitiesRequest request)
+                => Task.FromResult(new CapabilitiesResponse());
+        }
+
+        private sealed class ThrowingFileTransferService : IAsyncClientFileTransferService
+        {
+            public Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload)
+                => throw new NotSupportedException("Re-attach tests do not exercise file transfer.");
+
+            public Task<DataStream> DownloadFileAsync(string remotePath)
+                => throw new NotSupportedException("Re-attach tests do not exercise file transfer.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the test gap left by the resume-by-ticket feature. The full-pipeline resume E2E (`KubernetesResumeCheckpointE2ETests`) swaps in `CapturingExecutionStrategy`, which replaces `HalibutMachineExecutionStrategy` entirely — so `DispatchOrReattachAsync` / `TryReattachAsync` (the actual re-attach wiring) were never exercised above the unit tier. Unit tests pin the `AgentHasUsableScript` decision and the DB-backed store in isolation; nothing proved the end-to-end path where a ticket persisted by a prior (crashed) run is read back by a fresh strategy instance, the agent is probed with that same ticket, and the script is observed to completion **without a duplicate `StartScript`**.

These integration tests drive the **real** strategy + **real** observer + **real** DB-backed `InFlightScriptStore`, mocking only the Halibut RPC transport via a per-scope `IHalibutClientFactory` override (Rule 12 medium-mock — the agent's unknown-ticket contract is itself unit-pinned). The persisted checkpoint row carries the ticket across a simulated restart (the strategy resolves a fresh store from a new DI scope reading the same Postgres DB).

Scenarios:
- **Re-attach to a Complete script** → no duplicate dispatch; ticket cleared after.
- **Re-attach to a still-running script** → observed to completion; every probe targets the recorded ticket.
- **Stale ticket** (agent returns `Complete + UnknownResult(-1)`) → clears stale + exactly one fresh dispatch with a new ticket.
- **No recorded ticket** → fresh dispatch (re-attach can only ever avoid a duplicate).

## Test plan

- [x] 4 new tests pass against real Postgres (`HalibutResumeReattachTests`).
- [x] IntegrationTests project builds clean; tests deterministic (no real Halibut/timing).
- [x] Test-only change — no production code touched.

_Note: two pre-existing `UpgradeDispatchLockReconcilerIntegrationTests` (Redis) fail on a local host without Redis; unrelated to this change and green in CI._