### PR TITLE
Enforce machine-policy cleanup of unavailable targets

### DIFF
--- a/src/Squid.Core/Handlers/CommandHandlers/Machine/EnforceMachineCleanupCommandHandler.cs
+++ b/src/Squid.Core/Handlers/CommandHandlers/Machine/EnforceMachineCleanupCommandHandler.cs
@@ -1,0 +1,24 @@
+using Squid.Core.Services.Machines.Cleanup;
+using Squid.Message.Commands.Machine;
+
+namespace Squid.Core.Handlers.CommandHandlers.Machine;
+
+public class EnforceMachineCleanupCommandHandler(IMachineCleanupService machineCleanupService)
+    : ICommandHandler<EnforceMachineCleanupCommand, EnforceMachineCleanupResponse>
+{
+    public async Task<EnforceMachineCleanupResponse> Handle(IReceiveContext<EnforceMachineCleanupCommand> context, CancellationToken cancellationToken)
+    {
+        var outcome = await machineCleanupService.EnforceCleanupAsync(cancellationToken).ConfigureAwait(false);
+
+        return new EnforceMachineCleanupResponse
+        {
+            Data = new EnforceMachineCleanupResponseData
+            {
+                Mode = outcome.Mode.ToString(),
+                Scanned = outcome.Scanned,
+                Eligible = outcome.Eligible,
+                Deleted = outcome.Deleted
+            }
+        };
+    }
+}

--- a/src/Squid.Core/Jobs/RecurringJobs/MachineCleanupRecurringJob.cs
+++ b/src/Squid.Core/Jobs/RecurringJobs/MachineCleanupRecurringJob.cs
@@ -1,0 +1,15 @@
+using Squid.Message.Commands.Machine;
+
+namespace Squid.Core.Jobs.RecurringJobs;
+
+public class MachineCleanupRecurringJob(IMediator mediator) : IRecurringJob
+{
+    public string JobId => "machine-cleanup-enforcement";
+
+    public string CronExpression => "0 3 * * *"; // daily at 3 AM
+
+    public async Task Execute()
+    {
+        await mediator.SendAsync<EnforceMachineCleanupCommand, EnforceMachineCleanupResponse>(new EnforceMachineCleanupCommand()).ConfigureAwait(false);
+    }
+}

--- a/src/Squid.Core/Persistence/DbUpFiles/20260530_add_machine_unavailable_since.sql
+++ b/src/Squid.Core/Persistence/DbUpFiles/20260530_add_machine_unavailable_since.sql
@@ -1,0 +1,12 @@
+-- Machine policy cleanup enforcement: track when a deployment target FIRST went
+-- unavailable, so the policy's "delete unavailable targets after N" grace period
+-- can be measured against a stable instant rather than the last-checked time
+-- (which a recurring health check keeps refreshing).
+--
+-- Set when HealthStatus transitions into Unavailable, cleared when it next reports
+-- Healthy, preserved while it stays Unavailable. NULL = not currently
+-- known-unavailable. Pre-existing machines get NULL and are never eligible for
+-- auto-cleanup until their next unavailable transition records a go-bad instant.
+
+ALTER TABLE machine
+    ADD COLUMN unavailable_since timestamptz NULL;

--- a/src/Squid.Core/Persistence/Entities/Deployments/Machine.cs
+++ b/src/Squid.Core/Persistence/Entities/Deployments/Machine.cs
@@ -20,6 +20,12 @@ public class Machine : IEntity<int>, IAuditable
     public DateTimeOffset? HealthLastChecked { get; set; }
     public string HealthDetail { get; set; }
 
+    // Instant the machine FIRST transitioned into Unavailable (set on entry, cleared
+    // when it next reports Healthy, preserved while it stays Unavailable). NULL means
+    // "not currently known-unavailable". Drives the machine-policy cleanup grace
+    // period — we only auto-delete a target whose continuous downtime we can prove.
+    public DateTimeOffset? UnavailableSince { get; set; }
+
     // H2 — Persisted runtime capability snapshot (full MachineRuntimeCapabilities
     // serialised as JSON). NULL when the agent has never been health-checked.
     // The InMemoryMachineRuntimeCapabilitiesCache hydrates from this column at

