### PR TITLE
Honor MachineConnectivityBehavior during health checks

### DIFF
--- a/src/Squid.Core/Services/Machines/MachineConnectivityEvaluator.cs
+++ b/src/Squid.Core/Services/Machines/MachineConnectivityEvaluator.cs
@@ -1,0 +1,20 @@
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Machine;
+
+namespace Squid.Core.Services.Machines;
+
+/// <summary>
+/// Single source of truth for the machine-policy <c>MachineConnectivityBehavior</c>
+/// during health checks. Pure + deterministic so it can be unit-tested exhaustively.
+///
+/// <para><see cref="MachineConnectivityBehavior.ExpectedToBeOnline"/> (default, and the
+/// value when no policy is assigned) means an unreachable agent is a genuine
+/// health-check failure — today's behaviour. <see cref="MachineConnectivityBehavior.MayBeOfflineAndCanBeSkipped"/>
+/// means an unreachable agent is expected and reported as <i>tolerated</i> rather than
+/// a hard failure (for elastic / transient targets that legitimately scale to zero).</para>
+/// </summary>
+public static class MachineConnectivityEvaluator
+{
+    public static bool AllowsOffline(MachineConnectivityPolicyDto connectivityPolicy)
+        => connectivityPolicy?.MachineConnectivityBehavior == MachineConnectivityBehavior.MayBeOfflineAndCanBeSkipped;
+}

--- a/src/Squid.Core/Services/Machines/MachineHealthCheckService.cs
+++ b/src/Squid.Core/Services/Machines/MachineHealthCheckService.cs
@@ -111,11 +111,24 @@ public class MachineHealthCheckService : IMachineHealthCheckService
         {
             Successful = probeResult.Healthy,
             Detail = probeResult.Detail ?? string.Empty,
-            ErrorCode = probeResult.Healthy ? null : ManualHealthCheckErrorCodes.AgentUnreachable,
+            ErrorCode = ResolveUnreachableErrorCode(probeResult.Healthy, connectivityPolicy),
             AgentVersion = caps?.AgentVersion ?? string.Empty,
             Os = caps?.Os ?? string.Empty,
             CheckedAt = checkedAt
         };
+    }
+
+    // A reachable probe has no error code. An unreachable one is a hard
+    // agent_unreachable unless the machine policy's connectivity behaviour tolerates
+    // offline targets (MayBeOfflineAndCanBeSkipped), in which case it is reported as
+    // the benign offline_tolerated. Default / no policy → agent_unreachable (unchanged).
+    private static string ResolveUnreachableErrorCode(bool healthy, MachineConnectivityPolicyDto connectivityPolicy)
+    {
+        if (healthy) return null;
+
+        return MachineConnectivityEvaluator.AllowsOffline(connectivityPolicy)
+            ? ManualHealthCheckErrorCodes.OfflineTolerated
+            : ManualHealthCheckErrorCodes.AgentUnreachable;
     }
 
     public async Task AutoHealthCheckForAllAsync(CancellationToken cancellationToken = default)

--- a/src/Squid.Message/Models/Machines/ManualHealthCheckResult.cs
+++ b/src/Squid.Message/Models/Machines/ManualHealthCheckResult.cs
@@ -61,4 +61,9 @@ public static class ManualHealthCheckErrorCodes
     public const string MachineDisabled = "machine_disabled";
     public const string NoHealthChecker = "no_health_checker";
     public const string AgentUnreachable = "agent_unreachable";
+
+    /// <summary>Agent unreachable, but the machine policy's connectivity behaviour is
+    /// <c>MayBeOfflineAndCanBeSkipped</c> — the offline state is expected and reported as
+    /// tolerated, so the FE can render a benign "offline (expected)" rather than a hard error.</summary>
+    public const string OfflineTolerated = "offline_tolerated";
 }

