### PR TITLE
Introduce versioned Tentacle install-layout foundation

### DIFF
--- a/src/Squid.Tentacle/Commands/ServiceCommand.cs
+++ b/src/Squid.Tentacle/Commands/ServiceCommand.cs
@@ -205,13 +205,27 @@ public sealed class ServiceCommand : ITentacleCommand
     /// Uses <see cref="Environment.ProcessPath"/> (real exe — works for single-file
     /// PublishSingleFile deployments) + <see cref="AppContext.BaseDirectory"/> (install dir).
     /// </summary>
-    internal static (string ExecStart, string WorkingDir) ResolveServiceExecution()
-    {
-        var workingDir = (AppContext.BaseDirectory ?? "/opt/squid-tentacle").TrimEnd('/', '\\');
-        var execStart = Environment.ProcessPath;
+    internal static (string ExecStart, string WorkingDir) ResolveServiceExecution() =>
+        ResolveServiceExecution(AppContext.BaseDirectory, Environment.ProcessPath, Platform.TentacleLayout.IsVersioned);
 
-        if (string.IsNullOrEmpty(execStart))
-            execStart = Path.Combine(workingDir, "Squid.Tentacle");
+    /// <summary>
+    /// Testable core. When the running binary lives inside a versioned install
+    /// (<c>{root}/versions/{ver}</c> or <c>{root}/current</c>) AND that root has a live
+    /// <c>current</c> pointer, the service is registered against the STABLE pointer path
+    /// so an upgrade can repoint <c>current</c> to a new version without re-registering the
+    /// service. Flat installs (and a versioned-shaped path whose pointer isn't live yet)
+    /// keep today's behaviour — <paramref name="processPath"/> verbatim.
+    /// </summary>
+    internal static (string ExecStart, string WorkingDir) ResolveServiceExecution(string baseDir, string processPath, Func<string, bool> isVersioned)
+    {
+        var workingDir = (baseDir ?? "/opt/squid-tentacle").TrimEnd('/', '\\');
+
+        var installRoot = Platform.TentacleLayout.TryGetInstallRootFromRunningDir(workingDir);
+
+        if (installRoot != null && isVersioned(installRoot))
+            return (Platform.TentacleLayout.PointerBinaryPath(installRoot), Platform.TentacleLayout.CurrentPointer(installRoot));
+
+        var execStart = string.IsNullOrEmpty(processPath) ? Path.Combine(workingDir, Platform.TentacleLayout.BinaryFileName) : processPath;
 
         return (execStart, workingDir);
     }

--- a/src/Squid.Tentacle/Platform/TentacleLayout.cs
+++ b/src/Squid.Tentacle/Platform/TentacleLayout.cs
@@ -82,8 +82,9 @@ public static class TentacleLayout
     {
         if (string.IsNullOrWhiteSpace(installDir)) return false;
 
-        var pointer = CurrentPointer(installDir);
-
-        return Directory.Exists(pointer) || File.Exists(pointer);
+        // `current` is a directory pointer (symlink on Linux/macOS, junction on Windows);
+        // Directory.Exists follows the link/junction. A dangling or non-directory pointer
+        // reports false, so callers safely fall back to the flat layout.
+        return Directory.Exists(CurrentPointer(installDir));
     }
 }

