### PR TITLE
Emit upgrade-events.jsonl from the Windows upgrade script

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -134,9 +134,31 @@ $STATUS_FILE = Join-Path $STATUS_DIR 'last-upgrade.json'
 $LOCK_FILE   = Join-Path $STATUS_DIR 'upgrade.lock'
 $LOG_FILE    = Join-Path $STATUS_DIR 'upgrade.log'
 
+# Per-phase event timeline, parity with the Linux script's upgrade-events.jsonl.
+# The Squid server reads this via WindowsUpgradeStatusStorage on every
+# Capabilities RPC (EventsFileSubPath = upgrade\upgrade-events.jsonl) and
+# surfaces it as the per-phase upgrade timeline in the UI.
+$EVENTS_FILE = Join-Path $STATUS_DIR 'upgrade-events.jsonl'
+
+# Hard cap so a runaway loop can't fill the disk. Terminal-state events bypass
+# the cap so the operator-visible narrative always reaches a conclusion. Kept
+# in sync with the Linux script's EVENTS_MAX (drift-pinned by the parity test).
+$EVENTS_MAX  = 50
+
+# Current upgrade phase ('A' pre-swap, 'B' post-detach). Write-UpgradeStatus
+# auto-emits a matching event tagged with this phase; flipped to 'B' at the
+# Phase B entry below.
+$script:CURRENT_PHASE = 'A'
+
 if (-not (Test-Path $STATUS_DIR)) {
     New-Item -ItemType Directory -Path $STATUS_DIR -Force | Out-Null
 }