--- a/src/Squid.Core/Services/Machines/Cleanup/MachineCleanupEnforcement.cs
+++ b/src/Squid.Core/Services/Machines/Cleanup/MachineCleanupEnforcement.cs
@@ -1,0 +1,36 @@
+using Squid.Message.Hardening;
+
+namespace Squid.Core.Services.Machines.Cleanup;
+
+/// <summary>
+/// Three-mode enforcement (global CLAUDE.md Rule 11) for the machine-policy
+/// "Clean up — delete unavailable deployment targets after N" behaviour. Deleting
+/// a deployment target is destructive, so the global default is a DRY RUN: even
+/// when an operator opts a machine policy into <c>DeleteUnavailableMachines</c>,
+/// nothing is deleted until they ALSO flip this switch to <c>strict</c>.
+///
+/// <list type="bullet">
+///   <item><b>off</b> — never delete; skip the sweep entirely (debug-level only).</item>
+///   <item><b>warn</b> (DEFAULT) — evaluate eligibility and emit a structured
+///         warning naming each machine that WOULD be deleted + how to switch to
+///         strict, but delete nothing. Non-breaking: today's behaviour is "never
+///         auto-delete", which this preserves while surfacing the intent.</item>
+///   <item><b>strict</b> — actually delete the eligible machines via the same
+///         safe delete path the operator-facing "Delete" action uses.</item>
+/// </list>
+///
+/// <para>The per-policy <c>DeleteMachinesBehavior</c> still gates <i>eligibility</i>
+/// (default <c>DoNotDelete</c> → never eligible). This switch only governs whether
+/// an eligible machine is logged (warn) or actually removed (strict). Both gates
+/// must opt in for a deletion to occur — a deliberate double-opt-in for a
+/// destructive operation.</para>
+/// </summary>
+public static class MachineCleanupEnforcement
+{
+    /// <summary>Operator escape hatch (Rule 8). Pinned by a unit test.</summary>
+    public const string EnvVar = "SQUID_MACHINE_CLEANUP_ENFORCEMENT";
+
+    /// <summary>Resolve the current mode from <see cref="EnvVar"/>; defaults to
+    /// <see cref="EnforcementMode.Warn"/> (dry-run) when unset/blank/unrecognised.</summary>
+    public static EnforcementMode ResolveMode() => EnforcementModeReader.Read(EnvVar);
+}

--- a/src/Squid.Core/Services/Machines/Cleanup/MachineCleanupEvaluator.cs
+++ b/src/Squid.Core/Services/Machines/Cleanup/MachineCleanupEvaluator.cs
@@ -1,0 +1,35 @@
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Machine;
+
+namespace Squid.Core.Services.Machines.Cleanup;
+
+/// <summary>
+/// Single source of truth for "is this machine eligible to be auto-deleted by its
+/// machine policy's cleanup setting". Pure + deterministic so it can be unit-tested
+/// exhaustively; the orchestrating service and the three-mode enforcement decide
+/// what to DO with an eligible machine (log vs delete).
+///
+/// <para>A machine is eligible only when ALL hold: its policy opts in
+/// (<see cref="DeleteMachinesBehavior.DeleteUnavailableMachines"/>), it is currently
+/// <see cref="MachineHealthStatus.Unavailable"/>, we know WHEN it became unavailable
+/// (<paramref name="unavailableSince"/> is non-null), and that instant is at least
+/// the configured grace period in the past. An unknown go-bad time (null) is never
+/// eligible — we won't delete a target whose downtime duration we can't prove.</para>
+/// </summary>
+public static class MachineCleanupEvaluator
+{
+    public static bool IsEligible(MachineCleanupPolicyDto policy, MachineHealthStatus status, DateTimeOffset? unavailableSince, DateTimeOffset now)
+    {
+        if (policy == null) return false;
+
+        if (policy.DeleteMachinesBehavior != DeleteMachinesBehavior.DeleteUnavailableMachines) return false;
+
+        if (status != MachineHealthStatus.Unavailable) return false;
+
+        if (unavailableSince == null) return false;
+
+        if (policy.DeleteMachinesAfterSeconds <= 0) return false;
+
+        return unavailableSince.Value <= now.AddSeconds(-policy.DeleteMachinesAfterSeconds);
+    }
+}

