### PR TITLE
Stream deployment script output to the task log live

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Infrastructure/HalibutScriptObserver.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Infrastructure/HalibutScriptObserver.cs
@@ -45,8 +45,10 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
         CancellationToken ct,
         SensitiveValueMasker masker = null,
         ScriptStatusResponse initialStartResponse = null,
-        ServiceEndPoint? endpoint = null)
+        ServiceEndPoint? endpoint = null,
+        ScriptOutputSink outputSink = null)
     {
+        var streamed = outputSink != null;
         var startTime = DateTime.UtcNow;
         var pollInterval = TimeSpan.FromMilliseconds(_observerSettings.InitialPollIntervalMs);
         var maxPollInterval = TimeSpan.FromMilliseconds(_observerSettings.MaxPollIntervalMs);
@@ -54,12 +56,45 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
         var statusResponse = initialStartResponse
             ?? new ScriptStatusResponse(ticket, ProcessState.Pending, 0, new List<ProcessOutput>(), 0);
         var allLogs = new List<ProcessOutput>();
+        var streamFailed = false;
+
+        // Live streaming is best-effort: on any sink failure we set streamFailed so the bulk persist
+        // at completion runs as a fallback, guaranteeing lines are never lost (at-least-once; the
+        // fallback may duplicate already-streamed lines, which is preferable to losing them).
+        async Task StreamLinesAsync(IReadOnlyList<ScriptOutputLine> lines)
+        {
+            if (outputSink == null || lines == null || lines.Count == 0) return;
+
+            try
+            {
+                await outputSink(lines, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                streamFailed = true;
+                Log.Warning(ex, "[Deploy] Live log streaming failed for agent {MachineName}", machine.Name);
+            }
+        }
+
+        Task StreamBatchAsync(List<ProcessOutput> batch)
+        {
+            if (outputSink == null || batch == null || batch.Count == 0) return Task.CompletedTask;
+
+            var lines = batch
+                .OrderBy(l => l.Occurred)
+                .Where(l => !string.IsNullOrEmpty(l.Text))
+                .Select(l => new ScriptOutputLine(l.Text, l.Source == ProcessOutputSource.StdErr))
+                .ToList();
+
+            return StreamLinesAsync(lines);
+        }
 
         if (initialStartResponse != null)
         {
             allLogs.AddRange(initialStartResponse.Logs);
             TruncateIfExceeded(allLogs);
             LogOutput(initialStartResponse.Logs, machine.Name, masker);
+            await StreamBatchAsync(initialStartResponse.Logs).ConfigureAwait(false);
         }
 
         // Agent liveness probe: independent probing stream alongside the main polling
@@ -85,13 +120,16 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
                     .Select(l => masker?.Mask(l.Text) ?? l.Text)
                     .ToList();
 
-                collectedLogLines.Add($"Script execution exceeded {scriptTimeout.TotalMinutes}-minute timeout");
+                var timeoutLine = $"Script execution exceeded {scriptTimeout.TotalMinutes}-minute timeout";
+                collectedLogLines.Add(timeoutLine);
+                await StreamLinesAsync(new[] { new ScriptOutputLine(timeoutLine, IsStdErr: true) }).ConfigureAwait(false);
 
                 return new ScriptExecutionResult
                 {
                     Success = false,
                     ExitCode = ScriptExitCodes.Timeout,
-                    LogLines = collectedLogLines
+                    LogLines = collectedLogLines,
+                    OutputStreamed = streamed && !streamFailed
                 };
             }
 
@@ -127,6 +165,7 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
             allLogs.AddRange(statusResponse.Logs);
             TruncateIfExceeded(allLogs);
             LogOutput(statusResponse.Logs, machine.Name, masker);
+            await StreamBatchAsync(statusResponse.Logs).ConfigureAwait(false);
 
             if (statusResponse.State != ProcessState.Complete)
             {
@@ -155,6 +194,7 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
         allLogs.AddRange(completeResponse.Logs);
         TruncateIfExceeded(allLogs);
         LogOutput(completeResponse.Logs, machine.Name, masker);
+        await StreamBatchAsync(completeResponse.Logs).ConfigureAwait(false);
 
         var orderedLogs = allLogs
             .OrderBy(l => l.Occurred)
@@ -181,7 +221,8 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
             Success = success,
             LogLines = logLines,
             StderrLines = stderrLines,
-            ExitCode = completeResponse.ExitCode
+            ExitCode = completeResponse.ExitCode,
+            OutputStreamed = streamed && !streamFailed
         };
     }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Infrastructure/IHalibutScriptObserver.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Infrastructure/IHalibutScriptObserver.cs
@@ -15,5 +15,6 @@ public interface IHalibutScriptObserver : IScopedDependency
         CancellationToken ct,
         SensitiveValueMasker masker,
         ScriptStatusResponse initialStartResponse = null,
