### PR TITLE
Persist terminal upgrade trace to survive server restarts

### DIFF
--- a/src/Squid.Core/Persistence/DbUpFiles/20260601_add_machine_last_upgrade_trace_persistence.sql
+++ b/src/Squid.Core/Persistence/DbUpFiles/20260601_add_machine_last_upgrade_trace_persistence.sql
@@ -1,0 +1,34 @@
+-- Durable upgrade trace — persist the LAST TERMINAL upgrade outcome (status +
+-- event timeline + Phase B log) to the DB so a server pod restart no longer
+-- erases an operator's view of how the most recent upgrade concluded.
+--
+-- Background: the per-machine upgrade timeline lives in a process-local
+-- singleton (InMemoryUpgradeEventTimelineStore). That cache is intentionally
+-- in-memory because writing it on EVERY Capabilities probe (every few seconds
+-- during an active upgrade) would dominate the cost of the upgrade itself.
+-- This migration adds a durable backstop that is written ONCE per upgrade —
+-- only when the agent first reports a TERMINAL status (SUCCESS / FAILED /
+-- ROLLED_BACK / ...). The in-memory store stays the hot read cache; these
+-- columns are hydrated back into it at server startup.
+--
+-- Adds two columns to `machine`:
+--   * last_upgrade_trace_json — full UpgradeTraceSnapshot (status payload +
+--     event list + Phase B log) as JSON (jsonb for efficient ->> queries from
+--     future admin filters). NULL means "no terminal upgrade ever observed" —
+--     the cache stays empty for that machine until its next upgrade concludes.
+--   * last_upgrade_trace_updated_at — when the terminal snapshot was persisted.
+--
+-- Backward compatibility: pre-existing machines get NULL columns. The
+-- UpgradeTraceHydrator IStartable skips NULL rows at startup, so a machine
+-- that never upgraded simply has an empty upgrade timeline (same as today).
+
+ALTER TABLE machine
+    ADD COLUMN last_upgrade_trace_json       jsonb       NULL,
+    ADD COLUMN last_upgrade_trace_updated_at timestamptz NULL;
+
+-- Optional partial index for future "which machines upgraded recently" admin
+-- queries. WHERE clause keeps it small for the common case where most fleets
+-- have only a handful of machines with a recorded terminal upgrade.
+CREATE INDEX ix_machine_last_upgrade_trace_updated_at
+    ON machine USING btree (last_upgrade_trace_updated_at DESC)
+    WHERE last_upgrade_trace_updated_at IS NOT NULL;

--- a/src/Squid.Core/Persistence/Entities/Deployments/Machine.cs
+++ b/src/Squid.Core/Persistence/Entities/Deployments/Machine.cs
@@ -36,6 +36,16 @@ public class Machine : IEntity<int>, IAuditable
     public string RuntimeCapabilitiesJson { get; set; }
     public DateTimeOffset? RuntimeCapabilitiesUpdatedAt { get; set; }
 
+    // Durable upgrade trace — the LAST TERMINAL upgrade outcome (status payload +
+    // event timeline + Phase B log) serialised as JSON. NULL when no terminal
+    // upgrade has ever been observed for this machine. Written once per upgrade
+    // (when the agent first reports a terminal status) by IUpgradeTracePersistence;
+    // hydrated back into InMemoryUpgradeEventTimelineStore at startup by
+    // UpgradeTraceHydrator so a server pod restart no longer erases the operator's
+    // view of how the most recent upgrade concluded.
+    public string LastUpgradeTraceJson { get; set; }
+    public DateTimeOffset? LastUpgradeTraceUpdatedAt { get; set; }
+
     // IAuditable
     public DateTimeOffset CreatedDate { get; set; }
     public int CreatedBy { get; set; }

--- a/src/Squid.Core/Persistence/EntityConfigurations/MachineConfiguration.cs
+++ b/src/Squid.Core/Persistence/EntityConfigurations/MachineConfiguration.cs
@@ -23,5 +23,12 @@ public class MachineConfiguration: IEntityTypeConfiguration<Machine>
         // pre-existing machines have NULL until next health check populates them.
         builder.Property(p => p.RuntimeCapabilitiesJson).HasColumnType("jsonb");
         builder.Property(p => p.RuntimeCapabilitiesUpdatedAt);
+
+        // Durable upgrade trace (column added by
+        // 20260601_add_machine_last_upgrade_trace_persistence.sql). Mapped to
+        // jsonb so Npgsql writes jsonb rather than text. Nullable — machines
+        // with no observed terminal upgrade have NULL.
+        builder.Property(p => p.LastUpgradeTraceJson).HasColumnType("jsonb");
+        builder.Property(p => p.LastUpgradeTraceUpdatedAt);
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
@@ -39,14 +39,18 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
     private readonly IMachineRuntimeCapabilitiesPersistence _capabilitiesPersistence;
     private readonly IUpgradeDispatchLockReconciler _upgradeLockReconciler;
     private readonly IUpgradeEventTimelineStore _upgradeEventStore;
+    private readonly IUpgradeTracePersistence _upgradeTracePersistence;
+    private readonly IUpgradeTracePersistenceGate _upgradeTraceGate;
 
-    public TentacleHealthCheckStrategy(IHalibutClientFactory halibutClientFactory, IMachineRuntimeCapabilitiesCache capabilitiesCache = null, IMachineRuntimeCapabilitiesPersistence capabilitiesPersistence = null, IUpgradeDispatchLockReconciler upgradeLockReconciler = null, IUpgradeEventTimelineStore upgradeEventStore = null)
+    public TentacleHealthCheckStrategy(IHalibutClientFactory halibutClientFactory, IMachineRuntimeCapabilitiesCache capabilitiesCache = null, IMachineRuntimeCapabilitiesPersistence capabilitiesPersistence = null, IUpgradeDispatchLockReconciler upgradeLockReconciler = null, IUpgradeEventTimelineStore upgradeEventStore = null, IUpgradeTracePersistence upgradeTracePersistence = null, IUpgradeTracePersistenceGate upgradeTraceGate = null)
     {
         _halibutClientFactory = halibutClientFactory;
         _capabilitiesCache = capabilitiesCache;
         _capabilitiesPersistence = capabilitiesPersistence;
         _upgradeLockReconciler = upgradeLockReconciler;
         _upgradeEventStore = upgradeEventStore;
+        _upgradeTracePersistence = upgradeTracePersistence;
+        _upgradeTraceGate = upgradeTraceGate;
     }
 
     /// <summary>
@@ -80,6 +84,8 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
             await ProcessUpgradeStatusAsync(machine, response, ct).ConfigureAwait(false);
 
             CaptureUpgradeEventTimeline(machine, response);
+
+            await PersistUpgradeTraceIfTerminalAsync(machine, ct).ConfigureAwait(false);
 
             var os = ReadMetadata(response, "os");
             var shell = ReadMetadata(response, "defaultShell");
@@ -281,6 +287,56 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
             {
                 Log.Warning(ex, "[UpgradeAudit] Failed to capture Phase B log for machine {MachineId}", machine.Id);
             }
+        }
+    }
+
+    /// <summary>
+    /// Durable backstop for the in-memory upgrade timeline. When the agent has
+    /// reported a TERMINAL upgrade status (the upgrade concluded), persist the
+    /// current trace snapshot (status + events + Phase B log) to the DB so it
+    /// survives a server pod restart. Gated by
+    /// <see cref="IUpgradeTracePersistenceGate"/> so the SAME terminal outcome —
+    /// which the agent keeps re-reporting on every subsequent probe — is written
+    /// exactly once, not on every probe (that per-probe write cost is the whole
+    /// reason the timeline cache is in-memory).
+    ///
+    /// <para>Reads the snapshot from the in-memory store, which the preceding
+    /// <see cref="ProcessUpgradeStatusAsync"/> + <see cref="CaptureUpgradeEventTimeline"/>
+    /// steps have already populated from THIS probe — so the persisted snapshot
+    /// is internally consistent (status, events, log all from one probe).</para>
+    ///
+    /// <para>Never throws: durable persistence is advisory; a DB hiccup must not
+    /// turn a healthy tentacle unhealthy. The in-memory store still holds the
+    /// trace and the gate is left open so the next probe retries the write.</para>
+    /// </summary>
+    private async Task PersistUpgradeTraceIfTerminalAsync(Machine machine, CancellationToken ct)
+    {
+        if (_upgradeTracePersistence == null || _upgradeTraceGate == null || _upgradeEventStore == null || machine == null) return;
+
+        var status = _upgradeEventStore.GetStatus(machine.Id);
+
+        if (status == null || !UpgradeStatusClassifier.IsTerminal(status.Status)) return;
+
+        var snapshot = new UpgradeTraceSnapshot
+        {
+            Status = status,
+            Events = _upgradeEventStore.Get(machine.Id),
+            Log = _upgradeEventStore.GetLog(machine.Id)
+        };
+
+        if (_upgradeTraceGate.AlreadyPersisted(machine.Id, snapshot.Signature)) return;
+
+        try
+        {
+            await _upgradeTracePersistence.SaveAsync(machine.Id, snapshot, ct).ConfigureAwait(false);
+
+            _upgradeTraceGate.MarkPersisted(machine.Id, snapshot.Signature);
+
+            Log.Information("[UpgradeAudit] Persisted terminal upgrade trace for machine {MachineId} (status {Status}) — survives server pod restart.", machine.Id, status.Status);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[UpgradeAudit] Failed to persist terminal upgrade trace for machine {MachineId} — in-memory cache still holds it; next health-check probe will retry the DB write.", machine.Id);
         }
     }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleHealthCheckStrategy.cs
@@ -39,18 +39,16 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
     private readonly IMachineRuntimeCapabilitiesPersistence _capabilitiesPersistence;
     private readonly IUpgradeDispatchLockReconciler _upgradeLockReconciler;
     private readonly IUpgradeEventTimelineStore _upgradeEventStore;
-    private readonly IUpgradeTracePersistence _upgradeTracePersistence;
-    private readonly IUpgradeTracePersistenceGate _upgradeTraceGate;
+    private readonly IUpgradeTracePersister _upgradeTracePersister;
 