--- a/src/Squid.Core/Services/Machines/Cleanup/MachineCleanupService.cs
+++ b/src/Squid.Core/Services/Machines/Cleanup/MachineCleanupService.cs
@@ -1,0 +1,120 @@
+using Squid.Core.DependencyInjection;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Message.Commands.Machine;
+using Squid.Message.Enums;
+using Squid.Message.Hardening;
+
+namespace Squid.Core.Services.Machines.Cleanup;
+
+public sealed record MachineCleanupOutcome(EnforcementMode Mode, int Scanned, int Eligible, int Deleted);
+
+public interface IMachineCleanupService : IScopedDependency
+{
+    Task<MachineCleanupOutcome> EnforceCleanupAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Enforces the machine-policy "Clean up — delete unavailable deployment targets
+/// after N" behaviour. Runs on a schedule via <c>MachineCleanupRecurringJob</c>.
+///
+/// <para>Double-opt-in for this destructive operation: a machine is eligible only
+/// when its policy sets <see cref="DeleteMachinesBehavior.DeleteUnavailableMachines"/>
+/// AND it has been continuously unavailable for the configured grace period
+/// (<see cref="MachineCleanupEvaluator"/>). Whether an eligible machine is merely
+/// logged or actually deleted is then gated by <see cref="MachineCleanupEnforcement"/>
+/// (default <c>warn</c> = dry-run). Deletion goes through the same
+/// <see cref="IMachineService.DeleteMachinesAsync"/> path the operator-facing delete
+/// uses, so Halibut trust is reconfigured exactly as for a manual removal.</para>
+/// </summary>
+public sealed class MachineCleanupService(
+    IMachineDataProvider machineDataProvider,
+    IMachinePolicyDataProvider policyDataProvider,
+    IMachineService machineService) : IMachineCleanupService
+{
+    public async Task<MachineCleanupOutcome> EnforceCleanupAsync(CancellationToken cancellationToken = default)
+    {
+        var mode = MachineCleanupEnforcement.ResolveMode();
+
+        if (mode == EnforcementMode.Off)
+        {
+            Log.Debug("[MachineCleanup] Disabled via {EnvVar}=off — skipping sweep.", MachineCleanupEnforcement.EnvVar);
+            return new MachineCleanupOutcome(mode, 0, 0, 0);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        var (_, machines) = await machineDataProvider.GetMachinesAllSpacesPagingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var eligible = await ResolveEligibleAsync(machines, now, cancellationToken).ConfigureAwait(false);
+
+        if (eligible.Count == 0)
+            return new MachineCleanupOutcome(mode, machines.Count, 0, 0);
+
+        if (mode == EnforcementMode.Warn)
+        {
+            WarnWouldDelete(eligible);
+            return new MachineCleanupOutcome(mode, machines.Count, eligible.Count, 0);
+        }
+
+        var deleted = await DeleteAsync(eligible, cancellationToken).ConfigureAwait(false);
+
+        return new MachineCleanupOutcome(mode, machines.Count, eligible.Count, deleted);
+    }
+
+    private async Task<List<Machine>> ResolveEligibleAsync(List<Machine> machines, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        var eligible = new List<Machine>();
+
+        foreach (var machine in machines)
+        {
+            // Cheap pre-filter before the per-machine policy load.
+            if (machine.HealthStatus != MachineHealthStatus.Unavailable || machine.MachinePolicyId == null)
+                continue;
+
+            var policy = await LoadCleanupPolicyAsync(machine.MachinePolicyId.Value, cancellationToken).ConfigureAwait(false);
+
+            if (MachineCleanupEvaluator.IsEligible(policy, machine.HealthStatus, machine.UnavailableSince, now))
+                eligible.Add(machine);
+        }
+
+        return eligible;
+    }
+
+    private void WarnWouldDelete(List<Machine> eligible)
+    {
+        foreach (var machine in eligible)
+            Log.Warning(
+                "[MachineCleanup] WOULD delete unavailable target {MachineName} (id {MachineId}, unavailable since {Since:o}) per its machine policy. " +
+                "Set {EnvVar}=strict to actually delete, or =off to silence.",
+                machine.Name, machine.Id, machine.UnavailableSince, MachineCleanupEnforcement.EnvVar);
+    }
+
+    private async Task<int> DeleteAsync(List<Machine> eligible, CancellationToken cancellationToken)
+    {
+        var ids = eligible.Select(m => m.Id).ToList();
+
+        try
+        {
+            await machineService.DeleteMachinesAsync(new DeleteMachinesCommand { Ids = ids }, cancellationToken).ConfigureAwait(false);
+
+            foreach (var machine in eligible)
+                Log.Information(
+                    "[MachineCleanup] Deleted unavailable target {MachineName} (id {MachineId}, unavailable since {Since:o}) per its machine policy.",
+                    machine.Name, machine.Id, machine.UnavailableSince);
+
+            return ids.Count;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[MachineCleanup] Failed to delete {Count} unavailable target(s) — leaving them in place.", ids.Count);
+            return 0;
+        }
+    }
+
+    private async Task<Message.Models.Deployments.Machine.MachineCleanupPolicyDto> LoadCleanupPolicyAsync(int policyId, CancellationToken cancellationToken)
+    {
+        var policy = await policyDataProvider.GetByIdAsync(policyId, cancellationToken).ConfigureAwait(false);
+
+        return policy == null ? null : MachinePolicyService.ToDto(policy).MachineCleanupPolicy;
+    }
+}

--- a/src/Squid.Core/Services/Machines/MachineHealthCheckService.cs
+++ b/src/Squid.Core/Services/Machines/MachineHealthCheckService.cs
@@ -207,11 +207,25 @@ public class MachineHealthCheckService : IMachineHealthCheckService
 
     private async Task RecordHealthStatusAsync(Machine machine, MachineHealthStatus status, string detail, CancellationToken cancellationToken)
     {
+        var now = DateTimeOffset.UtcNow;
+
+        machine.UnavailableSince = ResolveUnavailableSince(machine.HealthStatus, machine.UnavailableSince, status, now);
         machine.HealthStatus = status;
-        machine.HealthLastChecked = DateTimeOffset.UtcNow;
+        machine.HealthLastChecked = now;
         machine.HealthDetail = detail;
 
         await _machineDataProvider.UpdateMachineAsync(machine, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    // Track the FIRST instant a machine became Unavailable: stamp it on entry,
+    // preserve it while the machine stays Unavailable, clear it once the machine
+    // recovers to any non-Unavailable status. Pure so the transition is
+    // unit-testable and the cleanup grace period measures continuous downtime.
+    internal static DateTimeOffset? ResolveUnavailableSince(MachineHealthStatus previous, DateTimeOffset? previousUnavailableSince, MachineHealthStatus next, DateTimeOffset now)
+    {
+        if (next != MachineHealthStatus.Unavailable) return null;
+
+        return previous == MachineHealthStatus.Unavailable ? previousUnavailableSince : now;
     }
 
     private Task RecordUnavailableAsync(Machine machine, string detail, CancellationToken cancellationToken)

--- a/src/Squid.Message/Commands/Machine/EnforceMachineCleanupCommand.cs
+++ b/src/Squid.Message/Commands/Machine/EnforceMachineCleanupCommand.cs
@@ -1,0 +1,28 @@
+using Squid.Message.Response;
+
+namespace Squid.Message.Commands.Machine;
+
+/// <summary>
+/// System-triggered (recurring job) sweep that enforces each machine policy's
+/// "delete unavailable deployment targets after N" cleanup behaviour. Not exposed
+/// via a controller — runs cross-space under the internal service identity, so it
+/// carries no permission attribute or space scope.
+/// </summary>
+public class EnforceMachineCleanupCommand : ICommand
+{
+}
+
+public class EnforceMachineCleanupResponse : SquidResponse<EnforceMachineCleanupResponseData>
+{
+}
+
+public class EnforceMachineCleanupResponseData
+{
+    public string Mode { get; set; }
+
+    public int Scanned { get; set; }
+
+    public int Eligible { get; set; }
+
+    public int Deleted { get; set; }
+}

--- a/tests/Squid.IntegrationTests/Services/Machines/MachineCleanupServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Machines/MachineCleanupServiceTests.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Machines;
+using Squid.Core.Services.Machines.Cleanup;
+using Squid.IntegrationTests.Base;
+using Squid.Message.Enums;
+using Squid.Message.Hardening;
+using Squid.Message.Models.Deployments.Machine;
+
+namespace Squid.IntegrationTests.Services.Machines;
+
+/// <summary>
+/// Integration coverage for machine-policy cleanup enforcement against a real
+/// Postgres DB. Verifies the three-mode gate end-to-end: off skips, warn is a
+/// dry run (the eligible machine survives), strict actually deletes it through the
+/// real <c>IMachineService</c> path. Also pins the per-policy eligibility gates
+/// (DoNotDelete, within-grace, unknown go-bad instant) against the live DB, and the
+/// UnavailableSince column round-trip.
+///
+/// <para>Env var is process-global; this class runs serially (xUnit doesn't
+/// parallelise within a class) and each test restores the prior value.</para>
+/// </summary>
+public class MachineCleanupServiceTests : TestBase
+{
+    private static readonly JsonSerializerOptions PolicyJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public MachineCleanupServiceTests() : base("MachineCleanup", "squid_it_machine_cleanup")
+    {
+    }
+
+    [Fact]
+    public async Task StrictMode_EligibleMachine_IsDeleted()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: DateTimeOffset.UtcNow.AddDays(-7)).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("strict").ConfigureAwait(false);
+
+        outcome.Deleted.ShouldBe(1);
+        outcome.Eligible.ShouldBe(1);
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "Strict mode must delete an eligible long-unavailable target via the real delete path.");
+    }
+
+    [Fact]
+    public async Task WarnMode_EligibleMachine_IsReportedButNotDeleted()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: DateTimeOffset.UtcNow.AddDays(-7)).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("warn").ConfigureAwait(false);
+
+        outcome.Eligible.ShouldBe(1);
+        outcome.Deleted.ShouldBe(0,
+            customMessage: "Warn mode is a dry run — it must report eligibility but delete nothing (non-breaking default).");
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task OffMode_SkipsSweepEntirely()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: DateTimeOffset.UtcNow.AddDays(-7)).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("off").ConfigureAwait(false);
+
+        outcome.Scanned.ShouldBe(0);
+        outcome.Deleted.ShouldBe(0);
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DoNotDeletePolicy_StrictMode_KeepsMachine()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DoNotDelete, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: DateTimeOffset.UtcNow.AddDays(-30)).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("strict").ConfigureAwait(false);
+
+        outcome.Eligible.ShouldBe(0);
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A DoNotDelete policy must never make a machine eligible, even in strict mode.");
+    }
+
+    [Fact]
+    public async Task WithinGracePeriod_StrictMode_KeepsMachine()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: DateTimeOffset.UtcNow.AddHours(-1)).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("strict").ConfigureAwait(false);
+
+        outcome.Eligible.ShouldBe(0);
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UnknownGoBadInstant_StrictMode_KeepsMachine()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: null).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("strict").ConfigureAwait(false);
+
+        outcome.Eligible.ShouldBe(0);
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A null UnavailableSince means unknown downtime duration — never eligible.");
+    }
+
+    [Fact]
+    public async Task HealthyMachine_StrictMode_KeepsMachine()
+    {
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400,
+            status: MachineHealthStatus.Healthy, unavailableSince: null).ConfigureAwait(false);
+
+        var outcome = await EnforceAsync("strict").ConfigureAwait(false);
+
+        outcome.Eligible.ShouldBe(0);
+        (await MachineExistsAsync(machineId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UnavailableSince_RoundTripsThroughDb()
+    {
+        var since = new DateTimeOffset(2026, 5, 20, 8, 0, 0, TimeSpan.Zero);
+
+        var machineId = await SeedMachineAsync(DeleteMachinesBehavior.DoNotDelete, afterSeconds: 86400,
+            status: MachineHealthStatus.Unavailable, unavailableSince: since).ConfigureAwait(false);
+
+        var loaded = await Run<IMachineDataProvider, Machine>(p => p.GetMachinesByIdAsync(machineId, CancellationToken.None)).ConfigureAwait(false);
+
+        loaded.ShouldNotBeNull();
+        loaded.UnavailableSince.ShouldBe(since);
+    }
+
+    // ── helpers ──
+
+    private Task<MachineCleanupOutcome> EnforceAsync(string mode)
+    {
+        var original = System.Environment.GetEnvironmentVariable(MachineCleanupEnforcement.EnvVar);
+        System.Environment.SetEnvironmentVariable(MachineCleanupEnforcement.EnvVar, mode);
+
+        return Run<IMachineCleanupService, MachineCleanupOutcome>(async svc =>
+        {
+            try
+            {
+                return await svc.EnforceCleanupAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable(MachineCleanupEnforcement.EnvVar, original);
+            }
+        });
+    }
+
+    private async Task<int> SeedMachineAsync(DeleteMachinesBehavior behavior, int afterSeconds, MachineHealthStatus status, DateTimeOffset? unavailableSince)
+    {
+        var machineId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var cleanupJson = JsonSerializer.Serialize(new MachineCleanupPolicyDto
+            {
+                DeleteMachinesBehavior = behavior,
+                DeleteMachinesAfterSeconds = afterSeconds
+            }, PolicyJson);
+
+            var policy = new MachinePolicy
+            {
+                SpaceId = 1,
+                Name = $"cleanup-policy-{Guid.NewGuid():N}",
+                Description = "integration test policy",
+                IsDefault = false,
+                MachineCleanupPolicy = cleanupJson,
+                MachineHealthCheckPolicy = "{}",
+                MachineConnectivityPolicy = "{}",
+                MachineUpdatePolicy = "{}",
+                MachineRpcCallRetryPolicy = "{}",
+                PollingRequestQueueTimeout = "00:10:00",
+                ConnectionRetrySleepInterval = "00:00:01",
+                ConnectionRetryTimeLimit = "00:05:00",
+                ConnectionConnectTimeout = "00:01:00"
+            };
+            await repo.InsertAsync(policy, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            var machine = new Machine
+            {
+                Name = $"cleanup-target-{Guid.NewGuid():N}",
+                IsDisabled = false,
+                Roles = "[]",
+                EnvironmentIds = "[]",
+                MachinePolicyId = policy.Id,
+                Endpoint = "{\"CommunicationStyle\":\"KubernetesApi\"}",
+                SpaceId = 1,
+                Slug = $"cleanup-target-{Guid.NewGuid():N}",
+                HealthStatus = status,
+                HealthLastChecked = DateTimeOffset.UtcNow,
+                UnavailableSince = unavailableSince
+            };
+            await repo.InsertAsync(machine, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            machineId = machine.Id;
+        }).ConfigureAwait(false);
+
+        return machineId;
+    }
+
+    private Task<bool> MachineExistsAsync(int machineId)
+        => Run<IMachineDataProvider, bool>(async p => await p.GetMachinesByIdAsync(machineId, CancellationToken.None).ConfigureAwait(false) != null);
+}

--- a/tests/Squid.UnitTests/Services/Machines/Cleanup/MachineCleanupEnforcementTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Cleanup/MachineCleanupEnforcementTests.cs
@@ -1,0 +1,50 @@
+using Squid.Core.Services.Machines.Cleanup;
+using Squid.Message.Hardening;
+
+namespace Squid.UnitTests.Services.Machines.Cleanup;
+
+[CollectionDefinition("MachineCleanupEnforcementEnv", DisableParallelization = true)]
+public class MachineCleanupEnforcementEnvCollection { }
+
+/// <summary>
+/// Pins the operator escape hatch (Rule 8) + the three-mode resolution (Rule 11)
+/// for machine cleanup. Default is <c>Warn</c> (dry-run) so the destructive delete
+/// is opt-in. Shares a serial collection because the env var is process-global.
+/// </summary>
+[Collection("MachineCleanupEnforcementEnv")]
+public class MachineCleanupEnforcementTests
+{
+    [Fact]
+    public void EnvVar_ConstantNamePinned()
+    {
+        // Renaming this breaks every operator who pinned the cleanup mode via env.
+        MachineCleanupEnforcement.EnvVar.ShouldBe("SQUID_MACHINE_CLEANUP_ENFORCEMENT");
+    }
+
+    [Fact]
+    public void Unset_DefaultsToWarn()
+        => WithEnv(null, () => MachineCleanupEnforcement.ResolveMode().ShouldBe(EnforcementMode.Warn));
+
+    [Theory]
+    [InlineData("off", EnforcementMode.Off)]
+    [InlineData("warn", EnforcementMode.Warn)]
+    [InlineData("strict", EnforcementMode.Strict)]
+    [InlineData("STRICT", EnforcementMode.Strict)]
+    [InlineData("garbage", EnforcementMode.Warn)]
+    public void ResolvesMode(string raw, EnforcementMode expected)
+        => WithEnv(raw, () => MachineCleanupEnforcement.ResolveMode().ShouldBe(expected));
+
+    private static void WithEnv(string value, Action body)
+    {
+        var original = Environment.GetEnvironmentVariable(MachineCleanupEnforcement.EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(MachineCleanupEnforcement.EnvVar, value);
+            body();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MachineCleanupEnforcement.EnvVar, original);
+        }
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Cleanup/MachineCleanupEvaluatorTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Cleanup/MachineCleanupEvaluatorTests.cs
@@ -1,0 +1,68 @@
+using Squid.Core.Services.Machines.Cleanup;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Machine;
+
+namespace Squid.UnitTests.Services.Machines.Cleanup;
+
+/// <summary>
+/// Exhaustive matrix for the machine-cleanup eligibility predicate — the single
+/// source of truth for "may this unavailable target be auto-deleted by its policy".
+/// Every guard is pinned independently so a future edit that drops one fails loudly.
+/// </summary>
+public class MachineCleanupEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 30, 12, 0, 0, TimeSpan.Zero);
+
+    private static MachineCleanupPolicyDto Policy(DeleteMachinesBehavior behavior, int afterSeconds = 86400) => new()
+    {
+        DeleteMachinesBehavior = behavior,
+        DeleteMachinesAfterSeconds = afterSeconds
+    };
+
+    [Fact]
+    public void NullPolicy_NotEligible()
+        => MachineCleanupEvaluator.IsEligible(null, MachineHealthStatus.Unavailable, Now.AddDays(-30), Now).ShouldBeFalse();
+
+    [Fact]
+    public void DoNotDelete_EvenWhenLongUnavailable_NotEligible()
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DoNotDelete), MachineHealthStatus.Unavailable, Now.AddDays(-30), Now)
+            .ShouldBeFalse();
+
+    [Theory]
+    [InlineData(MachineHealthStatus.Healthy)]
+    [InlineData(MachineHealthStatus.Unknown)]
+    [InlineData(MachineHealthStatus.HasWarnings)]
+    [InlineData(MachineHealthStatus.Unhealthy)]
+    public void NotUnavailable_NotEligible(MachineHealthStatus status)
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DeleteUnavailableMachines), status, Now.AddDays(-30), Now)
+            .ShouldBeFalse();
+
+    [Fact]
+    public void UnknownGoBadInstant_NotEligible()
+        // We refuse to delete a target whose continuous-downtime duration we can't prove.
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DeleteUnavailableMachines), MachineHealthStatus.Unavailable, unavailableSince: null, Now)
+            .ShouldBeFalse();
+
+    [Fact]
+    public void WithinGracePeriod_NotEligible()
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400), MachineHealthStatus.Unavailable, Now.AddHours(-1), Now)
+            .ShouldBeFalse();
+
+    [Fact]
+    public void ExactlyAtGraceBoundary_Eligible()
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 3600), MachineHealthStatus.Unavailable, Now.AddSeconds(-3600), Now)
+            .ShouldBeTrue();
+
+    [Fact]
+    public void PastGracePeriod_Eligible()
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds: 86400), MachineHealthStatus.Unavailable, Now.AddDays(-7), Now)
+            .ShouldBeTrue();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void NonPositiveGrace_NotEligible(int afterSeconds)
+        // Misconfigured grace period must never collapse into "delete immediately".
+        => MachineCleanupEvaluator.IsEligible(Policy(DeleteMachinesBehavior.DeleteUnavailableMachines, afterSeconds), MachineHealthStatus.Unavailable, Now.AddDays(-30), Now)
+            .ShouldBeFalse();
+}