-        ServiceEndPoint endpoint = null);
+        ServiceEndPoint endpoint = null,
+        ScriptOutputSink outputSink = null);
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleEvents.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleEvents.cs
@@ -55,6 +55,9 @@ public class DeploymentEventContext
     // Script output
     public ScriptExecutionResult ScriptResult { get; init; }
 
+    // Live script output chunk (incremental lines streamed while the script is still running)
+    public IReadOnlyList<ScriptOutputLine> ScriptOutputChunk { get; init; }
+
     // Output variables
     public List<string> OutputVariableNames { get; init; }
 
@@ -119,6 +122,7 @@ public sealed record ActionSucceededEvent(DeploymentEventContext Context) : Depl
 public sealed record ActionFailedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 
 // === Script Output ===
+public sealed record ScriptProgressReceivedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record ScriptOutputReceivedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 public sealed record OutputVariablesCapturedEvent(DeploymentEventContext Context) : DeploymentLifecycleEvent(Context);
 

--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleHandlerBase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleHandlerBase.cs
@@ -42,6 +42,7 @@ public abstract class DeploymentLifecycleHandlerBase : IDeploymentLifecycleHandl
         ActionExecutingEvent e => OnActionExecutingAsync(e.Context, ct),
         ActionSucceededEvent e => OnActionSucceededAsync(e.Context, ct),
         ActionFailedEvent e => OnActionFailedAsync(e.Context, ct),
+        ScriptProgressReceivedEvent e => OnScriptProgressReceivedAsync(e.Context, ct),
         ScriptOutputReceivedEvent e => OnScriptOutputReceivedAsync(e.Context, ct),
         OutputVariablesCapturedEvent e => OnOutputVariablesCapturedAsync(e.Context, ct),
         GuidedFailurePromptEvent e => OnGuidedFailurePromptAsync(e.Context, ct),
@@ -102,6 +103,7 @@ public abstract class DeploymentLifecycleHandlerBase : IDeploymentLifecycleHandl
     protected virtual Task OnActionFailedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
 
     // === Script Output ===
+    protected virtual Task OnScriptProgressReceivedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnScriptOutputReceivedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnOutputVariablesCapturedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
 

--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentActivityLogger.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentActivityLogger.cs
@@ -380,6 +380,15 @@ public sealed class DeploymentActivityLogger : DeploymentLifecycleHandlerBase
 
     // === Script Output ===
 
+    // Live (incremental) script output — persisted to the task log as it streams in, so a
+    // long-running action shows progress instead of an empty "Running" node until completion.
+    protected override Task OnScriptProgressReceivedAsync(DeploymentEventContext ctx, CancellationToken ct)
+    {
+        var actionNodeId = LookupActionNode(ctx.StepDisplayOrder, ctx.MachineName, ctx.ActionSortOrder);
+
+        return PersistScriptChunkAsync(ctx.ScriptOutputChunk, ctx.MachineName, actionNodeId, ct);
+    }
+
     protected override Task OnScriptOutputReceivedAsync(DeploymentEventContext ctx, CancellationToken ct)
     {
         var actionNodeId = LookupActionNode(ctx.StepDisplayOrder, ctx.MachineName, ctx.ActionSortOrder);
@@ -551,9 +560,37 @@ public sealed class DeploymentActivityLogger : DeploymentLifecycleHandlerBase
         }
     }
 
