### PR TITLE
Surface the real Halibut connection log per machine

### DIFF
--- a/src/Squid.Api/Controllers/MachineController.cs
+++ b/src/Squid.Api/Controllers/MachineController.cs
@@ -226,6 +226,25 @@ public class MachineController : ControllerBase
     }
 
     /// <summary>
+    /// The machine's REAL Halibut connection log — the transport-level events
+    /// the server runtime recorded for this agent's endpoint (opening a new
+    /// connection, TLS/security negotiation, message exchange, listener accept,
+    /// errors). The genuine "why is this agent connected / why did it fail",
+    /// versus the health-status summary which only reflects the last Capabilities
+    /// probe. In-memory recent-events buffer (not persisted across restarts).
+    /// </summary>
+    [HttpGet("{machineId:int}/connection-log")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GetMachineConnectionLogResponse))]
+    public async Task<IActionResult> GetConnectionLogAsync([FromRoute] int machineId, [FromQuery] GetMachineConnectionLogRequest request, CancellationToken ct)
+    {
+        request.MachineId = machineId;   // route value is authoritative over any query binding
+
+        var response = await _mediator.RequestAsync<GetMachineConnectionLogRequest, GetMachineConnectionLogResponse>(request, ct).ConfigureAwait(false);
+
+        return Ok(response);
+    }
+
+    /// <summary>
     /// agent-reported upgrade-status snapshot for the
     /// most recent upgrade attempt. Exposes the structured <c>ExitCode</c>
     /// field that <c>GET /upgrade-events</c> (event stream) and

--- a/src/Squid.Core/Halibut/HalibutModule.cs
+++ b/src/Squid.Core/Halibut/HalibutModule.cs
@@ -35,6 +35,16 @@ public class HalibutModule : Module
 
     protected override void Load(ContainerBuilder builder)
     {
+        // Connection-log factory: Halibut's own per-endpoint in-memory connection
+        // log (bounded recent-events buffer). Registered as a singleton and wired
+        // into the runtime via WithLogFactory so we hold the reference and can
+        // read the REAL connection events back per machine (OpeningNewConnection,
+        // SecurityNegotiation, MessageExchange, Error, ...) — surfaced to operators
+        // via GET /api/machine/{id}/connection-log instead of only the last
+        // health-check summary. Without this, Halibut builds its own factory
+        // internally and the events are unreachable.
+        builder.Register(_ => new LogFactory()).As<ILogFactory>().SingleInstance();
+
         builder.Register(ctx =>
         {
             var selfCertSetting = ctx.Resolve<SelfCertSetting>();
@@ -50,6 +60,7 @@ public class HalibutModule : Module
                 .WithServiceFactory(services)
                 .WithServerCertificate(serverCert)
                 .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .WithLogFactory(ctx.Resolve<ILogFactory>())
                 .Build();
 
             Log.Information("HalibutRuntime created. ServerCertThumbprint={Thumbprint}", serverCert.Thumbprint);

--- a/src/Squid.Core/Handlers/RequestHandlers/Machines/GetMachineConnectionLogRequestHandler.cs
+++ b/src/Squid.Core/Handlers/RequestHandlers/Machines/GetMachineConnectionLogRequestHandler.cs
@@ -1,0 +1,38 @@
+using Squid.Core.Services.Machines;
+using Squid.Message.Requests.Machines;
+
+namespace Squid.Core.Handlers.RequestHandlers.Machines;
+
+/// <summary>
+/// Mediator bridge for the connection-log endpoint. Clamps the requested entry
+/// cap to a sane range and delegates to <see cref="IMachineConnectionLogReader"/>,
+/// which resolves the machine's Halibut endpoint URI and reads the real
+/// per-endpoint connection events the server runtime recorded.
+/// </summary>
+public sealed class GetMachineConnectionLogRequestHandler : IRequestHandler<GetMachineConnectionLogRequest, GetMachineConnectionLogResponse>
+{
+    private readonly IMachineConnectionLogReader _connectionLogReader;
+
+    public GetMachineConnectionLogRequestHandler(IMachineConnectionLogReader connectionLogReader)
+    {
+        _connectionLogReader = connectionLogReader;
+    }
+
+    public async Task<GetMachineConnectionLogResponse> Handle(IReceiveContext<GetMachineConnectionLogRequest> context, CancellationToken cancellationToken)
+    {
+        var maxEntries = ClampMaxEntries(context.Message.MaxEntries);
+
+        var data = await _connectionLogReader.ReadAsync(context.Message.MachineId, maxEntries, cancellationToken).ConfigureAwait(false);
+
+        return new GetMachineConnectionLogResponse { Data = data };
+    }
+
+    private static int ClampMaxEntries(int? requested)
+    {
+        var value = requested ?? GetMachineConnectionLogRequest.DefaultMaxEntries;
+
+        if (value < 1) return 1;
+
+        return value > GetMachineConnectionLogRequest.MaxAllowedEntries ? GetMachineConnectionLogRequest.MaxAllowedEntries : value;
+    }
+}

--- a/src/Squid.Core/Services/Machines/EndpointJsonHelper.cs
+++ b/src/Squid.Core/Services/Machines/EndpointJsonHelper.cs
@@ -80,4 +80,24 @@ public static class EndpointJsonHelper
             return null;
         }
     }
+
+    /// <summary>
+    /// Resolve the Halibut endpoint <see cref="Uri"/> a machine's connection log
+    /// is keyed under — <c>poll://{subscriptionId}/</c> for polling tentacles,
+    /// <c>https://host:port/</c> for listening. Returns null when the endpoint
+    /// JSON is missing required fields. Derives from the SAME
+    /// <see cref="ParseHalibutEndpoint"/> / <see cref="ParseTentacleListeningEndpoint"/>
+    /// methods the health-check + dispatch paths use, so the resolved Uri matches
+    /// the key Halibut recorded connection events under.
+    /// </summary>
+    public static Uri ResolveConnectionEndpointUri(string endpointJson)
+    {
+        var style = GetField(endpointJson, "CommunicationStyle");
+
+        var endpoint = style == nameof(Squid.Message.Enums.CommunicationStyle.TentacleListening)
+            ? ParseTentacleListeningEndpoint(endpointJson)
+            : ParseHalibutEndpoint(endpointJson);
+
+        return endpoint?.BaseUri;
+    }
 }

