### PR TITLE
Add versioned blue-green Tentacle install + upgrade

### DIFF
--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -282,17 +282,61 @@ Possible causes:
         exit 1
     }
 
-    # ── Extract ─────────────────────────────────────────────────────────────
+    # ── Extract into a versioned ("blue-green") layout ───────────────────────
+    # Binary lives in versions\<v>; a stable `current` junction selects the active
+    # version. A later upgrade repoints `current` without touching the running
+    # version's directory, so any failure leaves the old version intact. Stage
+    # first, then name the dir by the concrete version the binary reports (works
+    # for both `latest` and an explicit -Version). Junctions need no elevation.
     if (-not (Test-Path $InstallDir)) {
         New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
     }
 
-    Write-Host "Extracting to $InstallDir..."
-    Expand-Archive -Path $archivePath -DestinationPath $InstallDir -Force
+    $stagingDir = Join-Path $tempDir 'extract'
+    New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
 
-    $binaryPath = Join-Path $InstallDir $BinaryName
+    Write-Host "Extracting..."
+    Expand-Archive -Path $archivePath -DestinationPath $stagingDir -Force
+
+    $stagedBinary = Join-Path $stagingDir $BinaryName
+    if (-not (Test-Path $stagedBinary)) {
+        Write-Error "Extraction completed but $BinaryName is missing. The archive may be corrupt."
+        exit 1
+    }
+
+    $resolvedVersion = ''
+    try {
+        $verOut = & $stagedBinary version 2>$null | Select-Object -First 1
+        if ($verOut) { $resolvedVersion = ($verOut -replace '[^0-9A-Za-z._-]', '') }
+    } catch { }
+
+    if ($resolvedVersion) {
+        $versionsRoot = Join-Path $InstallDir 'versions'
+        $versionDir = Join-Path $versionsRoot $resolvedVersion
+        if (-not (Test-Path $versionsRoot)) { New-Item -ItemType Directory -Path $versionsRoot -Force | Out-Null }
+        if (Test-Path $versionDir) { Remove-Item -Path $versionDir -Recurse -Force }
+        Move-Item -Path $stagingDir -Destination $versionDir
+
+        # Repoint `current` at the new version. Delete the old junction
+        # NON-recursively ([Directory]::Delete(path, $false)) so we remove only the
+        # reparse point, never the target version's files.
+        $currentPath = Join-Path $InstallDir 'current'
+        if (Test-Path $currentPath) { [System.IO.Directory]::Delete($currentPath, $false) }
+        New-Item -ItemType Junction -Path $currentPath -Target $versionDir | Out-Null
+
+        $binaryPath = Join-Path $currentPath $BinaryName
+        Write-Host "Installed versioned layout: current -> versions\$resolvedVersion"
+    } else {
+        # Best-effort fallback: the binary couldn't report its version. Extract flat
+        # so the install completes exactly as it did before the versioned layout
+        # existed. Never fail an install that used to succeed.
+        Write-Host "Warning: binary did not report a version; using flat layout (no versioned upgrades)."
+        Copy-Item -Path (Join-Path $stagingDir '*') -Destination $InstallDir -Recurse -Force
+        $binaryPath = Join-Path $InstallDir $BinaryName
+    }
+
     if (-not (Test-Path $binaryPath)) {
-        Write-Error "Extraction completed but $BinaryName is missing from $InstallDir. The archive may be corrupt."
+        Write-Error "Install completed but $BinaryName is missing at $binaryPath. The archive may be corrupt."
         exit 1
     }
 

--- a/deploy/scripts/install-tentacle.sh
+++ b/deploy/scripts/install-tentacle.sh
@@ -246,17 +246,62 @@ if [ "$PKG_INSTALL_DONE" != "1" ]; then
         fi
     fi
 
-    # Extract (tar contents are flat - no wrapper dir)
-    mkdir -p "$INSTALL_DIR"
-    tar xzf "$ARCHIVE_PATH" -C "$INSTALL_DIR"
+    # Extract into a versioned ("blue-green") layout: the binary lives in
+    # versions/<v> and a stable `current` symlink selects the active version.
+    # A later in-UI upgrade activates a new version by atomically repointing
+    # `current`, so it never touches the running version's directory — any
+    # upgrade failure leaves the old version intact. tar contents are flat (no
+    # wrapper dir), so stage first, then name the directory by the concrete
+    # version the binary reports (works for both `latest` and explicit --version).
+    STAGING_DIR="$TMP_DIR/extract"
+    mkdir -p "$STAGING_DIR"
+    tar xzf "$ARCHIVE_PATH" -C "$STAGING_DIR"
+
+    chmod +x "$STAGING_DIR/Squid.Tentacle"
+
+    RESOLVED_VERSION=$(timeout 10 "$STAGING_DIR/Squid.Tentacle" version </dev/null 2>/dev/null | head -1 | tr -cd '[:alnum:]._-' || true)
+
+    if [ -n "$RESOLVED_VERSION" ]; then
+        VERSION_DIR="$INSTALL_DIR/versions/$RESOLVED_VERSION"
+        mkdir -p "$INSTALL_DIR/versions"
+
+        # Replace any prior copy of this exact version, then move the staged tree in.
+        if [ -d "$VERSION_DIR" ]; then rm -rf "$VERSION_DIR"; fi
+        mv "$STAGING_DIR" "$VERSION_DIR"
+
+        # Point `current` at the new version atomically (symlink rename is atomic).
+        ln -sfn "$VERSION_DIR" "$INSTALL_DIR/current.tmp"
+        mv -T "$INSTALL_DIR/current.tmp" "$INSTALL_DIR/current"
+
+        VERSIONED=1
+        echo "Installed versioned layout: current -> versions/$RESOLVED_VERSION"
+    else
+        # Best-effort fallback: the binary couldn't report its version (e.g. missing
+        # runtime deps). Extract flat so the install still completes exactly as it did
+        # before the versioned layout existed; the binary-verify step below surfaces
+        # any real runtime problem. Never fail an install that used to succeed.
+        echo "Warning: binary did not report a version; using flat layout (no versioned upgrades)."
+        mkdir -p "$INSTALL_DIR"
+        cp -a "$STAGING_DIR/." "$INSTALL_DIR/"
+    fi
+fi
+
+# Resolve the directory holding the runnable binaries. Versioned (tarball) installs
+# run through the stable `current` pointer; package-manager (apt/yum) installs are
+# flat in $INSTALL_DIR. Everything below is layout-agnostic via $BIN_DIR.
+if [ "${VERSIONED:-0}" = "1" ]; then
+    BIN_DIR="$INSTALL_DIR/current"
+else
+    BIN_DIR="$INSTALL_DIR"
 fi
 
 # Make binaries executable. Calamari is spawned by Tentacle at runtime, so it also needs +x.
