### PR TITLE
Prune expired releases and ref-count their snapshots in retention

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/3_LoadDeploymentDataPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/3_LoadDeploymentDataPhase.cs
@@ -35,6 +35,9 @@ public sealed class LoadDeploymentDataPhase(
         ctx.Deployment.DeploymentRequestPayload = DeploymentTargetFinder.ParseRequestPayload(deployment.Json);
 
         var release = await releaseDataProvider.GetReleaseByIdAsync(deployment.ReleaseId, ct).ConfigureAwait(false);
+
+        if (release == null) throw new DeploymentEntityNotFoundException("Release", $"id:{deployment.ReleaseId}");
+
         var project = await projectDataProvider.GetProjectByIdAsync(deployment.ProjectId, ct).ConfigureAwait(false);
         var environment = await environmentDataProvider.GetEnvironmentByIdAsync(deployment.EnvironmentId, ct).ConfigureAwait(false);
         var channel = await channelDataProvider.GetChannelByIdAsync(deployment.ChannelId, ct).ConfigureAwait(false);

--- a/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
+++ b/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
@@ -142,10 +142,19 @@ public class RetentionPolicyEnforcer(
         var processSnapshotIds = releasesToDelete.Select(r => r.ProjectDeploymentProcessSnapshotId).Where(id => id != 0).Distinct().ToList();
         var variableSnapshotIds = releasesToDelete.Select(r => r.ProjectVariableSetSnapshotId).Where(id => id != 0).Distinct().ToList();
 
+        // Atomic anti-race guard: re-check at DELETE time that no deployment references the
+        // release. A deployment created between the in-memory read above and these deletes
+        // (e.g. someone deploys a long-undeployed release just as retention runs) must protect
+        // its release. The subquery re-evaluates per DELETE, so such a release is excluded from
+        // BOTH deletes — never leaving a release without its packages, nor a deployment whose
+        // release was pruned. (Its snapshots are likewise kept: the surviving release and the
+        // new deployment both still reference them, so DeleteOrphanedSnapshotsAsync skips them.)
+        var releaseIdsReferencedByDeployment = repository.QueryNoTracking<Deployment>().Select(d => d.ReleaseId);
+
         // Children before parent: delete package selections, then the release (the anchor) last,
         // so a mid-sequence crash leaves the release for the next run to retry idempotently.
-        await repository.ExecuteDeleteAsync<ReleaseSelectedPackage>(p => releaseIds.Contains(p.ReleaseId), cancellationToken).ConfigureAwait(false);
-        await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.Release>(r => releaseIds.Contains(r.Id), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<ReleaseSelectedPackage>(p => releaseIds.Contains(p.ReleaseId) && !releaseIdsReferencedByDeployment.Contains(p.ReleaseId), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.Release>(r => releaseIds.Contains(r.Id) && !releaseIdsReferencedByDeployment.Contains(r.Id), cancellationToken).ConfigureAwait(false);
 
         await DeleteOrphanedSnapshotsAsync(processSnapshotIds, variableSnapshotIds, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
+++ b/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
@@ -78,6 +78,8 @@ public class RetentionPolicyEnforcer(
                 projectId, environmentIds, effectiveUnit, effectiveQuantity,
                 currentlyDeployedReleaseIds, cancellationToken).ConfigureAwait(false);
         }
+
+        await PruneExpiredReleasesAsync(projectId, lifecycle.ReleaseRetentionKeepForever, lifecycle.ReleaseRetentionUnit, lifecycle.ReleaseRetentionQuantity, currentlyDeployedReleaseIds, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task EnforceForEnvironmentsAsync(int projectId, List<int> environmentIds, RetentionPolicyUnit unit, int quantity, HashSet<int> currentlyDeployedReleaseIds, CancellationToken cancellationToken)
@@ -116,6 +118,87 @@ public class RetentionPolicyEnforcer(
         await repository.ExecuteDeleteAsync<DeploymentExecutionCheckpoint>(c => taskIds.Contains(c.ServerTaskId), cancellationToken).ConfigureAwait(false);
         await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.ActivityLog>(a => taskIds.Contains(a.ServerTaskId), cancellationToken).ConfigureAwait(false);
         await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.ServerTask>(t => taskIds.Contains(t.Id), cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task PruneExpiredReleasesAsync(int projectId, bool keepForever, RetentionPolicyUnit unit, int quantity, HashSet<int> currentlyDeployedReleaseIds, CancellationToken cancellationToken)
+    {
+        if (keepForever) return;
+
+        var cutoff = CalculateCutoff(unit, quantity);
+
+        var releases = await repository.QueryNoTracking<Persistence.Entities.Deployments.Release>(r => r.ProjectId == projectId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var releaseIdsWithDeployments = (await repository.QueryNoTracking<Deployment>(d => d.ProjectId == projectId)
+            .Select(d => d.ReleaseId).Distinct().ToListAsync(cancellationToken).ConfigureAwait(false)).ToHashSet();
+
+        var releasesToDelete = GetReleasesExceedingRetention(releases, cutoff, currentlyDeployedReleaseIds, releaseIdsWithDeployments);
+
+        if (releasesToDelete.Count == 0) return;
+
+        Log.Information("Retention: deleting {Count} releases for project {ProjectId}", releasesToDelete.Count, projectId);
+
+        var releaseIds = releasesToDelete.Select(r => r.Id).ToList();
+        var processSnapshotIds = releasesToDelete.Select(r => r.ProjectDeploymentProcessSnapshotId).Where(id => id != 0).Distinct().ToList();
+        var variableSnapshotIds = releasesToDelete.Select(r => r.ProjectVariableSetSnapshotId).Where(id => id != 0).Distinct().ToList();
+
+        // Children before parent: delete package selections, then the release (the anchor) last,
+        // so a mid-sequence crash leaves the release for the next run to retry idempotently.
+        await repository.ExecuteDeleteAsync<ReleaseSelectedPackage>(p => releaseIds.Contains(p.ReleaseId), cancellationToken).ConfigureAwait(false);
+        await repository.ExecuteDeleteAsync<Persistence.Entities.Deployments.Release>(r => releaseIds.Contains(r.Id), cancellationToken).ConfigureAwait(false);
+
+        await DeleteOrphanedSnapshotsAsync(processSnapshotIds, variableSnapshotIds, cancellationToken).ConfigureAwait(false);
+    }
+
+    public static List<Persistence.Entities.Deployments.Release> GetReleasesExceedingRetention(List<Persistence.Entities.Deployments.Release> releases, DateTimeOffset cutoff, HashSet<int> currentlyDeployedReleaseIds, HashSet<int> releaseIdsWithDeployments)
+    {
+        var result = new List<Persistence.Entities.Deployments.Release>();
+
+        foreach (var release in releases)
+        {
+            if (currentlyDeployedReleaseIds.Contains(release.Id)) continue;
+
+            if (releaseIdsWithDeployments.Contains(release.Id)) continue;
+
+            if (release.CreatedDate >= cutoff) continue;
+
+            result.Add(release);
+        }
+
+        return result;
+    }
+
+    private async Task DeleteOrphanedSnapshotsAsync(List<int> processSnapshotIds, List<int> variableSnapshotIds, CancellationToken cancellationToken)
+    {
+        if (processSnapshotIds.Count > 0)
+        {
+            var referencedByRelease = await repository.QueryNoTracking<Persistence.Entities.Deployments.Release>(r => processSnapshotIds.Contains(r.ProjectDeploymentProcessSnapshotId))
+                .Select(r => r.ProjectDeploymentProcessSnapshotId).ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var referencedByDeployment = await repository.QueryNoTracking<Deployment>(d => d.ProcessSnapshotId != null && processSnapshotIds.Contains(d.ProcessSnapshotId.Value))
+                .Select(d => d.ProcessSnapshotId!.Value).ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var stillReferenced = referencedByRelease.Concat(referencedByDeployment).ToHashSet();
+            var orphaned = processSnapshotIds.Where(id => !stillReferenced.Contains(id)).ToList();
+
+            if (orphaned.Count > 0)
+                await repository.ExecuteDeleteAsync<DeploymentProcessSnapshot>(s => orphaned.Contains(s.Id), cancellationToken).ConfigureAwait(false);
+        }
+
+        if (variableSnapshotIds.Count > 0)
+        {
+            var referencedByRelease = await repository.QueryNoTracking<Persistence.Entities.Deployments.Release>(r => variableSnapshotIds.Contains(r.ProjectVariableSetSnapshotId))
+                .Select(r => r.ProjectVariableSetSnapshotId).ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var referencedByDeployment = await repository.QueryNoTracking<Deployment>(d => d.VariableSetSnapshotId != null && variableSnapshotIds.Contains(d.VariableSetSnapshotId.Value))
+                .Select(d => d.VariableSetSnapshotId!.Value).ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var stillReferenced = referencedByRelease.Concat(referencedByDeployment).ToHashSet();
+            var orphaned = variableSnapshotIds.Where(id => !stillReferenced.Contains(id)).ToList();
+
+            if (orphaned.Count > 0)
+                await repository.ExecuteDeleteAsync<VariableSetSnapshot>(s => orphaned.Contains(s.Id), cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public static List<Deployment> GetDeploymentsExceedingRetention(List<Deployment> deployments, RetentionPolicyUnit unit, int quantity, HashSet<int> currentlyDeployedReleaseIds)

--- a/tests/Squid.IntegrationTests/Services/Deployments/Retention/ReleaseRetentionTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Retention/ReleaseRetentionTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.LifeCycle;
+using Squid.IntegrationTests.Base;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Enums.Deployments;
+using ProjectEntity = Squid.Core.Persistence.Entities.Deployments.Project;
+
+namespace Squid.IntegrationTests.Services.Deployments.Retention;
+
+/// <summary>
+/// Integration coverage (real Postgres) for release-level retention: when a lifecycle has a
+/// finite release-retention window, <c>RetentionPolicyEnforcer</c> prunes releases that are
+/// past the window, not currently deployed, and have no surviving deployments — cascading
+/// their <c>ReleaseSelectedPackage</c> rows and ref-count-GCing their process/variable
+/// snapshots (a snapshot shared by a surviving release/deployment is kept). KeepForever
+/// (the lifecycle default) prunes nothing, so the feature is opt-in / non-breaking.
+/// Each test seeds its own isolated project graph.
+/// </summary>
+public class ReleaseRetentionTests : TestBase
+{
+    public ReleaseRetentionTests() : base("ReleaseRetention", "squid_it_release_retention")
+    {
+    }
+
+    [Fact]
+    public async Task OldUndeployedRelease_PrunedWithPackagesAndSnapshots()
+    {
+        var graph = await SeedGraphAsync(keepForever: false).ConfigureAwait(false);
+        var snap = await SeedSnapshotPairAsync().ConfigureAwait(false);
+        var releaseId = await SeedReleaseAsync(graph, ageDays: 40, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await ReleaseExistsAsync(releaseId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "An old, undeployed release past the window must be pruned.");
+        (await PackageCountAsync(releaseId).ConfigureAwait(false)).ShouldBe(0, customMessage: "ReleaseSelectedPackage rows must cascade with the release.");
+        (await ProcessSnapshotExistsAsync(snap.ProcessSnapshotId).ConfigureAwait(false)).ShouldBeFalse(customMessage: "Orphaned process snapshot must be GC'd.");
+        (await VariableSnapshotExistsAsync(snap.VariableSnapshotId).ConfigureAwait(false)).ShouldBeFalse(customMessage: "Orphaned variable snapshot must be GC'd.");
+    }
+
+    [Fact]
+    public async Task RecentRelease_Kept()
+    {
+        var graph = await SeedGraphAsync(keepForever: false).ConfigureAwait(false);
+        var snap = await SeedSnapshotPairAsync().ConfigureAwait(false);
+        var releaseId = await SeedReleaseAsync(graph, ageDays: 5, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await ReleaseExistsAsync(releaseId).ConfigureAwait(false)).ShouldBeTrue();
+        (await ProcessSnapshotExistsAsync(snap.ProcessSnapshotId).ConfigureAwait(false)).ShouldBeTrue();
+        (await VariableSnapshotExistsAsync(snap.VariableSnapshotId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CurrentlyDeployedOldRelease_Kept()
+    {
+        var graph = await SeedGraphAsync(keepForever: false).ConfigureAwait(false);
+        var snap = await SeedSnapshotPairAsync().ConfigureAwait(false);
+        var releaseId = await SeedReleaseAsync(graph, ageDays: 40, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+        await SeedDeploymentForReleaseAsync(graph, releaseId, withSuccessCompletion: true).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await ReleaseExistsAsync(releaseId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A currently-deployed release must be preserved even when old.");
+        (await ProcessSnapshotExistsAsync(snap.ProcessSnapshotId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task OldReleaseWithSurvivingDeployment_Kept()
+    {
+        var graph = await SeedGraphAsync(keepForever: false).ConfigureAwait(false);
+        var snap = await SeedSnapshotPairAsync().ConfigureAwait(false);
+        var releaseId = await SeedReleaseAsync(graph, ageDays: 40, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+        await SeedDeploymentForReleaseAsync(graph, releaseId, withSuccessCompletion: false).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await ReleaseExistsAsync(releaseId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A release with a surviving (recent) deployment must be kept.");
+    }
+
+    [Fact]
+    public async Task SharedSnapshot_KeptWhileAnotherReleaseStillReferencesIt()
+    {
+        var graph = await SeedGraphAsync(keepForever: false).ConfigureAwait(false);
+        var snap = await SeedSnapshotPairAsync().ConfigureAwait(false);
+
+        // Two old releases share the SAME snapshots. One is pruned (undeployed), the other is
+        // preserved (currently deployed) — so the shared snapshots must survive (ref-count).
+        var prunedReleaseId = await SeedReleaseAsync(graph, ageDays: 40, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+        var keptReleaseId = await SeedReleaseAsync(graph, ageDays: 40, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+        await SeedDeploymentForReleaseAsync(graph, keptReleaseId, withSuccessCompletion: true).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await ReleaseExistsAsync(prunedReleaseId).ConfigureAwait(false)).ShouldBeFalse();
+        (await ReleaseExistsAsync(keptReleaseId).ConfigureAwait(false)).ShouldBeTrue();
+        (await ProcessSnapshotExistsAsync(snap.ProcessSnapshotId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A snapshot still referenced by a surviving release must NOT be GC'd.");
+        (await VariableSnapshotExistsAsync(snap.VariableSnapshotId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task KeepForeverLifecycle_PrunesNothing()
+    {
+        var graph = await SeedGraphAsync(keepForever: true).ConfigureAwait(false);
+        var snap = await SeedSnapshotPairAsync().ConfigureAwait(false);
+        var releaseId = await SeedReleaseAsync(graph, ageDays: 400, snap.ProcessSnapshotId, snap.VariableSnapshotId).ConfigureAwait(false);
+
+        await EnforceAsync(graph.ProjectId).ConfigureAwait(false);
+
+        (await ReleaseExistsAsync(releaseId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "KeepForever (the lifecycle default) must prune no releases — opt-in / non-breaking.");
+        (await ProcessSnapshotExistsAsync(snap.ProcessSnapshotId).ConfigureAwait(false)).ShouldBeTrue();
+    }
+
+    // ── enforce / assertion helpers ──
+
+    private Task EnforceAsync(int projectId)
+        => Run<IRetentionPolicyEnforcer>(enforcer => enforcer.EnforceRetentionForProjectAsync(projectId, CancellationToken.None));
+
+    private Task<bool> ReleaseExistsAsync(int id)
+        => Run<IRepository, bool>(repo => repo.AnyAsync<Release>(r => r.Id == id, CancellationToken.None));
+
+    private Task<int> PackageCountAsync(int releaseId)
+        => Run<IRepository, int>(repo => repo.CountAsync<ReleaseSelectedPackage>(p => p.ReleaseId == releaseId, CancellationToken.None));
+
+    private Task<bool> ProcessSnapshotExistsAsync(int id)
+        => Run<IRepository, bool>(repo => repo.AnyAsync<DeploymentProcessSnapshot>(s => s.Id == id, CancellationToken.None));
+
+    private Task<bool> VariableSnapshotExistsAsync(int id)
+        => Run<IRepository, bool>(repo => repo.AnyAsync<VariableSetSnapshot>(s => s.Id == id, CancellationToken.None));
+
+    // ── seeding helpers ──
+
+    private async Task<(int ProjectId, int EnvironmentId, int ChannelId)> SeedGraphAsync(bool keepForever, int windowDays = 30)
+    {
+        var graph = (ProjectId: 0, EnvironmentId: 0, ChannelId: 0);
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var builder = new TestDataBuilder(repo, uow);
+            var suffix = Guid.NewGuid().ToString("N");
+
+            var environment = await builder.CreateEnvironmentAsync($"env-{suffix}").ConfigureAwait(false);
+
+            var lifecycle = new Lifecycle
+            {
+                Name = $"lifecycle-{suffix}",
+                SpaceId = 1,
+                Slug = $"lifecycle-{suffix}",
+                ReleaseRetentionKeepForever = keepForever,
+                ReleaseRetentionUnit = RetentionPolicyUnit.Days,
+                ReleaseRetentionQuantity = windowDays,
+                TentacleRetentionKeepForever = true
+            };
+            await repo.InsertAsync(lifecycle, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            await builder.CreateLifecyclePhaseAsync(lifecycle.Id, environment.Id, $"phase-{suffix}").ConfigureAwait(false);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+
+            var project = new ProjectEntity
+            {
+                Name = $"project-{suffix}",
+                Slug = $"project-{suffix}",
+                IsDisabled = false,
+                VariableSetId = variableSet.Id,
+                DeploymentProcessId = 0,
+                ProjectGroupId = 1,
+                LifecycleId = lifecycle.Id,
+                AutoCreateRelease = false,
+                Json = string.Empty,
+                IncludedLibraryVariableSetIds = "[]",
+                DiscreteChannelRelease = false,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                AllowIgnoreChannelRules = false
+            };
+            await repo.InsertAsync(project, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, lifecycle.Id, $"channel-{suffix}").ConfigureAwait(false);
+
+            graph = (project.Id, environment.Id, channel.Id);
+        }).ConfigureAwait(false);
+
+        return graph;
+    }
+
+    private async Task<(int ProcessSnapshotId, int VariableSnapshotId)> SeedSnapshotPairAsync()
+    {
+        var ids = (ProcessSnapshotId: 0, VariableSnapshotId: 0);
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var processSnapshot = new DeploymentProcessSnapshot
+            {
+                OriginalProcessId = 0,
+                Version = 1,
+                SnapshotData = new byte[] { 1 },
+                ContentHash = $"proc-{Guid.NewGuid():N}",
+                UncompressedSize = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow
+            };
+            await repo.InsertAsync(processSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            var variableSnapshot = new VariableSetSnapshot
+            {
+                SnapshotData = new byte[] { 1 },
+                ContentHash = $"var-{Guid.NewGuid():N}",
+                UncompressedSize = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow
+            };
+            await repo.InsertAsync(variableSnapshot, CancellationToken.None).ConfigureAwait(false);
+
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            ids = (processSnapshot.Id, variableSnapshot.Id);
+        }).ConfigureAwait(false);
+
+        return ids;
+    }
+
+    private async Task<int> SeedReleaseAsync((int ProjectId, int EnvironmentId, int ChannelId) graph, int ageDays, int processSnapshotId, int variableSnapshotId, bool withPackage = true)
+    {
+        var releaseId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var release = new Release
+            {
+                Version = $"1.0.{Guid.NewGuid():N}",
+                ProjectId = graph.ProjectId,
+                ChannelId = graph.ChannelId,
+                ProjectDeploymentProcessSnapshotId = processSnapshotId,
+                ProjectVariableSetSnapshotId = variableSnapshotId,
+                SpaceId = 1,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastModifiedDate = DateTimeOffset.UtcNow
+            };
+            await repo.InsertAsync(release, CancellationToken.None).ConfigureAwait(false);
+            await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            releaseId = release.Id;
+
+            if (withPackage)
+            {
+                await repo.InsertAsync(new ReleaseSelectedPackage
+                {
+                    ReleaseId = releaseId,
+                    FeedId = 1,
+                    ActionName = "action",
+                    PackageReferenceName = string.Empty,
+                    Version = "1.0.0"
+                }, CancellationToken.None).ConfigureAwait(false);
+
+                await uow.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            await repo.ExecuteUpdateAsync<Release>(
+                r => r.Id == releaseId,
+                s => s.SetProperty(r => r.CreatedDate, DateTimeOffset.UtcNow.AddDays(-ageDays)),
+                CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        return releaseId;
+    }
+
+    private Task SeedDeploymentForReleaseAsync((int ProjectId, int EnvironmentId, int ChannelId) graph, int releaseId, bool withSuccessCompletion)
+        => Run<IRepository, IUnitOfWork>(async (repo, uow) =>
+        {
+            var builder = new TestDataBuilder(repo, uow);
+
+            var task = await builder.CreateServerTaskAsync("Success").ConfigureAwait(false);
+            var deployment = await builder.CreateDeploymentAsync(graph.ProjectId, graph.EnvironmentId, releaseId, task.Id, graph.ChannelId).ConfigureAwait(false);
+
+            if (withSuccessCompletion)
+                await builder.CreateDeploymentCompletionAsync(deployment.Id, "Success").ConfigureAwait(false);
+        });
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Retention/RetentionPolicyEnforcerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Retention/RetentionPolicyEnforcerTests.cs
@@ -9,6 +9,7 @@ using Squid.Core.Services.Deployments.LifeCycle;
 using Squid.Core.Services.Deployments.Project;
 using Squid.Core.Services.Deployments.Release;
 using Squid.Message.Enums.Deployments;
+using ReleaseEntity = Squid.Core.Persistence.Entities.Deployments.Release;
 
 namespace Squid.UnitTests.Services.Deployments.Retention;
 
@@ -182,5 +183,78 @@ public class RetentionPolicyEnforcerTests
             ProjectId = 1,
             EnvironmentId = 1
         };
+    }
+
+    // ─── GetReleasesExceedingRetention (pure static) ───
+
+    [Fact]
+    public void Release_OldUndeployedNotCurrent_Pruned()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var result = RetentionPolicyEnforcer.GetReleasesExceedingRetention(
+            new List<ReleaseEntity> { MakeRelease(1, now.AddDays(-40)) },
+            cutoff: now.AddDays(-30), new HashSet<int>(), new HashSet<int>());
+
+        result.Select(r => r.Id).ShouldBe(new[] { 1 });
+    }
+
+    [Fact]
+    public void Release_CurrentlyDeployed_Kept()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var result = RetentionPolicyEnforcer.GetReleasesExceedingRetention(
+            new List<ReleaseEntity> { MakeRelease(1, now.AddDays(-100)) },
+            cutoff: now.AddDays(-30), new HashSet<int> { 1 }, new HashSet<int>());
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Release_WithSurvivingDeployments_Kept()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var result = RetentionPolicyEnforcer.GetReleasesExceedingRetention(
+            new List<ReleaseEntity> { MakeRelease(1, now.AddDays(-100)) },
+            cutoff: now.AddDays(-30), new HashSet<int>(), new HashSet<int> { 1 });
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Release_Recent_Kept()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var result = RetentionPolicyEnforcer.GetReleasesExceedingRetention(
+            new List<ReleaseEntity> { MakeRelease(1, now.AddDays(-5)) },
+            cutoff: now.AddDays(-30), new HashSet<int>(), new HashSet<int>());
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Releases_MixedSet_OnlyEligiblePruned()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var releases = new List<ReleaseEntity>
+        {
+            MakeRelease(1, now.AddDays(-40)),  // old, undeployed, not current → prune
+            MakeRelease(2, now.AddDays(-40)),  // old but currently deployed → keep
+            MakeRelease(3, now.AddDays(-40)),  // old but has surviving deployments → keep
+            MakeRelease(4, now.AddDays(-5))    // recent → keep
+        };
+
+        var result = RetentionPolicyEnforcer.GetReleasesExceedingRetention(
+            releases, cutoff: now.AddDays(-30), new HashSet<int> { 2 }, new HashSet<int> { 3 });
+
+        result.Select(r => r.Id).ShouldBe(new[] { 1 });
+    }
+
+    private static ReleaseEntity MakeRelease(int id, DateTimeOffset created)
+    {
+        return new ReleaseEntity { Id = id, ProjectId = 1, CreatedDate = created };
     }
 }


### PR DESCRIPTION
## Summary

- Releases and their content-deduped process/variable snapshots were never pruned by retention (only deployments were), so they grew without bound.
- After the per-environment deployment pruning, `RetentionPolicyEnforcer` now prunes a `Release` only when ALL hold: lifecycle window is finite (`ReleaseRetentionKeepForever == false`), the release is **past the window**, **not currently deployed**, and has **no surviving deployments**. It cascades the release's `ReleaseSelectedPackage` rows and **ref-count-GCs** its `DeploymentProcessSnapshot` / `VariableSetSnapshot` (kept if any surviving release or deployment still references the snapshot).
- **Opt-in / non-breaking**: gated on `ReleaseRetentionKeepForever`, which **defaults to true**, so nothing is pruned unless an operator configures a finite window. No schema/DTO/signature changes.

## Deletion-rule review (global)

Every referencer was enumerated and handled:

- **Release is referenced only by** `ReleaseSelectedPackage.ReleaseId` (cascaded) and `Deployment.ReleaseId` (a release with any deployment is never pruned). No other entity, JSON blob, Hangfire arg, cache, or checkpoint references a release id.
- **Snapshots are referenced only by** `Release` (`Project{DeploymentProcess,VariableSet}SnapshotId`) and `Deployment` (`{Process,VariableSet}SnapshotId`). Deployments **copy** the snapshot ids at creation, so an in-flight/re-deployable deployment keeps its own snapshot alive; the GC ref-counts both. No snapshot id lives anywhere else.
- **Latest-release / dashboard**: all release consumers are null-tolerant (dashboard takes top-N, triggers no-op on null); no "newest release per channel" invariant exists, so pruning an old undeployed release breaks nothing.

## Safety hardening (from the review)

- **Anti-race**: the package/release deletes carry an atomic `NOT EXISTS deployment` subquery re-evaluated at DELETE time, so a release that gains a deployment between the candidate read and the delete is excluded from both deletes (no orphaned package, no deployment with a pruned release).
- **Defensive guard**: `LoadDeploymentDataPhase` now throws `DeploymentEntityNotFoundException` for a missing release instead of a `NullReferenceException`, turning the residual cross-transaction window (and any externally-deleted release) into a clean, logged deployment failure.
- Release (the anchor) is deleted **last** so a mid-sequence crash retries idempotently next run — no permanent orphans.

## Test plan

- [x] Unit (`RetentionPolicyEnforcerTests`, +5): `GetReleasesExceedingRetention` matrix — old-undeployed-not-current pruned; currently-deployed kept; has-surviving-deployments kept; recent kept; mixed set prunes only the eligible one.
- [x] Integration (`ReleaseRetentionTests`, 6, real Postgres): old undeployed release → release + packages + snapshots gone; recent kept; currently-deployed old release kept; old release with a surviving deployment kept; **shared snapshot kept while another surviving release references it** (ref-count); KeepForever lifecycle prunes nothing.
- [x] Regression: existing deployment/task-cleanup integration green; full unit suite green (5743); solution builds clean.