+    private async Task PersistScriptChunkAsync(IReadOnlyList<ScriptOutputLine> chunk, string source, long? activityNodeId, CancellationToken ct)
+    {
+        if (chunk == null || chunk.Count == 0) return;
+
+        try
+        {
+            var entries = chunk.Select(line => new ServerTaskLogWriteEntry
+            {
+                Category = line.IsStdErr ? ServerTaskLogCategory.Error : ServerTaskLogCategory.Info,
+                MessageText = MaskSensitiveValues(line.Text),
+                Source = source,
+                OccurredAt = DateTimeOffset.UtcNow,
+                SequenceNumber = Ctx.NextLogSequence(),
+                ActivityNodeId = activityNodeId
+            }).ToList();
+
+            await _logWriter.AddLogsAsync(Ctx.ServerTaskId, entries, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[Deploy] Failed to persist live script output for task {TaskId}", Ctx.ServerTaskId);
+        }
+    }
+
     private async Task PersistScriptOutputAsync(ScriptExecutionResult execResult, string source, long? activityNodeId, CancellationToken ct)
     {
         if (execResult?.LogLines == null || execResult.LogLines.Count == 0) return;
+
+        // Output already streamed live (line-by-line) while the script ran — skip the bulk persist
+        // so those lines are not duplicated. (Set only on the live-streaming Halibut path.)
+        if (execResult.OutputStreamed) return;
 
         var stderrSet = execResult.StderrLines?.Count > 0 ? new HashSet<string>(execResult.StderrLines, StringComparer.Ordinal) : null;
 

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
@@ -367,6 +367,11 @@ public sealed partial class ExecuteStepsPhase
 
             var request = await DescribeExpandAndRenderAsync(prepared, tc, step, effectiveVariables, stepTimeout, stepDisplayOrder, ct).ConfigureAwait(false);
 
+            // Live log tail: stream each incremental output batch to the task log as it arrives, so a
+            // long-running action shows progress instead of sitting on an empty node until completion.
+            request.OutputSink = (lines, sinkCt) => lifecycle.EmitAsync(
+                new ScriptProgressReceivedEvent(new DeploymentEventContext { StepDisplayOrder = stepDisplayOrder, MachineName = tc.Machine.Name, ActionSortOrder = actionSortOrder, ScriptOutputChunk = lines }), sinkCt);
+
             var execResult = await strategy.ExecuteScriptAsync(request, ct).ConfigureAwait(false);
 
             // P1-B.7: cross-reference output-variable values against the

--- a/src/Squid.Core/Services/DeploymentExecution/Script/ScriptExecutionRequest.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Script/ScriptExecutionRequest.cs
@@ -38,6 +38,13 @@ public class ScriptExecutionRequest
     public string StepName { get; set; }
     public string ActionName { get; set; }
 
+    /// <summary>
+    /// Optional live-output sink. When set, an execution strategy that observes incremental output
+    /// (the Halibut/Tentacle poll loop) invokes it with each new batch of lines as they arrive, so
+    /// the task log tails live. Runtime-only (never serialized to an agent); null = legacy behavior.
+    /// </summary>
+    public ScriptOutputSink OutputSink { get; set; }
+
     public ExecutionMode ResolveExecutionMode()
     {
         if (ExecutionMode == ExecutionMode.Unspecified)

--- a/src/Squid.Core/Services/DeploymentExecution/Script/ScriptExecutionResult.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Script/ScriptExecutionResult.cs
@@ -9,6 +9,13 @@ public class ScriptExecutionResult
     public List<string> StderrLines { get; set; } = new();
     public int ExitCode { get; set; }
 
+    /// <summary>
+    /// True when output was streamed live to the task log as the script ran. The bulk
+    /// post-completion persistence is then skipped to avoid duplicating those lines. Defaults to
+    /// false, so any execution path that does not stream behaves exactly as before.
+    /// </summary>
+    public bool OutputStreamed { get; set; }
+
     public string BuildErrorSummary(int maxLines = 10)
     {
         var description = ScriptExitCodes.Describe(ExitCode);

--- a/src/Squid.Core/Services/DeploymentExecution/Script/ScriptOutputLine.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Script/ScriptOutputLine.cs
@@ -1,0 +1,15 @@
+namespace Squid.Core.Services.DeploymentExecution.Script;
+
+/// <summary>
+/// A single line of script output streamed live from an agent while a script is still running.
+/// Carries the raw (unmasked) text plus its source so the consumer can categorise and mask it
+/// exactly as the post-completion persistence path does.
+/// </summary>
+public sealed record ScriptOutputLine(string Text, bool IsStdErr);
+
+/// <summary>
+/// Optional live-output sink threaded into a script execution. When set, the observer invokes it
+/// with each incremental batch of new output lines as they arrive (before the script completes),
+/// enabling a live log tail. When null, output is only surfaced once at completion (legacy behavior).
+/// </summary>
+public delegate Task ScriptOutputSink(IReadOnlyList<ScriptOutputLine> lines, CancellationToken ct);

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -233,7 +233,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
 
         try
         {
-            return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, scriptTicket, scriptTimeout, ct, request.Masker, startResponse, endpoint).ConfigureAwait(false);
+            return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, scriptTicket, scriptTimeout, ct, request.Masker, startResponse, endpoint, request.OutputSink).ConfigureAwait(false);
         }
         finally
         {
@@ -285,7 +285,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
 
         try
         {
-            return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, existingTicket, scriptTimeout, ct, request.Masker, probe, endpoint).ConfigureAwait(false);
+            return await _observer.ObserveAndCompleteAsync(request.Machine, scriptClient, existingTicket, scriptTimeout, ct, request.Masker, probe, endpoint, request.OutputSink).ConfigureAwait(false);
         }
         finally
         {

--- a/tests/Squid.UnitTests/Services/Deployments/Halibut/HalibutScriptObserverStreamingTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Halibut/HalibutScriptObserverStreamingTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution.Infrastructure;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Message.Constants;
+using Squid.Message.Contracts.Tentacle;
+
+namespace Squid.UnitTests.Services.Deployments.Halibut;
+
+/// <summary>
+/// Live log tail: when an output sink is wired, <see cref="HalibutScriptObserver"/> streams each
+/// incremental batch of agent output to the sink AS IT ARRIVES (before completion), tags the source,
+/// and marks the result OutputStreamed so the bulk post-completion persist is skipped (no duplication).
+/// When no sink is wired, behaviour is unchanged. Streaming failures fall back to bulk (no data loss).
+/// </summary>
+public class HalibutScriptObserverStreamingTests
+{
+    private readonly HalibutScriptObserver _observer = new();
+    private readonly Mock<IAsyncScriptService> _scriptClient = new();
+    private readonly Machine _machine = new() { Name = "test-agent" };
+    private readonly ScriptTicket _ticket = new("test-ticket");
+    private readonly TimeSpan _timeout = TimeSpan.FromMinutes(30);
+
+    private (List<ScriptOutputLine> lines, List<int> batchSizes) RecordingSink(out ScriptOutputSink sink)
+    {
+        var lines = new List<ScriptOutputLine>();
+        var batchSizes = new List<int>();
+        sink = (batch, ct) =>
+        {
+            batchSizes.Add(batch.Count);
+            lines.AddRange(batch);
+            return Task.CompletedTask;
+        };
+        return (lines, batchSizes);
+    }
+
+    [Fact]
+    public async Task Streaming_InvokesSinkPerBatch_InOrder_AndMarksOutputStreamed()
+    {
+        var callCount = 0;
+
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount < 3)
+                    return new ScriptStatusResponse(_ticket, ProcessState.Running, 0,
+                        new List<ProcessOutput> { new(ProcessOutputSource.StdOut, $"log-{callCount}") }, callCount);
+
+                return new ScriptStatusResponse(_ticket, ProcessState.Complete, 0,
+                    new List<ProcessOutput> { new(ProcessOutputSource.StdOut, "log-final") }, callCount);
+            });
+
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 0));
+
+        var (streamed, batchSizes) = RecordingSink(out var sink);
+
+        var result = await _observer.ObserveAndCompleteAsync(
+            _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None, outputSink: sink);
+
+        result.OutputStreamed.ShouldBeTrue();
+        // Delivered per poll batch (not one bulk dump at the end).
+        batchSizes.Count.ShouldBeGreaterThanOrEqualTo(3);
+        var texts = streamed.Select(l => l.Text).ToList();
+        texts.ShouldBe(new[] { "log-1", "log-2", "log-final" });
+    }
+
+    [Fact]
+    public async Task NoSink_DoesNotStream_AndOutputStreamedIsFalse()
+    {
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0,
+                new List<ProcessOutput> { new(ProcessOutputSource.StdOut, "out") }, 1));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 1));
+
+        var result = await _observer.ObserveAndCompleteAsync(
+            _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None);
+
+        result.OutputStreamed.ShouldBeFalse();
+        result.LogLines.ShouldContain("out");
+    }
+
+    [Fact]
+    public async Task Streaming_TagsStdErrLines()
+    {
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 1,
+                new List<ProcessOutput>
+                {
+                    new(ProcessOutputSource.StdOut, "normal"),
+                    new(ProcessOutputSource.StdErr, "boom")
+                }, 1));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 1, new List<ProcessOutput>(), 1));
+
+        var (streamed, _) = RecordingSink(out var sink);
+
+        await _observer.ObserveAndCompleteAsync(
+            _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None, outputSink: sink);
+
+        streamed.Single(l => l.Text == "normal").IsStdErr.ShouldBeFalse();
+        streamed.Single(l => l.Text == "boom").IsStdErr.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Streaming_SkipsEmptyLines()
+    {
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0,
+                new List<ProcessOutput>
+                {
+                    new(ProcessOutputSource.StdOut, ""),
+                    new(ProcessOutputSource.StdOut, "real")
+                }, 1));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 1));
+
+        var (streamed, _) = RecordingSink(out var sink);
+
+        await _observer.ObserveAndCompleteAsync(
+            _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None, outputSink: sink);
+
+        streamed.Select(l => l.Text).ShouldBe(new[] { "real" });
+    }
+
+    [Fact]
+    public async Task Streaming_SinkThrows_FallsBackToBulk_OutputStreamedFalse_NoDataLoss()
+    {
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0,
+                new List<ProcessOutput> { new(ProcessOutputSource.StdOut, "line-a") }, 1));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 1));
+
+        ScriptOutputSink throwingSink = (batch, ct) => throw new InvalidOperationException("sink down");
+
+        var result = await _observer.ObserveAndCompleteAsync(
+            _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None, outputSink: throwingSink);
+
+        // Sink failure must NOT fail the script, and must fall back to the bulk persist (flag false)
+        // so the lines are still surfaced from the returned result — never silently lost.
+        result.Success.ShouldBeTrue();
+        result.OutputStreamed.ShouldBeFalse();
+        result.LogLines.ShouldContain("line-a");
+    }
+
+    [Fact]
+    public async Task Streaming_Timeout_StreamsSyntheticLine_AndMarksOutputStreamed()
+    {
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Running, 0, new List<ProcessOutput>(), 0));
+        _scriptClient.Setup(s => s.CancelScriptAsync(It.IsAny<CancelScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, ScriptExitCodes.Canceled, new List<ProcessOutput>(), 0));
+
+        var (streamed, _) = RecordingSink(out var sink);
+
+        var result = await _observer.ObserveAndCompleteAsync(
+            _machine, _scriptClient.Object, _ticket, TimeSpan.FromMilliseconds(100), CancellationToken.None, outputSink: sink);
+
+        result.ExitCode.ShouldBe(ScriptExitCodes.Timeout);
+        result.OutputStreamed.ShouldBeTrue();
+        streamed.ShouldContain(l => l.Text.Contains("timeout") && l.IsStdErr);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
@@ -198,7 +198,7 @@ public class HalibutMachineExecutionStrategyTests
                 It.IsAny<CancellationToken>(),
                 It.IsAny<SensitiveValueMasker>(),
                 It.IsAny<ScriptStatusResponse>(),