-    public TentacleHealthCheckStrategy(IHalibutClientFactory halibutClientFactory, IMachineRuntimeCapabilitiesCache capabilitiesCache = null, IMachineRuntimeCapabilitiesPersistence capabilitiesPersistence = null, IUpgradeDispatchLockReconciler upgradeLockReconciler = null, IUpgradeEventTimelineStore upgradeEventStore = null, IUpgradeTracePersistence upgradeTracePersistence = null, IUpgradeTracePersistenceGate upgradeTraceGate = null)
+    public TentacleHealthCheckStrategy(IHalibutClientFactory halibutClientFactory, IMachineRuntimeCapabilitiesCache capabilitiesCache = null, IMachineRuntimeCapabilitiesPersistence capabilitiesPersistence = null, IUpgradeDispatchLockReconciler upgradeLockReconciler = null, IUpgradeEventTimelineStore upgradeEventStore = null, IUpgradeTracePersister upgradeTracePersister = null)
     {
         _halibutClientFactory = halibutClientFactory;
         _capabilitiesCache = capabilitiesCache;
         _capabilitiesPersistence = capabilitiesPersistence;
         _upgradeLockReconciler = upgradeLockReconciler;
         _upgradeEventStore = upgradeEventStore;
-        _upgradeTracePersistence = upgradeTracePersistence;
-        _upgradeTraceGate = upgradeTraceGate;
+        _upgradeTracePersister = upgradeTracePersister;
     }
 
     /// <summary>
@@ -291,53 +289,21 @@ public class TentacleHealthCheckStrategy : IHealthCheckStrategy
     }
 
     /// <summary>
-    /// Durable backstop for the in-memory upgrade timeline. When the agent has
-    /// reported a TERMINAL upgrade status (the upgrade concluded), persist the
-    /// current trace snapshot (status + events + Phase B log) to the DB so it
-    /// survives a server pod restart. Gated by
-    /// <see cref="IUpgradeTracePersistenceGate"/> so the SAME terminal outcome —
-    /// which the agent keeps re-reporting on every subsequent probe — is written
-    /// exactly once, not on every probe (that per-probe write cost is the whole
-    /// reason the timeline cache is in-memory).
-    ///
-    /// <para>Reads the snapshot from the in-memory store, which the preceding
-    /// <see cref="ProcessUpgradeStatusAsync"/> + <see cref="CaptureUpgradeEventTimeline"/>
-    /// steps have already populated from THIS probe — so the persisted snapshot
-    /// is internally consistent (status, events, log all from one probe).</para>
-    ///
-    /// <para>Never throws: durable persistence is advisory; a DB hiccup must not
-    /// turn a healthy tentacle unhealthy. The in-memory store still holds the
-    /// trace and the gate is left open so the next probe retries the write.</para>
+    /// Durable backstop for the in-memory upgrade timeline. Delegates to
+    /// <see cref="IUpgradeTracePersister"/>, which persists the current trace
+    /// snapshot to the DB only when the agent has reported a TERMINAL status and
+    /// that outcome hasn't been persisted yet — so it survives a server pod
+    /// restart. Runs after <see cref="ProcessUpgradeStatusAsync"/> +
+    /// <see cref="CaptureUpgradeEventTimeline"/> have populated the in-memory
+    /// store from THIS probe, so the snapshot is internally consistent.
+    /// Optional dependency: a strategy wired without the persister simply skips
+    /// durable persistence. Never throws (the persister swallows DB errors).
     /// </summary>
     private async Task PersistUpgradeTraceIfTerminalAsync(Machine machine, CancellationToken ct)
     {
-        if (_upgradeTracePersistence == null || _upgradeTraceGate == null || _upgradeEventStore == null || machine == null) return;
+        if (_upgradeTracePersister == null || machine == null) return;
 
-        var status = _upgradeEventStore.GetStatus(machine.Id);
-
-        if (status == null || !UpgradeStatusClassifier.IsTerminal(status.Status)) return;
-
-        var snapshot = new UpgradeTraceSnapshot
-        {
-            Status = status,
-            Events = _upgradeEventStore.Get(machine.Id),
-            Log = _upgradeEventStore.GetLog(machine.Id)
-        };
-
-        if (_upgradeTraceGate.AlreadyPersisted(machine.Id, snapshot.Signature)) return;
-
-        try
-        {
-            await _upgradeTracePersistence.SaveAsync(machine.Id, snapshot, ct).ConfigureAwait(false);
-
-            _upgradeTraceGate.MarkPersisted(machine.Id, snapshot.Signature);
-
-            Log.Information("[UpgradeAudit] Persisted terminal upgrade trace for machine {MachineId} (status {Status}) — survives server pod restart.", machine.Id, status.Status);
-        }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "[UpgradeAudit] Failed to persist terminal upgrade trace for machine {MachineId} — in-memory cache still holds it; next health-check probe will retry the DB write.", machine.Id);
-        }
+        await _upgradeTracePersister.PersistIfTerminalAsync(machine.Id, ct).ConfigureAwait(false);
     }
 
     private static string ReadMetadata(CapabilitiesResponse response, string key)