--- a/src/Squid.Core/Services/Machines/MachineConnectionLogReader.cs
+++ b/src/Squid.Core/Services/Machines/MachineConnectionLogReader.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Halibut.Diagnostics;
+using Squid.Message.Requests.Machines;
+
+namespace Squid.Core.Services.Machines;
+
+/// <summary>
+/// Reads the REAL Halibut connection log for a machine and projects it into the
+/// API DTO. Composes the singleton Halibut <see cref="ILogFactory"/> (wired into
+/// the server runtime in <c>HalibutModule</c> so it accumulates per-endpoint
+/// connection events) with the machine's endpoint URI, resolved the same way the
+/// health-check + dispatch paths resolve it — so the URI we read matches the key
+/// Halibut wrote under.
+///
+/// <para>The Halibut event type never leaks past this reader — callers get the
+/// transport-agnostic <see cref="MachineConnectionLogEntry"/> shape.</para>
+/// </summary>
+public interface IMachineConnectionLogReader
+{
+    Task<GetMachineConnectionLogResponseData> ReadAsync(int machineId, int maxEntries, CancellationToken ct);
+}
+
+public sealed class MachineConnectionLogReader : IMachineConnectionLogReader, IScopedDependency
+{
+    private readonly IMachineDataProvider _machineDataProvider;
+    private readonly ILogFactory _connectionLogFactory;
+
+    public MachineConnectionLogReader(IMachineDataProvider machineDataProvider, ILogFactory connectionLogFactory)
+    {
+        _machineDataProvider = machineDataProvider;
+        _connectionLogFactory = connectionLogFactory;
+    }
+
+    public async Task<GetMachineConnectionLogResponseData> ReadAsync(int machineId, int maxEntries, CancellationToken ct)
+    {
+        var machine = await _machineDataProvider.GetMachinesByIdAsync(machineId, ct).ConfigureAwait(false);
+
+        var data = new GetMachineConnectionLogResponseData { MachineId = machineId };
+
+        var endpointUri = machine == null ? null : EndpointJsonHelper.ResolveConnectionEndpointUri(machine.Endpoint);
+
+        if (endpointUri == null) return data;
+
+        data.Endpoint = endpointUri.ToString();
+        data.Entries = ReadRecentEntries(endpointUri, maxEntries);
+
+        return data;
+    }
+
+    private List<MachineConnectionLogEntry> ReadRecentEntries(Uri endpointUri, int maxEntries)
+    {
+        var events = _connectionLogFactory.ForEndpoint(endpointUri).GetLogs() ?? new List<LogEvent>();
+
+        var skip = Math.Max(0, events.Count - maxEntries);
+
+        return events.Skip(skip).Select(Project).ToList();
+    }
+
+    private static MachineConnectionLogEntry Project(LogEvent ev) => new()
+    {
+        OccurredAt = ev.Time,
+        Type = ev.Type.ToString(),
+        Message = ev.FormattedMessage ?? string.Empty,
+        Error = ev.Error?.Message ?? string.Empty
+    };
+}