-                It.IsAny<global::Halibut.ServiceEndPoint>()))
+                It.IsAny<global::Halibut.ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = true, ExitCode = 0, LogLines = new List<string>() });
 
         var strategy = new HalibutMachineExecutionStrategy(
@@ -221,7 +221,7 @@ public class HalibutMachineExecutionStrategyTests
             It.IsAny<CancellationToken>(),
             It.IsAny<SensitiveValueMasker>(),
             It.IsAny<ScriptStatusResponse>(),
-            It.IsAny<global::Halibut.ServiceEndPoint>()), Times.Once);
+            It.IsAny<global::Halibut.ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()), Times.Once);
     }
 
     [Fact]
@@ -245,7 +245,7 @@ public class HalibutMachineExecutionStrategyTests
                 It.IsAny<CancellationToken>(),
                 It.IsAny<SensitiveValueMasker>(),
                 It.IsAny<ScriptStatusResponse>(),
-                It.IsAny<global::Halibut.ServiceEndPoint>()))
+                It.IsAny<global::Halibut.ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = false, ExitCode = 7, LogLines = new List<string> { "x" } });
 
         var strategy = new HalibutMachineExecutionStrategy(
@@ -267,7 +267,7 @@ public class HalibutMachineExecutionStrategyTests
             It.IsAny<CancellationToken>(),
             It.IsAny<SensitiveValueMasker>(),
             It.IsAny<ScriptStatusResponse>(),
-            It.IsAny<global::Halibut.ServiceEndPoint>()), Times.Once);
+            It.IsAny<global::Halibut.ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()), Times.Once);
     }
 
     // === Request Timeout Override ===

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentActivityLoggerStreamingTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentActivityLoggerStreamingTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.DeploymentExecution.Lifecycle.Handlers;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Message.Enums.Deployments;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.Deployments.Pipeline;
+
+/// <summary>
+/// Live log tail (server side): <see cref="DeploymentActivityLogger"/> persists each incremental
+/// script-output chunk to the task log as it streams in (correct category, source, masking, monotonic
+/// sequence), and SKIPS the bulk post-completion persist when the result is marked OutputStreamed so
+/// those lines are not duplicated. When not streamed, the legacy bulk persist is unchanged.
+/// </summary>
+public class DeploymentActivityLoggerStreamingTests
+{
+    private static (DeploymentActivityLogger logger, Mock<IDeploymentLogWriter> writer, List<ServerTaskLogWriteEntry> captured) Build(IEnumerable<VariableDto> variables = null)
+    {
+        var writer = new Mock<IDeploymentLogWriter>();
+        var captured = new List<ServerTaskLogWriteEntry>();
+
+        writer.Setup(w => w.AddLogsAsync(It.IsAny<int>(), It.IsAny<IReadOnlyCollection<ServerTaskLogWriteEntry>>(), It.IsAny<CancellationToken>()))
+            .Callback<int, IReadOnlyCollection<ServerTaskLogWriteEntry>, CancellationToken>((_, entries, _) => captured.AddRange(entries))
+            .Returns(Task.CompletedTask);
+        writer.Setup(w => w.AddActivityNodeAsync(It.IsAny<int>(), It.IsAny<long?>(), It.IsAny<string>(), It.IsAny<DeploymentActivityLogNodeType>(), It.IsAny<DeploymentActivityLogNodeStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivityLog { Id = 1 });
+        writer.Setup(w => w.AddLogAsync(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<ServerTaskLogCategory>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var logger = new DeploymentActivityLogger(writer.Object);
+        logger.Initialize(new DeploymentTaskContext { ServerTaskId = 1, Variables = variables?.ToList() });
+        return (logger, writer, captured);
+    }
+
+    // Masker is initialized on DeploymentStarting (as in production, before any action streams).
+    private static Task StartAsync(DeploymentActivityLogger logger)
+        => logger.HandleAsync(new DeploymentStartingEvent(new DeploymentEventContext()), CancellationToken.None);
+
+    [Fact]
+    public async Task ScriptProgress_PersistsChunkLive_WithSourceCategoryMaskingAndSequence()
+    {
+        var (logger, _, captured) = Build(new[] { new VariableDto { Value = "topsecret", IsSensitive = true } });
+        await StartAsync(logger);
+
+        var chunk = new List<ScriptOutputLine>
+        {
+            new("deploying app", IsStdErr: false),
+            new("warning: topsecret leaked", IsStdErr: true)
+        };
+
+        await logger.HandleAsync(new ScriptProgressReceivedEvent(new DeploymentEventContext
+        {
+            StepDisplayOrder = 1, MachineName = "agent-x", ActionSortOrder = 0, ScriptOutputChunk = chunk
+        }), CancellationToken.None);
+
+        captured.Count.ShouldBe(2);
+
+        captured[0].MessageText.ShouldBe("deploying app");
+        captured[0].Category.ShouldBe(ServerTaskLogCategory.Info);
+        captured[0].Source.ShouldBe("agent-x");
+
+        captured[1].Category.ShouldBe(ServerTaskLogCategory.Error);          // stderr → Error
+        captured[1].MessageText.ShouldNotContain("topsecret");               // sensitive value masked
+        captured[1].MessageText.ShouldContain("********");
+        captured[1].SequenceNumber.ShouldBeGreaterThan(captured[0].SequenceNumber);   // monotonic
+    }
+
+    [Fact]
+    public async Task ScriptProgress_EmptyChunk_DoesNotPersist()
+    {
+        var (logger, writer, _) = Build();
+
+        await logger.HandleAsync(new ScriptProgressReceivedEvent(new DeploymentEventContext
+        {
+            StepDisplayOrder = 1, MachineName = "agent-x", ScriptOutputChunk = new List<ScriptOutputLine>()
+        }), CancellationToken.None);
+
+        writer.Verify(w => w.AddLogsAsync(It.IsAny<int>(), It.IsAny<IReadOnlyCollection<ServerTaskLogWriteEntry>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScriptOutputReceived_OutputStreamed_SkipsBulkPersist_NoDuplication()
+    {
+        var (logger, writer, _) = Build();
+
+        await logger.HandleAsync(new ScriptOutputReceivedEvent(new DeploymentEventContext
+        {
+            StepDisplayOrder = 1, MachineName = "agent-x", ActionSortOrder = 0,
+            ScriptResult = new ScriptExecutionResult { LogLines = new List<string> { "a", "b" }, OutputStreamed = true }
+        }), CancellationToken.None);
+
+        writer.Verify(w => w.AddLogsAsync(It.IsAny<int>(), It.IsAny<IReadOnlyCollection<ServerTaskLogWriteEntry>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScriptOutputReceived_NotStreamed_PersistsBulk_LegacyBehavior()
+    {
+        var (logger, _, captured) = Build();
+
+        await logger.HandleAsync(new ScriptOutputReceivedEvent(new DeploymentEventContext
+        {
+            StepDisplayOrder = 1, MachineName = "agent-x", ActionSortOrder = 0,
+            ScriptResult = new ScriptExecutionResult { LogLines = new List<string> { "a", "b" }, OutputStreamed = false }
+        }), CancellationToken.None);
+
+        captured.Select(e => e.MessageText).ShouldBe(new[] { "a", "b" });
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentLogWriterIntegrationTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentLogWriterIntegrationTests.cs
@@ -268,6 +268,71 @@ public class DeploymentLogWriterIntegrationTests : IAsyncDisposable
         logs.ShouldContain(l => l.Category == ServerTaskLogCategory.Error && l.MessageText.Contains("error line"));
     }
 
+    // === Live log tail: streamed chunks persist incrementally, final bulk skipped (no dup) ===
+
+    [Fact]
+    public async Task LiveStreaming_ChunksPersistIncrementally_FinalBulkSkipped_NoDuplication()
+    {
+        var ctx = CreateContext(taskId: 50);
+        _lifecycle.Initialize(ctx);
+
+        await EmitAsync(new DeploymentStartingEvent(new DeploymentEventContext()));
+        await EmitAsync(new StepStartingEvent(new DeploymentEventContext { StepName = "Deploy", StepDisplayOrder = 1 }));
+        await EmitAsync(new ActionExecutingEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1 }));
+
+        // Two live chunks arrive WHILE the script runs.
+        await EmitAsync(new ScriptProgressReceivedEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1, ScriptOutputChunk = new List<ScriptOutputLine> { new("step 1 of 3", false) } }));
+        await EmitAsync(new ScriptProgressReceivedEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1, ScriptOutputChunk = new List<ScriptOutputLine> { new("step 2 of 3", false), new("a warning", true) } }));
+
+        // Completion: result is marked OutputStreamed → the bulk persist MUST be skipped (no dup),
+        // even though the result still carries every line (for the failure summary / output capture).
+        await EmitAsync(new ScriptOutputReceivedEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1, ScriptResult = new ScriptExecutionResult { Success = true, ExitCode = 0, LogLines = new List<string> { "step 1 of 3", "step 2 of 3", "a warning" }, OutputStreamed = true } }));
+
+        await EmitAsync(new ActionSucceededEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1, ExitCode = 0 }));
+        await EmitAsync(new StepCompletedEvent(new DeploymentEventContext { StepName = "Deploy", StepDisplayOrder = 1 }));
+        await EmitAsync(new DeploymentSucceededEvent(new DeploymentEventContext()));
+
+        await using var db = new SquidDbContext(_dbOptions);
+        var logs = await db.Set<ServerTaskLog>().Where(l => l.ServerTaskId == 50).ToListAsync();
+
+        // Each streamed line appears EXACTLY ONCE — final bulk persist did not duplicate them.
+        logs.Count(l => l.MessageText == "step 1 of 3").ShouldBe(1);
+        logs.Count(l => l.MessageText == "step 2 of 3").ShouldBe(1);
+
+        var warning = logs.Single(l => l.MessageText == "a warning");
+        warning.Category.ShouldBe(ServerTaskLogCategory.Error);   // stderr chunk line
+        warning.Source.ShouldBe("agent-1");
+
+        // Streamed lines are attributed to the action node, just like the bulk path.
+        var actionNode = await db.Set<ActivityLog>().FirstAsync(n => n.ServerTaskId == 50 && n.NodeType == DeploymentActivityLogNodeType.Action);
+        logs.Single(l => l.MessageText == "step 1 of 3").ActivityNodeId.ShouldBe(actionNode.Id);
+
+        // Sequence numbers remain unique + increasing across the whole task.
+        var seqs = logs.Select(l => l.SequenceNumber).ToList();
+        seqs.ShouldBe(seqs.Distinct().ToList());
+    }
+
+    [Fact]
+    public async Task NotStreamed_FinalBulkPersistsScriptOutput_LegacyPathUnchanged()
+    {
+        var ctx = CreateContext(taskId: 51);
+        _lifecycle.Initialize(ctx);
+
+        await EmitAsync(new DeploymentStartingEvent(new DeploymentEventContext()));
+        await EmitAsync(new StepStartingEvent(new DeploymentEventContext { StepName = "Deploy", StepDisplayOrder = 1 }));
+        await EmitAsync(new ActionExecutingEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1 }));
+
+        // No live chunks; OutputStreamed=false → final bulk persist writes the output (legacy path).
+        await EmitAsync(new ScriptOutputReceivedEvent(new DeploymentEventContext { StepDisplayOrder = 1, MachineName = "agent-1", ActionSortOrder = 1, ScriptResult = new ScriptExecutionResult { Success = true, ExitCode = 0, LogLines = new List<string> { "only-at-end" }, OutputStreamed = false } }));
+
+        await EmitAsync(new DeploymentSucceededEvent(new DeploymentEventContext()));
+
+        await using var db = new SquidDbContext(_dbOptions);
+        var logs = await db.Set<ServerTaskLog>().Where(l => l.ServerTaskId == 51).ToListAsync();
+
+        logs.Count(l => l.MessageText == "only-at-end").ShouldBe(1);
+    }
+
     // === Helpers ===
 
     private Task EmitAsync(DeploymentLifecycleEvent @event)

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -775,7 +775,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(2, "TentaclePolling", "sub-2", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = true, LogLines = new List<string> { "downloading…", "swapping…", "✓ done" }, ExitCode = 0 });
 
         var outcome = await strategy.UpgradeAsync(machine, "1.4.2", CancellationToken.None);
