### PR TITLE
Add project Transient Deployment Targets deployment setting

### DIFF
--- a/src/Squid.Api/Controllers/ProjectController.cs
+++ b/src/Squid.Api/Controllers/ProjectController.cs
@@ -60,6 +60,26 @@ public class ProjectController : ControllerBase
         return Ok(response);
     }
 
+    [HttpGet("{id:int}/deployment-settings")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GetDeploymentSettingsResponse))]
+    public async Task<IActionResult> GetDeploymentSettingsAsync(int id)
+    {
+        var request = new GetDeploymentSettingsRequest { ProjectId = id };
+        var response = await _mediator.RequestAsync<GetDeploymentSettingsRequest, GetDeploymentSettingsResponse>(request).ConfigureAwait(false);
+
+        return Ok(response);
+    }
+
+    [HttpPost("{id:int}/deployment-settings")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SaveDeploymentSettingsResponse))]
+    public async Task<IActionResult> SaveDeploymentSettingsAsync(int id, [FromBody] SaveDeploymentSettingsCommand command)
+    {
+        command.ProjectId = id;
+        var response = await _mediator.SendAsync<SaveDeploymentSettingsCommand, SaveDeploymentSettingsResponse>(command).ConfigureAwait(false);
+
+        return Ok(response);
+    }
+
     [HttpGet("summaries")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GetProjectSummariesResponse))]
     public async Task<IActionResult> GetProjectSummariesAsync([FromQuery] GetProjectSummariesRequest request)

--- a/src/Squid.Core/Handlers/CommandHandlers/Deployments/Project/SaveDeploymentSettingsCommandHandler.cs
+++ b/src/Squid.Core/Handlers/CommandHandlers/Deployments/Project/SaveDeploymentSettingsCommandHandler.cs
@@ -1,0 +1,15 @@
+using Squid.Core.Services.Deployments.Project;
+using Squid.Message.Commands.Deployments.Project;
+
+namespace Squid.Core.Handlers.CommandHandlers.Deployments.Project;
+
+public class SaveDeploymentSettingsCommandHandler(IProjectDeploymentSettingsService deploymentSettingsService)
+    : ICommandHandler<SaveDeploymentSettingsCommand, SaveDeploymentSettingsResponse>
+{
+    public async Task<SaveDeploymentSettingsResponse> Handle(IReceiveContext<SaveDeploymentSettingsCommand> context, CancellationToken cancellationToken)
+    {
+        var saved = await deploymentSettingsService.SaveAsync(context.Message.ProjectId, context.Message.DeploymentSettings, cancellationToken).ConfigureAwait(false);
+
+        return new SaveDeploymentSettingsResponse { Data = saved };
+    }
+}

--- a/src/Squid.Core/Handlers/RequestHandlers/Deployments/Project/GetDeploymentSettingsRequestHandler.cs
+++ b/src/Squid.Core/Handlers/RequestHandlers/Deployments/Project/GetDeploymentSettingsRequestHandler.cs
@@ -1,0 +1,15 @@
+using Squid.Core.Services.Deployments.Project;
+using Squid.Message.Requests.Deployments.Project;
+
+namespace Squid.Core.Handlers.RequestHandlers.Deployments.Project;
+
+public class GetDeploymentSettingsRequestHandler(IProjectDeploymentSettingsService deploymentSettingsService)
+    : IRequestHandler<GetDeploymentSettingsRequest, GetDeploymentSettingsResponse>
+{
+    public async Task<GetDeploymentSettingsResponse> Handle(IReceiveContext<GetDeploymentSettingsRequest> context, CancellationToken cancellationToken)
+    {
+        var settings = await deploymentSettingsService.GetAsync(context.Message.ProjectId, cancellationToken).ConfigureAwait(false);
+
+        return new GetDeploymentSettingsResponse { Data = settings };
+    }
+}

--- a/src/Squid.Core/Persistence/DbUpFiles/20260530_add_project_deployment_settings.sql
+++ b/src/Squid.Core/Persistence/DbUpFiles/20260530_add_project_deployment_settings.sql
@@ -1,0 +1,7 @@
+-- Project-level deployment settings (DeploymentSettingsDto) as a JSON blob — the
+-- "Transient Deployment Targets" behaviour today, room to grow without a per-setting
+-- migration. NULL = all defaults, which preserve today's runtime behaviour (unavailable
+-- targets skipped, unhealthy targets excluded). Pre-existing projects get NULL.
+
+ALTER TABLE project
+    ADD COLUMN deployment_settings_json jsonb NULL;