--- a/src/Squid.Message/Requests/Machines/GetMachineConnectionLogRequest.cs
+++ b/src/Squid.Message/Requests/Machines/GetMachineConnectionLogRequest.cs
@@ -1,0 +1,92 @@
+using Squid.Message.Attributes;
+using Squid.Message.Enums;
+using Squid.Message.Response;
+
+namespace Squid.Message.Requests.Machines;
+
+/// <summary>
+/// Read-only fetch of a machine's REAL Halibut connection log — the actual
+/// transport-level events the server's Halibut runtime recorded for this
+/// agent's endpoint (opening a new connection, TLS/security negotiation,
+/// message exchange, listener accept, errors). This is the genuine "why is
+/// this agent connected / why did it fail to connect" trace, as opposed to the
+/// <see cref="MachineHealthStatus"/> summary which only reflects whether the
+/// last Capabilities health check succeeded.
+///
+/// <para>Surfaced so an operator investigating a flaky / disconnected agent can
+/// see the connection narrative without SSHing to the host or reading server
+/// logs. Most informative for listening tentacles (the server dials the agent,
+/// so connect attempts + failures are logged under the agent's URI); polling
+/// agents dial in, so their server-side connection events may be sparser.</para>
+///
+/// <para>Empty list when: the agent has never connected, the server pod
+/// restarted recently (the log is an in-memory recent-events buffer, not
+/// persisted), or the machine's endpoint JSON can't be resolved to a Halibut
+/// URI.</para>
+/// </summary>
+[RequiresPermission(Permission.MachineView)]
+public class GetMachineConnectionLogRequest : IRequest, ISpaceScoped
+{
+    public int? SpaceId { get; set; }
+
+    public int MachineId { get; set; }
+
+    /// <summary>
+    /// Cap on how many of the most-recent connection-log entries to return
+    /// (chronological order, oldest-to-newest within the cap). Defaults to
+    /// <see cref="DefaultMaxEntries"/>; values outside [1, MaxAllowedEntries]
+    /// are clamped server-side.
+    /// </summary>
+    public int? MaxEntries { get; set; }
+
+    public const int DefaultMaxEntries = 200;
+
+    public const int MaxAllowedEntries = 1000;
+}
+
+public class GetMachineConnectionLogResponse : SquidResponse<GetMachineConnectionLogResponseData>
+{
+}
+
+public class GetMachineConnectionLogResponseData
+{
+    public int MachineId { get; set; }
+
+    /// <summary>
+    /// The Halibut endpoint URI the connection log is keyed under
+    /// (<c>poll://{subscriptionId}/</c> or <c>https://host:port/</c>), or empty
+    /// when the endpoint JSON couldn't be resolved. Surfaced so operators can
+    /// confirm which endpoint the events belong to.
+    /// </summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    public List<MachineConnectionLogEntry> Entries { get; set; } = new();
+}
+
+/// <summary>
+/// One Halibut connection-log event projected for the API. Mirrors
+/// <c>Halibut.Diagnostics.LogEvent</c> without leaking the Halibut type past
+/// the service layer.
+/// </summary>
+public class MachineConnectionLogEntry
+{
+    /// <summary>When the event occurred (from Halibut's LogEvent.Time).</summary>
+    public DateTimeOffset OccurredAt { get; set; }
+
+    /// <summary>
+    /// Halibut event category, e.g. <c>OpeningNewConnection</c>,
+    /// <c>SecurityNegotiation</c>, <c>MessageExchange</c>,
+    /// <c>ListenerAcceptedClient</c>, <c>Error</c>.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Human-readable event message.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Concise error detail (the exception message) when the event carried an
+    /// error, else empty. Full stack traces are intentionally omitted — this is
+    /// an operator-facing connection narrative, not a server crash dump.
+    /// </summary>
+    public string Error { get; set; } = string.Empty;
+}

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Agent/KubernetesAgentE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Agent/KubernetesAgentE2ETests.cs
@@ -230,6 +230,36 @@ public class KubernetesAgentE2ETests
         response.AgentVersion.ShouldNotBeNullOrWhiteSpace();
     }
 
