### PR TITLE
Add Linux versioned-upgrade E2E (blue-green happy + rollback)

### DIFF
--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxServiceFixture.cs
@@ -94,6 +94,24 @@ public sealed class LinuxServiceFixture : IDisposable
     /// <summary>Path to the systemd unit file under <c>/etc/systemd/system/</c>.</summary>
     public string UnitFilePath => $"/etc/systemd/system/{_serviceName}.service";
 
+    // ── Versioned (blue-green) layout helpers ───────────────────────────────
+
+    /// <summary>Versioned layout: {InstallDir}/versions parent directory.</summary>
+    public string VersionsRoot => Path.Combine(_installDir, "versions");
+
+    /// <summary>Versioned layout: the stable {InstallDir}/current pointer.</summary>
+    public string CurrentPointer => Path.Combine(_installDir, "current");
+
+    /// <summary>Versioned layout: {InstallDir}/versions/{version} directory.</summary>
+    public string VersionDir(string version) => Path.Combine(VersionsRoot, version);
+
+    /// <summary>
+    /// Versioned layout: a version's marker file. The test service (run via the
+    /// `current` pointer with no INSTALL_DIR env) auto-resolves INSTALL_DIR to its
+    /// own version directory, so each version writes its marker there.
+    /// </summary>
+    public string VersionedMarkerPath(string version) => Path.Combine(VersionDir(version), "service-running.marker");
+
     /// <summary>
     /// Construct against a UNIQUE service name + UNIQUE install dir.
     /// Caller responsible for uniqueness (recommended: GUID-suffix).
@@ -193,6 +211,93 @@ public sealed class LinuxServiceFixture : IDisposable
         var status = RunSudoCapture($"systemctl status {Quote(_serviceName)} --no-pager") ?? "(systemctl status unavailable)";
         throw new TimeoutException(
             $"systemd service '{_serviceName}' did not reach active(running) within {startTimeout}. " +
+            $"systemctl status:\n{status}");
+    }
+
+    /// <summary>
+    /// Stage the test service in a VERSIONED ("blue-green") layout and start it: the
+    /// binary lives at versions/&lt;version&gt;/Squid.Tentacle selected by a `current`
+    /// symlink, and the systemd unit's ExecStart runs through the pointer
+    /// (`bash {InstallDir}/current/Squid.Tentacle`). Deliberately does NOT set an
+    /// INSTALL_DIR env var, so the service auto-resolves INSTALL_DIR to its own
+    /// version directory (per-version version.txt + marker) — the production
+    /// versioned shape the upgrade script's blue-green path operates on.
+    /// </summary>
+    public void InstallVersionedAndStart(string testServiceScriptSourcePath, string initialVersion, TimeSpan startTimeout, IReadOnlyDictionary<string, string> extraEnvironment = null)
+    {
+        if (!IsAvailable) throw new PlatformNotSupportedException("LinuxServiceFixture only runs on Linux with passwordless sudo");
+
+        if (!File.Exists(testServiceScriptSourcePath))
+            throw new FileNotFoundException($"test service script not found at: {testServiceScriptSourcePath}");
+
+        TryUninstall();
+
+        // Stage versions/<v1>/{Squid.Tentacle, version.txt}.
+        var v1Dir = VersionDir(initialVersion);
+        Directory.CreateDirectory(v1Dir);
+
+        var v1Binary = Path.Combine(v1Dir, "Squid.Tentacle");
+        File.Copy(testServiceScriptSourcePath, v1Binary, overwrite: true);
+        File.WriteAllText(Path.Combine(v1Dir, "version.txt"), initialVersion);
+        RunSudo("chmod +x " + Quote(v1Binary));
+
+        // current -> versions/<v1>, and the stable squid-tentacle name symlink ->
+        // current/Squid.Tentacle (the upgrade script's version checks read it).
+        RunSudo($"ln -sfn {Quote(v1Dir)} {Quote(CurrentPointer)}");
+        RunSudo($"ln -sf {Quote(Path.Combine(CurrentPointer, "Squid.Tentacle"))} {Quote(Path.Combine(_installDir, "squid-tentacle"))}");
+
+        // Unit: ExecStart through the pointer; NO INSTALL_DIR env so the service
+        // auto-resolves INSTALL_DIR to its own version dir via readlink.
+        var execTarget = Path.Combine(CurrentPointer, "Squid.Tentacle");
+        var unitBuilder = new StringBuilder()
+            .AppendLine("[Unit]")
+            .AppendLine($"Description=Squid Linux Tentacle E2E Versioned Test Service — {_serviceName}")
+            .AppendLine()
+            .AppendLine("[Service]")
+            .AppendLine("Type=simple");
+
+        if (extraEnvironment != null)
+        {
+            foreach (var kvp in extraEnvironment)
+                unitBuilder.AppendLine($"Environment={kvp.Key}={kvp.Value}");
+        }
+
+        var unitContent = unitBuilder
+            .AppendLine($"ExecStart=/usr/bin/env bash {execTarget}")
+            .AppendLine("KillMode=mixed")
+            .AppendLine("Restart=no")
+            .AppendLine()
+            .AppendLine("[Install]")
+            .AppendLine("WantedBy=multi-user.target")
+            .ToString();
+
+        var tempUnit = Path.Combine(Path.GetTempPath(), $"{_serviceName}.versioned-unit-staging");
+        File.WriteAllText(tempUnit, unitContent);
+        try
+        {
+            RunSudo($"cp {Quote(tempUnit)} {Quote(UnitFilePath)}");
+            RunSudo($"chmod 644 {Quote(UnitFilePath)}");
+        }
+        finally
+        {
+            try { File.Delete(tempUnit); } catch { /* best-effort */ }
+        }
+
+        RunSudo("systemctl daemon-reload");
+        RunSudo($"systemctl start {Quote(_serviceName)}");
+
+        _installed = true;
+
+        var deadline = DateTime.UtcNow + startTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (IsActive()) return;
+            Thread.Sleep(200);
+        }
+
+        var status = RunSudoCapture($"systemctl status {Quote(_serviceName)} --no-pager") ?? "(systemctl status unavailable)";
+        throw new TimeoutException(
+            $"versioned systemd service '{_serviceName}' did not reach active(running) within {startTimeout}. " +
             $"systemctl status:\n{status}");
     }
 

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/squid-linux-test-service.sh
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/squid-linux-test-service.sh
@@ -45,8 +45,18 @@ MARKER_FILE="$INSTALL_DIR/service-running.marker"
 # itself wrote it correctly. Bug found by J.L.E.7.4 diagnostic dump
 # (Linux runner). Real Squid.Tentacle's CLI handles `version` similarly.
 if [ "${1:-}" = "version" ]; then