--- a/tests/Squid.UnitTests/Services/Machines/MachineUnavailableSinceTransitionTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineUnavailableSinceTransitionTests.cs
@@ -1,0 +1,44 @@
+using Squid.Core.Services.Machines;
+using Squid.Message.Enums;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// Pins the UnavailableSince transition (drives the cleanup grace period): stamp on
+/// entry to Unavailable, preserve while it stays Unavailable, clear on any recovery.
+/// </summary>
+public class MachineUnavailableSinceTransitionTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 30, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Earlier = Now.AddDays(-3);
+
+    [Theory]
+    [InlineData(MachineHealthStatus.Unknown)]
+    [InlineData(MachineHealthStatus.Healthy)]
+    [InlineData(MachineHealthStatus.HasWarnings)]
+    [InlineData(MachineHealthStatus.Unhealthy)]
+    public void EnteringUnavailable_StampsNow(MachineHealthStatus previous)
+        => MachineHealthCheckService.ResolveUnavailableSince(previous, previousUnavailableSince: null, MachineHealthStatus.Unavailable, Now)
+            .ShouldBe(Now);
+
+    [Fact]
+    public void StayingUnavailable_PreservesOriginalInstant()
+        => MachineHealthCheckService.ResolveUnavailableSince(MachineHealthStatus.Unavailable, Earlier, MachineHealthStatus.Unavailable, Now)
+            .ShouldBe(Earlier);
+
+    [Fact]
+    public void StayingUnavailable_WithNullOrigin_StaysNull()
+        // A machine that was already Unavailable before the column existed keeps a null
+        // origin (and so stays cleanup-ineligible) until it recovers and goes bad again.
+        => MachineHealthCheckService.ResolveUnavailableSince(MachineHealthStatus.Unavailable, previousUnavailableSince: null, MachineHealthStatus.Unavailable, Now)
+            .ShouldBeNull();
+
+    [Theory]
+    [InlineData(MachineHealthStatus.Healthy)]
+    [InlineData(MachineHealthStatus.Unknown)]
+    [InlineData(MachineHealthStatus.HasWarnings)]
+    [InlineData(MachineHealthStatus.Unhealthy)]
+    public void Recovering_ClearsInstant(MachineHealthStatus next)
+        => MachineHealthCheckService.ResolveUnavailableSince(MachineHealthStatus.Unavailable, Earlier, next, Now)
+            .ShouldBeNull();
+}