--- a/src/Squid.Core/Persistence/Entities/Deployments/Project.cs
+++ b/src/Squid.Core/Persistence/Entities/Deployments/Project.cs
@@ -25,6 +25,11 @@ public class Project : IEntity<int>, IAuditable
 
     public string Json { get; set; }
 
+    // Project-level deployment settings (DeploymentSettingsDto) as JSON. NULL means
+    // "all defaults", which preserve today's runtime behaviour. Currently carries the
+    // transient-target behaviour; the blob can grow without a per-setting migration.
+    public string DeploymentSettingsJson { get; set; }
+
     public string IncludedLibraryVariableSetIds { get; set; }
 
     public List<int> GetIncludedLibraryVariableSetIdList()

--- a/src/Squid.Core/Persistence/EntityConfigurations/ProjectConfiguration.cs
+++ b/src/Squid.Core/Persistence/EntityConfigurations/ProjectConfiguration.cs
@@ -10,5 +10,9 @@ public class ProjectConfiguration: IEntityTypeConfiguration<Project>
 
         builder.HasKey(p => p.Id);
         builder.Property(p => p.Id).ValueGeneratedOnAdd();
+
+        // Stored as jsonb (see 20260530_add_project_deployment_settings.sql); map the
+        // string property accordingly so Npgsql writes jsonb rather than text.
+        builder.Property(p => p.DeploymentSettingsJson).HasColumnType("jsonb");
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
@@ -1,0 +1,68 @@
+using Squid.Message.Enums;
+using Squid.Message.Enums.Deployments;
+using Machine = Squid.Core.Persistence.Entities.Deployments.Machine;
+
+namespace Squid.Core.Services.DeploymentExecution.Filtering;
+
+/// <summary>
+/// Outcome of applying a project's "Transient Deployment Targets" setting to the
+/// candidate targets. <see cref="Kept"/> proceed; <see cref="Skipped"/> are removed
+/// from the deployment (unhealthy-excluded and/or unavailable-skipped) and announced;
+/// <see cref="FailedUnavailable"/> are unavailable targets whose policy is
+/// <see cref="UnavailableDeploymentTargetBehavior.FailDeployment"/> — a non-empty list
+/// means the caller must fail the deployment.
+/// </summary>
+public sealed record TransientTargetResult(
+    List<Machine> Kept,
+    List<Machine> Skipped,
+    List<Machine> FailedUnavailable);
+
+/// <summary>
+/// Single source of truth for the project "Transient Deployment Targets" behaviour.
+/// Pure + deterministic so it can be unit-tested exhaustively.
+///
+/// <para>Defaults (<see cref="UnavailableDeploymentTargetBehavior.SkipAndContinue"/> +
+/// <see cref="UnhealthyDeploymentTargetBehavior.Exclude"/>) reproduce Squid's historical
+/// unconditional exclusion of unavailable + unhealthy targets, so honouring the setting
+/// is non-breaking for projects that haven't configured it.</para>
+/// </summary>
+public static class TransientDeploymentTargetEvaluator
+{
+    public static TransientTargetResult Apply(
+        IReadOnlyList<Machine> candidates,
+        UnavailableDeploymentTargetBehavior unavailableBehavior,
+        UnhealthyDeploymentTargetBehavior unhealthyBehavior)
+    {
+        var kept = new List<Machine>();
+        var skipped = new List<Machine>();
+        var failedUnavailable = new List<Machine>();
+
+        foreach (var machine in candidates)
+        {
+            switch (machine.HealthStatus)
+            {
+                case MachineHealthStatus.Unavailable when unavailableBehavior == UnavailableDeploymentTargetBehavior.FailDeployment:
+                    failedUnavailable.Add(machine);
+                    break;
+
+                case MachineHealthStatus.Unavailable:
+                    skipped.Add(machine); // SkipAndContinue (default)
+                    break;
+
+                case MachineHealthStatus.Unhealthy when unhealthyBehavior == UnhealthyDeploymentTargetBehavior.DoNotExclude:
+                    kept.Add(machine);
+                    break;
+
+                case MachineHealthStatus.Unhealthy:
+                    skipped.Add(machine); // Exclude (default)
+                    break;
+
+                default:
+                    kept.Add(machine); // Healthy / Unknown / HasWarnings — unchanged
+                    break;
+            }
+        }
+
+        return new TransientTargetResult(kept, skipped, failedUnavailable);
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
@@ -1,5 +1,6 @@
 using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.Deployments.Deployments;
+using Squid.Core.Services.Deployments.Project;
 using Squid.Core.Services.Deployments.Snapshots;
 using Squid.Message.Models.Deployments.Variable;
 using Squid.Core.Services.DeploymentExecution.Variables;
@@ -91,17 +92,36 @@ public sealed class PrepareDeploymentPhase(
     {
         ctx.AllTargets = await targetFinder.FindTargetsAsync(ctx.Deployment, ct).ConfigureAwait(false);
 
-        var (healthy, excludedByHealth) = DeploymentTargetFinder.FilterByHealthStatus(ctx.AllTargets);
-
-        if (excludedByHealth.Count > 0)
-        {
-            ctx.AllTargets = healthy;
-            ctx.ExcludedByHealthTargets = excludedByHealth;
-        }
+        ApplyTransientTargetPolicy(ctx);
 
         if (ctx.AllTargets.Count == 0) throw new DeploymentTargetException($"No target machines found for deployment {ctx.Deployment.Id}", ctx.Deployment.Id);
 
         Log.Information("[Deploy] Found {Count} target machines for deployment {DeploymentId}", ctx.AllTargets.Count, ctx.Deployment.Id);
+    }
+
+    // Honour the project's "Transient Deployment Targets" setting. Defaults
+    // (SkipAndContinue + Exclude) reproduce the historical unconditional exclusion of
+    // unavailable + unhealthy targets, so an unconfigured project behaves exactly as
+    // before. FailDeployment on an unavailable target aborts the deployment up front.
+    internal static void ApplyTransientTargetPolicy(DeploymentTaskContext ctx)
+    {
+        var transient = DeploymentSettingsSerializer.Deserialize(ctx.Project?.DeploymentSettingsJson).TransientDeploymentTargets;
+
+        var result = TransientDeploymentTargetEvaluator.Apply(
+            ctx.AllTargets, transient.UnavailableDeploymentTargets, transient.UnhealthyDeploymentTargets);
+
+        if (result.FailedUnavailable.Count > 0)
+        {
+            var names = string.Join(", ", result.FailedUnavailable.Select(m => m.Name));
+            throw new DeploymentTargetException(
+                $"Deployment {ctx.Deployment.Id} cannot start: {result.FailedUnavailable.Count} deployment target(s) are unavailable and the project's Transient Deployment Targets setting is 'Fail deployment': {names}",
+                ctx.Deployment.Id);
+        }
+
+        ctx.AllTargets = result.Kept;
+
+        if (result.Skipped.Count > 0)
+            ctx.ExcludedByHealthTargets = result.Skipped;
     }
 
     private static void ConvertSnapshotToSteps(DeploymentTaskContext ctx)

--- a/src/Squid.Core/Services/Deployments/Project/DeploymentSettingsSerializer.cs
+++ b/src/Squid.Core/Services/Deployments/Project/DeploymentSettingsSerializer.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Squid.Message.Models.Deployments.Project;
+
+namespace Squid.Core.Services.Deployments.Project;
+
+/// <summary>
+/// Shared (de)serialisation for the project's <see cref="DeploymentSettingsDto"/> JSON
+/// blob. A null / blank / malformed blob deserialises to a default-constructed DTO so
+/// every consumer (the deploy pipeline + the get/save service) sees "all defaults" =
+/// today's behaviour rather than throwing.
+/// </summary>
+public static class DeploymentSettingsSerializer
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public static DeploymentSettingsDto Deserialize(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new DeploymentSettingsDto();
+
+        try
+        {
+            return JsonSerializer.Deserialize<DeploymentSettingsDto>(json, Options) ?? new DeploymentSettingsDto();
+        }
+        catch (JsonException)
+        {
+            return new DeploymentSettingsDto();
+        }
+    }
+
+    public static string Serialize(DeploymentSettingsDto settings)
+        => JsonSerializer.Serialize(settings ?? new DeploymentSettingsDto(), Options);
+}

--- a/src/Squid.Core/Services/Deployments/Project/ProjectDeploymentSettingsService.cs
+++ b/src/Squid.Core/Services/Deployments/Project/ProjectDeploymentSettingsService.cs
@@ -1,0 +1,47 @@
+using Squid.Core.DependencyInjection;
+using Squid.Message.Models.Deployments.Project;
+
+namespace Squid.Core.Services.Deployments.Project;
+
+public interface IProjectDeploymentSettingsService : IScopedDependency
+{
+    Task<DeploymentSettingsDto> GetAsync(int projectId, CancellationToken cancellationToken = default);
+
+    Task<DeploymentSettingsDto> SaveAsync(int projectId, DeploymentSettingsDto settings, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Reads and writes a project's <see cref="DeploymentSettingsDto"/> (persisted on the
+/// project's <c>DeploymentSettingsJson</c> column). The deploy pipeline reads the same
+/// column directly; this service is the operator-facing get/save surface.
+/// </summary>
+public sealed class ProjectDeploymentSettingsService(IProjectDataProvider projectDataProvider) : IProjectDeploymentSettingsService
+{
+    public async Task<DeploymentSettingsDto> GetAsync(int projectId, CancellationToken cancellationToken = default)
+    {
+        var project = await LoadProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
+
+        return DeploymentSettingsSerializer.Deserialize(project.DeploymentSettingsJson);
+    }
+
+    public async Task<DeploymentSettingsDto> SaveAsync(int projectId, DeploymentSettingsDto settings, CancellationToken cancellationToken = default)
+    {
+        var project = await LoadProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
+
+        project.DeploymentSettingsJson = DeploymentSettingsSerializer.Serialize(settings);
+
+        await projectDataProvider.UpdateProjectAsync(project, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return DeploymentSettingsSerializer.Deserialize(project.DeploymentSettingsJson);
+    }
+
+    private async Task<Persistence.Entities.Deployments.Project> LoadProjectAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var project = await projectDataProvider.GetProjectByIdAsync(projectId, cancellationToken).ConfigureAwait(false);
+
+        if (project == null)
+            throw new InvalidOperationException($"Project {projectId} not found");
+
+        return project;
+    }
+}

--- a/src/Squid.Message/Commands/Deployments/Project/SaveDeploymentSettingsCommand.cs
+++ b/src/Squid.Message/Commands/Deployments/Project/SaveDeploymentSettingsCommand.cs
@@ -1,0 +1,18 @@
+using Squid.Message.Attributes;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Project;
+using Squid.Message.Response;
+
+namespace Squid.Message.Commands.Deployments.Project;
+
+[RequiresPermission(Permission.ProjectEdit)]
+public class SaveDeploymentSettingsCommand : ICommand, ISpaceScoped
+{
+    public int? SpaceId { get; set; }
+    public int ProjectId { get; set; }
+    public DeploymentSettingsDto DeploymentSettings { get; set; } = new();
+}
+
+public class SaveDeploymentSettingsResponse : SquidResponse<DeploymentSettingsDto>
+{
+}

--- a/src/Squid.Message/Enums/Deployments/DeploymentSettingsEnums.cs
+++ b/src/Squid.Message/Enums/Deployments/DeploymentSettingsEnums.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Squid.Message.Enums.Deployments;
+
+/// <summary>
+/// What to do when a deployment target is UNAVAILABLE at the start of, or becomes
+/// unavailable during, a deployment. Default (value 0) = <see cref="SkipAndContinue"/>,
+/// which preserves Squid's historical behaviour (unavailable targets are skipped and
+/// removed from the deployment) — so wiring this is non-breaking.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum UnavailableDeploymentTargetBehavior
+{
+    SkipAndContinue = 0,
+    FailDeployment = 1,
+}
+
+/// <summary>
+/// What to do with UNHEALTHY deployment targets at the start of a deployment. Default
+/// (value 0) = <see cref="Exclude"/>, which preserves Squid's historical behaviour
+/// (unhealthy targets are skipped and removed) — so wiring this is non-breaking.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum UnhealthyDeploymentTargetBehavior
+{
+    Exclude = 0,
+    DoNotExclude = 1,
+}

--- a/src/Squid.Message/Models/Deployments/Project/DeploymentSettingsDto.cs
+++ b/src/Squid.Message/Models/Deployments/Project/DeploymentSettingsDto.cs
@@ -1,0 +1,26 @@
+using Squid.Message.Enums.Deployments;
+
+namespace Squid.Message.Models.Deployments.Project;
+
+/// <summary>
+/// Project-level deployment settings. Persisted as a JSON blob on the project so the
+/// shape can grow (release versioning, default failure mode, default package download,
+/// etc.) without a migration per setting. Today it carries the transient-target
+/// behaviour; an absent / null blob means "all defaults", which preserve today's
+/// runtime behaviour.
+/// </summary>
+public class DeploymentSettingsDto
+{
+    public TransientDeploymentTargetsDto TransientDeploymentTargets { get; set; } = new();
+}
+
+/// <summary>
+/// How a deployment treats targets that are unavailable or unhealthy when it starts.
+/// Mirrors the project "Transient Deployment Targets" setting.
+/// </summary>
+public class TransientDeploymentTargetsDto
+{
+    public UnavailableDeploymentTargetBehavior UnavailableDeploymentTargets { get; set; }
+
+    public UnhealthyDeploymentTargetBehavior UnhealthyDeploymentTargets { get; set; }
+}

--- a/src/Squid.Message/Requests/Deployments/Project/GetDeploymentSettingsRequest.cs
+++ b/src/Squid.Message/Requests/Deployments/Project/GetDeploymentSettingsRequest.cs
@@ -1,0 +1,17 @@
+using Squid.Message.Attributes;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Project;
+using Squid.Message.Response;
+
+namespace Squid.Message.Requests.Deployments.Project;
+
+[RequiresPermission(Permission.ProjectView)]
+public class GetDeploymentSettingsRequest : IRequest, ISpaceScoped
+{
+    public int? SpaceId { get; set; }
+    public int ProjectId { get; set; }
+}
+
+public class GetDeploymentSettingsResponse : SquidResponse<DeploymentSettingsDto>
+{
+}

--- a/tests/Squid.IntegrationTests/Services/Deployments/ProjectSettings/ProjectDeploymentSettingsServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/ProjectSettings/ProjectDeploymentSettingsServiceTests.cs
@@ -1,0 +1,83 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.Project;
+using Squid.IntegrationTests.Base;
+using Squid.Message.Enums.Deployments;
+using Squid.Message.Models.Deployments.Project;
+using ProjectEntity = Squid.Core.Persistence.Entities.Deployments.Project;
+
+namespace Squid.IntegrationTests.Services.Deployments.ProjectSettings;
+
+/// <summary>
+/// Integration coverage for project DeploymentSettings persistence against a real
+/// Postgres DB: a project with no settings reads back all-defaults (today's behaviour),
+/// and a saved configuration round-trips through the <c>deployment_settings_json</c> column.
+/// </summary>
+public class ProjectDeploymentSettingsServiceTests : TestBase
+{
+    public ProjectDeploymentSettingsServiceTests() : base("ProjectDeploymentSettings", "squid_it_project_deploy_settings")
+    {
+    }
+
+    [Fact]
+    public async Task Get_NoStoredSettings_ReturnsDefaults()
+    {
+        var projectId = await SeedProjectAsync(deploymentSettingsJson: null).ConfigureAwait(false);
+
+        var settings = await Run<IProjectDeploymentSettingsService, DeploymentSettingsDto>(s => s.GetAsync(projectId)).ConfigureAwait(false);
+
+        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.SkipAndContinue);
+        settings.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.Exclude);
+    }
+
+    [Fact]
+    public async Task Save_ThenGet_RoundTripsThroughDb()
+    {
+        var projectId = await SeedProjectAsync(deploymentSettingsJson: null).ConfigureAwait(false);
+
+        var toSave = new DeploymentSettingsDto
+        {
+            TransientDeploymentTargets = new TransientDeploymentTargetsDto
+            {
+                UnavailableDeploymentTargets = UnavailableDeploymentTargetBehavior.FailDeployment,
+                UnhealthyDeploymentTargets = UnhealthyDeploymentTargetBehavior.DoNotExclude
+            }
+        };
+
+        await Run<IProjectDeploymentSettingsService, DeploymentSettingsDto>(s => s.SaveAsync(projectId, toSave)).ConfigureAwait(false);
+
+        var reloaded = await Run<IProjectDeploymentSettingsService, DeploymentSettingsDto>(s => s.GetAsync(projectId)).ConfigureAwait(false);
+
+        reloaded.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.FailDeployment);
+        reloaded.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.DoNotExclude);
+
+        // The JSON physically persisted to the new column.
+        var project = await Run<IProjectDataProvider, ProjectEntity>(p => p.GetProjectByIdAsync(projectId, CancellationToken.None)).ConfigureAwait(false);
+        project.DeploymentSettingsJson.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    private async Task<int> SeedProjectAsync(string deploymentSettingsJson)
+    {
+        var projectId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var project = new ProjectEntity
+            {
+                Name = $"deploy-settings-proj-{Guid.NewGuid():N}",
+                Slug = $"deploy-settings-proj-{Guid.NewGuid():N}",
+                SpaceId = 1,
+                Json = string.Empty,
+                IncludedLibraryVariableSetIds = "[]",
+                DeploymentSettingsJson = deploymentSettingsJson
+            };
+            await repo.InsertAsync(project, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            projectId = project.Id;
+        }).ConfigureAwait(false);
+
+        return projectId;
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ProjectSettings/DeploymentSettingsSerializerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ProjectSettings/DeploymentSettingsSerializerTests.cs
@@ -1,0 +1,64 @@
+using Squid.Core.Services.Deployments.Project;
+using Squid.Message.Enums.Deployments;
+using Squid.Message.Models.Deployments.Project;
+
+namespace Squid.UnitTests.Services.Deployments.ProjectSettings;
+
+/// <summary>
+/// Pins the project DeploymentSettings (de)serialisation: null / blank / malformed JSON
+/// degrade to "all defaults" (today's behaviour) rather than throwing, and a configured
+/// blob round-trips with enums as stable string values.
+/// </summary>
+public class DeploymentSettingsSerializerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{ not valid json")]
+    public void Deserialize_NullBlankOrMalformed_ReturnsDefaults(string json)
+    {
+        var settings = DeploymentSettingsSerializer.Deserialize(json);
+
+        settings.ShouldNotBeNull();
+        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.SkipAndContinue);
+        settings.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.Exclude);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesConfiguredValues()
+    {
+        var original = new DeploymentSettingsDto
+        {
+            TransientDeploymentTargets = new TransientDeploymentTargetsDto
+            {
+                UnavailableDeploymentTargets = UnavailableDeploymentTargetBehavior.FailDeployment,
+                UnhealthyDeploymentTargets = UnhealthyDeploymentTargetBehavior.DoNotExclude
+            }
+        };
+
+        var restored = DeploymentSettingsSerializer.Deserialize(DeploymentSettingsSerializer.Serialize(original));
+
+        restored.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.FailDeployment);
+        restored.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.DoNotExclude);
+    }
+
+    [Fact]
+    public void Serialize_WritesEnumsAsStableStrings()
+    {
+        var json = DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto
+        {
+            TransientDeploymentTargets = new TransientDeploymentTargetsDto
+            {
+                UnavailableDeploymentTargets = UnavailableDeploymentTargetBehavior.FailDeployment,
+                UnhealthyDeploymentTargets = UnhealthyDeploymentTargetBehavior.DoNotExclude
+            }
+        });
+
+        // String enum values (not numeric) so the blob is human-readable + stable across
+        // enum reordering; camelCase property names for FE/consumer parity.
+        json.ShouldContain("FailDeployment");
+        json.ShouldContain("DoNotExclude");
+        json.ShouldContain("transientDeploymentTargets");
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/PrepareDeploymentPhaseTransientTargetTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/PrepareDeploymentPhaseTransientTargetTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
+using Squid.Core.Services.Deployments.Project;
+using Squid.Message.Enums;
+using Squid.Message.Enums.Deployments;
+using Squid.Message.Models.Deployments.Project;
+using ProjectEntity = Squid.Core.Persistence.Entities.Deployments.Project;
+
+namespace Squid.UnitTests.Services.Deployments.Targets;
+
+/// <summary>
+/// Pins how phase 4 applies the project "Transient Deployment Targets" setting to the
+/// candidate targets: default (no settings) reproduces today's unconditional exclusion;
+/// FailDeployment aborts on an unavailable target; DoNotExclude keeps unhealthy targets.
+/// </summary>
+public class PrepareDeploymentPhaseTransientTargetTests
+{
+    private static Machine M(string name, MachineHealthStatus status) => new() { Name = name, HealthStatus = status };
+
+    private static DeploymentTaskContext Context(string deploymentSettingsJson, params Machine[] targets) => new()
+    {
+        Deployment = new Deployment { Id = 1 },
+        Project = new ProjectEntity { DeploymentSettingsJson = deploymentSettingsJson },
+        AllTargets = targets.ToList()
+    };
+
+    private static string Json(UnavailableDeploymentTargetBehavior unavailable, UnhealthyDeploymentTargetBehavior unhealthy)
+        => DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto
+        {
+            TransientDeploymentTargets = new TransientDeploymentTargetsDto
+            {
+                UnavailableDeploymentTargets = unavailable,
+                UnhealthyDeploymentTargets = unhealthy
+            }
+        });
+
+    [Fact]
+    public void Default_NullSettings_ExcludesUnavailableAndUnhealthy()
+    {
+        var ctx = Context(null,
+            M("healthy", MachineHealthStatus.Healthy),
+            M("unhealthy", MachineHealthStatus.Unhealthy),
+            M("unavailable", MachineHealthStatus.Unavailable));
+
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
+
+        ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy" });
+        ctx.ExcludedByHealthTargets.Select(m => m.Name).ShouldBe(new[] { "unhealthy", "unavailable" });
+    }
+
+    [Fact]
+    public void FailDeployment_UnavailableTarget_Throws()
+    {
+        var ctx = Context(
+            Json(UnavailableDeploymentTargetBehavior.FailDeployment, UnhealthyDeploymentTargetBehavior.Exclude),
+            M("healthy", MachineHealthStatus.Healthy),
+            M("down", MachineHealthStatus.Unavailable));
+
+        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx))
+            .Message.ShouldContain("down");
+    }
+
+    [Fact]
+    public void DoNotExclude_UnhealthyTarget_IsKept()
+    {
+        var ctx = Context(
+            Json(UnavailableDeploymentTargetBehavior.SkipAndContinue, UnhealthyDeploymentTargetBehavior.DoNotExclude),
+            M("healthy", MachineHealthStatus.Healthy),
+            M("sick", MachineHealthStatus.Unhealthy));
+
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
+
+        ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy", "sick" });
+    }
+
+    [Fact]
+    public void SkipAndContinue_UnavailableTarget_IsSkipped()
+    {
+        var ctx = Context(
+            Json(UnavailableDeploymentTargetBehavior.SkipAndContinue, UnhealthyDeploymentTargetBehavior.Exclude),
+            M("healthy", MachineHealthStatus.Healthy),
+            M("down", MachineHealthStatus.Unavailable));
+
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
+
+        ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy" });
+        ctx.ExcludedByHealthTargets.Select(m => m.Name).ShouldBe(new[] { "down" });
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Message.Enums;
+using Squid.Message.Enums.Deployments;
+
+namespace Squid.UnitTests.Services.Deployments.Targets;
+
+/// <summary>
+/// Exhaustive matrix for the project "Transient Deployment Targets" evaluator.
+/// The default behaviours (SkipAndContinue + Exclude) MUST reproduce the historical
+/// unconditional exclusion of unavailable + unhealthy targets, so the wiring is
+/// non-breaking for unconfigured projects.
+/// </summary>
+public class TransientDeploymentTargetEvaluatorTests
+{
+    private static Machine M(string name, MachineHealthStatus status) => new() { Name = name, HealthStatus = status };
+
+    private static TransientTargetResult Apply(IReadOnlyList<Machine> candidates,
+        UnavailableDeploymentTargetBehavior unavailable = UnavailableDeploymentTargetBehavior.SkipAndContinue,
+        UnhealthyDeploymentTargetBehavior unhealthy = UnhealthyDeploymentTargetBehavior.Exclude)
+        => TransientDeploymentTargetEvaluator.Apply(candidates, unavailable, unhealthy);
+
+    [Theory]
+    [InlineData(MachineHealthStatus.Healthy)]
+    [InlineData(MachineHealthStatus.Unknown)]
+    [InlineData(MachineHealthStatus.HasWarnings)]
+    public void Healthyish_AlwaysKept(MachineHealthStatus status)
+    {
+        var result = Apply(new[] { M("m", status) });
+
+        result.Kept.Select(m => m.Name).ShouldBe(new[] { "m" });
+        result.Skipped.ShouldBeEmpty();
+        result.FailedUnavailable.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Defaults_ReproduceHistoricalExclusion()
+    {
+        // SkipAndContinue + Exclude (the defaults) == FilterByHealthStatus: unavailable
+        // + unhealthy are removed (skipped), everything else kept, nothing fails.
+        var machines = new[]
+        {
+            M("healthy", MachineHealthStatus.Healthy),
+            M("unhealthy", MachineHealthStatus.Unhealthy),
+            M("unknown", MachineHealthStatus.Unknown),
+            M("unavailable", MachineHealthStatus.Unavailable),
+            M("warnings", MachineHealthStatus.HasWarnings)
+        };
+
+        var result = Apply(machines);
+
+        result.Kept.Select(m => m.Name).ShouldBe(new[] { "healthy", "unknown", "warnings" });
+        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "unhealthy", "unavailable" });
+        result.FailedUnavailable.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Unavailable_FailDeployment_GoesToFailedList()
+    {
+        var result = Apply(new[] { M("down", MachineHealthStatus.Unavailable) },
+            unavailable: UnavailableDeploymentTargetBehavior.FailDeployment);
+
+        result.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "down" });
+        result.Kept.ShouldBeEmpty();
+        result.Skipped.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Unavailable_SkipAndContinue_GoesToSkipped()
+    {
+        var result = Apply(new[] { M("down", MachineHealthStatus.Unavailable) },
+            unavailable: UnavailableDeploymentTargetBehavior.SkipAndContinue);
+
+        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "down" });
+        result.FailedUnavailable.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Unhealthy_DoNotExclude_IsKept()
+    {
+        var result = Apply(new[] { M("sick", MachineHealthStatus.Unhealthy) },
+            unhealthy: UnhealthyDeploymentTargetBehavior.DoNotExclude);
+
+        result.Kept.Select(m => m.Name).ShouldBe(new[] { "sick" });
+        result.Skipped.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Unhealthy_Exclude_IsSkipped()
+    {
+        var result = Apply(new[] { M("sick", MachineHealthStatus.Unhealthy) },
+            unhealthy: UnhealthyDeploymentTargetBehavior.Exclude);
+
+        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "sick" });
+        result.Kept.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MaxParity_FailUnavailable_KeepUnhealthy_Combined()
+    {
+        // The non-default combination: fail on unavailable, keep unhealthy.
+        var machines = new[]
+        {
+            M("healthy", MachineHealthStatus.Healthy),
+            M("sick", MachineHealthStatus.Unhealthy),
+            M("down", MachineHealthStatus.Unavailable)
+        };
+
+        var result = Apply(machines,
+            unavailable: UnavailableDeploymentTargetBehavior.FailDeployment,
+            unhealthy: UnhealthyDeploymentTargetBehavior.DoNotExclude);
+
+        result.Kept.Select(m => m.Name).ShouldBe(new[] { "healthy", "sick" });
+        result.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "down" });
+        result.Skipped.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void EmptyInput_AllListsEmpty()
+    {
+        var result = Apply(new List<Machine>());
+
+        result.Kept.ShouldBeEmpty();
+        result.Skipped.ShouldBeEmpty();
+        result.FailedUnavailable.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Item 3 of the Machine Policy / deployment-settings series. Introduces a **project-level `DeploymentSettings`** concept (persisted as a `jsonb` blob on the project — extensible without a per-setting migration) and its first member, **Transient Deployment Targets**, mirroring the project deployment setting:

- **Unavailable deployment targets**: `SkipAndContinue` (default) or `FailDeployment`.
- **Unhealthy deployment targets**: `Exclude` (default) or `DoNotExclude`.

The deploy pipeline (`4_PrepareDeploymentPhase`) now honours it. Previously it **unconditionally** excluded unavailable + unhealthy targets; a pure `TransientDeploymentTargetEvaluator` splits the two categories and the phase skips, keeps, or fails accordingly.

Settable via a dedicated get/save (`GET`/`POST` `projects/{id}/deployment-settings`), kept isolated from the project CRUD mapping. A null/blank/malformed blob degrades to all-defaults rather than throwing.

## Why non-breaking

- **Defaults = today's behaviour**: `SkipAndContinue` + `Exclude` (enum value 0) reproduce the historical unconditional exclusion exactly, so an unconfigured project — and every pre-existing project, whose new column is `null` — behaves identically.
- New nullable `jsonb` column (additive DbUp migration); new files + an isolated get/save endpoint; no change to project CRUD, no enum/wire renames, no Octopus wording.
- Operators opt into `FailDeployment` / `DoNotExclude` per project.

## Test plan

- [x] Unit — `TransientDeploymentTargetEvaluator` full matrix (default reproduces historical exclusion; FailDeployment; DoNotExclude; mixed; empty).
- [x] Unit — `DeploymentSettingsSerializer` (null/blank/malformed → defaults; round-trip; enums as stable strings).
- [x] Unit — `PrepareDeploymentPhase.ApplyTransientTargetPolicy` (ctx mutation: default exclusion, FailDeployment throws, DoNotExclude keeps, SkipAndContinue skips).
- [x] Integration (real Postgres) — `ProjectDeploymentSettingsService` get-defaults + save/get round-trip through the `deployment_settings_json` column.
- [x] Full solution build 0 errors; full unit sweep 5738 passed.