+
+# Truncate the events file at the start of this (single-invocation) upgrade so
+# stale events from a previous attempt don't pollute this run's timeline.
+# BOM-less UTF8 (PS 5.1's Set-Content -Encoding UTF8 prepends a BOM that would
+# corrupt the first JSON line the server parses). Best-effort.
+try { [System.IO.File]::WriteAllText($EVENTS_FILE, '', (New-Object System.Text.UTF8Encoding($false))) } catch { }
 
 # ── Status file helper — atomic write via temp+rename ────────────────────────
 function Write-UpgradeStatus {
@@ -164,6 +186,23 @@ function Write-UpgradeStatus {
     $temp = "$STATUS_FILE.tmp"
     Set-Content -Path $temp -Value $payload -Encoding UTF8 -Force
     Move-Item -Path $temp -Destination $STATUS_FILE -Force
+
+    # Mirror the status transition into the per-phase event timeline (parity
+    # with Linux). Phase comes from $script:CURRENT_PHASE; the kind is mapped
+    # from the status so the timeline tracks the status file 1:1.
+    $eventKind = switch ($Status) {
+        'IN_PROGRESS'              { 'start' }
+        'SWAPPED'                  { 'swapped' }
+        'SUCCESS'                  { 'success' }
+        'FAILED'                   { 'method-exhausted' }
+        'ROLLBACK_NEEDED'          { 'rollback-fail' }
+        'ROLLED_BACK'              { 'rollback-ok' }
+        'ROLLBACK_CRITICAL_FAILED' { 'rollback-critical-failed' }
+        default                    { $null }
+    }
+    if ($null -ne $eventKind) {
+        Write-UpgradeEvent -Phase $script:CURRENT_PHASE -Kind $eventKind -Msg $Detail
+    }
 }
 
 function Append-UpgradeLog {
@@ -172,6 +211,43 @@ function Append-UpgradeLog {
     $stamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
     Add-Content -Path $LOG_FILE -Value "[$stamp] $Line"
     Write-Host $Line
+}
+
+# ── Event timeline helper — append one structured event (parity with the ─────
+# Linux script's emit_event). One JSON object per line:
+#   {"t":"2026-06-01T02:57:04Z","phase":"A","kind":"start","msg":"..."}
+function Write-UpgradeEvent {
+    param(
+        [string] $Phase,
+        [string] $Kind,
+        [string] $Msg = ''
+    )
+
+    # Terminal-state events ALWAYS emit regardless of the cap — operators MUST
+    # see the final outcome. This set MUST stay in sync with the Linux script's
+    # emit_event terminal list (drift-pinned by the cross-script parity test)
+    # and the FE's UPGRADE_EVENTS_TERMINAL_KINDS.
+    $terminalKinds = @('success', 'rollback-ok', 'rollback-fail', 'rollback-critical-failed', 'method-exhausted', 'restart-fail', 'healthz-fail')
+
+    if ($terminalKinds -notcontains $Kind) {
+        $lineCount = @(Get-Content -Path $EVENTS_FILE -ErrorAction SilentlyContinue).Count
+        if ($lineCount -ge $EVENTS_MAX) { return }
+    }
+
+    # Minimal JSON-safe escaping: drop quotes and backslashes (events originate
+    # from our own controlled strings — versions, methods, exit codes). Matches
+    # the Linux emit_event `tr -d '"\\'`.
+    $safeMsg = $Msg -replace '["\\]', ''
+
+    $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $line = '{"t":"' + $now + '","phase":"' + $Phase + '","kind":"' + $Kind + '","msg":"' + $safeMsg + '"}'
+
+    # BOM-less UTF8 append — PS 5.1's Add-Content -Encoding UTF8 prepends a BOM
+    # that would corrupt the first JSON line the server parses. Best-effort:
+    # events are advisory, never fail the upgrade on an event-write hiccup.
+    try {
+        [System.IO.File]::AppendAllText($EVENTS_FILE, $line + "`n", (New-Object System.Text.UTF8Encoding($false)))
+    } catch { }
 }
 
 # ── Rollback helper (J.E.6) ──────────────────────────────────────────────────
@@ -511,6 +587,9 @@ try {
     # concern owned by E.3's strategy, not by this template.
     Append-UpgradeLog "[upgrade] Phase B starting — stopping service '$SERVICE_NAME' and swapping binary"
 
+    # Entering Phase B — events emitted from here are tagged phase 'B'.
+    $script:CURRENT_PHASE = 'B'
+
     $serviceWasRunning = $false
     $svc = Get-Service -Name $SERVICE_NAME -ErrorAction SilentlyContinue
 
@@ -582,6 +661,7 @@ try {
     # that synchronously so the catch is reachable.
     if ($null -ne (Get-Service -Name $SERVICE_NAME -ErrorAction SilentlyContinue)) {
         Append-UpgradeLog "[upgrade] Starting service $SERVICE_NAME"
+        Write-UpgradeEvent -Phase 'B' -Kind 'restart-start' -Msg "Starting service $SERVICE_NAME"
         try {
             Start-Service -Name $SERVICE_NAME
 
@@ -620,6 +700,7 @@ try {
 
             if ($resp.StatusCode -eq 200) {
                 $healthOk = $true
+                Write-UpgradeEvent -Phase 'B' -Kind 'healthz-pass' -Msg "Service healthy after restart (attempt $($i + 1))"
                 break
             }
         }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeEventsParityTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeEventsParityTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Squid.Core.Services.Machines.Upgrade;
+using Squid.Tentacle.Platform;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Drift detector + parity pins for the Windows upgrade script's event timeline.
+/// The Linux script emits upgrade-events.jsonl (per-phase timeline) which the
+/// server surfaces; this PR adds the same to Windows. These tests read BOTH
+/// embedded scripts and assert the Windows emission matches the Linux contract
+/// (format, cap, terminal-kind set) and the path the agent reads
+/// (<see cref="object"/> — WindowsUpgradeStatusStorage.EventsFileSubPath), so a
+/// future edit to one script that diverges from the other is caught at build.
+/// </summary>
+public sealed class WindowsUpgradeEventsParityTests
+{
+    private const string LinuxResource = "Squid.Core.Resources.Upgrade.upgrade-linux-tentacle.sh";
+    private const string WindowsResource = "Squid.Core.Resources.Upgrade.upgrade-windows-tentacle.ps1";
+
+    private static string ReadScript(string resourceName)
+    {
+        var asm = typeof(WindowsTentacleUpgradeStrategy).Assembly;
+        using var stream = asm.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource not found: {resourceName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static readonly string Windows = ReadScript(WindowsResource);
+    private static readonly string Linux = ReadScript(LinuxResource);
+
+    [Fact]
+    public void Windows_DefinesEventEmitter_WritingToEventsJsonl()
+    {
+        Windows.ShouldContain("function Write-UpgradeEvent", customMessage: "Windows must define an event emitter for parity with Linux emit_event.");
+        Windows.ShouldContain("upgrade-events.jsonl", customMessage: "Windows must write the per-phase timeline to upgrade-events.jsonl.");
+    }
+
+    [Fact]
+    public void Windows_EmitsCanonicalEventJsonShape()
+    {
+        // The server parses each line as UpgradeEvent {t, phase, kind, msg}.
+        Windows.ShouldContain("\"t\":\"", customMessage: "event must carry the timestamp field 't'.");
+        Windows.ShouldContain("\"phase\":\"");
+        Windows.ShouldContain("\"kind\":\"");
+        Windows.ShouldContain("\"msg\":\"");
+    }
+
+    [Fact]
+    public void Windows_EventsCap_MatchesLinux()
+    {
+        var win = Regex.Match(Windows, @"\$EVENTS_MAX\s*=\s*(\d+)");
+        var lin = Regex.Match(Linux, @"EVENTS_MAX=(\d+)");
+
+        win.Success.ShouldBeTrue("Windows must define an $EVENTS_MAX cap.");
+        lin.Success.ShouldBeTrue("Linux must define an EVENTS_MAX cap.");
+        win.Groups[1].Value.ShouldBe(lin.Groups[1].Value,
+            customMessage: "the per-run event cap must be identical across the two scripts.");
+    }
+
+    [Fact]
+    public void Windows_TerminalKinds_MatchLinux()
+    {
+        // Linux: case "$kind" in success|rollback-ok|...|healthz-fail)
+        var linuxList = Regex.Match(Linux, @"case ""\$kind"" in\s*\n\s*([a-z|\-]+)\)");
+        linuxList.Success.ShouldBeTrue("could not locate the Linux terminal-kind case list.");
+        var linuxKinds = linuxList.Groups[1].Value.Split('|').Select(k => k.Trim()).Where(k => k.Length > 0).ToHashSet();
+
+        // Windows: $terminalKinds = @('success', 'rollback-ok', ...)
+        var winList = Regex.Match(Windows, @"\$terminalKinds\s*=\s*@\(([^)]*)\)");
+        winList.Success.ShouldBeTrue("could not locate the Windows $terminalKinds array.");
+        var winKinds = Regex.Matches(winList.Groups[1].Value, @"'([^']+)'").Select(m => m.Groups[1].Value).ToHashSet();
+
+        winKinds.ShouldBe(linuxKinds, ignoreOrder: true,
+            customMessage: "Windows and Linux terminal-event kinds must stay identical — both feed the FE's " +
+                           "stop-polling logic and the cap-bypass guarantee. If one changes, update the other.");
+    }
+
+    [Fact]
+    public void Windows_TruncatesEventsFileBeforeRun()
+    {
+        // Phase A starts fresh (single invocation), like Linux's `: > "$EVENTS_FILE"`.
+        Windows.ShouldContain("WriteAllText($EVENTS_FILE",
+            customMessage: "Windows must truncate the events file at the start of the run so a prior attempt's events don't leak.");
+    }
+
+    [Fact]
+    public void Windows_StatusTransitions_AutoEmitEvents()
+    {
+        // Write-UpgradeStatus maps each status → an event kind, so the timeline
+        // tracks the status file 1:1 without per-call-site duplication.
+        Windows.ShouldContain("switch ($Status)");
+        foreach (var mapped in new[] { "'IN_PROGRESS'", "'SWAPPED'", "'SUCCESS'", "'FAILED'", "'ROLLED_BACK'" })
+            Windows.ShouldContain(mapped, customMessage: $"status→event map must handle {mapped}.");
+    }
+
+    [Fact]
+    public void Windows_EventsPath_MatchesAgentReadPath()
+    {
+        // The agent reads upgrade\upgrade-events.jsonl under the system config dir;
+        // the script must write to the same relative location.
+        WindowsUpgradeStatusStorage.EventsFileSubPath.ShouldBe(@"upgrade\upgrade-events.jsonl");
+        Windows.ShouldContain("Squid\\Tentacle\\upgrade",
+            customMessage: "Windows must write under %ProgramData%\\Squid\\Tentacle\\upgrade to match WindowsUpgradeStatusStorage.");
+        Windows.ShouldContain("'upgrade-events.jsonl'");
+    }
+
+    [Fact]
+    public void Windows_AppendsEventsWithoutBom()
+    {
+        // PS 5.1 Add-Content -Encoding UTF8 prepends a BOM that corrupts the
+        // first JSON line. The script must use BOM-less .NET IO instead.
+        Windows.ShouldContain("UTF8Encoding($false)",
+            customMessage: "events must be appended BOM-less so the server can parse the first line.");
+    }
+}


### PR DESCRIPTION
## Summary

- The Linux upgrade script emits a per-phase event timeline (`upgrade-events.jsonl`) that the server reads on each Capabilities RPC and surfaces in the upgrade timeline/UI. The Windows script emitted **only** the status file, so Windows operators saw no per-phase timeline. The agent already reads the Windows path (`WindowsUpgradeStatusStorage.EventsFileSubPath = upgrade\upgrade-events.jsonl`) — nothing wrote it.
- Add `Write-UpgradeEvent` mirroring Linux `emit_event`: same JSONL shape (`{t,phase,kind,msg}`), same `EVENTS_MAX=50` cap, same terminal-kind set that bypasses the cap, **BOM-less** UTF8 append (PS 5.1's `Add-Content -Encoding UTF8` prepends a BOM that would corrupt the first parsed line).
- `Write-UpgradeStatus` now auto-emits a phase-tagged event mapped from each status (`start`/`swapped`/`success`/`method-exhausted`/`rollback-*`), so the timeline tracks the status file 1:1 with no per-call-site duplication; plus event-only emits for `restart-start` and `healthz-pass`. The events file is truncated at the start of the (single-invocation) run so a prior attempt doesn't leak.

## Design notes

- **Agent-side only / non-breaking**: the server is already OS-agnostic (reads the `upgradeEvents` metadata key regardless of OS). No server, API, or schema change.
- Phase is tracked via `$script:CURRENT_PHASE` (`A` pre-swap → `B` at Phase B entry); em-dashes stay confined to comments (new string literals are ASCII), consistent with the existing script.

## Test plan

- [x] `WindowsUpgradeEventsParityTests` (8 cross-platform drift pins): Windows defines `Write-UpgradeEvent` + writes `upgrade-events.jsonl`; canonical `{t,phase,kind,msg}` shape; `$EVENTS_MAX` matches Linux; **terminal-kind set matches Linux**; truncates before run; status→event map present; events path matches `WindowsUpgradeStatusStorage`; BOM-less append
- [x] Full unit suite: 5841/5841 green (no drift-detector regression)
- [ ] Runtime emission exercised by the Windows upgrade E2E suite on Windows CI (`pwsh` isn't available on the dev host, so the `.ps1` is validated structurally here + at runtime on CI)