@@ -793,7 +793,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(3, "TentaclePolling", "sub-3", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = false, ExitCode = 7, LogLines = new List<string> { "Downloading…", "::error:: SHA256 mismatch. Expected ABC, got DEF" } });
 
         var outcome = await strategy.UpgradeAsync(machine, "1.4.2", CancellationToken.None);
@@ -818,7 +818,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(33, "TentaclePolling", "sub-33", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult
             {
                 Success = false,
@@ -861,7 +861,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(4, "TentaclePolling", "sub-4", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = false, ExitCode = 9, LogLines = new List<string>() });
 
         var outcome = await strategy.UpgradeAsync(machine, "1.4.2", CancellationToken.None);
@@ -883,7 +883,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(5, "TentaclePolling", "sub-5", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new HalibutClientException("connection closed"));
 
         var outcome = await strategy.UpgradeAsync(machine, "1.4.2", CancellationToken.None);
@@ -912,7 +912,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(25, "TentaclePolling", "sub-25", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new AgentUnreachableException("mars mac", consecutiveFailures: 2));
 
         var outcome = await strategy.UpgradeAsync(machine, "1.5.5", CancellationToken.None);
@@ -1028,7 +1028,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(6, "TentaclePolling", "sub-6", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new OperationCanceledException());
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
@@ -1044,7 +1044,7 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(7, "TentaclePolling", "sub-7", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new InvalidOperationException("hash provider exploded"));
 
         var outcome = await strategy.UpgradeAsync(machine, "1.4.2", CancellationToken.None);

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -1072,7 +1072,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(2, "TentaclePolling", "sub-2", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = true, ExitCode = 0, LogLines = new List<string> { "[upgrade-wrapper] Task triggered" } });
 
         var outcome = await strategy.UpgradeAsync(machine, "1.6.0", CancellationToken.None);