-chmod +x "$INSTALL_DIR/Squid.Tentacle"
-[ -f "$INSTALL_DIR/Squid.Calamari" ] && chmod +x "$INSTALL_DIR/Squid.Calamari"
+chmod +x "$BIN_DIR/Squid.Tentacle"
+[ -f "$BIN_DIR/Squid.Calamari" ] && chmod +x "$BIN_DIR/Squid.Calamari"
 
-# Create well-known-name symlink inside install dir
-ln -sf "$INSTALL_DIR/Squid.Tentacle" "$INSTALL_DIR/${BINARY_NAME}"
+# Well-known-name symlink at the install root. Stable across upgrades — for versioned
+# installs it resolves through `current`, so the path survives a version swap.
+ln -sf "$BIN_DIR/Squid.Tentacle" "$INSTALL_DIR/${BINARY_NAME}"
 
 # Expose on PATH
 if [ -d /usr/local/bin ]; then

--- a/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
@@ -374,11 +374,37 @@ if [ -z "${SQUID_UPGRADE_SCOPED:-}" ]; then
   require_free_mb "$(dirname "$INSTALL_DIR")" 500 "install directory"
   emit_event A disk-precheck-pass "Disk space sufficient (>=500MB on /tmp and install dir)"
 
+  # ── Layout detection (blue-green) ────────────────────────────────────────
+  # A versioned install selects its active version via the `current` symlink
+  # ({INSTALL_DIR}/current -> versions/<v>). Upgrades of a versioned install MUST
+  # go through the blue-green tarball path: extract the new version into
+  # versions/<target> and atomically repoint `current`, NEVER touching the
+  # running version's directory — so any failure leaves the old version intact
+  # and instantly restorable. apt/yum write flat files and would orphan the
+  # pointer, so they are skipped when versioned. Flat installs (no `current`
+  # symlink) keep today's behaviour unchanged.
+  IS_VERSIONED=0
+  OLD_VER_TARGET=""
+  if [ -L "$INSTALL_DIR/current" ]; then
+    IS_VERSIONED=1
+    OLD_VER_TARGET=$(readlink -f "$INSTALL_DIR/current" 2>/dev/null || true)
+    emit_event A versioned-detected "Versioned layout; current -> ${OLD_VER_TARGET:-unknown}"
+  fi
+
   # ── Method dispatch (apt → yum → tarball-marker, server-injected) ────────
   # Each snippet's contract: short-circuit when INSTALL_OK=1 (a higher-
   # priority method already succeeded), otherwise probe the host and either
   # install + set INSTALL_OK=1 or fall through silently.
-  {{INSTALL_METHODS}}
+  #
+  # Versioned installs bypass the package-manager methods entirely and use the
+  # inline tarball path below — apt/yum would write flat files and break the
+  # `current` pointer. DOWNLOAD_URL is a top-level template var, so the inline
+  # tarball block has everything it needs without the injected marker.
+  if [ "$IS_VERSIONED" = "1" ]; then
+    INSTALL_METHOD="tarball"
+  else
+{{INSTALL_METHODS}}
+  fi
 
   # ── Tarball install (only when no package-manager method matched) ────────
   # Kept inline (not in the INSTALL_METHODS placeholder block) because the
@@ -534,6 +560,8 @@ if [ -z "${SQUID_UPGRADE_SCOPED:-}" ]; then
     --setenv=INSTALL_METHOD="$INSTALL_METHOD" \
     --setenv=OLD_VERSION_APT="$OLD_VERSION_APT" \
     --setenv=OLD_VERSION_RPM="$OLD_VERSION_RPM" \
