### PR TITLE
Surface an operator-visible marker when script log output is truncated

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Infrastructure/HalibutScriptObserver.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Infrastructure/HalibutScriptObserver.cs
@@ -12,6 +12,11 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
 {
     internal const int DefaultMaxLogEntries = 100_000;
 
+    // Stable prefix of the truncation gap marker. Used both to render the marker
+    // and to recognise a prior marker at the buffer head, so a re-truncation of
+    // an otherwise-unchanged buffer doesn't emit a duplicate marker.
+    internal const string TruncationMarkerPrefix = "[Squid] Older log lines were truncated here";
+
     private readonly ObserverSettings _observerSettings;
     private readonly LivenessSettings _livenessSettings;
     private readonly IAgentLivenessProbe? _livenessProbe;
@@ -89,10 +94,21 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
             return StreamLinesAsync(lines);
         }
 
+        // Cap the buffer; if truncation produced a gap marker, stream it too so
+        // it persists even when the streaming path skips the bulk persist (the
+        // marker is also left in allLogs for the non-streaming bulk path — so it
+        // lands exactly once in either mode).
+        async Task TruncateAndStreamMarkerAsync()
+        {
+            var marker = TruncateIfExceeded(allLogs);
+            if (marker != null)
+                await StreamLinesAsync(new[] { new ScriptOutputLine(marker.Text, IsStdErr: false) }).ConfigureAwait(false);
+        }
+
         if (initialStartResponse != null)
         {
             allLogs.AddRange(initialStartResponse.Logs);
-            TruncateIfExceeded(allLogs);
+            await TruncateAndStreamMarkerAsync().ConfigureAwait(false);
             LogOutput(initialStartResponse.Logs, machine.Name, masker);
             await StreamBatchAsync(initialStartResponse.Logs).ConfigureAwait(false);
         }
@@ -163,7 +179,7 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
                 new ScriptStatusRequest(ticket, statusResponse.NextLogSequence)).ConfigureAwait(false);
 
             allLogs.AddRange(statusResponse.Logs);
-            TruncateIfExceeded(allLogs);
+            await TruncateAndStreamMarkerAsync().ConfigureAwait(false);
             LogOutput(statusResponse.Logs, machine.Name, masker);
             await StreamBatchAsync(statusResponse.Logs).ConfigureAwait(false);
 
@@ -192,7 +208,7 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
             new CompleteScriptCommand(ticket, statusResponse.NextLogSequence)).ConfigureAwait(false);
 
         allLogs.AddRange(completeResponse.Logs);
-        TruncateIfExceeded(allLogs);
+        await TruncateAndStreamMarkerAsync().ConfigureAwait(false);
         LogOutput(completeResponse.Logs, machine.Name, masker);
         await StreamBatchAsync(completeResponse.Logs).ConfigureAwait(false);
 
@@ -279,14 +295,42 @@ public sealed class HalibutScriptObserver : IHalibutScriptObserver
                 machineName, log.Source, masker?.Mask(log.Text) ?? log.Text);
     }
 