+    [Fact]
+    public async Task Agent_ConnectionLog_RecordsRealHalibutEvents_ForPollingEndpoint()
+    {
+        // Connection truth: drive a real Halibut RPC to the polling agent, then
+        // read back the per-endpoint connection log the server runtime recorded.
+        // Proves (a) HalibutModule.WithLogFactory is wired to the same ILogFactory
+        // we read, and (b) the polling endpoint IS populated with real transport
+        // events — the genuine "why is this agent connected" trace the
+        // GET /connection-log endpoint surfaces (vs. the health-check summary).
+        var endpoint = new ServiceEndPoint(
+            $"poll://{_fixture.Stub.SubscriptionId}/",
+            _fixture.Stub.Thumbprint,
+            HalibutTimeoutsAndLimits.RecommendedValues());
+
+        var halibutRuntime = _fixture.LifetimeScope.Resolve<HalibutRuntime>();
+        var client = halibutRuntime.CreateAsyncClient<ICapabilitiesService, IAsyncCapabilitiesService>(endpoint);
+
+        await client.GetCapabilitiesAsync(new CapabilitiesRequest());
+
+        var logFactory = _fixture.LifetimeScope.Resolve<ILogFactory>();
+        var events = logFactory.ForEndpoint(endpoint.BaseUri).GetLogs();
+
+        events.ShouldNotBeNull();
+        events.ShouldNotBeEmpty(
+            "the server Halibut runtime must record real connection events for the polling endpoint after an RPC — " +
+            "if empty, either WithLogFactory isn't wired or polling connections are logged under a different key.");
+        events.ShouldContain(e => !string.IsNullOrEmpty(e.FormattedMessage),
+            "connection-log events must carry human-readable messages for operators.");
+    }
+
     // ========================================================================
     // Seed Helpers
     // ========================================================================