-    if [ -f "$VERSION_FILE" ]; then
-        cat "$VERSION_FILE" | tr -d '[:space:]'
+    # Resolve version.txt relative to THIS binary's own directory, independent of
+    # the INSTALL_DIR env var. A real Squid.Tentacle reports its own embedded
+    # version regardless of cwd/env; the upgrade script's post-restart check runs
+    # `$INSTALL_DIR/squid-tentacle version` with INSTALL_DIR set to the install
+    # ROOT, but in the versioned layout each versions/<v>/ has its own version.txt,
+    # so we must read from the resolved binary dir (versions/<v>) — not $INSTALL_DIR.
+    # For a flat install the resolved dir IS the install dir, so behaviour is
+    # unchanged. Bug class: env-based read returned the root's (absent) version.txt
+    # -> "unknown" != TARGET_VERSION -> the versioned happy-path wrongly rolled back.
+    SELF_VERSION_FILE="$(dirname "$(readlink -f "$0")")/version.txt"
+    if [ -f "$SELF_VERSION_FILE" ]; then
+        cat "$SELF_VERSION_FILE" | tr -d '[:space:]'
     else
         echo "unknown"
     fi

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxVersionedUpgradeE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxVersionedUpgradeE2ETests.cs
@@ -1,0 +1,165 @@
+using System.Security.Cryptography;
+using Squid.LinuxTentacleE2ETests.Infrastructure;
+
+namespace Squid.LinuxTentacleE2ETests;
+
+/// <summary>
+/// Real-systemd E2E for the blue-green (versioned-layout) upgrade path of
+/// <c>upgrade-linux-tentacle.sh</c>. Stages a v1 service in the versioned layout
+/// (<c>versions/&lt;v1&gt;/Squid.Tentacle</c> selected by a <c>current</c> symlink,
+/// unit ExecStart through the pointer), then drives the production upgrade script
+/// end-to-end (systemd-run --scope → repoint <c>current</c> → systemctl restart →
+/// healthz).
+///
+/// <para>The defining guarantee under test: the upgrade <b>never touches the
+/// directory of the version that is running</b>. Both tests capture the v1 binary's
+/// SHA256 before the upgrade and assert it is byte-for-byte unchanged afterward —
+/// on the happy path (v1 superseded by v2 but preserved) AND on the rollback path
+/// (v1 restored by repointing <c>current</c> back).</para>
+///
+/// <para>Tier: 🟢 H (Rule 12.4) — real production .sh, real systemd unit, real
+/// systemd-run scope, real systemctl restart, real python3 /healthz responder,
+/// real symlink repoint. No mocks at the OS-resource layer.</para>
+/// </summary>
+[Trait("Category", LinuxTentacleE2ECategories.UpgradeLifecycle)]
+[Collection(LinuxTentacleHostStateCollection.Name)]
+public sealed class TentacleLinuxVersionedUpgradeE2ETests
+{
+    private const string V1 = "1.0.0-test";
+    private const string V2 = "2.0.0-test";
+
+    // ========================================================================
+    // Versioned happy path — current repoints v1→v2, v1 dir byte-unchanged.
+    // ========================================================================
+
+    [Fact]
+    public void Versioned_HappyPath_RepointsCurrentToV2_AndLeavesV1Intact()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(
+            ctx.TestServiceScript,
+            initialVersion: V1,
+            startTimeout: TimeSpan.FromSeconds(15),
+            extraEnvironment: new Dictionary<string, string> { ["SQUID_TEST_SERVICE_HEALTHZ"] = "1" });
+
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath(V1), V1, TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running (per-version marker) before the versioned upgrade can be validated");
+
+        var v1Binary = Path.Combine(ctx.Fixture.VersionDir(V1), "Squid.Tentacle");
+        var v1HashBefore = Sha256Hex(v1Binary);
+
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleTarGz(targetVersion: V2));
+        var (exitCode, output) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion(targetVersion: V2));
+
+        exitCode.ShouldBe(0, customMessage: Tail("versioned happy-path upgrade MUST exit 0", exitCode, output));
+
+        var status = ctx.ReadLastUpgradeStatus();
+        status.ShouldNotBeNull(customMessage: $"last-upgrade.json MUST be written. Path: {ctx.StatusFilePath}");
+        status.Status.ShouldBe("SUCCESS", customMessage: $"status MUST be SUCCESS. Got '{status.Status}'. Detail: {status.Detail}");
+
+        // `current` now resolves to versions/<V2> (atomic repoint landed).
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe(V2,
+            customMessage: "current/version.txt MUST be V2 — the `current` pointer was repointed to versions/<V2>");
+
+        // The previous version directory is still present AND byte-for-byte unchanged:
+        // the blue-green swap staged V2 into a SEPARATE versions/<V2> dir and only
+        // repointed the pointer — it never moved/overwrote/deleted versions/<V1>.
+        Directory.Exists(ctx.Fixture.VersionDir(V1)).ShouldBeTrue(
+            "versions/<V1> MUST remain after a blue-green upgrade (failure isolation — old version preserved)");
+        Sha256Hex(v1Binary).ShouldBe(v1HashBefore,
+            "the previous version's binary MUST be byte-for-byte unchanged — the upgrade never touches the running version's directory");
+
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath(V2), V2, TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            "after repoint + restart, the V2 service MUST write its per-version marker (proves it started on the new version through `current`)");
+
+        ctx.Fixture.IsActive().ShouldBeTrue(customMessage: "service MUST still be active after the versioned upgrade");
+
+        ctx.MarkClean();
+    }
+
+    // ========================================================================
+    // Versioned rollback — V2 healthz fails, current repoints back to V1,
+    // V1 dir byte-unchanged (it was never touched), service runs V1 again.
+    // ========================================================================
+
+    [Fact]
+    public void Versioned_HealthzFails_RollsBackByRepointingCurrentToV1()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(
+            ctx.TestServiceScript,
+            initialVersion: V1,
+            startTimeout: TimeSpan.FromSeconds(15),
+            extraEnvironment: new Dictionary<string, string> { ["SQUID_TEST_SERVICE_HEALTHZ"] = "1" });
+
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath(V1), V1, TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running before the rollback scenario can be validated");
+
+        var v1Binary = Path.Combine(ctx.Fixture.VersionDir(V1), "Squid.Tentacle");
+        var v1HashBefore = Sha256Hex(v1Binary);
+
+        // failHealthz=true → V2's /healthz responder returns 503 → .sh's Phase B
+        // healthcheck loop exhausts → rollback fires.
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleTarGz(targetVersion: V2, failHealthz: true));
+        var (exitCode, output) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion(targetVersion: V2));
+
+        // Exit 4 is the documented ROLLED_BACK code (upgrade-linux-tentacle.sh header).
+        exitCode.ShouldBe(4, customMessage: Tail("versioned rollback MUST exit 4 (ROLLED_BACK)", exitCode, output));
+
+        var status = ctx.ReadLastUpgradeStatus();
+        status.ShouldNotBeNull(customMessage: $"last-upgrade.json MUST be written. Path: {ctx.StatusFilePath}");
+        status.Status.ShouldBe("ROLLED_BACK",
+            customMessage: $"status MUST be ROLLED_BACK after healthz failure. Got '{status.Status}'. Detail: {status.Detail}");
+
+        // `current` was repointed BACK to versions/<V1>.
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe(V1,
+            customMessage: "current/version.txt MUST be back to V1 — rollback repointed `current` to the previous version");
+
+        // V1 binary byte-for-byte unchanged: the rollback is a pointer flip, and the
+        // V1 directory was never touched during the (failed) upgrade attempt.
+        Sha256Hex(v1Binary).ShouldBe(v1HashBefore,
+            "the previous version's binary MUST be byte-for-byte unchanged through a failed upgrade + rollback");
+
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath(V1), V1, TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            "the V1 service MUST be running again after rollback (current repointed back + restart)");
+
+        ctx.Fixture.IsActive().ShouldBeTrue(customMessage: "service MUST be active on the previous version after rollback");
+
+        ctx.MarkClean();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static string ReadThroughCurrent(LinuxLifecycleContext ctx, string fileName)
+    {
+        var path = Path.Combine(ctx.Fixture.CurrentPointer, fileName);
+        return File.Exists(path) ? File.ReadAllText(path).Trim() : "(absent)";
+    }
+
+    private static string Sha256Hex(string path)
+    {
+        using var sha = SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(File.ReadAllBytes(path)));
+    }
+
+    private static bool WaitForFileContent(string path, string expected, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(path) && File.ReadAllText(path).Trim() == expected) return true;
+            Thread.Sleep(200);
+        }
+
+        return false;
+    }
+
+    private static string Tail(string prefix, int exitCode, string output) =>
+        $"{prefix}. Got exit {exitCode}.\noutput tail (last 2k chars):\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}";
+}