@@ -1093,7 +1093,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(3, "TentaclePolling", "sub-3", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = false, ExitCode = 1, LogLines = new List<string> { "Connecting...", "::error:: schtasks /Create failed" } });
 
         var outcome = await strategy.UpgradeAsync(machine, "1.6.0", CancellationToken.None);
@@ -1112,7 +1112,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(4, "TentaclePolling", "sub-4", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ReturnsAsync(new ScriptExecutionResult { Success = false, ExitCode = 1, LogLines = new List<string>() });
 
         var outcome = await strategy.UpgradeAsync(machine, "1.6.0", CancellationToken.None);
@@ -1128,7 +1128,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(5, "TentaclePolling", "sub-5", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new HalibutClientException("connection closed"));
 
         var outcome = await strategy.UpgradeAsync(machine, "1.6.0", CancellationToken.None);
@@ -1146,7 +1146,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(25, "TentaclePolling", "sub-25", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new AgentUnreachableException("win-agent", consecutiveFailures: 2));
 
         var outcome = await strategy.UpgradeAsync(machine, "1.6.0", CancellationToken.None);
@@ -1191,7 +1191,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(6, "TentaclePolling", "sub-6", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new OperationCanceledException());
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
@@ -1205,7 +1205,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         var machine = MakeMachine(7, "TentaclePolling", "sub-7", "AABB");
 
         observer
-            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>()))
+            .Setup(o => o.ObserveAndCompleteAsync(It.IsAny<Machine>(), It.IsAny<IAsyncScriptService>(), It.IsAny<ScriptTicket>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>(), It.IsAny<SensitiveValueMasker>(), It.IsAny<ScriptStatusResponse>(), It.IsAny<ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()))
             .ThrowsAsync(new InvalidOperationException("observer state corrupted"));
 
         var outcome = await strategy.UpgradeAsync(machine, "1.6.0", CancellationToken.None);


