### PR TITLE
Prune a deployment's task data when release retention deletes it

### DIFF
--- a/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
+++ b/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
@@ -96,9 +96,26 @@ public class RetentionPolicyEnforcer(
             Log.Information("Retention: deleting {Count} deployments for project {ProjectId} environment {EnvironmentId}", deploymentsToDelete.Count, projectId, environmentId);
 
             var ids = deploymentsToDelete.Select(d => d.Id).ToList();
+            var taskIds = deploymentsToDelete.Where(d => d.TaskId.HasValue).Select(d => d.TaskId!.Value).Distinct().ToList();
+
+            // Delete the deployment LAST. It is the retention anchor: if any child delete
+            // below crashes mid-way, the surviving deployment is re-selected next run and the
+            // whole cleanup retries idempotently, so nothing is left permanently orphaned.
+            await DeleteServerTaskDataAsync(taskIds, cancellationToken).ConfigureAwait(false);
             await deploymentCompletionDataProvider.DeleteByDeploymentIdsAsync(ids, cancellationToken).ConfigureAwait(false);
             await deploymentDataProvider.DeleteDeploymentsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private async Task DeleteServerTaskDataAsync(List<int> taskIds, CancellationToken cancellationToken)
+    {
+        if (taskIds.Count == 0) return;
+
+        await repository.ExecuteDeleteAsync<ServerTaskLog>(l => taskIds.Contains(l.ServerTaskId), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<DeploymentInterruption>(i => taskIds.Contains(i.ServerTaskId), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<DeploymentExecutionCheckpoint>(c => taskIds.Contains(c.ServerTaskId), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.ActivityLog>(a => taskIds.Contains(a.ServerTaskId), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.ServerTask>(t => taskIds.Contains(t.Id), cancellationToken).ConfigureAwait(false);
     }
 
     public static List<Deployment> GetDeploymentsExceedingRetention(List<Deployment> deployments, RetentionPolicyUnit unit, int quantity, HashSet<int> currentlyDeployedReleaseIds)

--- a/tests/Squid.IntegrationTests/Services/Deployments/Retention/RetentionTaskCleanupTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Retention/RetentionTaskCleanupTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.LifeCycle;
+using Squid.IntegrationTests.Base;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Enums.Deployments;
+using ProjectEntity = Squid.Core.Persistence.Entities.Deployments.Project;
+
+namespace Squid.IntegrationTests.Services.Deployments.Retention;
+
+/// <summary>
+/// Integration coverage for release-retention pruning the server-task data tied to each
+/// pruned deployment. Against a real Postgres DB: when <c>RetentionPolicyEnforcer</c>
+/// deletes a deployment past its lifecycle's release-retention window, it also deletes that
+/// deployment's <c>ServerTask</c> + <c>ActivityLog</c> tree + <c>ServerTaskLog</c> lines +
+/// <c>DeploymentInterruption</c> + <c>DeploymentExecutionCheckpoint</c>. Deployments within
+/// the window, or preserved because their release is currently deployed, keep their task
+/// data. Multiple aged deployments are all pruned; an aged deployment with no task is pruned
+/// without error. Each test seeds its own isolated project graph.
+/// </summary>
+public class RetentionTaskCleanupTests : TestBase
+{
+    public RetentionTaskCleanupTests() : base("RetentionTaskCleanup", "squid_it_retention_task_cleanup")
+    {
+    }
+
+    [Fact]
+    public async Task OldDeployment_PrunesDeploymentAndAllTaskData()
+    {
+        var graph = await SeedGraphAsync().ConfigureAwait(false);
+        var (deploymentId, taskId) = await SeedAgedDeploymentAsync(graph, ageDays: 40).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await DeploymentExistsAsync(deploymentId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "A deployment past its release-retention window must be pruned.");
+        (await TaskExistsAsync(taskId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "The pruned deployment's ServerTask must be deleted with it.");
+        (await ActivityCountAsync(taskId).ConfigureAwait(false)).ShouldBe(0, customMessage: "Activity-log tree must be pruned with the task.");
+        (await LogCountAsync(taskId).ConfigureAwait(false)).ShouldBe(0, customMessage: "Task-log lines must be pruned with the task.");
+        (await InterruptionCountAsync(taskId).ConfigureAwait(false)).ShouldBe(0, customMessage: "Manual-intervention / guided-failure rows must be pruned with the task, not orphaned.");
+        (await CheckpointCountAsync(taskId).ConfigureAwait(false)).ShouldBe(0, customMessage: "Execution checkpoints must be pruned with the task, not orphaned.");
+    }
+
+    [Fact]
+    public async Task RecentDeployment_KeepsDeploymentAndTaskData()
+    {
+        var graph = await SeedGraphAsync().ConfigureAwait(false);
+        var (deploymentId, taskId) = await SeedAgedDeploymentAsync(graph, ageDays: 5).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await DeploymentExistsAsync(deploymentId).ConfigureAwait(false)).ShouldBeTrue();
+        (await TaskExistsAsync(taskId).ConfigureAwait(false)).ShouldBeTrue();
+        (await ActivityCountAsync(taskId).ConfigureAwait(false)).ShouldBe(1);
+        (await LogCountAsync(taskId).ConfigureAwait(false)).ShouldBe(1);
+        (await InterruptionCountAsync(taskId).ConfigureAwait(false)).ShouldBe(1);
+        (await CheckpointCountAsync(taskId).ConfigureAwait(false)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CurrentlyDeployedRelease_KeepsTaskDataEvenWhenOld()
+    {
+        var graph = await SeedGraphAsync().ConfigureAwait(false);
+        var (deploymentId, taskId) = await SeedAgedDeploymentAsync(graph, ageDays: 40, currentlyDeployed: true).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await DeploymentExistsAsync(deploymentId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A currently-deployed release is preserved by retention, so its task data must survive too.");
+        (await TaskExistsAsync(taskId).ConfigureAwait(false)).ShouldBeTrue();
+        (await LogCountAsync(taskId).ConfigureAwait(false)).ShouldBe(1);
+        (await CheckpointCountAsync(taskId).ConfigureAwait(false)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task MultipleAgedDeployments_AllPruned()
+    {
+        var graph = await SeedGraphAsync().ConfigureAwait(false);
+        var first = await SeedAgedDeploymentAsync(graph, ageDays: 40).ConfigureAwait(false);
+        var second = await SeedAgedDeploymentAsync(graph, ageDays: 50).ConfigureAwait(false);
+        var third = await SeedAgedDeploymentAsync(graph, ageDays: 60).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        foreach (var (deploymentId, taskId) in new[] { first, second, third })
+        {
+            (await DeploymentExistsAsync(deploymentId).ConfigureAwait(false)).ShouldBeFalse(
+                customMessage: "Every aged deployment in the batch must be pruned.");
+            (await TaskExistsAsync(taskId).ConfigureAwait(false)).ShouldBeFalse(
+                customMessage: "Every aged deployment's task must be pruned (multi-id IN clause).");
+            (await LogCountAsync(taskId).ConfigureAwait(false)).ShouldBe(0);
+            (await ActivityCountAsync(taskId).ConfigureAwait(false)).ShouldBe(0);
+        }
+    }
+
+    [Fact]
+    public async Task AgedDeploymentWithoutTask_PrunedWithoutError()
+    {
+        var graph = await SeedGraphAsync().ConfigureAwait(false);
+        var deploymentId = await SeedAgedDeploymentWithoutTaskAsync(graph, ageDays: 40).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await DeploymentExistsAsync(deploymentId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "An aged deployment with no task (TaskId null) must still be pruned, with no task-data delete attempted.");
+    }
+
+    // ── enforce / assertion helpers ──
+
+    private Task EnforceAsync(int projectId)
+        => Run<IRetentionPolicyEnforcer>(enforcer => enforcer.EnforceRetentionForProjectAsync(projectId, CancellationToken.None));
+
+    private Task<bool> DeploymentExistsAsync(int id)
+        => Run<IRepository, bool>(repo => repo.AnyAsync<Deployment>(d => d.Id == id, CancellationToken.None));
+
+    private Task<bool> TaskExistsAsync(int id)
+        => Run<IRepository, bool>(repo => repo.AnyAsync<ServerTask>(t => t.Id == id, CancellationToken.None));
+
+    private Task<int> ActivityCountAsync(int taskId)
+        => Run<IRepository, int>(repo => repo.CountAsync<ActivityLog>(a => a.ServerTaskId == taskId, CancellationToken.None));
+
+    private Task<int> LogCountAsync(int taskId)
+        => Run<IRepository, int>(repo => repo.CountAsync<ServerTaskLog>(l => l.ServerTaskId == taskId, CancellationToken.None));
+
+    private Task<int> InterruptionCountAsync(int taskId)
+        => Run<IRepository, int>(repo => repo.CountAsync<DeploymentInterruption>(i => i.ServerTaskId == taskId, CancellationToken.None));
+
+    private Task<int> CheckpointCountAsync(int taskId)
+        => Run<IRepository, int>(repo => repo.CountAsync<DeploymentExecutionCheckpoint>(c => c.ServerTaskId == taskId, CancellationToken.None));
+
+    // ── seeding helpers ──
+
+    private async Task<(int ProjectId, int EnvironmentId, int ChannelId)> SeedGraphAsync()
+    {
+        var graph = (ProjectId: 0, EnvironmentId: 0, ChannelId: 0);
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var builder = new TestDataBuilder(repo, uow);
+            var suffix = Guid.NewGuid().ToString("N");
+
+            var environment = await builder.CreateEnvironmentAsync($"env-{suffix}").ConfigureAwait(false);
+
+            var lifecycle = new Lifecycle
+            {
+                Name = $"lifecycle-{suffix}",
+                SpaceId = 1,
+                Slug = $"lifecycle-{suffix}",
+                ReleaseRetentionKeepForever = false,
+                ReleaseRetentionUnit = RetentionPolicyUnit.Days,
+                ReleaseRetentionQuantity = 30,
+                TentacleRetentionKeepForever = true
+            };
+            await repo.InsertAsync(lifecycle, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            await builder.CreateLifecyclePhaseAsync(lifecycle.Id, environment.Id, $"phase-{suffix}").ConfigureAwait(false);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+
+            var project = new ProjectEntity
+            {
+                Name = $"project-{suffix}",
+                Slug = $"project-{suffix}",
+                IsDisabled = false,
+                VariableSetId = variableSet.Id,
+                DeploymentProcessId = 0,
+                ProjectGroupId = 1,
+                LifecycleId = lifecycle.Id,
+                AutoCreateRelease = false,
+                Json = string.Empty,
+                IncludedLibraryVariableSetIds = "[]",
+                DiscreteChannelRelease = false,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                AllowIgnoreChannelRules = false
+            };
+            await repo.InsertAsync(project, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, lifecycle.Id, $"channel-{suffix}").ConfigureAwait(false);
+
+            graph = (project.Id, environment.Id, channel.Id);
+        }).ConfigureAwait(false);
+
+        return graph;
+    }
+
+    private async Task<(int DeploymentId, int TaskId)> SeedAgedDeploymentAsync((int ProjectId, int EnvironmentId, int ChannelId) graph, int ageDays, bool currentlyDeployed = false)
+    {
+        var result = (DeploymentId: 0, TaskId: 0);
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var builder = new TestDataBuilder(repo, uow);
+
+            var release = await builder.CreateReleaseAsync(graph.ProjectId, graph.ChannelId, $"1.0.{Guid.NewGuid():N}").ConfigureAwait(false);
+            var task = await builder.CreateServerTaskAsync("Success").ConfigureAwait(false);
+
+            await repo.InsertAsync(new ActivityLog
+            {
+                ServerTaskId = task.Id,
+                Name = "root",
+                NodeType = DeploymentActivityLogNodeType.Task,
+                Category = DeploymentActivityLogCategory.Info,
+                Status = DeploymentActivityLogNodeStatus.Success,
+                StartedAt = DateTimeOffset.UtcNow.AddDays(-ageDays),
+                SortOrder = 0,
+                LastModifiedDate = DateTimeOffset.UtcNow
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            await repo.InsertAsync(new ServerTaskLog
+            {
+                ServerTaskId = task.Id,
+                Category = ServerTaskLogCategory.Info,
+                MessageText = "deployment log line",
+                Source = "test",
+                OccurredAt = DateTimeOffset.UtcNow.AddDays(-ageDays),
+                SequenceNumber = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            var deployment = await builder.CreateDeploymentAsync(graph.ProjectId, graph.EnvironmentId, release.Id, task.Id, graph.ChannelId).ConfigureAwait(false);
+
+            await repo.InsertAsync(new DeploymentInterruption
+            {
+                ServerTaskId = task.Id,
+                DeploymentId = deployment.Id,
+                StepName = "step",
+                ActionName = "action",
+                MachineName = "machine",
+                ErrorMessage = string.Empty,
+                FormJson = "{}",
+                SubmittedValuesJson = "{}",
+                ResponsibleUserId = string.Empty,
+                ResponsibleTeamIds = string.Empty,
+                Resolution = string.Empty,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            await repo.InsertAsync(new DeploymentExecutionCheckpoint
+            {
+                ServerTaskId = task.Id,
+                DeploymentId = deployment.Id,
+                LastCompletedBatchIndex = 0,
+                FailureEncountered = false,
+                OutputVariablesJson = "{}",
+                LastModifiedDate = DateTimeOffset.UtcNow
+            }, CancellationToken.None).ConfigureAwait(false);
+
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            await repo.ExecuteUpdateAsync<Deployment>(
+                d => d.Id == deployment.Id,
+                s => s.SetProperty(d => d.CreatedDate, DateTimeOffset.UtcNow.AddDays(-ageDays)),
+                CancellationToken.None).ConfigureAwait(false);
+
+            if (currentlyDeployed)
+                await builder.CreateDeploymentCompletionAsync(deployment.Id, "Success").ConfigureAwait(false);
+
+            result = (deployment.Id, task.Id);
+        }).ConfigureAwait(false);
+
+        return result;
+    }
+
+    private async Task<int> SeedAgedDeploymentWithoutTaskAsync((int ProjectId, int EnvironmentId, int ChannelId) graph, int ageDays)
+    {
+        var deploymentId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var builder = new TestDataBuilder(repo, uow);
+
+            var release = await builder.CreateReleaseAsync(graph.ProjectId, graph.ChannelId, $"1.0.{Guid.NewGuid():N}").ConfigureAwait(false);
+
+            var deployment = new Deployment
+            {
+                Name = "no-task",
+                TaskId = null,
+                SpaceId = 1,
+                ChannelId = graph.ChannelId,
+                ProjectId = graph.ProjectId,
+                ReleaseId = release.Id,
+                EnvironmentId = graph.EnvironmentId,
+                MachineId = 0,
+                Json = "{}",
+                DeployedBy = 0,
+                DeployedToMachineIds = string.Empty,
+                CreatedDate = DateTimeOffset.UtcNow
+            };
+            await repo.InsertAsync(deployment, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            await repo.ExecuteUpdateAsync<Deployment>(
+                d => d.Id == deployment.Id,
+                s => s.SetProperty(d => d.CreatedDate, DateTimeOffset.UtcNow.AddDays(-ageDays)),
+                CancellationToken.None).ConfigureAwait(false);
+
+            deploymentId = deployment.Id;
+        }).ConfigureAwait(false);
+
+        return deploymentId;
+    }
+}


### PR DESCRIPTION
## Summary

- `ServerTask` and its child rows (`ServerTaskLog`, `ActivityLog`, `DeploymentInterruption`, `DeploymentExecutionCheckpoint`) were never pruned by any retention path — `RetentionPolicyEnforcer` only deleted `Deployment` + `DeploymentCompletion` — so they grew without bound.
- When release retention deletes a `Deployment` past its lifecycle/phase window, it now also deletes that deployment's task and **every row keyed by its `ServerTaskId`** (via `Deployment.TaskId`), so nothing is orphaned.
- The `Deployment` row is deleted **last**: if any child delete crashes mid-sequence, the surviving deployment is re-selected on the next run and the cleanup retries idempotently — no permanent orphans.
- **No new control surface** — rides entirely on the release-retention policy already configured per lifecycle/phase. No setting, no new field, no signature change.
- Safe because every `ServerTask` is a deployment task (only `DeploymentService` creates them; health checks write results in-place on the `Machine` row), so this bounds all the tables.

## Test plan

- [x] Integration (`RetentionTaskCleanupTests`, real Postgres, 5 scenarios): aged deployment → deployment + task + activity + logs + interruption + checkpoint all pruned; recent → all kept; currently-deployed old release → preserved with task data; multiple aged deployments → all pruned (multi-id path); aged deployment with no task (`TaskId` null) → pruned without error.
- [x] Existing `RetentionPolicyEnforcerTests` (pure cutoff logic) unchanged + green.
- [x] Full solution builds clean; full unit suite green.