--- a/tests/Squid.UnitTests/Services/Machines/MachineConnectivityEvaluatorTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineConnectivityEvaluatorTests.cs
@@ -1,0 +1,38 @@
+using Squid.Core.Services.Machines;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Machine;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// Pins the machine-policy connectivity-behaviour predicate that decides whether an
+/// unreachable agent is tolerated during a health check. Default / null /
+/// ExpectedToBeOnline = not tolerated (today's behaviour); only the explicit
+/// MayBeOfflineAndCanBeSkipped opts in.
+/// </summary>
+public class MachineConnectivityEvaluatorTests
+{
+    [Fact]
+    public void NullPolicy_DoesNotAllowOffline()
+        => MachineConnectivityEvaluator.AllowsOffline(null).ShouldBeFalse();
+
+    [Fact]
+    public void ExpectedToBeOnline_DoesNotAllowOffline()
+        => MachineConnectivityEvaluator.AllowsOffline(new MachineConnectivityPolicyDto
+        {
+            MachineConnectivityBehavior = MachineConnectivityBehavior.ExpectedToBeOnline
+        }).ShouldBeFalse();
+
+    [Fact]
+    public void MayBeOfflineAndCanBeSkipped_AllowsOffline()
+        => MachineConnectivityEvaluator.AllowsOffline(new MachineConnectivityPolicyDto
+        {
+            MachineConnectivityBehavior = MachineConnectivityBehavior.MayBeOfflineAndCanBeSkipped
+        }).ShouldBeTrue();
+
+    [Fact]
+    public void DefaultConstructedPolicy_DoesNotAllowOffline()
+        // A freshly-constructed DTO defaults to ExpectedToBeOnline (enum 0) — the
+        // non-breaking default that mirrors today's "offline = failure" behaviour.
+        => MachineConnectivityEvaluator.AllowsOffline(new MachineConnectivityPolicyDto()).ShouldBeFalse();
+}

--- a/tests/Squid.UnitTests/Services/Machines/MachineHealthCheckServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineHealthCheckServiceTests.cs
@@ -215,6 +215,41 @@ public class MachineHealthCheckServiceTests
     }
 
     [Fact]