-    private void TruncateIfExceeded(List<ProcessOutput> logs)
+    /// <summary>
+    /// Cap the in-memory log buffer for a single script. When truncation occurs,
+    /// inserts an operator-visible gap marker at the head and RETURNS it so the
+    /// caller can also stream it — without a marker the operator's log silently
+    /// jumps (oldest lines vanish with only a Seq warning). Returns null when no
+    /// truncation was needed.
+    /// </summary>
+    private ProcessOutput TruncateIfExceeded(List<ProcessOutput> logs)
     {
         var max = _observerSettings.MaxLogEntries > 0 ? _observerSettings.MaxLogEntries : DefaultMaxLogEntries;
-        if (logs.Count <= max) return;
+
+        // A marker already at the head shouldn't itself count toward the cap —
+        // otherwise it would trigger a redundant re-truncation (and a duplicate
+        // marker) on the next call even when no real lines need dropping.
+        var hasMarker = logs.Count > 0 && logs[0].Text.StartsWith(TruncationMarkerPrefix, StringComparison.Ordinal);
+        var realCount = logs.Count - (hasMarker ? 1 : 0);
+
+        if (realCount <= max) return null;
+
+        if (hasMarker) logs.RemoveAt(0);   // drop the stale marker; a fresh one is re-inserted below
 
         var overflow = logs.Count - max;
         logs.RemoveRange(0, overflow);
         Log.Warning("[Deploy] Log buffer exceeded {Max} entries, truncated {Overflow} oldest entries", max, overflow);
+
+        // Anchor the marker to the oldest-retained entry's timestamp so the
+        // stable Occurred-ordering keeps it just ahead of that entry (i.e. at
+        // the head of the final log). Source = StdOut so it surfaces as an
+        // informational notice, never a false error signal.
+        var anchor = logs.Count > 0 ? logs[0].Occurred : DateTimeOffset.UtcNow;
+        var marker = new ProcessOutput(
+            ProcessOutputSource.StdOut,
+            $"{TruncationMarkerPrefix} - this step's output exceeded the {max}-line retention buffer and the oldest lines were dropped.",
+            anchor);
+        logs.Insert(0, marker);
+        return marker;
     }
 
     private static async Task TryCancelScriptAsync(

--- a/tests/Squid.UnitTests/Services/Deployments/Halibut/HalibutScriptObserverStreamingTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Halibut/HalibutScriptObserverStreamingTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Settings.Halibut;
 using Squid.Message.Constants;
 using Squid.Message.Contracts.Tentacle;
 
@@ -166,5 +167,68 @@ public class HalibutScriptObserverStreamingTests
         result.ExitCode.ShouldBe(ScriptExitCodes.Timeout);
         result.OutputStreamed.ShouldBeTrue();
         streamed.ShouldContain(l => l.Text.Contains("timeout") && l.IsStdErr);
+    }
+
+    // ── Gap marker on log-buffer truncation (#5a) ────────────────────────────
+    // When a single script's output exceeds the retention buffer, the observer
+    // drops the oldest entries. Without a marker the operator sees a silent jump;
+    // these pin that an operator-visible marker is inserted (bulk path) AND
+    // streamed (so it persists when the streaming path skips the bulk persist).
+
+    private static ScriptStatusResponse CompleteWith(ScriptTicket ticket, List<ProcessOutput> logs)
+        => new(ticket, ProcessState.Complete, 0, logs, logs.Count);
+
+    private static List<ProcessOutput> Lines(int count)
+    {
+        var logs = new List<ProcessOutput>();
+        for (var i = 1; i <= count; i++)
+            logs.Add(new ProcessOutput(ProcessOutputSource.StdOut, $"line-{i}", DateTimeOffset.UtcNow.AddSeconds(i)));
+        return logs;
+    }
+
+    [Fact]
+    public async Task Truncation_InsertsGapMarkerAtHead_AndDropsOldest()
+    {
+        var observer = new HalibutScriptObserver(new ObserverSettings { MaxLogEntries = 3 });
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>())).ReturnsAsync(CompleteWith(_ticket, Lines(5)));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 0));
+
+        var result = await observer.ObserveAndCompleteAsync(_machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None);
+
+        result.LogLines[0].ShouldContain("truncated", customMessage: "the gap marker must sort to the head of the log so the operator sees it where the older lines were.");
+        result.LogLines.ShouldContain("line-5", customMessage: "newest lines are retained.");
+        result.LogLines.ShouldNotContain("line-1", customMessage: "oldest lines are dropped past the buffer cap.");
+    }
+
+    [Fact]
+    public async Task Truncation_StreamsGapMarker_AsInformationalNotErrorLine()
+    {
+        var observer = new HalibutScriptObserver(new ObserverSettings { MaxLogEntries = 3 });
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>())).ReturnsAsync(CompleteWith(_ticket, Lines(5)));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 0));
+        var (streamed, _) = RecordingSink(out var sink);
+
+        await observer.ObserveAndCompleteAsync(_machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None, outputSink: sink);
+
+        streamed.ShouldContain(l => l.Text.Contains("truncated"),
+            customMessage: "the marker must be streamed so it persists even when bulk persist is skipped in streaming mode.");
+        streamed.Single(l => l.Text.Contains("truncated")).IsStdErr.ShouldBeFalse(
+            customMessage: "truncation is an informational notice, not a script error — must not surface as stderr/Error.");
+    }
+
+    [Fact]
+    public async Task NoTruncation_EmitsNoGapMarker()
+    {
+        var observer = new HalibutScriptObserver(new ObserverSettings { MaxLogEntries = 100 });
+        _scriptClient.Setup(s => s.GetStatusAsync(It.IsAny<ScriptStatusRequest>())).ReturnsAsync(CompleteWith(_ticket, Lines(3)));
+        _scriptClient.Setup(s => s.CompleteScriptAsync(It.IsAny<CompleteScriptCommand>()))
+            .ReturnsAsync(new ScriptStatusResponse(_ticket, ProcessState.Complete, 0, new List<ProcessOutput>(), 0));
+
+        var result = await observer.ObserveAndCompleteAsync(_machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None);
+
+        result.LogLines.ShouldNotContain(l => l.Contains("truncated"));
+        result.LogLines.Count.ShouldBe(3);
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutScriptObserverTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutScriptObserverTests.cs
@@ -285,7 +285,11 @@ public class HalibutScriptObserverTests
             _machine, _scriptClient.Object, _ticket, _timeout, CancellationToken.None);
 
         result.Success.ShouldBeTrue();