+    --setenv=IS_VERSIONED="$IS_VERSIONED" \
+    --setenv=OLD_VER_TARGET="$OLD_VER_TARGET" \
     bash "$SCOPED_SCRIPT" || {
       echo "::error:: Failed to spawn scope for upgrade handoff."
       write_status "FAILED" "systemd-run --scope failed to launch"
@@ -562,8 +590,40 @@ echo "=== In scope: continuing upgrade to $TARGET_VERSION (method=$INSTALL_METHO
 
 BAK_DIR="${INSTALL_DIR}.bak"
 
-# ── Conditional swap (tarball only — apt/yum already wrote files via dpkg/rpm)
-if [ "$INSTALL_METHOD" = "tarball" ]; then
+# ── Conditional swap ──────────────────────────────────────────────────────
+# Versioned (blue-green): extract the new version into versions/<target> and
+# atomically repoint `current`; the running version directory is NEVER touched,
+# so any failure here or below leaves it intact and instantly restorable.
+# Flat tarball: legacy move-aside (.bak) swap. apt/yum: dpkg/rpm wrote files.
+if [ "$IS_VERSIONED" = "1" ]; then
+  NEW_VER_DIR="$INSTALL_DIR/versions/$TARGET_VERSION"
+  sudo mkdir -p "$INSTALL_DIR/versions"
+
+  # Never delete the currently-running version's directory.
+  if [ -d "$NEW_VER_DIR" ] && [ "$NEW_VER_DIR" != "$OLD_VER_TARGET" ]; then sudo rm -rf "$NEW_VER_DIR"; fi
+
+  if ! sudo mv "$EXTRACT" "$NEW_VER_DIR"; then
+    echo "::error:: Failed to stage new version into $NEW_VER_DIR. Running version untouched; no damage."
+    write_status "FAILED" "Failed to stage new version (versioned); running version intact at $OLD_VER_TARGET"
+    exit 10
+  fi
+
+  sudo chmod +x "$NEW_VER_DIR/Squid.Tentacle"
+  [ -f "$NEW_VER_DIR/Squid.Calamari" ] && sudo chmod +x "$NEW_VER_DIR/Squid.Calamari"
+
+  if id "$SERVICE_USER" >/dev/null 2>&1; then
+    sudo chown -R "$SERVICE_USER:$SERVICE_USER" "$NEW_VER_DIR" 2>/dev/null || true
+  fi
+
+  # Activate atomically: ln into a temp name then rename onto `current`.
+  sudo ln -sfn "$NEW_VER_DIR" "$INSTALL_DIR/current.tmp"
+  if ! sudo mv -T "$INSTALL_DIR/current.tmp" "$INSTALL_DIR/current"; then
+    sudo rm -rf "$INSTALL_DIR/current.tmp" 2>/dev/null || true
+    echo "::error:: Failed to repoint current -> $NEW_VER_DIR. Running version untouched; no damage."
+    write_status "FAILED" "Failed to activate new version (current repoint); running version intact at $OLD_VER_TARGET"
+    exit 10
+  fi
+elif [ "$INSTALL_METHOD" = "tarball" ]; then
   if [ -d "$BAK_DIR" ]; then sudo rm -rf "$BAK_DIR"; fi
 
   INSTALL_DIR_BACKED_UP=0
@@ -691,6 +751,50 @@ BASELINE_HEALTHZ_PRE="${SQUID_UPGRADE_BASELINE_HEALTHZ:-unknown}"
 BASELINE_VERSION="${SQUID_UPGRADE_BASELINE_VERSION:-unknown}"
 if [ "$BASELINE_HEALTHZ_PRE" = "FAIL" ]; then
   emit_event B baseline-was-fail "Pre-upgrade healthz was already FAIL — failure may be environmental, not upgrade-caused"
+fi
+
+if [ "$IS_VERSIONED" = "1" ]; then
+  # Blue-green rollback: repoint `current` back to the previous version. The old
+  # version directory was never touched during the swap, so this is instant and
+  # cannot lose the previous binaries — even if the repoint or the restart fails,
+  # the previous version remains intact on disk at $OLD_VER_TARGET.
+  echo "Rolling back: repointing current -> $OLD_VER_TARGET ..."
+  emit_event B rollback-start "Versioned rollback: repointing current to previous version"
+  write_status "ROLLING_BACK" "Health check failed after restart — repointing current to previous version"
+
+  timeout 30 sudo systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+
+  sudo ln -sfn "$OLD_VER_TARGET" "$INSTALL_DIR/current.tmp"
+  if ! sudo mv -T "$INSTALL_DIR/current.tmp" "$INSTALL_DIR/current"; then
+    sudo rm -rf "$INSTALL_DIR/current.tmp" 2>/dev/null || true
+    echo "::error:: CRITICAL: failed to repoint current back to previous version."
+    emit_event B rollback-fail "Failed to repoint current back; previous version dir still intact at $OLD_VER_TARGET"
+    write_status "ROLLBACK_CRITICAL_FAILED" "Failed to repoint current; previous version intact at $OLD_VER_TARGET, manual repoint required"
+    exit 9
+  fi
+
+  timeout 30 sudo systemctl start "$SERVICE_NAME"
+
+  ROLLBACK_OK=0
+  for i in $(seq 1 30); do
+    if sudo systemctl is-active --quiet "$SERVICE_NAME"; then
+      ROLLBACK_OK=1
+      break
+    fi
+    sleep 1
+  done
+
+  if [ "$ROLLBACK_OK" = "1" ]; then
+    echo "Rollback succeeded; agent is healthy on the previous version."
+    emit_event B rollback-ok "Versioned rollback succeeded; running previous version $BASELINE_VERSION"
+    write_status "ROLLED_BACK" "New version failed health check; repointed current to previous version (was: $BASELINE_VERSION, healthz=$BASELINE_HEALTHZ_PRE)"
+    exit 4
+  fi
+
+  echo "::error:: CRITICAL: rollback repoint succeeded but service won't start on the previous version."
+  emit_event B rollback-fail "Repointed to previous version but service won't start; previous binaries intact at $OLD_VER_TARGET"
+  write_status "ROLLBACK_CRITICAL_FAILED" "Repointed to previous version but service won't start; previous binaries intact at $OLD_VER_TARGET"
+  exit 9
 fi
 
 if [ "$INSTALL_METHOD" = "tarball" ]; then

--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -134,6 +134,30 @@ $STATUS_FILE = Join-Path $STATUS_DIR 'last-upgrade.json'
 $LOCK_FILE   = Join-Path $STATUS_DIR 'upgrade.lock'
 $LOG_FILE    = Join-Path $STATUS_DIR 'upgrade.log'
 
+# ── Layout detection (blue-green) ────────────────────────────────────────────
+# A versioned install selects its active version via the `current` junction
+# ({INSTALL_DIR}\current -> versions\<v>). When versioned, Phase B activates the
+# new version by repointing `current` and NEVER touches the running version's
+# directory, so any failure leaves the old version intact and instantly
+# restorable. Flat installs (no `current` junction) keep today's .bak swap
+# byte-for-byte — the entire blue-green path is gated on $isVersioned. We only
+# treat the install as versioned when `current` is a reparse point AND its
+# target reads back cleanly; anything else falls back to the flat path.
+$isVersioned = $false
+$oldVerTarget = ''
+$currentPointer = Join-Path $INSTALL_DIR 'current'
+try {
+    $cp = Get-Item -LiteralPath $currentPointer -Force -ErrorAction SilentlyContinue
+    if ($null -ne $cp -and (($cp.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        $t = @($cp.Target)[0]
+        if (-not [string]::IsNullOrWhiteSpace($t)) {
+            # Strip a leading \??\ NT-path prefix that some junctions report.
+            $oldVerTarget = ($t -replace '^\\\?\?\\', '')
+            $isVersioned = $true
+        }
+    }
+} catch { }
+
 # Per-phase event timeline, parity with the Linux script's upgrade-events.jsonl.
 # The Squid server reads this via WindowsUpgradeStatusStorage on every
 # Capabilities RPC (EventsFileSubPath = upgrade\upgrade-events.jsonl) and
@@ -291,6 +315,35 @@ function Invoke-Rollback {
         }
     } catch {
         Append-UpgradeLog "[rollback] Couldn't cleanly stop new service: $($_.Exception.Message). Proceeding with restore — Move-Item might still succeed if SCM has released the binary."
+    }
+
+    # ── Versioned (blue-green) rollback ──────────────────────────────────────
+    # Repoint `current` back to the previous version. The previous version
+    # directory was never touched during the swap, so this cannot lose it — even
+    # if the repoint or the restart fails, the previous binaries remain intact at
+    # $oldVerTarget. Flat installs fall through to the .bak restore below.
+    if ($isVersioned) {
+        Append-UpgradeLog "[rollback] Repointing current -> $oldVerTarget (previous version)"
+        try {
+            if (Test-Path $currentPointer) { [System.IO.Directory]::Delete($currentPointer, $false) }
+            New-Item -ItemType Junction -Path $currentPointer -Target $oldVerTarget | Out-Null
+        } catch {
+            Append-UpgradeLog "::error:: [rollback] Failed to repoint current back to previous version: $($_.Exception.Message)"
+            Write-UpgradeStatus -Status 'ROLLBACK_CRITICAL_FAILED' -InstallMethod $INSTALL_METHOD -Detail "Failed to repoint current; previous version intact at $oldVerTarget, manual repoint required. Failure: $Reason." -ExitCode $ExitCode
+            exit $ExitCode
+        }
+
+        try {
+            Append-UpgradeLog "[rollback] Starting service on previous version"
+            Start-Service -Name $SERVICE_NAME
+            (Get-Service -Name $SERVICE_NAME).WaitForStatus('Running', $SERVICE_TIMEOUT_SPAN)
+            Append-UpgradeLog "[rollback] Service running on previous version"
+            Write-UpgradeStatus -Status 'ROLLED_BACK' -InstallMethod $INSTALL_METHOD -Detail "Rolled back by repointing current to the previous version. Reason: $Reason." -ExitCode $ExitCode
+        } catch {
+            Append-UpgradeLog "::error:: [rollback] Repointed to previous version but service won't start: $($_.Exception.Message)"
+            Write-UpgradeStatus -Status 'ROLLBACK_CRITICAL_FAILED' -InstallMethod $INSTALL_METHOD -Detail "Repointed current to previous version but service won't start; previous binaries intact at $oldVerTarget. Reason: $Reason." -ExitCode $ExitCode
+        }
+        exit $ExitCode
     }
 
     # Resolve the .bak path the same way Phase B's backup step did.
@@ -610,8 +663,40 @@ try {
         Append-UpgradeLog "[upgrade] Service $SERVICE_NAME not registered yet — first install path"
     }
 
-    # Backup current install (zip method requires explicit swap)
-    if ($INSTALL_METHOD -eq 'zip') {
+    # ── Conditional swap ────────────────────────────────────────────────────
+    # Versioned (blue-green): stage the new version into versions\<target> and
+    # repoint the `current` junction; the running version directory is NEVER
+    # touched, so any failure leaves it intact. Flat: legacy move-aside .bak swap.
+    if ($isVersioned) {
+        if (-not (Test-Path $extractDir)) {
+            Append-UpgradeLog "::error:: Phase B can't find Phase A staging dir at expected path: $extractDir"
+            Write-UpgradeStatus -Status 'ROLLBACK_CRITICAL_FAILED' -InstallMethod 'zip' -Detail "Staging dir disappeared between phases: $extractDir" -ExitCode 14
+            exit 14
+        }
+
+        $versionsRoot = Join-Path $INSTALL_DIR 'versions'
+        $newVerDir = Join-Path $versionsRoot $TARGET_VERSION
+        New-Item -ItemType Directory -Path $versionsRoot -Force | Out-Null
+
+        # Never delete the currently-running version's directory.
+        if ((Test-Path $newVerDir) -and ($newVerDir -ne $oldVerTarget)) {
+            Remove-Item -Path $newVerDir -Recurse -Force
+        }
+
+        Append-UpgradeLog "[upgrade] Staging new version into $newVerDir"
+        Move-Item -Path $extractDir -Destination $newVerDir -Force
+
+        # Repoint `current` junction. Delete the old junction NON-recursively
+        # ([Directory]::Delete(path,$false)) so we remove only the reparse point,
+        # never the target version's files.
+        Append-UpgradeLog "[upgrade] Repointing current -> $newVerDir"
+        if (Test-Path $currentPointer) { [System.IO.Directory]::Delete($currentPointer, $false) }
+        New-Item -ItemType Junction -Path $currentPointer -Target $newVerDir | Out-Null
+
+        Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Activated versions\$TARGET_VERSION via current junction — restarting service"
+    }
+    elseif ($INSTALL_METHOD -eq 'zip') {
+        # Backup current install (zip method requires explicit swap).
         # Robust .bak sibling path: Split-Path normalises trailing separators
         # so a future operator setting INSTALL_DIR with a trailing backslash
         # ("C:\Squid\") doesn't produce a hidden ".bak" leaf inside the dir.

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
@@ -202,11 +202,21 @@ public sealed class TentacleLinuxInstallScriptE2ETests
                           $"OR symlink chain didn't put `squid-tentacle` on PATH. " +
                           $"output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
 
-        // Binary exists at INSTALL_DIR/Squid.Tentacle (extracted by tar).
-        var binaryPath = Path.Combine(ctx.InstallDir, "Squid.Tentacle");
-        File.Exists(binaryPath).ShouldBeTrue(
-            customMessage: $"Squid.Tentacle binary MUST exist at {binaryPath} after install. " +
-                          "If absent: tar extraction failed silently, OR tarball had a different entry name (mirror serving wrong content?), OR INSTALL_DIR override didn't propagate to .sh.");
+        // Versioned layout: the binary lives under versions/<v>, selected by a stable
+        // `current` symlink. (The placeholder reports "unknown" — no version.txt in the
+        // install tarball — so the dir is versions/unknown; the test asserts the
+        // structure, not the specific name.)
+        var versionsDir = Path.Combine(ctx.InstallDir, "versions");
+        Directory.Exists(versionsDir).ShouldBeTrue(
+            customMessage: $"versioned install MUST create {versionsDir}. If absent: the .sh fell back to flat layout (binary couldn't report a version) OR the versioned extract regressed.");
+
+        var currentPointer = Path.Combine(ctx.InstallDir, "current");
+        new DirectoryInfo(currentPointer).LinkTarget.ShouldNotBeNull(
+            $"{currentPointer} MUST be a symlink (the version pointer). If null: `current` is a real dir, not the atomic pointer — the `ln -sfn` / `mv -T` swap regressed.");
+
+        File.Exists(Path.Combine(currentPointer, "Squid.Tentacle")).ShouldBeTrue(
+            customMessage: $"binary MUST be reachable at {currentPointer}/Squid.Tentacle (through the `current` pointer). " +
+                          "If absent: `current` points at the wrong dir OR the staged tree wasn't moved into versions/<v>.");
 
         // Symlink within INSTALL_DIR — `ln -sf $INSTALL_DIR/Squid.Tentacle $INSTALL_DIR/squid-tentacle`.
         var binaryNameSymlink = Path.Combine(ctx.InstallDir, "squid-tentacle");
@@ -322,8 +332,11 @@ public sealed class TentacleLinuxInstallScriptE2ETests
                           "Operators verify which URL form succeeded by reading this log.");
 
         // Sanity: the install actually completed end-to-end via the v-prefix path.
-        File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle")).ShouldBeTrue(
-            customMessage: $"Squid.Tentacle binary MUST exist at {ctx.InstallDir}/Squid.Tentacle after v-prefix fallback install. " +
+        // Assert the stable `squid-tentacle` entry point (resolves through `current`
+        // in the versioned layout, or directly in a flat install) rather than the
+        // version-specific binary path.
+        File.Exists(Path.Combine(ctx.InstallDir, "squid-tentacle")).ShouldBeTrue(
+            customMessage: $"squid-tentacle entry point MUST exist at {ctx.InstallDir}/squid-tentacle after v-prefix fallback install. " +
                           "If absent: .sh logged retry but never actually downloaded — retry construction may produce a malformed URL.");
 
         File.Exists("/usr/local/bin/squid-tentacle").ShouldBeTrue(
@@ -399,7 +412,7 @@ public sealed class TentacleLinuxInstallScriptE2ETests
         output1.ShouldContain("Verified: squid-tentacle executable",
             customMessage: "first run MUST log verification — sanity check before re-run.");
 
-        File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle")).ShouldBeTrue("first run MUST install binary");
+        File.Exists(Path.Combine(ctx.InstallDir, "squid-tentacle")).ShouldBeTrue("first run MUST install binary (stable squid-tentacle entry point, resolves through `current` when versioned)");
         File.Exists("/usr/local/bin/squid-tentacle").ShouldBeTrue("first run MUST create PATH symlink");
 
         // ── Run 2: re-run on existing state ────────────────────────────────
@@ -428,9 +441,11 @@ public sealed class TentacleLinuxInstallScriptE2ETests
         output2.ShouldNotContain("Error: install dir not empty",
             customMessage: "second run MUST NOT error on non-empty INSTALL_DIR. The .sh uses tar xzf which overwrites existing files; a regression to 'fail-if-not-empty' breaks every fleet refresh.");
 
-        // Final state assertions — same as single-install.
-        File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle")).ShouldBeTrue(
-            customMessage: $"binary MUST still exist at {ctx.InstallDir}/Squid.Tentacle after re-install. If absent: re-extract failed silently OR rm-then-extract pattern dropped the binary mid-flight.");
+        // Final state assertions — same as single-install. Re-running the versioned
+        // installer replaces versions/<v> and repoints `current`, so assert the stable
+        // entry point that survives the swap.
+        File.Exists(Path.Combine(ctx.InstallDir, "squid-tentacle")).ShouldBeTrue(
+            customMessage: $"squid-tentacle entry point MUST still exist at {ctx.InstallDir}/squid-tentacle after re-install. If absent: re-extract failed silently OR the current-pointer repoint dropped the binary mid-flight.");
 
         File.Exists("/usr/local/bin/squid-tentacle").ShouldBeTrue(
             customMessage: "/usr/local/bin/squid-tentacle MUST still exist after re-install. ln -sf overwrites; if symlink is gone, ln -sf regressed to plain ln (fails on existing target).");
@@ -758,9 +773,10 @@ public sealed class TentacleLinuxInstallScriptE2ETests
         output.ShouldContain("Installation Complete",
             customMessage: "stdout MUST contain 'Installation Complete' even on the latest path — operators tail this banner for confirmation regardless of version arg.");
 
-        // Final state: binary installed.
-        File.Exists(Path.Combine(ctx.InstallDir, "Squid.Tentacle")).ShouldBeTrue(
-            customMessage: $"Squid.Tentacle binary MUST exist at {ctx.InstallDir}/Squid.Tentacle after latest-version install.");
+        // Final state: binary installed (assert the stable squid-tentacle entry point,
+        // which resolves through `current` in the versioned layout).
+        File.Exists(Path.Combine(ctx.InstallDir, "squid-tentacle")).ShouldBeTrue(
+            customMessage: $"squid-tentacle entry point MUST exist at {ctx.InstallDir}/squid-tentacle after latest-version install.");
 
         File.Exists("/usr/local/bin/squid-tentacle").ShouldBeTrue(
             customMessage: "/usr/local/bin/squid-tentacle symlink MUST exist after latest-version install — confirms post-extract steps ran the same way as tagged-version paths.");

--- a/tests/Squid.Tentacle.Tests/Platform/InstallScriptVersionedLayoutDriftTests.cs
+++ b/tests/Squid.Tentacle.Tests/Platform/InstallScriptVersionedLayoutDriftTests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Tests.Platform;
+
+/// <summary>
+/// Rule 12.5 drift detector. The install scripts (<c>deploy/scripts/install-tentacle.sh</c>
+/// and <c>.ps1</c>) hard-code the versioned-layout directory names that
+/// <see cref="TentacleLayout"/> defines in C#. There is no compile-time link between the
+/// shell/PowerShell literals and the C# constants, so this test fails if either side
+/// drifts — e.g. renaming <see cref="TentacleLayout.VersionsDirName"/> without updating
+/// the scripts would silently break atomic-pointer upgrades.
+///
+/// It also pins the load-bearing safety mechanics (atomic `current` swap on Linux,
+/// unprivileged junction on Windows) and the best-effort flat fallback, so a refactor
+/// can't quietly drop them.
+/// </summary>
+public sealed class InstallScriptVersionedLayoutDriftTests
+{
+    private static string RepoRoot()
+    {
+        // Walk up from the test binary dir until we find .git — stable from any cwd.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid repo working tree");
+    }
+
+    private static string ReadScript(string relativePath)
+    {
+        var path = Path.Combine(RepoRoot(), relativePath);
+        File.Exists(path).ShouldBeTrue($"Install script not found at {path}");
+
+        return File.ReadAllText(path);
+    }
+
+    private static string LinuxScript() => ReadScript(Path.Combine("deploy", "scripts", "install-tentacle.sh"));
+
+    private static string WindowsScript() => ReadScript(Path.Combine("deploy", "scripts", "install-tentacle.ps1"));
+
+    // ── Contract-name drift (the primary guard) ─────────────────────────────
+
+    [Fact]
+    public void LinuxScript_UsesTentacleLayoutDirNames()
+    {
+        var sh = LinuxScript();
+
+        sh.Contains($"$INSTALL_DIR/{TentacleLayout.VersionsDirName}").ShouldBeTrue(
+            $"install-tentacle.sh must place versions under '{TentacleLayout.VersionsDirName}' to match TentacleLayout.VersionsDirName. If you renamed the C# constant, update the script too.");
+        sh.Contains($"$INSTALL_DIR/{TentacleLayout.CurrentPointerName}").ShouldBeTrue(
+            $"install-tentacle.sh must use the '{TentacleLayout.CurrentPointerName}' pointer to match TentacleLayout.CurrentPointerName.");
+    }
+
+    [Fact]
+    public void WindowsScript_UsesTentacleLayoutDirNames()
+    {
+        var ps = WindowsScript();
+
+        ps.Contains($"'{TentacleLayout.VersionsDirName}'").ShouldBeTrue(
+            $"install-tentacle.ps1 must Join-Path the '{TentacleLayout.VersionsDirName}' dir to match TentacleLayout.VersionsDirName.");
+        ps.Contains($"'{TentacleLayout.CurrentPointerName}'").ShouldBeTrue(
+            $"install-tentacle.ps1 must Join-Path the '{TentacleLayout.CurrentPointerName}' pointer to match TentacleLayout.CurrentPointerName.");
+    }
+
+    // ── Safety mechanics (atomic swap + unprivileged junction) ──────────────
+
+    [Fact]
+    public void LinuxScript_SwapsCurrentPointerAtomically()
+    {
+        var sh = LinuxScript();
+
+        // `mv -T` onto an existing symlink is the atomic rename that activates a version
+        // without a window where `current` is absent. Losing it reintroduces a race.
+        sh.Contains("mv -T").ShouldBeTrue(
+            "install-tentacle.sh must repoint `current` via `mv -T` (atomic symlink replace). Without -T, mv moves INTO the target dir.");
+        sh.Contains("ln -sfn").ShouldBeTrue(
+            "install-tentacle.sh must create the `current` symlink with `ln -sfn`.");
+    }
+
+    [Fact]
+    public void WindowsScript_UsesJunctionAndSafeDelete()
+    {
+        var ps = WindowsScript();
+
+        // Junctions need no elevation (unlike symlinks) — required for user-dir installs.
+        ps.Contains("-ItemType Junction").ShouldBeTrue(
+            "install-tentacle.ps1 must create `current` as a directory Junction (unprivileged, unlike symlinks).");
+        // Non-recursive delete removes ONLY the reparse point; Remove-Item -Recurse on a
+        // junction can delete the TARGET version's files — a data-loss footgun.
+        ps.Contains("[System.IO.Directory]::Delete(").ShouldBeTrue(
+            "install-tentacle.ps1 must delete the old `current` junction non-recursively to avoid wiping the target version's files.");
+    }
+
+    // ── Best-effort flat fallback (non-breaking guarantee) ──────────────────
+
+    [Fact]
+    public void BothScripts_KeepFlatFallback_WhenVersionUnresolved()
+    {
+        // If the freshly-extracted binary can't report its version, both scripts must
+        // fall back to a flat install (today's behaviour) rather than fail — so a missing
+        // runtime dep never turns a previously-successful install into a hard failure.
+        LinuxScript().Contains("flat layout").ShouldBeTrue(
+            "install-tentacle.sh must keep the flat-layout fallback when the version can't be resolved.");
+        WindowsScript().Contains("flat layout").ShouldBeTrue(
+            "install-tentacle.ps1 must keep the flat-layout fallback when the version can't be resolved.");
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeLinuxTentacleScriptTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeLinuxTentacleScriptTests.cs
@@ -80,6 +80,60 @@ public sealed class UpgradeLinuxTentacleScriptTests
         RenderedScript.ShouldContain("set -euo pipefail");
     }
 
+    // ── Versioned (blue-green) upgrade ──────────────────────────────────────
+
+    [Fact]
+    public void Versioned_DetectsCurrentPointerAndCapturesRollbackAnchor()
+    {
+        RenderedScript.ShouldContain("if [ -L \"$INSTALL_DIR/current\" ]; then",
+            customMessage: "must detect the versioned layout by testing whether $INSTALL_DIR/current is a symlink");
+        RenderedScript.ShouldContain("IS_VERSIONED=1");
+        RenderedScript.ShouldContain("OLD_VER_TARGET=$(readlink -f \"$INSTALL_DIR/current\"",
+            customMessage: "must capture the previous version dir (the rollback anchor) before any change");
+    }
+
+    [Fact]
+    public void Versioned_ForcesTarballMethod_SkippingAptYum()
+    {
+        // apt/yum write flat files and would orphan the `current` pointer, so a
+        // versioned install must always upgrade via the inline tarball path.
+        RenderedScript.ShouldContain("Versioned installs bypass the package-manager methods",
+            customMessage: "versioned installs must skip apt/yum and force the tarball path");
+    }
+
+    [Fact]
+    public void Versioned_SwapsAtomicallyWithoutTouchingRunningVersion()
+    {
+        RenderedScript.ShouldContain("NEW_VER_DIR=\"$INSTALL_DIR/versions/$TARGET_VERSION\"",
+            customMessage: "the new version must be staged into versions/<target>, not over the running version");
+        RenderedScript.ShouldContain("[ \"$NEW_VER_DIR\" != \"$OLD_VER_TARGET\" ]",
+            customMessage: "the rm must be guarded so the currently-running version directory is never deleted");
+        RenderedScript.ShouldContain("mv -T \"$INSTALL_DIR/current.tmp\" \"$INSTALL_DIR/current\"",
+            customMessage: "current must be repointed atomically via `mv -T` (rename), never rm+recreate");
+    }
+
+    [Fact]
+    public void Versioned_RollbackRepointsToPreviousVersion_AndKeepsItIntactOnFailure()
+    {
+        RenderedScript.ShouldContain("Versioned rollback: repointing current to previous version",
+            customMessage: "the versioned rollback must repoint `current` back to the previous version");
+        RenderedScript.ShouldContain("ln -sfn \"$OLD_VER_TARGET\" \"$INSTALL_DIR/current.tmp\"",
+            customMessage: "rollback must point current back at the previous version dir ($OLD_VER_TARGET)");
+        // The previous version dir is never touched during the swap, so even a failed
+        // rollback leaves it intact — the critical-failure status must say so.
+        RenderedScript.ShouldContain("previous version intact at $OLD_VER_TARGET",
+            customMessage: "ROLLBACK_CRITICAL_FAILED status must state the previous version is still intact on disk");
+    }
+
+    [Fact]
+    public void Versioned_PropagatesFlagsThroughScopeHandoff()
+    {
+        RenderedScript.ShouldContain("--setenv=IS_VERSIONED=\"$IS_VERSIONED\"",
+            customMessage: "IS_VERSIONED must cross the systemd-run scope boundary into Phase B");
+        RenderedScript.ShouldContain("--setenv=OLD_VER_TARGET=\"$OLD_VER_TARGET\"",
+            customMessage: "OLD_VER_TARGET (the rollback anchor) must cross into Phase B");
+    }
+
     // ── Exit code taxonomy — 9 codes, each anchor pinned ────────────────────
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -1231,4 +1231,57 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
 
         return (new WindowsTentacleUpgradeStrategy(halibut.Object, observer.Object), halibut, observer);
     }
+
+    // ── Versioned (blue-green) upgrade ──────────────────────────────────────
+
+    [Fact]
+    public void RenderInnerScript_Versioned_DetectsCurrentJunctionAndCapturesAnchor()
+    {
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("[System.IO.FileAttributes]::ReparsePoint",
+            customMessage: "must detect the versioned layout by testing whether $INSTALL_DIR\\current is a reparse point (junction)");
+        inner.ShouldContain("$isVersioned = $true");
+        inner.ShouldContain("$oldVerTarget = ",
+            customMessage: "must capture the previous version dir (the rollback anchor) from the current junction target");
+    }
+
+    [Fact]
+    public void RenderInnerScript_Versioned_SwapsViaJunctionWithoutTouchingRunningVersion()
+    {
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("$newVerDir = Join-Path $versionsRoot $TARGET_VERSION",
+            customMessage: "the new version must be staged into versions\\<target>, not over the running version");
+        inner.ShouldContain("($newVerDir -ne $oldVerTarget)",
+            customMessage: "the Remove-Item must be guarded so the currently-running version directory is never deleted");
+        inner.ShouldContain("[System.IO.Directory]::Delete($currentPointer, $false)",
+            customMessage: "the old junction must be removed non-recursively so the target version's files are never wiped");
+        inner.ShouldContain("New-Item -ItemType Junction -Path $currentPointer -Target $newVerDir",
+            customMessage: "current must be repointed at the new version via a junction");
+    }
+
+    [Fact]
+    public void RenderInnerScript_Versioned_RollbackRepointsToPreviousVersion_AndKeepsItIntact()
+    {
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("New-Item -ItemType Junction -Path $currentPointer -Target $oldVerTarget",
+            customMessage: "the versioned rollback must repoint current back to the previous version dir ($oldVerTarget)");
+        inner.ShouldContain("previous version intact at $oldVerTarget",
+            customMessage: "ROLLBACK_CRITICAL_FAILED status must state the previous version is still intact on disk");
+    }
+
+    [Fact]
+    public void RenderInnerScript_FlatPathUnchanged_StillHasBakAndFailedSwap()
+    {
+        // Non-breaking guard: the flat (.bak / .failed) swap + restore must still be
+        // present — the blue-green path is purely additive, gated on $isVersioned.
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("$installLeaf.bak",
+            customMessage: "the flat .bak swap must remain for non-versioned installs (non-breaking)");
+        inner.ShouldContain("$installLeaf.failed",
+            customMessage: "the flat rollback's .failed post-mortem archive must remain for non-versioned installs");
+    }
 }


### PR DESCRIPTION
## Summary

Builds on the versioned-layout foundation (#402) to make Tentacle upgrades **failure-isolated**: an upgrade never touches the directory of the version that is running, so any failure — download, verify, stage, activate, restart, health check, or even a failed rollback — leaves the previous version byte-for-byte intact and instantly restorable.

- **Install** (`install-tentacle.{sh,ps1}`): fresh tarball/zip installs lay down a versioned layout — binary in `versions/<v>`, selected by a stable `current` pointer (symlink on Linux, junction on Windows) — and register the service against the pointer. Best-effort: if the extracted binary can't report its version, both scripts fall back to the prior flat extraction, so an install that used to succeed never starts failing. apt/yum `latest` installs stay flat.
- **Upgrade** (`upgrade-{linux,windows}-tentacle.*`): when a versioned install is detected, extract the new version into `versions/<target>` and **atomically repoint `current`** (Linux `mv -T` rename; Windows non-recursive junction replace); roll back by repointing `current` back to the previous version dir.

### Strictly non-breaking
The entire blue-green path is **gated on the versioned layout** (`current` symlink/junction). Flat installs — every existing agent, plus apt/yum installs — keep today's `install` + `apt/yum/tarball` + `.bak`/`.failed` swap/restore **byte-for-byte**. Nothing creates a versioned layout for an existing agent, so existing fleets are unaffected until they are freshly reinstalled.

## Test plan

- [x] **Unit / drift** (runnable everywhere): `TentacleLayout` contract (19); layout-aware `ResolveServiceExecution` (7); install-script drift detector ties `versions`/`current` literals to the C# constants + pins the atomic-swap mechanics + the flat fallback (5); Linux upgrade blue-green assertions + `bash -n` on the **rendered** script with real method snippets (UpgradeLinuxTentacleScriptTests, 71); Windows upgrade blue-green assertions + **flat-path-unchanged guard** (WindowsTentacleUpgradeStrategyTests). All 690 upgrade unit tests pass.
- [x] **Linux install E2E** migrated to assert the versioned layout (`versions/<v>` + `current` symlink + reachable through the pointer); incidental checks use the stable `squid-tentacle` entry point (resolves in both layouts).
- [x] Non-breaking verified by stashing for the foundation change; flat paths covered byte-for-byte by the existing green suites.
- [ ] **Remaining before merge** (see notes): a real versioned-**upgrade** E2E per OS (happy + health-fail→rollback, asserting the previous version dir is byte-unchanged); Windows needs a version-reporting test shim to exercise the versioned path (today's fake-binary install E2E hits the flat fallback).

## Notes
- **flat→versioned migration is intentionally deferred** — it modifies a running service's registration and is the riskiest sub-step. It is not required for correctness: existing flat agents keep their (working) flat upgrades; only fresh installs are versioned. Migration can land as a separate, guarded change.
- Squashed history: foundation (#402) + versioned install scripts + Linux install E2E migration + Linux upgrade + Windows upgrade.