--- a/src/Squid.Core/Services/Machines/Upgrade/IUpgradeTracePersistence.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/IUpgradeTracePersistence.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// DB-backed durable persistence for an <see cref="UpgradeTraceSnapshot"/>.
+/// Composed with the in-memory <see cref="IUpgradeEventTimelineStore"/> so that
+/// when an upgrade FIRST reaches a terminal status, its snapshot is written
+/// through to the <c>machine.last_upgrade_trace_json</c> column, and the
+/// <see cref="UpgradeTraceHydrator"/> re-populates the in-memory store from
+/// these rows at server startup.
+///
+/// <para><b>Why this exists</b>: the upgrade timeline cache is intentionally
+/// in-memory (writing it on every Capabilities probe would dominate the cost of
+/// the upgrade). But that means a server pod restart erased an operator's view
+/// of how the most recent upgrade concluded. This persistence is the durable
+/// backstop — written ONCE per upgrade (gated by
+/// <see cref="IUpgradeTracePersistenceGate"/> so a terminal status the agent
+/// keeps re-reporting on every probe is persisted only the first time).</para>
+///
+/// <para><b>Stability</b>: this interface is internal to the upgrade subsystem.
+/// Tests use a fake implementation. Production wires
+/// <see cref="UpgradeTracePersistence"/> via <see cref="IScopedDependency"/>.</para>
+/// </summary>
+public interface IUpgradeTracePersistence
+{
+    /// <summary>
+    /// Persist <paramref name="snapshot"/> for <paramref name="machineId"/> to
+    /// <c>machine.last_upgrade_trace_json</c> + set
+    /// <c>last_upgrade_trace_updated_at</c>. Atomic single-row update via
+    /// <see cref="IRepository.ExecuteUpdateAsync{T}"/> — no entity tracking, no
+    /// concurrent-write race with concurrent <c>UpdateMachineAsync</c> calls.
+    /// </summary>
+    Task SaveAsync(int machineId, UpgradeTraceSnapshot snapshot, CancellationToken ct);
+
+    /// <summary>
+    /// Load every machine row with a non-NULL <c>last_upgrade_trace_json</c> for
+    /// the hydrator. Skips rows where deserialisation fails (logged warning) so
+    /// one corrupt JSON blob can't block startup.
+    /// </summary>
+    Task<IReadOnlyList<(int MachineId, UpgradeTraceSnapshot Snapshot)>> LoadAllAsync(CancellationToken ct);
+}
+
+public sealed class UpgradeTracePersistence : IUpgradeTracePersistence, IScopedDependency
+{
+    /// <summary>
+    /// Stable JSON serialisation contract. The wrapper keys are written via
+    /// explicit <c>[JsonPropertyName]</c> on <see cref="UpgradeTraceSnapshot"/>
+    /// and the nested <see cref="UpgradeStatusPayload"/> / <see cref="UpgradeEvent"/>;
+    /// camelCase is set anyway to match the existing persistence convention and
+    /// guard against a future plain-POCO field slipping in without an attribute.
+    /// Pinned by <c>UpgradeTracePersistenceShapeTests</c> so a future
+    /// <see cref="JsonSerializerOptions"/> default change doesn't silently break
+    /// the hydration round-trip on operators' existing rows.
+    /// </summary>
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly IRepository _repository;
+
+    public UpgradeTracePersistence(IRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task SaveAsync(int machineId, UpgradeTraceSnapshot snapshot, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var json = JsonSerializer.Serialize(snapshot, SerializerOptions);
+
+        var now = DateTimeOffset.UtcNow;
+
+        await _repository.ExecuteUpdateAsync<Machine>(
+            m => m.Id == machineId,
+            s => s.SetProperty(m => m.LastUpgradeTraceJson, json)
+                  .SetProperty(m => m.LastUpgradeTraceUpdatedAt, (DateTimeOffset?)now),
+            ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<(int MachineId, UpgradeTraceSnapshot Snapshot)>> LoadAllAsync(CancellationToken ct)
+    {
+        // Project to (id, json) — avoid full entity hydration just for the trace
+        // blob on startup. Skip rows with NULL json (machines that never had a
+        // terminal upgrade observed).
+        var rows = await _repository.QueryNoTracking<Machine>(m => m.LastUpgradeTraceJson != null)
+            .Select(m => new { m.Id, m.LastUpgradeTraceJson })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var results = new List<(int, UpgradeTraceSnapshot)>(rows.Count);
+
+        foreach (var row in rows)
+        {
+            var snapshot = TryDeserialize(row.Id, row.LastUpgradeTraceJson);
+
+            if (snapshot != null) results.Add((row.Id, snapshot));
+        }
+
+        return results;
+    }
+
+    private static UpgradeTraceSnapshot TryDeserialize(int machineId, string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<UpgradeTraceSnapshot>(json, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            // One corrupted row can't block startup. Log + skip so the next
+            // terminal upgrade overwrites the bad blob without needing a
+            // server-image rebuild.
+            Log.Warning(ex,
+                "Failed to deserialise persisted upgrade trace for machine {MachineId} — skipping. " +
+                "The cache will repopulate from the next terminal upgrade for this machine.",
+                machineId);
+
+            return null;
+        }
+    }
+}

--- a/src/Squid.Core/Services/Machines/Upgrade/IUpgradeTracePersistenceGate.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/IUpgradeTracePersistenceGate.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// Process-local dedup gate that lets the durable upgrade-trace persister write
+/// a terminal outcome <b>exactly once</b> per concluded upgrade, instead of on
+/// every Capabilities probe.
+///
+/// <para><b>Why it's needed</b>: once an upgrade concludes, the agent keeps
+/// reporting the SAME terminal status (e.g. <c>SUCCESS</c>) on every subsequent
+/// probe — its <c>last-upgrade.json</c> isn't rewritten until the next upgrade.
+/// Persisting on every probe-with-a-terminal-status would re-introduce the
+/// per-probe DB-write cost the in-memory store was designed to avoid. This gate
+/// records the last <see cref="UpgradeTraceSnapshot.Signature"/> persisted per
+/// machine and reports whether the current one is new.</para>
+///
+/// <para><b>Lifetime</b>: singleton. The map is rebuilt on restart; the
+/// <see cref="UpgradeTraceHydrator"/> primes it from the DB at startup so the
+/// first post-restart probe doesn't re-persist a snapshot already on disk.
+/// A benign double-write under concurrent probes for the same machine is
+/// harmless (the DB write is idempotent — same signature ⇒ same bytes).</para>
+/// </summary>
+public interface IUpgradeTracePersistenceGate
+{
+    /// <summary>
+    /// True when a snapshot with <paramref name="signature"/> has already been
+    /// persisted for <paramref name="machineId"/> (so the caller should skip the
+    /// DB write). A different signature — i.e. a NEW terminal outcome — returns
+    /// false.
+    /// </summary>
+    bool AlreadyPersisted(int machineId, string signature);
+
+    /// <summary>
+    /// Record <paramref name="signature"/> as the last-persisted snapshot for
+    /// <paramref name="machineId"/>. Called only AFTER a successful DB write, so
+    /// a failed write leaves the gate open for the next probe to retry.
+    /// </summary>
+    void MarkPersisted(int machineId, string signature);
+}
+
+public sealed class UpgradeTracePersistenceGate : IUpgradeTracePersistenceGate, ISingletonDependency
+{
+    private readonly ConcurrentDictionary<int, string> _lastPersistedSignature = new();
+
+    public bool AlreadyPersisted(int machineId, string signature)
+    {
+        return _lastPersistedSignature.TryGetValue(machineId, out var existing)
+               && string.Equals(existing, signature, StringComparison.Ordinal);
+    }
+
+    public void MarkPersisted(int machineId, string signature)
+    {
+        _lastPersistedSignature[machineId] = signature ?? string.Empty;
+    }
+}

--- a/src/Squid.Core/Services/Machines/Upgrade/IUpgradeTracePersister.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/IUpgradeTracePersister.cs
@@ -1,0 +1,73 @@
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// Orchestrates the durable upgrade-trace backstop: when a machine's in-memory
+/// timeline reflects a TERMINAL upgrade outcome, snapshot it (status + events +
+/// Phase B log) and persist it to the DB — exactly once per concluded upgrade.
+///
+/// <para>This is the single home for the "should we durably persist this trace,
+/// and if so do it" decision, keeping that concern out of the health-check
+/// strategy (whose job is probing the agent, not trace durability). It composes
+/// three collaborators: the in-memory <see cref="IUpgradeEventTimelineStore"/>
+/// (source of the current snapshot), the <see cref="IUpgradeTracePersistence"/>
+/// (the DB write), and the <see cref="IUpgradeTracePersistenceGate"/> (dedup so
+/// the same terminal status the agent re-reports on every probe is written
+/// once, not per-probe).</para>
+/// </summary>
+public interface IUpgradeTracePersister
+{
+    /// <summary>
+    /// If the machine's current in-memory status is terminal AND not already
+    /// persisted, write the trace snapshot to the DB and mark the dedup gate.
+    /// No-op when the status is absent / in-flight / already persisted. Never
+    /// throws — a DB failure is logged and the gate left open to retry on the
+    /// next probe.
+    /// </summary>
+    Task PersistIfTerminalAsync(int machineId, CancellationToken ct);
+}
+
+public sealed class UpgradeTracePersister : IUpgradeTracePersister, IScopedDependency
+{
+    private readonly IUpgradeEventTimelineStore _store;
+    private readonly IUpgradeTracePersistence _persistence;
+    private readonly IUpgradeTracePersistenceGate _gate;
+
+    public UpgradeTracePersister(IUpgradeEventTimelineStore store, IUpgradeTracePersistence persistence, IUpgradeTracePersistenceGate gate)
+    {
+        _store = store;
+        _persistence = persistence;
+        _gate = gate;
+    }
+
+    public async Task PersistIfTerminalAsync(int machineId, CancellationToken ct)
+    {
+        var status = _store.GetStatus(machineId);
+
+        if (status == null || !UpgradeStatusClassifier.IsTerminal(status.Status)) return;
+
+        var snapshot = new UpgradeTraceSnapshot
+        {
+            Status = status,
+            Events = _store.Get(machineId),
+            Log = _store.GetLog(machineId)
+        };
+
+        if (_gate.AlreadyPersisted(machineId, snapshot.Signature)) return;
+
+        try
+        {
+            await _persistence.SaveAsync(machineId, snapshot, ct).ConfigureAwait(false);
+
+            _gate.MarkPersisted(machineId, snapshot.Signature);
+
+            Log.Information("[UpgradeAudit] Persisted terminal upgrade trace for machine {MachineId} (status {Status}) — survives server pod restart.", machineId, status.Status);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a DB hiccup must not fail the health check. The
+            // in-memory store still holds the trace; the gate is left open so
+            // the next probe retries the write.
+            Log.Warning(ex, "[UpgradeAudit] Failed to persist terminal upgrade trace for machine {MachineId} — in-memory cache still holds it; next health-check probe will retry the DB write.", machineId);
+        }
+    }
+}

--- a/src/Squid.Core/Services/Machines/Upgrade/UpgradeStatusClassifier.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/UpgradeStatusClassifier.cs
@@ -1,0 +1,59 @@
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// Classifies an agent-reported upgrade <see cref="UpgradeStatusPayload.Status"/>
+/// string as <b>in-flight</b> (the upgrade is still progressing — more status
+/// transitions are expected) or <b>terminal</b> (the upgrade attempt has
+/// concluded — no further automated transitions will come).
+///
+/// <para><b>Why "not in-flight" instead of an explicit terminal allow-list:</b>
+/// the agent's upgrade scripts already emit a known, <i>small</i> set of
+/// in-flight markers (<see cref="InFlightStatuses"/>) and a larger, evolving
+/// set of terminal markers (SUCCESS / FAILED / ROLLED_BACK /
+/// ROLLBACK_NEEDED / ROLLBACK_CRITICAL_FAILED / ...). Defining terminal as
+/// "non-empty AND not one of the few in-flight markers" means a NEW terminal
+/// status added to a future agent script is automatically treated as terminal
+/// by older servers — no server-side drift. The cost of being wrong is benign:
+/// the durable-trace persister only ever <i>writes a snapshot</i>, so
+/// over-classifying an unknown status as terminal at worst persists one extra
+/// (still-accurate) snapshot.</para>
+///
+/// <para>Comparison is ordinal + case-sensitive because the agent scripts emit
+/// these tokens as fixed upper-case literals (see <c>upgrade-linux-tentacle.sh</c>
+/// <c>write_status</c> calls and <c>upgrade-windows-tentacle.ps1</c>
+/// <c>Write-Status</c>). The in-flight token values are pinned by unit test so a
+/// rename on either side is a test-time-visible decision.</para>
+/// </summary>
+public static class UpgradeStatusClassifier
+{
+    /// <summary>Upgrade started; method selection / download / verification underway.</summary>
+    public const string InProgress = "IN_PROGRESS";
+
+    /// <summary>New binary swapped into place; service restart imminent.</summary>
+    public const string Swapped = "SWAPPED";
+
+    /// <summary>Health check failed after restart; previous version being restored.</summary>
+    public const string RollingBack = "ROLLING_BACK";
+
+    /// <summary>
+    /// The complete set of statuses that mean "still progressing — do NOT treat
+    /// as a final outcome". Ordinal set; any non-empty status outside this set
+    /// is terminal. Pinned by <c>UpgradeStatusClassifierTests</c>.
+    /// </summary>
+    public static readonly IReadOnlySet<string> InFlightStatuses =
+        new HashSet<string>(StringComparer.Ordinal) { InProgress, Swapped, RollingBack };
+
+    /// <summary>
+    /// True when <paramref name="status"/> represents a concluded upgrade
+    /// attempt — i.e. it is non-empty and is not one of the
+    /// <see cref="InFlightStatuses"/>. Whitespace / null / empty is NOT terminal
+    /// (a fresh agent that never upgraded, or a status file the agent hasn't
+    /// written yet, has nothing worth persisting).
+    /// </summary>
+    public static bool IsTerminal(string status)
+    {
+        if (string.IsNullOrWhiteSpace(status)) return false;
+
+        return !InFlightStatuses.Contains(status);
+    }
+}

--- a/src/Squid.Core/Services/Machines/Upgrade/UpgradeTraceHydrator.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/UpgradeTraceHydrator.cs
@@ -1,0 +1,95 @@
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// Hydrates the in-memory <see cref="IUpgradeEventTimelineStore"/> from the
+/// <c>machine.last_upgrade_trace_json</c> column at server startup, so a freshly
+/// deployed pod doesn't show operators an empty upgrade timeline for machines
+/// whose most recent upgrade concluded before the restart.
+///
+/// <para>Also primes the <see cref="IUpgradeTracePersistenceGate"/> with each
+/// hydrated snapshot's signature, so the first post-restart Capabilities probe
+/// doesn't re-persist a terminal outcome that's already on disk.</para>
+///
+/// <para>Autofac calls <see cref="Start"/> once at container build time on every
+/// <see cref="IStartable"/> singleton. We block on the async load inline —
+/// startup is single-threaded and there's no benefit to deferring the warm-up.
+/// A DB read failure logs + continues with an empty cache (strictly better than
+/// blocking server startup on a transient DB issue); the next terminal upgrade
+/// per machine repopulates the row.</para>
+/// </summary>
+public sealed class UpgradeTraceHydrator : IStartable
+{
+    private readonly IComponentContext _container;
+
+    /// <summary>
+    /// Take the container (not the services directly) because
+    /// <see cref="IUpgradeTracePersistence"/> is scoped
+    /// (<see cref="IScopedDependency"/>) — we open a lifetime scope for the
+    /// one-off startup query, then dispose it. The store + gate are singletons
+    /// resolved from the root context.
+    /// </summary>
+    public UpgradeTraceHydrator(IComponentContext container)
+    {
+        _container = container;
+    }
+
+    public void Start()
+    {
+        try
+        {
+            HydrateAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex,
+                "UpgradeTraceHydrator failed to load persisted upgrade traces — server will start with an " +
+                "empty in-memory upgrade timeline cache and repopulate per machine from the next terminal upgrade.");
+        }
+    }
+
+    private async Task HydrateAsync(CancellationToken ct)
+    {
+        var store = _container.Resolve<IUpgradeEventTimelineStore>();
+        var gate = _container.Resolve<IUpgradeTracePersistenceGate>();
+
+        // Persistence is scoped (IScopedDependency) so we MUST open a lifetime
+        // scope to resolve it (it depends on the EF DbContext / unit-of-work).
+        await using var scope = _container.Resolve<ILifetimeScope>().BeginLifetimeScope();
+
+        var persistence = scope.Resolve<IUpgradeTracePersistence>();
+
+        var rows = await persistence.LoadAllAsync(ct).ConfigureAwait(false);
+
+        var hydrated = ApplyTo(store, gate, rows);
+
+        Log.Information("UpgradeTraceHydrator hydrated {Count} machine(s) from persisted upgrade traces.", hydrated);
+    }
+
+    /// <summary>
+    /// Pure hydrate step: replay each persisted snapshot into the in-memory
+    /// store (status + events + log) and prime the dedup gate so the snapshot
+    /// already on disk isn't re-persisted on the first post-restart probe.
+    /// Public so it can be exercised by tests (unit + integration) without an
+    /// Autofac container — it has no instance state and no side effects beyond
+    /// the two collaborators passed in.
+    /// </summary>
+    public static int ApplyTo(IUpgradeEventTimelineStore store, IUpgradeTracePersistenceGate gate, IReadOnlyList<(int MachineId, UpgradeTraceSnapshot Snapshot)> snapshots)
+    {
+        var hydrated = 0;
+
+        foreach (var (machineId, snapshot) in snapshots)
+        {
+            if (snapshot == null) continue;
+
+            store.StoreStatus(machineId, snapshot.Status);
+            store.Store(machineId, snapshot.Events);
+            store.StoreLog(machineId, snapshot.Log);
+
+            gate.MarkPersisted(machineId, snapshot.Signature);
+
+            hydrated++;
+        }
+
+        return hydrated;
+    }
+}

--- a/src/Squid.Core/Services/Machines/Upgrade/UpgradeTraceSnapshot.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/UpgradeTraceSnapshot.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace Squid.Core.Services.Machines.Upgrade;
+
+/// <summary>
+/// A point-in-time durable snapshot of a machine's upgrade trace: the
+/// structured <see cref="UpgradeStatusPayload"/>, the parsed event
+/// <see cref="Events"/> timeline, and the Phase B <see cref="Log"/> text — the
+/// exact three pieces the in-memory <see cref="IUpgradeEventTimelineStore"/>
+/// holds per machine.
+///
+/// <para>Persisted as a single JSON blob in <c>machine.last_upgrade_trace_json</c>
+/// once per upgrade (when the agent first reports a terminal status) and
+/// hydrated back into the in-memory store at server startup, so a server pod
+/// restart no longer erases how the most recent upgrade concluded.</para>
+///
+/// <para>The wrapper keys (<c>status</c>/<c>events</c>/<c>log</c>) are explicit
+/// so the on-disk shape doesn't depend on a serializer naming policy; the nested
+/// <see cref="UpgradeStatusPayload"/> / <see cref="UpgradeEvent"/> already pin
+/// their own field names via <see cref="JsonPropertyNameAttribute"/>. The shape
+/// is pinned by <c>UpgradeTracePersistenceShapeTests</c>.</para>
+/// </summary>
+public sealed record UpgradeTraceSnapshot
+{
+    [JsonPropertyName("status")]
+    public UpgradeStatusPayload Status { get; init; }
+
+    [JsonPropertyName("events")]
+    public IReadOnlyList<UpgradeEvent> Events { get; init; } = Array.Empty<UpgradeEvent>();
+
+    [JsonPropertyName("log")]
+    public string Log { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Stable dedup key for the durable persister. Two probes that observe the
+    /// SAME terminal outcome produce the same signature, so the persister writes
+    /// the snapshot exactly once per concluded upgrade instead of on every probe.
+    ///
+    /// <para>Built from the status string + the agent's <c>updatedAt</c>
+    /// (immutable once the status is terminal — the agent writes it once at
+    /// conclusion). On a schema-v1 agent that omits <c>updatedAt</c>, the status
+    /// string alone dedups correctly because a terminal status doesn't change
+    /// after the upgrade concludes. Not serialised.</para>
+    /// </summary>
+    [JsonIgnore]
+    public string Signature => $"{Status?.Status}@{Status?.UpdatedAt?.ToString("O") ?? "-"}";
+}

--- a/src/Squid.Core/SquidModule.cs
+++ b/src/Squid.Core/SquidModule.cs
@@ -167,6 +167,14 @@ public class SquidModule : Module
         builder.RegisterType<Squid.Core.Services.DeploymentExecution.Tentacle.MachineRuntimeCapabilitiesCacheHydrator>()
             .As<IStartable>()
             .SingleInstance();
+
+        // Hydrate the in-memory upgrade timeline cache from the persisted
+        // last_upgrade_trace_json column at startup, so a server pod restart
+        // doesn't erase the operator's view of how the most recent upgrade
+        // concluded (and so the dedup gate doesn't re-persist on-disk snapshots).
+        builder.RegisterType<Squid.Core.Services.Machines.Upgrade.UpgradeTraceHydrator>()
+            .As<IStartable>()
+            .SingleInstance();
     }
 
     private void RegisterDependency(ContainerBuilder builder)

--- a/tests/Squid.IntegrationTests/Services/Machines/Upgrade/UpgradeTracePersistenceIntegrationTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Machines/Upgrade/UpgradeTracePersistenceIntegrationTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Machines.Upgrade;
+using Squid.IntegrationTests.Base;
+
+namespace Squid.IntegrationTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Real-DB coverage for the durable upgrade trace (Rule 9 integration tier):
+/// exercises <see cref="UpgradeTracePersistence"/> against a live Postgres,
+/// proving the snapshot writes to / loads from the
+/// <c>machine.last_upgrade_trace_json</c> column, and that a simulated server
+/// restart (a fresh in-memory store hydrated from the DB) restores the trace —
+/// the whole point of persisting the terminal outcome.
+/// </summary>
+public sealed class UpgradeTracePersistenceIntegrationTests : TestBase
+{
+    public UpgradeTracePersistenceIntegrationTests()
+        : base("UpgradeTracePersistence", "squid_it_upgrade_trace")
+    {
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesTraceJsonAndTimestamp_ToMachineRow()
+    {
+        var machineId = await SeedMachineAsync();
+
+        await Run<IUpgradeTracePersistence>(p => p.SaveAsync(machineId, SnapshotFor("SUCCESS", exitCode: 0), CancellationToken.None));
+
+        await Run<IRepository>(async repo =>
+        {
+            var machine = await repo.QueryNoTracking<Machine>(m => m.Id == machineId).FirstAsync(CancellationToken.None).ConfigureAwait(false);
+
+            machine.LastUpgradeTraceJson.ShouldNotBeNull();
+            // jsonb normalises formatting on read-back (reorders keys, adds a
+            // space after ':'), so assert on the value substring rather than an
+            // exact serialised layout. The round-trip shape is verified precisely
+            // by LoadAllAsync_RoundTripsSavedSnapshot (which deserialises).
+            machine.LastUpgradeTraceJson.ShouldContain("SUCCESS");
+            machine.LastUpgradeTraceUpdatedAt.ShouldNotBeNull(
+                customMessage: "persisting a terminal trace must stamp last_upgrade_trace_updated_at so admin queries can sort by recency.");
+        });
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_RoundTripsSavedSnapshot()
+    {
+        var machineId = await SeedMachineAsync();
+
+        await Run<IUpgradeTracePersistence>(p => p.SaveAsync(machineId, SnapshotFor("FAILED", exitCode: 7), CancellationToken.None));
+
+        var loaded = await Run<IUpgradeTracePersistence, (int, UpgradeTraceSnapshot)?>(async p =>
+        {
+            var all = await p.LoadAllAsync(CancellationToken.None).ConfigureAwait(false);
+            foreach (var row in all)
+                if (row.MachineId == machineId) return row;
+            return null;
+        });
+
+        loaded.ShouldNotBeNull("the saved machine must come back from LoadAllAsync.");
+        var snapshot = loaded.Value.Item2;
+        snapshot.Status.Status.ShouldBe("FAILED");
+        snapshot.Status.ExitCode.ShouldBe(7);
+        snapshot.Events.Count.ShouldBe(2);
+        snapshot.Events[1].Kind.ShouldBe("done");
+        snapshot.Log.ShouldContain("Restarting service");
+    }
+
+    [Fact]
+    public async Task SaveAsync_Twice_LatestOutcomeWins()
+    {
+        var machineId = await SeedMachineAsync();
+
+        await Run<IUpgradeTracePersistence>(p => p.SaveAsync(machineId, SnapshotFor("FAILED", exitCode: 7), CancellationToken.None));
+        await Run<IUpgradeTracePersistence>(p => p.SaveAsync(machineId, SnapshotFor("SUCCESS", exitCode: 0), CancellationToken.None));
+
+        var status = await LoadStatusAsync(machineId);
+
+        status.ShouldBe("SUCCESS", "a later terminal outcome (a re-run upgrade) must overwrite the earlier one — the column holds the LATEST trace.");
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_SkipsMachinesWithNoTrace()
+    {
+        // A machine that never had a terminal upgrade has NULL columns and must
+        // not appear in the hydrate set (its in-memory timeline stays empty).
+        var machineId = await SeedMachineAsync();
+
+        var present = await Run<IUpgradeTracePersistence, bool>(async p =>
+        {
+            var all = await p.LoadAllAsync(CancellationToken.None).ConfigureAwait(false);
+            foreach (var row in all)
+                if (row.MachineId == machineId) return true;
+            return false;
+        });
+
+        present.ShouldBeFalse("a machine with NULL last_upgrade_trace_json must be skipped by LoadAllAsync.");
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_SkipsUndeserialisableRow_DoesNotThrow()
+    {
+        // A jsonb column guarantees well-formed JSON (Postgres rejects malformed
+        // input at write time), so the realistic corruption is a VALID-JSON blob
+        // of the wrong shape — e.g. schema drift to an incompatible structure. A
+        // root-kind mismatch (array where an object is expected) makes
+        // Deserialize<UpgradeTraceSnapshot> throw; LoadAllAsync must log + skip
+        // it, never crash startup hydration.
+        var goodId = await SeedMachineAsync();
+        var badId = await SeedMachineAsync();
+
+        await Run<IUpgradeTracePersistence>(p => p.SaveAsync(goodId, SnapshotFor("SUCCESS", exitCode: 0), CancellationToken.None));
+
+        await Run<IRepository>(repo => repo.ExecuteUpdateAsync<Machine>(
+            m => m.Id == badId,
+            s => s.SetProperty(m => m.LastUpgradeTraceJson, "[1, 2, 3]"),
+            CancellationToken.None));
+
+        var loaded = await Run<IUpgradeTracePersistence, System.Collections.Generic.List<int>>(async p =>
+        {
+            var all = await p.LoadAllAsync(CancellationToken.None).ConfigureAwait(false);
+            var ids = new System.Collections.Generic.List<int>();
+            foreach (var row in all) ids.Add(row.MachineId);
+            return ids;
+        });
+
+        loaded.ShouldContain(goodId, "the well-formed row must still load despite a sibling corrupt row.");
+        loaded.ShouldNotContain(badId, "the malformed row must be skipped, not surfaced or thrown.");
+    }
+
+    [Fact]
+    public async Task Durability_SimulatedRestart_HydratorRestoresTraceIntoFreshStore()
+    {
+        // End-to-end proof of #2: persist a terminal outcome, then simulate a
+        // server pod restart with a brand-new (empty) in-memory store + gate,
+        // hydrate it from the DB, and confirm the operator-visible timeline is
+        // restored — status, events, AND Phase B log.
+        var machineId = await SeedMachineAsync();
+
+        await Run<IUpgradeTracePersistence>(p => p.SaveAsync(machineId, SnapshotFor("SUCCESS", exitCode: 0), CancellationToken.None));
+
+        var freshStore = new InMemoryUpgradeEventTimelineStore();   // "server just restarted"
+        var freshGate = new UpgradeTracePersistenceGate();
+
+        await Run<IUpgradeTracePersistence>(async p =>
+        {
+            var all = await p.LoadAllAsync(CancellationToken.None).ConfigureAwait(false);
+            UpgradeTraceHydrator.ApplyTo(freshStore, freshGate, all);
+        });
+
+        freshStore.GetStatus(machineId).ShouldNotBeNull("post-restart hydration must restore the status payload.");
+        freshStore.GetStatus(machineId).Status.ShouldBe("SUCCESS");
+        freshStore.GetStatus(machineId).ExitCode.ShouldBe(0);
+        freshStore.Get(machineId).Count.ShouldBe(2, "the event timeline must survive the restart.");
+        freshStore.GetLog(machineId).ShouldContain("Restarting service", customMessage: "the Phase B log must survive the restart.");
+
+        freshGate.AlreadyPersisted(machineId, SnapshotFor("SUCCESS", exitCode: 0).Signature)
+            .ShouldBeTrue("hydration must prime the gate so the first post-restart probe doesn't re-write the on-disk snapshot.");
+    }
+
+    private async Task<string> LoadStatusAsync(int machineId)
+    {
+        return await Run<IUpgradeTracePersistence, string>(async p =>
+        {
+            var all = await p.LoadAllAsync(CancellationToken.None).ConfigureAwait(false);
+            foreach (var row in all)
+                if (row.MachineId == machineId) return row.Snapshot.Status.Status;
+            return null;
+        });
+    }
+
+    private static UpgradeTraceSnapshot SnapshotFor(string status, int exitCode) => new()
+    {
+        Status = new UpgradeStatusPayload
+        {
+            SchemaVersion = 2,
+            Status = status,
+            TargetVersion = "1.8.7",
+            InstallMethod = "tarball",
+            ExitCode = exitCode,
+            UpdatedAt = DateTimeOffset.Parse("2026-06-01T10:01:30Z")
+        },
+        Events = new[]
+        {
+            new UpgradeEvent { Phase = "A", Kind = "start", Message = "Selecting upgrade method" },
+            new UpgradeEvent { Phase = "B", Kind = "done", Message = "finished" }
+        },
+        Log = "=== In scope ===\nRestarting service...\nUpgrade successful"
+    };
+
+    private async Task<int> SeedMachineAsync()
+    {
+        var machineId = 0;
+        var unique = Guid.NewGuid().ToString("N");
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var machine = new Machine
+            {
+                Name = $"trace-agent-{unique}",
+                IsDisabled = false,
+                Roles = System.Text.Json.JsonSerializer.Serialize(new[] { "web-server" }),
+                EnvironmentIds = System.Text.Json.JsonSerializer.Serialize(new[] { 1 }),
+                SpaceId = 1,
+                Endpoint = """{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub","Thumbprint":"AABB"}""",
+                Slug = $"trace-agent-{unique}"
+            };
+
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+            machineId = machine.Id;
+        });
+
+        return machineId;
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleHealthCheckStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleHealthCheckStrategyTests.cs
@@ -397,7 +397,8 @@ public class TentacleHealthCheckStrategyTests
         var gate = new UpgradeTracePersistenceGate();
         var (persistence, captured) = CapturingPersistence();
 
-        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: gate);
+        var persister = new UpgradeTracePersister(store, persistence.Object, gate);
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersister: persister);
 
         var result = await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
 
@@ -425,7 +426,7 @@ public class TentacleHealthCheckStrategyTests
         var store = new InMemoryUpgradeEventTimelineStore();
         var (persistence, _) = CapturingPersistence();
 
-        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: new UpgradeTracePersistenceGate());
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersister: new UpgradeTracePersister(store, persistence.Object, new UpgradeTracePersistenceGate()));
 
         await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
 
@@ -447,7 +448,8 @@ public class TentacleHealthCheckStrategyTests
         var gate = new UpgradeTracePersistenceGate();
         var (persistence, _) = CapturingPersistence();
 
-        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: gate);
+        var persister = new UpgradeTracePersister(store, persistence.Object, gate);
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersister: persister);
 
         await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
         await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