-        result.LogLines.Count.ShouldBeLessThanOrEqualTo(HalibutScriptObserver.DefaultMaxLogEntries);
+        // Real lines are capped at the buffer; the only addition beyond the cap
+        // is the single operator-visible gap marker (#5a) inserted at the head.
+        result.LogLines.Count.ShouldBeLessThanOrEqualTo(HalibutScriptObserver.DefaultMaxLogEntries + 1);
+        result.LogLines.ShouldContain(l => l.Contains("truncated"),
+            customMessage: "verbose output past the buffer must leave an operator-visible gap marker, not a silent jump.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- When a single script's output exceeded the in-memory retention buffer, `HalibutScriptObserver` dropped the oldest entries with only a Serilog/Seq warning — the operator's task log silently jumped, with no indication anything was lost.
- Insert an operator-visible gap marker at the head of the retained log on truncation, and **stream it via the output sink** so it persists even in streaming mode (where the bulk persist is skipped) — landing exactly once in either mode. Anchored to the oldest-retained entry's timestamp (stays at the head under `Occurred`-ordering); `StdOut` so it reads as an informational notice, not a false error.
- `TruncateIfExceeded` is marker-aware: a marker already at the head doesn't count toward the cap, so re-truncating an unchanged buffer never emits a duplicate marker.

## Scope decisions (the rest of #5/#6, after investigation)

- **`SuccessWithWarning` rollup — deliberately NOT added.** `ServerTask.State` is a string; a new terminal value would force every `State`-consuming caller (incl. the frontend) to change (semi-breaking) for no concrete need. The `Warning` log category already surfaces warnings.
- **#6 publish-success assertion — already implemented.** `success = completeResponse.ExitCode == 0` is a positive assertion from the agent's `CompleteScript` RPC (same model as Octopus/Calamari), not an inference. No change needed.

## Non-breaking

Private signature change only (`TruncateIfExceeded` void → returns the marker). No public API, schema, or response-shape change. Consumers of `LogLines` see at most one extra informational line on truncation (rare — only above the 100k-entry default buffer).

## Test plan

- [x] `HalibutScriptObserverStreamingTests`: marker at head + oldest dropped (bulk path); marker streamed as informational (not stderr/Error); no marker when under cap
- [x] Updated `HalibutScriptObserverTests.ObserveAndCompleteAsync_VerboseOutput_TruncatesOldestLogs` to assert the marker is present + the cap holds within +1
- [x] Full unit suite: 5844/5844 green
- [x] Full solution build: 0 errors