+    public async Task ManualHealthCheck_ProbeFails_ExpectedToBeOnline_ReturnsAgentUnreachable()
+    {
+        // Default machine-policy connectivity behaviour: an offline agent is a genuine
+        // failure (today's behaviour, preserved).
+        _healthChecker.Setup(h => h.CheckHealthAsync(It.IsAny<Machine>(), It.IsAny<MachineConnectivityPolicyDto>(), It.IsAny<CancellationToken>(), It.IsAny<MachineHealthCheckPolicyDto>()))
+            .ReturnsAsync(new HealthCheckResult(false, "connection refused"));
+
+        var machine = CreateActiveMachineWithEndpoint(CommunicationStyle.KubernetesApi, machinePolicyId: 1);
+        SetupMachineById(machine);
+        SetupConnectivityPolicy(1, MachineConnectivityBehavior.ExpectedToBeOnline);
+
+        var result = await _service.ManualHealthCheckAsync(machine.Id);
+
+        result.ErrorCode.ShouldBe(ManualHealthCheckErrorCodes.AgentUnreachable);
+    }
+
+    [Fact]
+    public async Task ManualHealthCheck_ProbeFails_MayBeOffline_ReturnsOfflineTolerated()
+    {
+        // MayBeOfflineAndCanBeSkipped: an offline agent is expected (elastic / transient
+        // target) — reported as the benign offline_tolerated, not a hard failure.
+        _healthChecker.Setup(h => h.CheckHealthAsync(It.IsAny<Machine>(), It.IsAny<MachineConnectivityPolicyDto>(), It.IsAny<CancellationToken>(), It.IsAny<MachineHealthCheckPolicyDto>()))
+            .ReturnsAsync(new HealthCheckResult(false, "connection refused"));
+
+        var machine = CreateActiveMachineWithEndpoint(CommunicationStyle.KubernetesApi, machinePolicyId: 1);
+        SetupMachineById(machine);
+        SetupConnectivityPolicy(1, MachineConnectivityBehavior.MayBeOfflineAndCanBeSkipped);
+
+        var result = await _service.ManualHealthCheckAsync(machine.Id);
+
+        result.ErrorCode.ShouldBe(ManualHealthCheckErrorCodes.OfflineTolerated,
+            customMessage: "MayBeOfflineAndCanBeSkipped MUST report the benign offline_tolerated so the FE renders 'offline (expected)' rather than a hard agent_unreachable error.");
+    }
+
+    [Fact]
     public async Task RunHealthCheck_NoTransport_RecordsUnavailable()
     {
         _transportRegistry.Setup(r => r.Resolve(It.IsAny<CommunicationStyle>())).Returns((IDeploymentTransport)null);
@@ -572,5 +607,14 @@ public class MachineHealthCheckServiceTests
 
         _policyDataProvider.Setup(p => p.GetByIdAsync(policyId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MachinePolicy { Id = policyId, MachineHealthCheckPolicy = policyJson });
+    }
+
+    private void SetupConnectivityPolicy(int policyId, MachineConnectivityBehavior behavior)
+    {
+        var connectivity = new MachineConnectivityPolicyDto { MachineConnectivityBehavior = behavior };
+        var policyJson = JsonSerializer.Serialize(connectivity, JsonOptions);
+
+        _policyDataProvider.Setup(p => p.GetByIdAsync(policyId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MachinePolicy { Id = policyId, MachineConnectivityPolicy = policyJson });
     }
 }

--- a/tests/Squid.UnitTests/Services/Machines/ManualHealthCheckErrorCodesIntegrityTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/ManualHealthCheckErrorCodesIntegrityTests.cs
@@ -34,6 +34,10 @@ public sealed class ManualHealthCheckErrorCodesIntegrityTests
         => ManualHealthCheckErrorCodes.AgentUnreachable.ShouldBe("agent_unreachable");
 
     [Fact]
+    public void OfflineTolerated_LiteralPinned()
+        => ManualHealthCheckErrorCodes.OfflineTolerated.ShouldBe("offline_tolerated");
+
+    [Fact]
     public void AllCodes_LowerSnakeCase_StableConvention()
     {
         // Convention: lower_snake_case so consumers can split-on-underscore +
@@ -44,7 +48,8 @@ public sealed class ManualHealthCheckErrorCodesIntegrityTests
             ManualHealthCheckErrorCodes.MachineNotFound,
             ManualHealthCheckErrorCodes.MachineDisabled,
             ManualHealthCheckErrorCodes.NoHealthChecker,
-            ManualHealthCheckErrorCodes.AgentUnreachable
+            ManualHealthCheckErrorCodes.AgentUnreachable,
+            ManualHealthCheckErrorCodes.OfflineTolerated
         };
 
         foreach (var code in codes)


### PR DESCRIPTION
## Summary

Item 2 of the Machine Policy enforcement series. The machine policy's `MachineConnectivityBehavior` was stored + shown in the UI but **never consumed** — an unreachable agent always reported `agent_unreachable` regardless of the policy.

This wires it into the manual health-check result (the generic seam in `MachineHealthCheckService`, so **all transports** benefit identically):
- `MayBeOfflineAndCanBeSkipped` → an unreachable agent is the benign **`offline_tolerated`** (for elastic / transient targets that legitimately scale to zero).
- `ExpectedToBeOnline` (default, and when no policy is assigned) → keeps the hard **`agent_unreachable`**.

This matches how Octopus splits the concern: the machine policy governs **health-check tolerance** only; deploy-time skip of unavailable/unhealthy targets is a separate project-level setting (next item).

## Why non-breaking

- Default `ExpectedToBeOnline` ⇒ error code unchanged out of the box.
- `offline_tolerated` is a **new additive** wire literal (pinned in the integrity test); no existing literal renamed.
- No schema / migration / interface changes. Logic is a pure `MachineConnectivityEvaluator` consumed by the service.
- No Octopus wording in code/literals.

## Test plan

- [x] Unit — `MachineConnectivityEvaluator` (null / ExpectedToBeOnline / MayBeOffline / default-ctor).
- [x] Unit — `MachineHealthCheckService`: probe-fails + ExpectedToBeOnline → `agent_unreachable`; probe-fails + MayBeOffline → `offline_tolerated`; existing no-policy probe-fails → `agent_unreachable` unchanged.
- [x] Unit — `offline_tolerated` literal pinned + lower-snake-case convention.
- [x] Full solution build 0 errors; full unit sweep 5718 passed.

_No integration tier: this is an in-service error-code resolution with no new persistence (mirrors the existing `agent_unreachable` unit coverage)._