@@ -471,7 +473,8 @@ public class TentacleHealthCheckStrategyTests
         persistence.Setup(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("db down"));
 
-        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: gate);
+        var persister = new UpgradeTracePersister(store, persistence.Object, gate);
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersister: persister);
 
         var result = await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
 

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleHealthCheckStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/TentacleHealthCheckStrategyTests.cs
@@ -381,6 +381,161 @@ public class TentacleHealthCheckStrategyTests
         cached.Detail.ShouldBe("previous good outcome");
     }
 
+    // ========================================================================
+    // Durable upgrade trace — when the agent reports a TERMINAL upgrade status,
+    // the strategy persists the current trace snapshot (status + events + log)
+    // to the DB exactly once (gated), so the outcome survives a server restart.
+    // ========================================================================
+
+    [Fact]
+    public async Task CheckHealth_TerminalUpgrade_PersistsTraceOnce_WithStatusEventsAndLog()
+    {
+        var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-1","Thumbprint":"CCDD"}""", machineId: 200);
+        SetupCapsClientReturning(TraceResponse("SUCCESS", exitCode: 0));
+
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+        var (persistence, captured) = CapturingPersistence();
+
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: gate);
+
+        var result = await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+
+        result.Healthy.ShouldBeTrue();
+
+        persistence.Verify(p => p.SaveAsync(200, It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Once);
+        captured.Count.ShouldBe(1);
+        captured[0].Status.Status.ShouldBe("SUCCESS");
+        captured[0].Status.ExitCode.ShouldBe(0);
+        captured[0].Events.Count.ShouldBe(2, "the persisted snapshot must include the event timeline captured on this probe.");
+        captured[0].Log.ShouldNotBeNullOrEmpty("the persisted snapshot must include the Phase B log captured on this probe.");
+
+        gate.AlreadyPersisted(200, captured[0].Signature).ShouldBeTrue("a successful persist must mark the gate so the same outcome isn't re-written.");
+    }
+
+    [Theory]
+    [InlineData("IN_PROGRESS")]
+    [InlineData("SWAPPED")]
+    [InlineData("ROLLING_BACK")]
+    public async Task CheckHealth_InFlightUpgrade_DoesNotPersistTrace(string inFlightStatus)
+    {
+        var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-1","Thumbprint":"CCDD"}""", machineId: 201);
+        SetupCapsClientReturning(TraceResponse(inFlightStatus));
+
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var (persistence, _) = CapturingPersistence();
+
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: new UpgradeTracePersistenceGate());
+
+        await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+
+        persistence.Verify(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an in-flight upgrade has not concluded — persisting now would write a non-final snapshot AND re-write on every probe.");
+    }
+
+    [Fact]
+    public async Task CheckHealth_SameTerminalOutcomeReReportedAcrossProbes_PersistsOnlyOnce()
+    {
+        // The agent keeps reporting SUCCESS on every probe until the next
+        // upgrade. The gate must suppress all but the first persist — this is
+        // what lets us keep the timeline cache in-memory without a per-probe
+        // DB write storm.
+        var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-1","Thumbprint":"CCDD"}""", machineId: 202);
+        SetupCapsClientReturning(TraceResponse("SUCCESS", exitCode: 0));
+
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+        var (persistence, _) = CapturingPersistence();
+
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: gate);
+
+        await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+        await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+        await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+
+        persistence.Verify(p => p.SaveAsync(202, It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Once,
+            "three probes reporting the same terminal outcome must result in exactly one durable write.");
+    }
+
+    [Fact]
+    public async Task CheckHealth_PersistenceThrows_HealthCheckStillHealthy_GateNotMarked()
+    {
+        // Best-effort: a DB hiccup must not fail the health check, and must leave
+        // the gate open so the NEXT probe retries the persist.
+        var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-1","Thumbprint":"CCDD"}""", machineId: 203);
+        SetupCapsClientReturning(TraceResponse("FAILED", exitCode: 7));
+
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+        var persistence = new Mock<IUpgradeTracePersistence>();
+        persistence.Setup(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store, upgradeTracePersistence: persistence.Object, upgradeTraceGate: gate);
+
+        var result = await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+
+        result.Healthy.ShouldBeTrue("a durable-persist failure is advisory and must not turn a healthy tentacle unhealthy.");
+        gate.AlreadyPersisted(203, "FAILED@2026-06-01T10:01:00.0000000+00:00").ShouldBeFalse(
+            "a failed write must NOT mark the gate, so the next probe retries.");
+    }
+
+    [Fact]
+    public async Task CheckHealth_TracePersistenceNotWired_NoThrow_StillHealthy()
+    {
+        // persistence + gate are OPTIONAL deps. A strategy wired without them
+        // (e.g. a context that doesn't need durable traces) must not NPE.
+        var machine = MachineWithEndpoint("""{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-1","Thumbprint":"CCDD"}""", machineId: 204);
+        SetupCapsClientReturning(TraceResponse("SUCCESS", exitCode: 0));
+
+        var store = new InMemoryUpgradeEventTimelineStore();
+        // No upgradeTracePersistence / upgradeTraceGate.
+        var strategy = new TentacleHealthCheckStrategy(_clientFactory.Object, upgradeEventStore: store);
+
+        var result = await strategy.CheckHealthAsync(machine, null, CancellationToken.None);
+
+        result.Healthy.ShouldBeTrue();
+    }
+
+    private static (Mock<IUpgradeTracePersistence> mock, List<UpgradeTraceSnapshot> captured) CapturingPersistence()
+    {
+        var captured = new List<UpgradeTraceSnapshot>();
+        var mock = new Mock<IUpgradeTracePersistence>();
+        mock.Setup(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<int, UpgradeTraceSnapshot, CancellationToken>((_, s, _) => captured.Add(s))
+            .Returns(Task.CompletedTask);
+        return (mock, captured);
+    }
+
+    private void SetupCapsClientReturning(CapabilitiesResponse response)
+    {
+        var capsClient = new Mock<IAsyncCapabilitiesService>();
+        capsClient.Setup(c => c.GetCapabilitiesAsync(It.IsAny<CapabilitiesRequest>())).ReturnsAsync(response);
+        _clientFactory.Setup(f => f.CreateCapabilitiesClient(It.IsAny<ServiceEndPoint>())).Returns(capsClient.Object);
+    }
+
+    private static CapabilitiesResponse TraceResponse(string status, int? exitCode = null)
+    {
+        var exitCodeField = exitCode.HasValue ? $",\"exitCode\":{exitCode.Value}" : string.Empty;
+        var statusJson = $"{{\"schemaVersion\":2,\"status\":\"{status}\",\"targetVersion\":\"1.8.7\",\"installMethod\":\"tarball\",\"updatedAt\":\"2026-06-01T10:01:00Z\"{exitCodeField}}}";
+
+        var eventsJsonl =
+            "{\"t\":\"2026-06-01T10:00:00Z\",\"phase\":\"A\",\"kind\":\"start\",\"msg\":\"Selecting upgrade method\"}\n" +
+            "{\"t\":\"2026-06-01T10:01:00Z\",\"phase\":\"B\",\"kind\":\"done\",\"msg\":\"finished\"}";
+
+        return new CapabilitiesResponse
+        {
+            AgentVersion = "1.8.7",
+            SupportedServices = new List<string> { "IScriptService/v1" },
+            Metadata = new Dictionary<string, string>
+            {
+                ["upgradeStatus"] = statusJson,
+                ["upgradeEvents"] = eventsJsonl,
+                ["upgradeLog"] = "=== In scope ===\nRestarting service...\nUpgrade successful"
+            }
+        };
+    }
+
     private Mock<IAsyncCapabilitiesService> SetupCapabilitiesClient(string agentVersion, params string[] services)
     {
         var capsClient = new Mock<IAsyncCapabilitiesService>();

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeStatusClassifierTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeStatusClassifierTests.cs
@@ -1,0 +1,90 @@
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Pins the terminal/in-flight classification that gates durable upgrade-trace
+/// persistence. Getting this wrong in the "false negative" direction (treating a
+/// concluded upgrade as still in-flight) means the outcome is never persisted
+/// and is lost on a server restart; the "false positive" direction (treating an
+/// in-flight status as terminal) would persist a non-final snapshot. Both are
+/// pinned here.
+/// </summary>
+public sealed class UpgradeStatusClassifierTests
+{
+    [Theory]
+    [InlineData("IN_PROGRESS")]   // upgrade started, downloading / verifying
+    [InlineData("SWAPPED")]       // binary in place, restart imminent
+    [InlineData("ROLLING_BACK")]  // health check failed, restoring previous version
+    public void IsTerminal_InFlightStatuses_ReturnsFalse(string status)
+    {
+        // These statuses mean "more transitions are coming". Persisting on them
+        // would write a non-final snapshot AND re-write on every probe until the
+        // upgrade concludes — exactly the per-probe cost we avoid.
+        UpgradeStatusClassifier.IsTerminal(status).ShouldBeFalse(
+            customMessage: $"'{status}' is an in-flight status — the upgrade has not concluded, so it must NOT be treated as terminal.");
+    }
+
+    [Theory]
+    [InlineData("SUCCESS")]
+    [InlineData("FAILED")]
+    [InlineData("ROLLED_BACK")]
+    [InlineData("ROLLBACK_NEEDED")]            // manual rollback required (agent gave up)
+    [InlineData("ROLLBACK_CRITICAL_FAILED")]   // agent in unknown state, manual intervention
+    public void IsTerminal_ConcludedStatuses_ReturnsTrue(string status)
+    {
+        // Every status the Linux .sh / Windows .ps1 scripts write at the END of
+        // an attempt. These are the outcomes worth persisting durably.
+        UpgradeStatusClassifier.IsTerminal(status).ShouldBeTrue(
+            customMessage: $"'{status}' is a concluded outcome — it must be treated as terminal so the durable trace is persisted.");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsTerminal_EmptyOrWhitespace_ReturnsFalse(string status)
+    {
+        // A fresh agent that never upgraded, or one whose status file hasn't been
+        // written yet, has nothing worth persisting.
+        UpgradeStatusClassifier.IsTerminal(status).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTerminal_UnknownNonEmptyStatus_TreatedAsTerminal()
+    {
+        // Drift resilience: a NEW terminal status added to a future agent script
+        // (that this server build doesn't know about) must still be persisted.
+        // "Not in the small, stable in-flight set" ⇒ terminal. Over-persisting an
+        // unexpected status is benign (we only ever write a snapshot).
+        UpgradeStatusClassifier.IsTerminal("SOME_FUTURE_TERMINAL_STATE").ShouldBeTrue(
+            customMessage: "an unrecognised non-empty status must be treated as terminal so a future agent's new outcome isn't silently dropped from the durable trace.");
+    }
+
+    [Fact]
+    public void IsTerminal_IsCaseSensitiveOrdinal()
+    {
+        // The agent emits fixed UPPER-CASE tokens. A lower-case "in_progress"
+        // does NOT match the in-flight set, so by the "not in-flight ⇒ terminal"
+        // rule it classifies as terminal. This pins the ordinal contract — if the
+        // agent ever changed casing, this test forces the decision to be explicit.
+        UpgradeStatusClassifier.IsTerminal("in_progress").ShouldBeTrue(
+            customMessage: "comparison is ordinal/case-sensitive against the agent's upper-case tokens; lower-case is not a recognised in-flight marker.");
+    }
+
+    [Fact]
+    public void InFlightStatuses_ConstantValues_Pinned()
+    {
+        // Rule 8 drift pin: these literals are the wire contract with the agent
+        // scripts (upgrade-linux-tentacle.sh write_status / upgrade-windows-tentacle.ps1
+        // Write-Status). A rename here without a matching agent change silently
+        // breaks classification.
+        UpgradeStatusClassifier.InProgress.ShouldBe("IN_PROGRESS");
+        UpgradeStatusClassifier.Swapped.ShouldBe("SWAPPED");
+        UpgradeStatusClassifier.RollingBack.ShouldBe("ROLLING_BACK");
+
+        UpgradeStatusClassifier.InFlightStatuses.ShouldBe(
+            new[] { "IN_PROGRESS", "SWAPPED", "ROLLING_BACK" },
+            ignoreOrder: true);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTraceHydratorTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTraceHydratorTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Pins the pure hydrate step that runs at server startup: persisted snapshots
+/// are replayed into the in-memory timeline store (so operators see the most
+/// recent upgrade outcome immediately after a restart) AND the dedup gate is
+/// primed (so the first post-restart probe doesn't re-write a snapshot already
+/// on disk).
+/// </summary>
+public sealed class UpgradeTraceHydratorTests
+{
+    private static UpgradeTraceSnapshot Snapshot(string status, string updatedAt, params string[] eventKinds)
+    {
+        var events = new List<UpgradeEvent>();
+        foreach (var k in eventKinds) events.Add(new UpgradeEvent { Kind = k });
+
+        return new UpgradeTraceSnapshot
+        {
+            Status = new UpgradeStatusPayload { Status = status, UpdatedAt = DateTimeOffset.Parse(updatedAt) },
+            Events = events,
+            Log = $"log-for-{status}"
+        };
+    }
+
+    [Fact]
+    public void ApplyTo_PopulatesStore_StatusEventsAndLog_PerMachine()
+    {
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+
+        var rows = new List<(int, UpgradeTraceSnapshot)>
+        {
+            (10, Snapshot("SUCCESS", "2026-06-01T10:00:00Z", "start", "success")),
+            (20, Snapshot("FAILED", "2026-06-01T11:00:00Z", "start", "fail"))
+        };
+
+        var hydrated = UpgradeTraceHydrator.ApplyTo(store, gate, rows);
+
+        hydrated.ShouldBe(2);
+
+        store.GetStatus(10).Status.ShouldBe("SUCCESS");
+        store.Get(10).Count.ShouldBe(2);
+        store.GetLog(10).ShouldBe("log-for-SUCCESS");
+
+        store.GetStatus(20).Status.ShouldBe("FAILED");
+        store.Get(20)[1].Kind.ShouldBe("fail");
+    }
+
+    [Fact]
+    public void ApplyTo_PrimesGate_SoHydratedSnapshotIsNotRePersisted()
+    {
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+        var snapshot = Snapshot("SUCCESS", "2026-06-01T10:00:00Z", "success");
+
+        UpgradeTraceHydrator.ApplyTo(store, gate, new List<(int, UpgradeTraceSnapshot)> { (10, snapshot) });
+
+        gate.AlreadyPersisted(10, snapshot.Signature).ShouldBeTrue(
+            customMessage: "hydrated snapshots must prime the gate; otherwise every machine re-persists its on-disk trace on the first post-restart probe (a write storm).");
+    }
+
+    [Fact]
+    public void ApplyTo_SkipsNullSnapshots_DoesNotThrow()
+    {
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+
+        var rows = new List<(int, UpgradeTraceSnapshot)>
+        {
+            (10, Snapshot("SUCCESS", "2026-06-01T10:00:00Z", "success")),
+            (20, null)
+        };
+
+        var hydrated = UpgradeTraceHydrator.ApplyTo(store, gate, rows);
+
+        hydrated.ShouldBe(1);
+        store.GetStatus(20).ShouldBeNull("a null snapshot row must be skipped, not stored as an empty entry.");
+    }
+
+    [Fact]
+    public void ApplyTo_EmptyInput_ReturnsZero()
+    {
+        var store = new InMemoryUpgradeEventTimelineStore();
+        var gate = new UpgradeTracePersistenceGate();
+
+        UpgradeTraceHydrator.ApplyTo(store, gate, Array.Empty<(int, UpgradeTraceSnapshot)>()).ShouldBe(0);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTracePersistenceGateTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTracePersistenceGateTests.cs
@@ -1,0 +1,84 @@
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Pins the dedup gate that makes durable persistence write a terminal outcome
+/// exactly once instead of on every probe. The gate is the mechanism that lets
+/// us keep the timeline cache in-memory (cheap per-probe writes) while still
+/// surviving a restart (one durable write per concluded upgrade).
+/// </summary>
+public sealed class UpgradeTracePersistenceGateTests
+{
+    [Fact]
+    public void AlreadyPersisted_ColdGate_ReturnsFalse()
+    {
+        var gate = new UpgradeTracePersistenceGate();
+
+        gate.AlreadyPersisted(machineId: 1, signature: "SUCCESS@2026-06-01T10:00:00Z")
+            .ShouldBeFalse("a machine never marked must report not-yet-persisted so its first terminal outcome is written.");
+    }
+
+    [Fact]
+    public void MarkPersisted_ThenAlreadyPersisted_SameSignature_ReturnsTrue()
+    {
+        var gate = new UpgradeTracePersistenceGate();
+
+        gate.MarkPersisted(1, "SUCCESS@2026-06-01T10:00:00Z");
+
+        gate.AlreadyPersisted(1, "SUCCESS@2026-06-01T10:00:00Z")
+            .ShouldBeTrue("the same terminal outcome the agent re-reports on every subsequent probe must NOT be re-persisted.");
+    }
+
+    [Fact]
+    public void AlreadyPersisted_DifferentSignature_ReturnsFalse()
+    {
+        // A NEW upgrade concluded with a different outcome (or same status at a
+        // later updatedAt). The signature changes → must persist again.
+        var gate = new UpgradeTracePersistenceGate();
+
+        gate.MarkPersisted(1, "FAILED@2026-06-01T10:00:00Z");
+
+        gate.AlreadyPersisted(1, "SUCCESS@2026-06-02T09:00:00Z")
+            .ShouldBeFalse("a new terminal outcome (different signature) must be persisted even after a prior one was.");
+    }
+
+    [Fact]
+    public void MarkPersisted_OverwritesPriorSignatureForMachine()
+    {
+        // After a second upgrade, only the latest signature is the dedup key —
+        // the previous one should no longer suppress writes (it can't recur
+        // anyway, but pin the replace semantics).
+        var gate = new UpgradeTracePersistenceGate();
+
+        gate.MarkPersisted(1, "FAILED@t1");
+        gate.MarkPersisted(1, "SUCCESS@t2");
+
+        gate.AlreadyPersisted(1, "SUCCESS@t2").ShouldBeTrue();
+        gate.AlreadyPersisted(1, "FAILED@t1").ShouldBeFalse(
+            "only the most recently persisted signature dedups; the gate tracks the latest, not history.");
+    }
+
+    [Fact]
+    public void Gate_PerMachineIsolation_NoCrossMachineSuppression()
+    {
+        var gate = new UpgradeTracePersistenceGate();
+
+        gate.MarkPersisted(1, "SUCCESS@t");
+
+        gate.AlreadyPersisted(2, "SUCCESS@t")
+            .ShouldBeFalse("machine 2 marking is independent of machine 1 — a shared signature must not suppress a different machine's write.");
+    }
+
+    [Fact]
+    public void MarkPersisted_NullSignature_DoesNotThrow_NormalisesToEmpty()
+    {
+        // Defensive: a snapshot with an all-null status would produce an odd
+        // signature; null must not poison the map.
+        var gate = new UpgradeTracePersistenceGate();
+
+        Should.NotThrow(() => gate.MarkPersisted(1, null));
+
+        gate.AlreadyPersisted(1, string.Empty).ShouldBeTrue();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTracePersistenceShapeTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTracePersistenceShapeTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Pins the on-disk JSON shape of <see cref="UpgradeTraceSnapshot"/>. These rows
+/// persist across server upgrades; a property-name change without a migration
+/// would mean the UpgradeTraceHydrator can no longer parse rows written by an
+/// older server — silently regressing operators back to an empty post-restart
+/// timeline. Mirrors the H2 MachineRuntimeCapabilitiesPersistence shape pins.
+/// </summary>
+public sealed class UpgradeTracePersistenceShapeTests
+{
+    private static UpgradeTraceSnapshot SampleSnapshot() => new()
+    {
+        Status = new UpgradeStatusPayload
+        {
+            SchemaVersion = 2,
+            Status = "SUCCESS",
+            TargetVersion = "1.8.7",
+            InstallMethod = "tarball",
+            ExitCode = 0,
+            Detail = "Agent restarted, healthz OK",
+            StartedAt = DateTimeOffset.Parse("2026-06-01T10:00:00Z"),
+            UpdatedAt = DateTimeOffset.Parse("2026-06-01T10:01:30Z")
+        },
+        Events = new[]
+        {
+            new UpgradeEvent { Phase = "A", Kind = "start", Message = "Selecting upgrade method" },
+            new UpgradeEvent { Phase = "B", Kind = "success", Message = "done" }
+        },
+        Log = "=== In scope ===\nRestarting service...\nUpgrade successful"
+    };
+
+    [Fact]
+    public void SerialisedShape_WrapperAndNestedKeys_Stable()
+    {
+        var json = JsonSerializer.Serialize(SampleSnapshot(), UpgradeTracePersistence.SerializerOptions);
+
+        // Wrapper keys — explicit so the shape is independent of naming policy.
+        json.ShouldContain("\"status\":{");
+        json.ShouldContain("\"events\":[");
+        json.ShouldContain("\"log\":");
+
+        // Nested status payload keys (its own [JsonPropertyName] contract).
+        json.ShouldContain("\"status\":\"SUCCESS\"");
+        json.ShouldContain("\"targetVersion\":\"1.8.7\"");
+        json.ShouldContain("\"installMethod\":\"tarball\"");
+        json.ShouldContain("\"exitCode\":0");
+
+        // Nested event keys (the compact "t/phase/kind/msg" wire shape).
+        json.ShouldContain("\"kind\":\"success\"");
+        json.ShouldContain("\"msg\":\"done\"");
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesStatusEventsAndLog()
+    {
+        var json = JsonSerializer.Serialize(SampleSnapshot(), UpgradeTracePersistence.SerializerOptions);
+
+        var restored = JsonSerializer.Deserialize<UpgradeTraceSnapshot>(json, UpgradeTracePersistence.SerializerOptions);
+
+        restored.ShouldNotBeNull();
+        restored!.Status.ShouldNotBeNull();
+        restored.Status.Status.ShouldBe("SUCCESS");
+        restored.Status.ExitCode.ShouldBe(0);
+        restored.Status.TargetVersion.ShouldBe("1.8.7");
+        restored.Status.UpdatedAt.ShouldBe(DateTimeOffset.Parse("2026-06-01T10:01:30Z"));
+
+        // The events array must round-trip into a populated list (pins that
+        // IReadOnlyList<UpgradeEvent> deserialises rather than coming back empty).
+        restored.Events.Count.ShouldBe(2);
+        restored.Events[0].Kind.ShouldBe("start");
+        restored.Events[1].Kind.ShouldBe("success");
+        restored.Events[1].Message.ShouldBe("done");
+
+        restored.Log.ShouldContain("Upgrade successful");
+    }
+
+    [Fact]
+    public void Deserialise_FromCanonicalJsonLiteral_RoundTrips()
+    {
+        // Inverse pin: a row written by an older server MUST still deserialise if
+        // the SerializerOptions defaults ever change. Hard-coded literal makes a
+        // naming-policy regression a test-time-visible decision.
+        var json = """
+            {
+              "status": { "schemaVersion": 2, "status": "FAILED", "targetVersion": "1.6.0", "installMethod": "zip", "exitCode": 7, "detail": "SHA256 mismatch" },
+              "events": [ { "t": "2026-05-04T10:00:00Z", "phase": "B", "kind": "fail", "msg": "checksum" } ],
+              "log": "download failed"
+            }
+            """;
+
+        var restored = JsonSerializer.Deserialize<UpgradeTraceSnapshot>(json, UpgradeTracePersistence.SerializerOptions);
+
+        restored.ShouldNotBeNull();
+        restored!.Status.Status.ShouldBe("FAILED");
+        restored.Status.ExitCode.ShouldBe(7);
+        restored.Events.Count.ShouldBe(1);
+        restored.Events[0].Kind.ShouldBe("fail");
+        restored.Log.ShouldBe("download failed");
+    }
+
+    [Fact]
+    public void Deserialise_MissingOptionalSections_DoesNotThrow()
+    {
+        // An older / partial blob may lack events or log. The defaults
+        // (empty list / empty string) must apply, never null-deref the hydrator.
+        var json = """{"status":{"status":"SUCCESS"}}""";
+
+        var restored = JsonSerializer.Deserialize<UpgradeTraceSnapshot>(json, UpgradeTracePersistence.SerializerOptions);
+
+        restored.ShouldNotBeNull();
+        restored!.Status.Status.ShouldBe("SUCCESS");
+        restored.Events.ShouldNotBeNull();
+        restored.Events.Count.ShouldBe(0);
+        restored.Log.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Signature_DerivedFromStatusAndUpdatedAt_NotSerialised()
+    {
+        var snapshot = SampleSnapshot();
+
+        snapshot.Signature.ShouldBe("SUCCESS@2026-06-01T10:01:30.0000000+00:00");
+
+        // The dedup key is derived state — it must NOT bloat the persisted blob.
+        var json = JsonSerializer.Serialize(snapshot, UpgradeTracePersistence.SerializerOptions);
+        json.ShouldNotContain("ignature");
+    }
+
+    [Fact]
+    public void Signature_NullStatus_DoesNotThrow()
+    {
+        // A snapshot with no status payload (shouldn't happen for a terminal
+        // trace, but the property must be null-safe).
+        new UpgradeTraceSnapshot().Signature.ShouldBe("@-");
+    }
+
+    [Fact]
+    public void SerializerOptions_NamingPolicy_PinnedToCamelCase()
+    {
+        UpgradeTracePersistence.SerializerOptions.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.CamelCase);
+    }
+
+    [Fact]
+    public void SerializerOptions_WriteIndented_PinnedToFalse()
+    {
+        UpgradeTracePersistence.SerializerOptions.WriteIndented.ShouldBeFalse();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTracePersisterTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeTracePersisterTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Pins the durable-trace orchestration in isolation: given the in-memory store
+/// state, the persister decides whether to write the snapshot (terminal + not
+/// already persisted) and marks the dedup gate only on a successful write.
+/// Uses the real store + real gate so the terminal/dedup contract is exercised
+/// end-to-end; the DB write itself is mocked.
+/// </summary>
+public sealed class UpgradeTracePersisterTests
+{
+    private readonly InMemoryUpgradeEventTimelineStore _store = new();
+    private readonly UpgradeTracePersistenceGate _gate = new();
+    private readonly Mock<IUpgradeTracePersistence> _persistence = new();
+    private readonly List<UpgradeTraceSnapshot> _saved = new();
+
+    private UpgradeTracePersister Build()
+    {
+        _persistence.Setup(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<int, UpgradeTraceSnapshot, CancellationToken>((_, s, _) => _saved.Add(s))
+            .Returns(Task.CompletedTask);
+
+        return new UpgradeTracePersister(_store, _persistence.Object, _gate);
+    }
+
+    private void SeedStore(int machineId, string status, string updatedAt = "2026-06-01T10:01:00Z")
+    {
+        _store.StoreStatus(machineId, new UpgradeStatusPayload { Status = status, ExitCode = 0, UpdatedAt = DateTimeOffset.Parse(updatedAt) });
+        _store.Store(machineId, new[] { new UpgradeEvent { Kind = "start" }, new UpgradeEvent { Kind = "done" } });
+        _store.StoreLog(machineId, "phase B log");
+    }
+
+    [Fact]
+    public async Task PersistIfTerminal_TerminalAndNew_SavesSnapshotAndMarksGate()
+    {
+        var persister = Build();
+        SeedStore(1, "SUCCESS");
+
+        await persister.PersistIfTerminalAsync(1, CancellationToken.None);
+
+        _saved.Count.ShouldBe(1);
+        _saved[0].Status.Status.ShouldBe("SUCCESS");
+        _saved[0].Events.Count.ShouldBe(2);
+        _saved[0].Log.ShouldBe("phase B log");
+        _gate.AlreadyPersisted(1, _saved[0].Signature).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PersistIfTerminal_NoStatusCached_DoesNothing()
+    {
+        var persister = Build();
+
+        await persister.PersistIfTerminalAsync(99, CancellationToken.None);
+
+        _persistence.Verify(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("IN_PROGRESS")]
+    [InlineData("SWAPPED")]
+    [InlineData("ROLLING_BACK")]
+    public async Task PersistIfTerminal_InFlight_DoesNotSave(string inFlight)
+    {
+        var persister = Build();
+        SeedStore(2, inFlight);
+
+        await persister.PersistIfTerminalAsync(2, CancellationToken.None);
+
+        _persistence.Verify(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PersistIfTerminal_AlreadyPersistedSameOutcome_DoesNotSaveAgain()
+    {
+        var persister = Build();
+        SeedStore(3, "SUCCESS");
+
+        await persister.PersistIfTerminalAsync(3, CancellationToken.None);
+        await persister.PersistIfTerminalAsync(3, CancellationToken.None);
+        await persister.PersistIfTerminalAsync(3, CancellationToken.None);
+
+        _persistence.Verify(p => p.SaveAsync(3, It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Once,
+            "the same terminal outcome the agent keeps reporting must be persisted exactly once.");
+    }
+
+    [Fact]
+    public async Task PersistIfTerminal_NewOutcomeAfterPriorPersist_SavesAgain()
+    {
+        var persister = Build();
+
+        SeedStore(4, "FAILED", updatedAt: "2026-06-01T10:00:00Z");
+        await persister.PersistIfTerminalAsync(4, CancellationToken.None);
+
+        // A re-run upgrade concludes later with a different outcome → new signature.
+        SeedStore(4, "SUCCESS", updatedAt: "2026-06-02T09:00:00Z");
+        await persister.PersistIfTerminalAsync(4, CancellationToken.None);
+
+        _persistence.Verify(p => p.SaveAsync(4, It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()), Times.Exactly(2),
+            "a genuinely new terminal outcome (different signature) must be persisted even after a prior one.");
+    }
+
+    [Fact]
+    public async Task PersistIfTerminal_SaveThrows_DoesNotThrow_GateLeftOpenForRetry()
+    {
+        _persistence.Setup(p => p.SaveAsync(It.IsAny<int>(), It.IsAny<UpgradeTraceSnapshot>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+        var persister = new UpgradeTracePersister(_store, _persistence.Object, _gate);
+        SeedStore(5, "SUCCESS");
+
+        await Should.NotThrowAsync(() => persister.PersistIfTerminalAsync(5, CancellationToken.None));
+
+        var signature = new UpgradeTraceSnapshot { Status = _store.GetStatus(5) }.Signature;
+        _gate.AlreadyPersisted(5, signature).ShouldBeFalse(
+            customMessage: "a failed write must NOT mark the gate, so the next probe retries the persist.");
+    }
+}


### PR DESCRIPTION
## Summary

- The per-machine upgrade timeline (status + event log + Phase B log) lived only in a process-local in-memory cache, so a server pod restart erased an operator's view of how the most recent upgrade concluded until the next Capabilities probe re-populated it.
- That cache is intentionally in-memory — writing it on every probe (every few seconds during an active upgrade) would dominate the cost of the upgrade. This adds a durable backstop that writes the trace **exactly once per upgrade**, only when the agent first reports a terminal status (`SUCCESS`/`FAILED`/`ROLLED_BACK`/`ROLLBACK_NEEDED`/`ROLLBACK_CRITICAL_FAILED`).
- A dedup gate (`IUpgradeTracePersistenceGate`) suppresses the repeated writes that would otherwise fire on every subsequent probe (the agent keeps re-reporting the same terminal status until the next upgrade). The snapshot is stored as `jsonb` on the `machine` row and hydrated back into the in-memory cache at startup, so reads stay in-memory and the three read handlers are untouched.
- Terminal classification is drift-resistant: a status is terminal when it is non-empty and not one of the small, stable in-flight set (`IN_PROGRESS`/`SWAPPED`/`ROLLING_BACK`), so a future agent's new terminal outcome is persisted without a server change.

## Design notes

- Mirrors the existing runtime-capabilities persistence pattern exactly: a scoped `IScopedDependency` persistence port (`UpgradeTracePersistence`, atomic `ExecuteUpdateAsync`), a startup `IStartable` hydrator (`UpgradeTraceHydrator`, which also primes the dedup gate to avoid a post-restart write storm), and `jsonb` columns on the `machine` table (`MachineConfiguration` maps the string property to `jsonb`).
- Fully additive / non-breaking: two optional collaborators appended to `TentacleHealthCheckStrategy`, a new migration, a new column. No existing interface, read path, or call site changes. A DB hiccup is best-effort — it logs and never fails the health check, leaving the gate open to retry on the next probe.

## Test plan

- [x] Unit — `UpgradeStatusClassifierTests` (terminal vs in-flight, empty, unknown-as-terminal, ordinal contract, pinned in-flight constants)
- [x] Unit — `UpgradeTracePersistenceGateTests` (dedup once-per-signature, new-signature resets, per-machine isolation)
- [x] Unit — `UpgradeTracePersistenceShapeTests` (jsonb shape pin, round-trip, canonical-literal back-compat, missing-section defaults, serializer options pinned)
- [x] Unit — `UpgradeTraceHydratorTests` (store hydration + gate priming + null-row skip)
- [x] Unit — `TentacleHealthCheckStrategyTests` (terminal persists once with status/events/log; in-flight skips; same outcome across 3 probes persists once; persistence throws → still healthy + gate not marked; optional deps unwired → no NRE)
- [x] Integration (real Postgres) — `UpgradeTracePersistenceIntegrationTests`: save writes column + timestamp, `LoadAllAsync` round-trips, latest-wins on re-run, NULL rows skipped, undeserialisable (wrong-shape jsonb) row skipped, and an end-to-end **simulated-restart durability proof** (persist → fresh empty store → hydrate from DB → status + events + log restored)
- [x] Full unit suite: 5805/5805 green
- [x] Full solution build: 0 errors