### PR DESCRIPTION
## Summary

First of the Machine Policy enforcement series: the policy's **"Clean up — delete unavailable deployment targets after N"** setting was stored and shown in the UI but **never consumed** (`DeleteMachinesBehavior` / `DeleteMachinesAfterSeconds` had zero runtime effect). This wires it.

**Safe-by-default — a deliberate double opt-in for a destructive operation:**
- **Per policy**: `DeleteMachinesBehavior` must be `DeleteUnavailableMachines` (default `DoNotDelete` → never eligible) AND the target must have been continuously unavailable for the configured grace period.
- **Globally** (Rule 11 three-mode): `SQUID_MACHINE_CLEANUP_ENFORCEMENT` — default **`warn` = dry-run** (logs what *would* be deleted, deletes nothing), `off` skips, `strict` actually deletes. So the default build behaviour is unchanged (no auto-deletion); a removal requires opting in twice.

To measure continuous downtime, `Machine` gains a nullable `UnavailableSince` — stamped on first entry to `Unavailable`, preserved while it stays unavailable, cleared on recovery (additive migration; pre-existing rows are `NULL` and never eligible until their next unavailable transition). Eligible machines are removed through the **same `IMachineService.DeleteMachinesAsync` path** the operator-facing delete uses (Halibut trust reconfigured identically). A daily recurring job dispatches the sweep via mediator (Rule 14/16).

## Why non-breaking

- New nullable column (additive DbUp migration); pre-existing machines `NULL`.
- New files + additive `UnavailableSince` tracking in the health-record path; no public surface removed/changed.
- Default per-policy `DoNotDelete` + default global `warn` (dry-run) ⇒ **zero machines deleted by default**.
- No enum/wire/contract changes; no Octopus wording.

## Test plan

- [x] Unit — eligibility matrix (`MachineCleanupEvaluator`: DoNotDelete, non-unavailable, null go-bad instant, within/at/past grace, non-positive grace), env-var pin + three-mode resolution, `UnavailableSince` transition function. (29 tests)
- [x] Integration (real Postgres) — off/warn/strict end-to-end, DoNotDelete/within-grace/null-instant/healthy keep the machine, strict deletes via the real path, `UnavailableSince` DB round-trip. (8 tests)
- [x] Full unit sweep 5718 passed; full integration 293 passed (2 pre-existing Redis-env failures unrelated, green in CI); full solution build 0 errors.