### PR DESCRIPTION
## Summary

- A long-running deployment action showed an empty **Running** node with no log lines until it completed: the agent's incremental output (received every Halibut `GetStatus` poll) went only to the server's Serilog, and the task log was populated once, in bulk, after completion. Operators couldn't see what an in-flight script was doing.
- Thread an **optional output sink** from the executor → execution strategy → script observer. On the Halibut/Tentacle path the observer forwards each incremental batch as it arrives; the executor emits a new `ScriptProgressReceivedEvent` and `DeploymentActivityLogger` persists it to `ServerTaskLog` **live**, reusing the exact sequence / category / source / activity-node / masking logic of the bulk path.
- The result is marked `OutputStreamed` so the post-completion bulk persist is **skipped** — lines are never duplicated.

## Non-breaking

- The sink is an optional param defaulting to `null`. Every other execution strategy (SSH, OpenClaw, local, K8s-API) and any caller that doesn't opt in behaves exactly as before: `OutputStreamed` stays false and the bulk persist runs unchanged.
- Streaming failure falls back to the bulk persist (`OutputStreamed=false`) — output is never lost (at-least-once; may duplicate on the rare failure, preferred over loss).
- Sequence allocation is already `Interlocked`, so concurrent streaming from parallel actions/targets is safe.
- No schema change. (The optional param forced `It.IsAny<ScriptOutputSink>()` into existing observer mocks — test-only.)

## Test plan

- [x] **Unit — observer** (`HalibutScriptObserverStreamingTests`): per-poll-batch delivery in order; stderr source tagging; empty-line skip; sink-throws → fallback (`OutputStreamed=false`, no loss); timeout streams its synthetic line + marks streamed; no-sink → unchanged.
- [x] **Unit — activity logger** (`DeploymentActivityLoggerStreamingTests`): live chunk persisted with category (stderr→Error), source, masking, monotonic sequence; empty chunk no-op; `OutputStreamed=true` skips bulk; `false` persists bulk (legacy).
- [x] **Integration — real pipeline + DB** (`DeploymentLogWriterIntegrationTests`): chunks persist incrementally and each line lands **exactly once** (final bulk skipped), stderr categorised, attributed to the action node; control path (`OutputStreamed=false`) persists at end.
- [x] Full unit suite 5766/5766; resume-reattach integration 4/4; full solution builds 0 errors.