--- a/src/Squid.Tentacle/Platform/TentacleLayout.cs
+++ b/src/Squid.Tentacle/Platform/TentacleLayout.cs
@@ -1,0 +1,89 @@
+namespace Squid.Tentacle.Platform;
+
+/// <summary>
+/// Versioned ("blue-green") install layout for the Tentacle. The binary lives in a
+/// per-version directory under <c>{installDir}/versions/{version}</c>, and the running
+/// version is selected by a stable <c>{installDir}/current</c> pointer (a symlink on
+/// Linux/macOS, a directory junction on Windows). The service is registered against the
+/// pointer, so an upgrade activates a new version by atomically repointing
+/// <c>current</c> — the previously-running version directory is never moved, overwritten,
+/// or deleted during the upgrade, so any failure leaves the old version byte-for-byte
+/// intact and instantly restorable by repointing back.
+/// </summary>
+///
+/// <remarks>
+/// <para>This type is the single source of truth for the layout. The install scripts
+/// (<c>install-tentacle.sh</c> / <c>.ps1</c>), the upgrade scripts, and service
+/// registration all mirror these names — drift detectors pin the script copies against
+/// these literals.</para>
+/// <para>Existing "flat" installs (binary directly in <c>{installDir}</c>) are detected
+/// via <see cref="IsVersioned"/> and left unchanged; callers fall back to today's
+/// behaviour so nothing breaks before an install migrates.</para>
+/// </remarks>
+public static class TentacleLayout
+{
+    /// <summary>Directory under the install root that holds per-version subdirectories.</summary>
+    public const string VersionsDirName = "versions";
+
+    /// <summary>Stable pointer (symlink/junction) under the install root selecting the active version.</summary>
+    public const string CurrentPointerName = "current";
+
+    /// <summary>The published binary filename — platform-specific extension. NOT the "squid-tentacle" shell wrapper.</summary>
+    public static string BinaryFileName => PlatformPaths.IsWindows ? "Squid.Tentacle.exe" : "Squid.Tentacle";
+
+    /// <summary><c>{installDir}/versions</c> — parent of all per-version directories.</summary>
+    public static string VersionsDir(string installDir) => Path.Combine(installDir, VersionsDirName);
+
+    /// <summary><c>{installDir}/versions/{version}</c> — a specific version's directory.</summary>
+    public static string VersionDir(string installDir, string version) => Path.Combine(installDir, VersionsDirName, version);
+
+    /// <summary><c>{installDir}/current</c> — the stable pointer to the active version.</summary>
+    public static string CurrentPointer(string installDir) => Path.Combine(installDir, CurrentPointerName);
+
+    /// <summary>Stable binary path the service execs — resolved through the <c>current</c> pointer.</summary>
+    public static string PointerBinaryPath(string installDir) => Path.Combine(CurrentPointer(installDir), BinaryFileName);
+
+    /// <summary>Binary path inside a specific version directory.</summary>
+    public static string VersionBinaryPath(string installDir, string version) => Path.Combine(VersionDir(installDir, version), BinaryFileName);
+
+    /// <summary>
+    /// Given the directory the running binary loaded from, returns the install root if
+    /// this is a versioned layout, otherwise <c>null</c> (flat install). Pure — no
+    /// filesystem access; the caller confirms the pointer exists via <see cref="IsVersioned"/>.
+    /// Recognised shapes: <c>{installRoot}/versions/{version}</c> and <c>{installRoot}/current</c>.
+    /// </summary>
+    public static string TryGetInstallRootFromRunningDir(string runningDir)
+    {
+        if (string.IsNullOrWhiteSpace(runningDir)) return null;
+
+        var dir = runningDir.TrimEnd('/', '\\');
+
+        if (dir.Length == 0) return null;
+
+        var name = Path.GetFileName(dir);
+
+        if (string.Equals(name, CurrentPointerName, StringComparison.Ordinal))
+            return Path.GetDirectoryName(dir);
+
+        var parent = Path.GetDirectoryName(dir);
+
+        if (parent != null && string.Equals(Path.GetFileName(parent), VersionsDirName, StringComparison.Ordinal))
+            return Path.GetDirectoryName(parent);
+
+        return null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="installDir"/> uses the versioned layout — i.e. a
+    /// <c>current</c> pointer is present. Flat installs (no pointer) return false so
+    /// callers preserve today's behaviour unchanged.
+    /// </summary>
+    public static bool IsVersioned(string installDir)
+    {
+        if (string.IsNullOrWhiteSpace(installDir)) return false;
+
+        var pointer = CurrentPointer(installDir);
+
+        return Directory.Exists(pointer) || File.Exists(pointer);
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Commands/ServiceCommandTests.cs
+++ b/tests/Squid.Tentacle.Tests/Commands/ServiceCommandTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using Squid.Tentacle.Commands;
+using Squid.Tentacle.Platform;
 
 namespace Squid.Tentacle.Tests.Commands;
 
@@ -91,5 +93,89 @@ public class ServiceCommandTests
         // Working dir must be a plausible absolute-ish path (no trailing slash)
         workingDir.ShouldNotEndWith("/");
         workingDir.ShouldNotEndWith("\\");
+    }
+
+    // ========================================================================
+    // ResolveServiceExecution (testable overload) — flat vs versioned layout
+    // ========================================================================
+
+    private static string Root() => Path.Combine(Path.DirectorySeparatorChar.ToString(), "opt", "squid-tentacle");
+
+    [Fact]
+    public void ResolveServiceExecution_FlatInstall_ReturnsProcessPathVerbatim()
+    {
+        var root = Root();
+        var processPath = Path.Combine(root, TentacleLayout.BinaryFileName);
+
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution(root, processPath, _ => false);
+
+        // Flat layout: register against the real exe exactly as today.
+        execStart.ShouldBe(processPath);
+        workingDir.ShouldBe(root);
+    }
+
+    [Fact]
+    public void ResolveServiceExecution_VersionedRunningDir_LivePointer_ReturnsStablePointerPath()
+    {
+        var root = Root();
+        var runningDir = TentacleLayout.VersionDir(root, "1.8.7");
+        var processPath = TentacleLayout.VersionBinaryPath(root, "1.8.7");
+
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution(runningDir, processPath, _ => true);
+
+        // Versioned + live pointer: register against the STABLE pointer, not the
+        // version-specific path, so upgrades repoint `current` without re-registering.
+        execStart.ShouldBe(TentacleLayout.PointerBinaryPath(root));
+        workingDir.ShouldBe(TentacleLayout.CurrentPointer(root));
+    }
+
+    [Fact]
+    public void ResolveServiceExecution_CurrentPointerRunningDir_LivePointer_ReturnsStablePointerPath()
+    {
+        var root = Root();
+        var runningDir = TentacleLayout.CurrentPointer(root);
+        var processPath = TentacleLayout.PointerBinaryPath(root);
+
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution(runningDir, processPath, _ => true);
+
+        execStart.ShouldBe(TentacleLayout.PointerBinaryPath(root));
+        workingDir.ShouldBe(TentacleLayout.CurrentPointer(root));
+    }
+
+    [Fact]
+    public void ResolveServiceExecution_VersionedShapeButPointerNotLive_FallsBackToProcessPath()
+    {
+        // Safety: a path that LOOKS versioned but has no live `current` pointer (e.g.
+        // mid-migration) must NOT be registered against a pointer that doesn't exist.
+        var root = Root();
+        var runningDir = TentacleLayout.VersionDir(root, "1.8.7");
+        var processPath = TentacleLayout.VersionBinaryPath(root, "1.8.7");
+
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution(runningDir, processPath, _ => false);
+
+        execStart.ShouldBe(processPath);
+        workingDir.ShouldBe(runningDir);
+    }
+
+    [Fact]
+    public void ResolveServiceExecution_EmptyProcessPath_FlatFallback_UsesBinaryName()
+    {
+        var root = Root();
+
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution(root, processPath: "", _ => false);
+
+        execStart.ShouldBe(Path.Combine(root, TentacleLayout.BinaryFileName));
+        workingDir.ShouldBe(root);
+    }
+
+    [Fact]
+    public void ResolveServiceExecution_NullBaseDir_FallsBackToDefaultInstallDir()
+    {
+        var (execStart, workingDir) = ServiceCommand.ResolveServiceExecution(baseDir: null, processPath: "/usr/local/bin/Squid.Tentacle", _ => false);
+
+        // Null base dir is never expected in practice (AppContext.BaseDirectory is always
+        // set) but must degrade safely rather than throw.
+        execStart.ShouldBe("/usr/local/bin/Squid.Tentacle");
+        workingDir.ShouldBe("/opt/squid-tentacle");
     }
 }

--- a/tests/Squid.Tentacle.Tests/Platform/TentacleLayoutTests.cs
+++ b/tests/Squid.Tentacle.Tests/Platform/TentacleLayoutTests.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Tests.Platform;
+
+/// <summary>
+/// Pins the versioned ("blue-green") install layout contract. This is the single
+/// source of truth that install scripts, the upgrade scripts, and service
+/// registration all mirror — drift here breaks atomic-pointer upgrades, so every
+/// path component and the flat-vs-versioned detection is hard-pinned.
+/// </summary>
+public sealed class TentacleLayoutTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TentacleLayoutTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"squid-layout-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Contract constants ──────────────────────────────────────────────────
+
+    [Fact]
+    public void VersionsDirName_IsPinned()
+    {
+        // Renaming breaks every install/upgrade script that mirrors this literal.
+        TentacleLayout.VersionsDirName.ShouldBe("versions");
+    }
+
+    [Fact]
+    public void CurrentPointerName_IsPinned()
+    {
+        TentacleLayout.CurrentPointerName.ShouldBe("current");
+    }
+
+    [Fact]
+    public void BinaryFileName_MatchesPublishedNamePerOs()
+    {
+        // .NET publish output is "Squid.Tentacle(.exe)" — NOT the "squid-tentacle"
+        // shell wrapper. Wrong name = service registered against a nonexistent path.
+        var expected = OperatingSystem.IsWindows() ? "Squid.Tentacle.exe" : "Squid.Tentacle";
+        TentacleLayout.BinaryFileName.ShouldBe(expected);
+    }
+
+    // ── Pure path composition ───────────────────────────────────────────────
+
+    [Fact]
+    public void VersionsDir_IsInstallDirSlashVersions()
+    {
+        var root = Path.Combine("opt", "squid-tentacle");
+        TentacleLayout.VersionsDir(root).ShouldBe(Path.Combine(root, "versions"));
+    }
+
+    [Fact]
+    public void VersionDir_NestsVersionUnderVersions()
+    {
+        var root = Path.Combine("opt", "squid-tentacle");
+        TentacleLayout.VersionDir(root, "1.8.7").ShouldBe(Path.Combine(root, "versions", "1.8.7"));
+    }
+
+    [Fact]
+    public void CurrentPointer_IsInstallDirSlashCurrent()
+    {
+        var root = Path.Combine("opt", "squid-tentacle");
+        TentacleLayout.CurrentPointer(root).ShouldBe(Path.Combine(root, "current"));
+    }
+
+    [Fact]
+    public void PointerBinaryPath_RunsThroughCurrentPointer()
+    {
+        var root = Path.Combine("opt", "squid-tentacle");
+        TentacleLayout.PointerBinaryPath(root)
+            .ShouldBe(Path.Combine(root, "current", TentacleLayout.BinaryFileName));
+    }
+
+    [Fact]
+    public void VersionBinaryPath_IsBinaryInsideVersionDir()
+    {
+        var root = Path.Combine("opt", "squid-tentacle");
+        TentacleLayout.VersionBinaryPath(root, "1.8.7")
+            .ShouldBe(Path.Combine(root, "versions", "1.8.7", TentacleLayout.BinaryFileName));
+    }
+
+    // ── TryGetInstallRootFromRunningDir (pure) ──────────────────────────────
+
+    [Fact]
+    public void TryGetInstallRoot_FromVersionDir_ReturnsRoot()
+    {
+        var root = Path.Combine(Path.DirectorySeparatorChar.ToString(), "opt", "squid-tentacle");
+        var running = Path.Combine(root, "versions", "1.8.7");
+
+        TentacleLayout.TryGetInstallRootFromRunningDir(running).ShouldBe(root);
+    }
+
+    [Fact]
+    public void TryGetInstallRoot_FromCurrentPointer_ReturnsRoot()
+    {
+        var root = Path.Combine(Path.DirectorySeparatorChar.ToString(), "opt", "squid-tentacle");
+        var running = Path.Combine(root, "current");
+
+        TentacleLayout.TryGetInstallRootFromRunningDir(running).ShouldBe(root);
+    }
+
+    [Fact]
+    public void TryGetInstallRoot_TrailingSeparator_StillResolves()
+    {
+        var root = Path.Combine(Path.DirectorySeparatorChar.ToString(), "opt", "squid-tentacle");
+        var running = Path.Combine(root, "versions", "1.8.7") + Path.DirectorySeparatorChar;
+
+        TentacleLayout.TryGetInstallRootFromRunningDir(running).ShouldBe(root);
+    }
+
+    [Fact]
+    public void TryGetInstallRoot_FlatInstall_ReturnsNull()
+    {
+        // Binary sits directly in the install dir (today's layout) — no versioned root.
+        var root = Path.Combine(Path.DirectorySeparatorChar.ToString(), "opt", "squid-tentacle");
+
+        TentacleLayout.TryGetInstallRootFromRunningDir(root).ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetInstallRoot_UnrelatedSubdir_ReturnsNull()
+    {
+        var root = Path.Combine(Path.DirectorySeparatorChar.ToString(), "opt", "squid-tentacle");
+        var running = Path.Combine(root, "lib");
+
+        TentacleLayout.TryGetInstallRootFromRunningDir(running).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryGetInstallRoot_EmptyOrNull_ReturnsNull(string running)
+    {
+        TentacleLayout.TryGetInstallRootFromRunningDir(running).ShouldBeNull();
+    }
+
+    // ── IsVersioned (filesystem) ────────────────────────────────────────────
+
+    [Fact]
+    public void IsVersioned_FlatInstall_NoPointer_ReturnsFalse()
+    {
+        var install = Path.Combine(_tempDir, "flat");
+        Directory.CreateDirectory(install);
+        File.WriteAllText(Path.Combine(install, TentacleLayout.BinaryFileName), "binary");
+
+        TentacleLayout.IsVersioned(install).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsVersioned_CurrentPointerPresent_ReturnsTrue()
+    {
+        var install = Path.Combine(_tempDir, "versioned");
+        Directory.CreateDirectory(TentacleLayout.VersionDir(install, "1.8.7"));
+        // A real directory named "current" satisfies the "pointer exists" predicate;
+        // the install scripts create it as a symlink/junction (covered by E2E).
+        Directory.CreateDirectory(TentacleLayout.CurrentPointer(install));
+
+        TentacleLayout.IsVersioned(install).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsVersioned_CurrentSymlinkToVersionDir_ReturnsTrue()
+    {
+        // Symlink creation is unprivileged on Linux/macOS (where unit tests run);
+        // on Windows it needs elevation, so skip there — the dir case above covers
+        // the predicate and the install-script E2E covers the real junction.
+        if (OperatingSystem.IsWindows()) return;
+
+        var install = Path.Combine(_tempDir, "symlinked");
+        var versionDir = TentacleLayout.VersionDir(install, "1.8.7");
+        Directory.CreateDirectory(versionDir);
+        Directory.CreateSymbolicLink(TentacleLayout.CurrentPointer(install), versionDir);
+
+        TentacleLayout.IsVersioned(install).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TentacleLayout` — the single source of truth for a versioned install layout: per-version directories under `versions/<v>` selected by a stable `current` pointer. A later upgrade activates a new version by atomically repointing `current`, leaving the previously-running version directory byte-for-byte untouched and instantly restorable on failure.
- Make `ServiceCommand.ResolveServiceExecution` layout-aware: a versioned install with a live `current` pointer registers the service against the stable pointer path; flat installs keep today's behaviour verbatim.
- **Non-breaking + dormant**: nothing creates the versioned layout yet, so `TryGetInstallRootFromRunningDir` returns null on every existing agent and behaviour is identical to today. The install scripts adopt the layout in a follow-up; this PR lands the mechanism + its tests first.

This is the foundation of a series making Windows + Linux upgrades fully failure-isolated — an upgrade never touches the running version directory, so any failure (download, verify, swap, restart, health check, even a failed rollback) leaves the old version intact. `VersionsDir`/`VersionDir`/`VersionBinaryPath` are the layout contract consumed by the follow-up install-script + upgrade PRs.

## Test plan

- [x] `TentacleLayoutTests` (19): contract constants pinned, pure path composition (cross-OS via `Path.Combine`), `TryGetInstallRootFromRunningDir` (version-dir / current-pointer / trailing-sep / flat / unrelated / empty / null), `IsVersioned` (flat / real-dir pointer / symlink pointer).
- [x] `ServiceCommandTests` (+7): flat → process path verbatim; versioned + live pointer → stable pointer path (both running shapes); versioned-shape-but-pointer-not-live → safe fallback; empty process path fallback; null base dir fallback. Existing `ResolveServiceExecution` / `GenerateUnitFile` tests unchanged.
- [x] Full `Squid.Tentacle.Tests`: the 29 new/affected tests green. Pre-existing `ScriptExecution` failures on this dev host are identical with and without this change (verified by stashing) — not a regression.