--- a/tests/Squid.UnitTests/Services/Machines/EndpointJsonHelperConnectionUriTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/EndpointJsonHelperConnectionUriTests.cs
@@ -1,0 +1,56 @@
+using Squid.Core.Services.Machines;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// Pins the machine-endpoint → Halibut connection-log URI resolution. The URI
+/// must match the key Halibut records connection events under, so the reader
+/// reads the right log: <c>poll://{subscriptionId}/</c> for polling,
+/// <c>https://host:port/</c> for listening.
+/// </summary>
+public sealed class EndpointJsonHelperConnectionUriTests
+{
+    [Fact]
+    public void Polling_ResolvesPollUri()
+    {
+        var uri = EndpointJsonHelper.ResolveConnectionEndpointUri(
+            """{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-abc","Thumbprint":"AABB"}""");
+
+        uri.ShouldNotBeNull();
+        uri.ToString().ShouldBe("poll://sub-abc/");
+    }
+
+    [Fact]
+    public void Listening_ResolvesHttpsUri()
+    {
+        var uri = EndpointJsonHelper.ResolveConnectionEndpointUri(
+            """{"CommunicationStyle":"TentacleListening","Uri":"https://10.0.0.5:10933/","Thumbprint":"CCDD"}""");
+
+        uri.ShouldNotBeNull();
+        uri.ToString().ShouldBe("https://10.0.0.5:10933/");
+    }
+
+    [Fact]
+    public void UnknownStyle_FallsBackToPollingParse()
+    {
+        // ResolveConnectionEndpointUri mirrors the health-check ParseEndpoint:
+        // any style that isn't TentacleListening is treated as a Halibut polling
+        // endpoint (the polling family is the default).
+        var uri = EndpointJsonHelper.ResolveConnectionEndpointUri(
+            """{"CommunicationStyle":"KubernetesAgent","SubscriptionId":"sub-k8s","Thumbprint":"EEFF"}""");
+
+        uri.ShouldNotBeNull();
+        uri.ToString().ShouldBe("poll://sub-k8s/");
+    }
+
+    [Theory]
+    [InlineData("""{"CommunicationStyle":"TentaclePolling"}""")]              // missing SubscriptionId/Thumbprint
+    [InlineData("""{"CommunicationStyle":"TentacleListening","Uri":""}""")]   // empty Uri
+    [InlineData("not json")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void MissingOrMalformed_ReturnsNull(string endpointJson)
+    {
+        EndpointJsonHelper.ResolveConnectionEndpointUri(endpointJson).ShouldBeNull();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/GetMachineConnectionLogRequestHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/GetMachineConnectionLogRequestHandlerTests.cs
@@ -1,0 +1,62 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Squid.Core.Handlers.RequestHandlers.Machines;
+using Squid.Core.Services.Machines;
+using Squid.Message.Requests.Machines;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// Pins the connection-log handler: it clamps the requested entry cap to a sane
+/// range and delegates to the reader with the route machine id.
+/// </summary>
+public sealed class GetMachineConnectionLogRequestHandlerTests
+{
+    private readonly Mock<IMachineConnectionLogReader> _reader = new();
+    private int _capturedMax = -1;
+
+    private GetMachineConnectionLogRequestHandler Build()
+    {
+        _reader.Setup(r => r.ReadAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, int, CancellationToken>((_, max, _) => _capturedMax = max)
+            .ReturnsAsync(new GetMachineConnectionLogResponseData());
+        return new GetMachineConnectionLogRequestHandler(_reader.Object);
+    }
+
+    private static Mock<IReceiveContext<GetMachineConnectionLogRequest>> Context(int machineId, int? maxEntries)
+    {
+        var ctx = new Mock<IReceiveContext<GetMachineConnectionLogRequest>>();
+        ctx.Setup(x => x.Message).Returns(new GetMachineConnectionLogRequest { MachineId = machineId, MaxEntries = maxEntries });
+        return ctx;
+    }
+
+    [Theory]
+    [InlineData(null, GetMachineConnectionLogRequest.DefaultMaxEntries)]   // unset → default
+    [InlineData(0, 1)]                                                     // below floor → 1
+    [InlineData(-10, 1)]                                                   // negative → 1
+    [InlineData(50, 50)]                                                   // in range → passthrough
+    [InlineData(99999, GetMachineConnectionLogRequest.MaxAllowedEntries)]  // above ceiling → cap
+    public async Task Handle_ClampsMaxEntries(int? requested, int expected)
+    {
+        var handler = Build();
+
+        await handler.Handle(Context(7, requested).Object, CancellationToken.None);
+
+        _capturedMax.ShouldBe(expected);
+        _reader.Verify(r => r.ReadAsync(7, expected, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WrapsReaderDataInResponse()
+    {
+        _reader.Setup(r => r.ReadAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetMachineConnectionLogResponseData { MachineId = 7, Endpoint = "poll://s/" });
+        var handler = new GetMachineConnectionLogRequestHandler(_reader.Object);
+
+        var response = await handler.Handle(Context(7, null).Object, CancellationToken.None);
+
+        response.Data.ShouldNotBeNull();
+        response.Data.MachineId.ShouldBe(7);
+        response.Data.Endpoint.ShouldBe("poll://s/");
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/MachineConnectionLogReaderTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/MachineConnectionLogReaderTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Diagnostics;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Machines;
+
+namespace Squid.UnitTests.Services.Machines;
+
+/// <summary>
+/// Pins the connection-log reader: it resolves a machine's Halibut endpoint URI,
+/// reads the real per-endpoint connection events, projects them to the API DTO
+/// (type/message/error/time), returns the most-recent N, and degrades safely
+/// (unknown machine, unresolvable endpoint, no events). Uses a fake ILogFactory
+/// so the mapping is exercised without a live Halibut runtime — Halibut's ILog
+/// interface is read-only (GetLogs), so a fake is the natural seam.
+/// </summary>
+public sealed class MachineConnectionLogReaderTests
+{
+    private const string PollingEndpoint = """{"CommunicationStyle":"TentaclePolling","SubscriptionId":"sub-xyz","Thumbprint":"AABB"}""";
+
+    private static LogEvent Event(EventType type, string message, Exception error = null)
+        => new(type, message, error, Array.Empty<object>());
+
+    private static (MachineConnectionLogReader reader, FakeLogFactory factory) Build(Machine machine)
+    {
+        var provider = new Mock<IMachineDataProvider>();
+        provider.Setup(p => p.GetMachinesByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(machine);
+
+        var factory = new FakeLogFactory();
+        return (new MachineConnectionLogReader(provider.Object, factory), factory);
+    }
+
+    private static Machine MachineWith(string endpoint) => new() { Id = 5, Name = "agent", Endpoint = endpoint };
+
+    [Fact]
+    public async Task ReadAsync_ProjectsEvents_TypeMessageErrorAndEndpoint()
+    {
+        var (reader, factory) = Build(MachineWith(PollingEndpoint));
+        var boom = new InvalidOperationException("handshake rejected");
+        factory.Seed("poll://sub-xyz/",
+            Event(EventType.OpeningNewConnection, "Opening a new connection"),
+            Event(EventType.Error, "Connection failed", boom));
+
+        var data = await reader.ReadAsync(5, maxEntries: 200, CancellationToken.None);
+
+        data.MachineId.ShouldBe(5);
+        data.Endpoint.ShouldBe("poll://sub-xyz/");
+        data.Entries.Count.ShouldBe(2);
+
+        data.Entries[0].Type.ShouldBe("OpeningNewConnection");
+        data.Entries[0].Message.ShouldBe("Opening a new connection");
+        data.Entries[0].Error.ShouldBe(string.Empty);
+
+        data.Entries[1].Type.ShouldBe("Error");
+        data.Entries[1].Error.ShouldBe("handshake rejected",
+            customMessage: "the error's concise message must be surfaced so operators see why a connection failed.");
+    }
+
+    [Fact]
+    public async Task ReadAsync_CapsToMostRecentEntries_InChronologicalOrder()
+    {
+        var (reader, factory) = Build(MachineWith(PollingEndpoint));
+        factory.Seed("poll://sub-xyz/",
+            Event(EventType.MessageExchange, "e1"),
+            Event(EventType.MessageExchange, "e2"),
+            Event(EventType.MessageExchange, "e3"),
+            Event(EventType.MessageExchange, "e4"));
+
+        var data = await reader.ReadAsync(5, maxEntries: 2, CancellationToken.None);
+
+        data.Entries.Select(e => e.Message).ShouldBe(new[] { "e3", "e4" },
+            customMessage: "must return the most recent N entries, oldest-to-newest within the cap.");
+    }
+
+    [Fact]
+    public async Task ReadAsync_ListeningEndpoint_ResolvesHttpsUri()
+    {
+        var listening = """{"CommunicationStyle":"TentacleListening","Uri":"https://10.0.0.9:10933/","Thumbprint":"CCDD"}""";
+        var (reader, factory) = Build(MachineWith(listening));
+        factory.Seed("https://10.0.0.9:10933/", Event(EventType.SecurityNegotiation, "TLS ok"));
+
+        var data = await reader.ReadAsync(5, maxEntries: 200, CancellationToken.None);
+
+        data.Endpoint.ShouldBe("https://10.0.0.9:10933/");
+        data.Entries.Single().Type.ShouldBe("SecurityNegotiation");
+    }
+
+    [Fact]
+    public async Task ReadAsync_NoEventsForEndpoint_ReturnsEndpointWithEmptyEntries()
+    {
+        var (reader, _) = Build(MachineWith(PollingEndpoint));   // factory seeded with nothing
+
+        var data = await reader.ReadAsync(5, maxEntries: 200, CancellationToken.None);
+
+        data.Endpoint.ShouldBe("poll://sub-xyz/");
+        data.Entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadAsync_UnknownMachine_ReturnsEmpty_NoEndpoint()
+    {
+        var (reader, _) = Build(machine: null);
+
+        var data = await reader.ReadAsync(404, maxEntries: 200, CancellationToken.None);
+
+        data.MachineId.ShouldBe(404);
+        data.Endpoint.ShouldBe(string.Empty);
+        data.Entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadAsync_UnresolvableEndpoint_ReturnsEmpty_NoEndpoint()
+    {
+        // Endpoint JSON missing the SubscriptionId/Thumbprint → no URI to key on.
+        var (reader, _) = Build(MachineWith("""{"CommunicationStyle":"TentaclePolling"}"""));
+
+        var data = await reader.ReadAsync(5, maxEntries: 200, CancellationToken.None);
+
+        data.Endpoint.ShouldBe(string.Empty);
+        data.Entries.ShouldBeEmpty();
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────────
+    // Halibut's ILog is read-only (GetLogs + ForContext); a fake factory keyed by
+    // URI lets us seed events without standing up a real HalibutRuntime.
+
+    private sealed class FakeLogFactory : ILogFactory
+    {
+        private readonly Dictionary<string, FakeLog> _byEndpoint = new(StringComparer.Ordinal);
+
+        public void Seed(string endpoint, params LogEvent[] events)
+            => _byEndpoint[endpoint] = new FakeLog(events.ToList());
+
+        public ILog ForEndpoint(Uri endpoint)
+            => _byEndpoint.TryGetValue(endpoint.ToString(), out var log) ? log : new FakeLog(new List<LogEvent>());
+
+        public ILog ForPrefix(string prefix) => new FakeLog(new List<LogEvent>());
+    }
+
+    private sealed class FakeLog : ILog
+    {
+        private readonly IList<LogEvent> _events;
+        public FakeLog(IList<LogEvent> events) { _events = events; }
+        public IList<LogEvent> GetLogs() => _events;
+        public ILog ForContext() => this;
+        public ILog ForContext<T>() => this;
+        public void Write(EventType type, string message, params object[] args) => _events.Add(new LogEvent(type, message, null, args));
+        public void WriteException(EventType type, string message, Exception ex, params object[] args) => _events.Add(new LogEvent(type, message, ex, args));
+    }
+}


### PR DESCRIPTION
## Summary

- An agent's operator-facing connection status was only `MachineHealthStatus`, derived from whether the last Capabilities probe succeeded — there was no way to see the actual transport-level story (connection opened, TLS/security negotiation, message exchange, listener accept, errors). A disconnected/flaky agent showed `Unhealthy` with no *why*.
- The server's Halibut runtime was built with **no** log factory, so Halibut's per-endpoint connection events were unreachable. This wires Halibut's own bounded in-memory `LogFactory` via `WithLogFactory`, holds the singleton reference, and exposes the events per machine via `GET /api/machine/{id}/connection-log` (mirrors the `upgrade-log` endpoint).
- The reader resolves the machine's Halibut endpoint URI the same way the health-check + dispatch paths do (`poll://{subscriptionId}/` or `https://host:port/`, via `EndpointJsonHelper`) so it reads the right log, and projects Halibut's `LogEvent` into a transport-agnostic DTO (no Halibut type leaks past the service). Works for both polling and listening tentacles.

## Design notes

- **Additive / non-breaking**: a new read-only endpoint, a new reader service (`IMachineConnectionLogReader`, `IScopedDependency`), a thin handler (Rule 16), and a one-line runtime wiring that passes Halibut the same `LogFactory` type it already uses internally. No schema change (the log is an in-memory recent-events buffer, not persisted), no changed response shapes, no frontend impact.
- The handler clamps the `maxEntries` query param to `[1, 1000]` (default 200). `MachineView` permission, same as the upgrade endpoints.

## Test plan

- [x] Unit — `EndpointJsonHelperConnectionUriTests`: URI resolution for polling / listening / unknown-style / malformed / null
- [x] Unit — `MachineConnectionLogReaderTests`: projects type/message/error/time, returns most-recent-N in chronological order, resolves listening vs polling, empty for no-events / unknown machine / unresolvable endpoint
- [x] Unit — `GetMachineConnectionLogRequestHandlerTests`: entry-cap clamping (null→default, ≤0→1, >max→cap, in-range passthrough) + delegation + response wrapping
- [x] E2E — `Agent_ConnectionLog_RecordsRealHalibutEvents_ForPollingEndpoint`: a real Halibut RPC to a polling agent, then reads back **non-empty, well-formed** connection events — proves the `WithLogFactory` wiring AND that the polling endpoint is populated (ran green locally, 1/1)
- [x] Full unit suite: 5833/5833 green
- [x] Full solution build: 0 errors