### PR TITLE
Read the runtime's built-in connection-log factory instead of supplying one

### DIFF
--- a/src/Squid.Core/Halibut/HalibutModule.cs
+++ b/src/Squid.Core/Halibut/HalibutModule.cs
@@ -35,15 +35,15 @@ public class HalibutModule : Module
 
     protected override void Load(ContainerBuilder builder)
     {
-        // Connection-log factory: Halibut's own per-endpoint in-memory connection
-        // log (bounded recent-events buffer). Registered as a singleton and wired
-        // into the runtime via WithLogFactory so we hold the reference and can
-        // read the REAL connection events back per machine (OpeningNewConnection,
-        // SecurityNegotiation, MessageExchange, Error, ...) — surfaced to operators
-        // via GET /api/machine/{id}/connection-log instead of only the last
-        // health-check summary. Without this, Halibut builds its own factory
-        // internally and the events are unreachable.
-        builder.Register(_ => new LogFactory()).As<ILogFactory>().SingleInstance();
+        // Connection-log factory: expose the runtime's OWN per-endpoint connection
+        // log (Halibut builds a bounded in-memory recent-events LogFactory by default
+        // and writes every connection event to it — OpeningNewConnection,
+        // SecurityNegotiation, MessageExchange, Error, ...). We surface that built-in
+        // factory as ILogFactory so the connection-log reader shares the exact
+        // instance the runtime uses (no parallel factory to keep in sync) and serves
+        // GET /api/machine/{id}/connection-log. Mirrors Octopus's CommunicationLogFactory,
+        // which reads halibut.Logs directly.
+        builder.Register(ctx => ctx.Resolve<HalibutRuntime>().Logs).As<ILogFactory>().SingleInstance();
 
         builder.Register(ctx =>
         {
@@ -60,7 +60,6 @@ public class HalibutModule : Module
                 .WithServiceFactory(services)
                 .WithServerCertificate(serverCert)
                 .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
-                .WithLogFactory(ctx.Resolve<ILogFactory>())
                 .Build();
 
             Log.Information("HalibutRuntime created. ServerCertThumbprint={Thumbprint}", serverCert.Thumbprint);


### PR DESCRIPTION
## Summary

- Follow-up to #398. The connection-log feature supplied its own `LogFactory` via `WithLogFactory` and injected that instance. Halibut already exposes the runtime's own per-endpoint log factory as `HalibutRuntime.Logs` (the default it builds and writes every connection event to) — which is exactly what Octopus's `CommunicationLogFactory` reads.
- Register `ILogFactory` *as* `halibut.Logs` and drop `WithLogFactory` + the parallel `LogFactory`. Same behaviour, one fewer moving part, and the factory the reader reads is guaranteed to be the one the runtime writes to (can't diverge). Keeps the `ILogFactory` injection seam so the reader stays unit-testable.

## Why

Direct alignment with Octopus's proven production pattern and the most generic shape: read Halibut's built-in accessor rather than maintaining a redundant supplied factory.

## Test plan

- [x] Connection-log unit tests (reader/handler/URI) — 20/20 green (unchanged; fake `ILogFactory`)
- [x] E2E `Agent_ConnectionLog_RecordsRealHalibutEvents_ForPollingEndpoint` re-run locally — green: a real polling RPC then reading `halibut.Logs` back (now with **no** `WithLogFactory`) returns non-empty, well-formed events, proving the built-in factory is the populated one
- [x] Full solution build: 0 errors