### PR DESCRIPTION
## Summary

Real-systemd E2E coverage for the blue-green (versioned-layout) upgrade path shipped in #403 — the rigorous runtime proof that the failure-isolation guarantee holds, not just the unit/drift assertions.

- `LinuxServiceFixture.InstallVersionedAndStart` — stages a v1 service in the versioned layout (`versions/<v1>/Squid.Tentacle` + `current` symlink, unit ExecStart through the pointer, no `INSTALL_DIR` env so the service auto-resolves to its own version dir). **Additive** — the flat `InstallAndStart` is untouched.
- Test service `version` subcommand resolves `version.txt` relative to its own directory (like a real binary reporting its embedded version) instead of via the `INSTALL_DIR` env var. Backward-compatible for flat installs (own dir == install dir); the flat lifecycle tests never invoke `version` through a name symlink, so they are unaffected.
- Two tests:
  1. **Happy path** — `current` repoints v1→v2, `versions/<v1>` is **byte-for-byte unchanged** (SHA256 captured before/after), v2 per-version marker written, service active.
  2. **Health-fail rollback** — exit 4 / `ROLLED_BACK`, `current` repointed back to v1, v1 **byte-for-byte unchanged**, service running v1 again.

## Test plan

- [x] `bash -n` on the modified test service script.
- [x] Linux E2E project compiles clean (new test class + fixture method).
- [ ] CI Linux runner executes the two `UpgradeLifecycle`-category E2E tests (real systemd + scope + restart + /healthz + symlink repoint). Local mac skips them (`LinuxLifecycleContext.IsAvailable` is false without systemd).

## Notes
- Non-breaking: purely test-infrastructure + a new test class. No production code changes.
- Follow-ups (separate): Windows versioned-upgrade E2E (needs a version-reporting test shim), same-version re-upgrade edge cleanup, version GC (P4).