### PR TITLE
Add Windows versioned-upgrade E2E (blue-green happy + rollback)

### DIFF
--- a/tests/Squid.WindowsTentacleE2ETests/Infrastructure/WindowsServiceFixture.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/Infrastructure/WindowsServiceFixture.cs
@@ -62,6 +62,26 @@ public sealed class WindowsServiceFixture : IDisposable
     /// <summary>The path to the marker file the service writes on Start (containing the version it read).</summary>
     public string MarkerFilePath => Path.Combine(_installDir, "service-running.marker");
 
+    // ── Versioned (blue-green) layout helpers ───────────────────────────────
+
+    /// <summary>Versioned layout: {InstallDir}\versions parent directory.</summary>
+    public string VersionsRoot => Path.Combine(_installDir, "versions");
+
+    /// <summary>Versioned layout: the stable {InstallDir}\current junction.</summary>
+    public string CurrentPointer => Path.Combine(_installDir, "current");
+
+    /// <summary>Versioned layout: {InstallDir}\versions\{version} directory.</summary>
+    public string VersionDir(string version) => Path.Combine(VersionsRoot, version);
+
+    /// <summary>
+    /// Versioned layout: a version's marker file. The test service writes its
+    /// marker next to its own exe, so each version has its marker inside its dir.
+    /// </summary>
+    public string VersionedMarkerPath(string version) => Path.Combine(VersionDir(version), "service-running.marker");
+
+    /// <summary>Versioned layout: the service exe inside a specific version dir.</summary>
+    public string VersionedServiceExePath(string version) => Path.Combine(VersionDir(version), "SquidUpgradeE2ETestService.exe");
+
     /// <summary>
     /// Construct the fixture against a UNIQUE service name + UNIQUE install
     /// dir. Caller responsibility to make these unique across concurrent
@@ -156,6 +176,94 @@ public sealed class WindowsServiceFixture : IDisposable
         );
 
         WaitForState("RUNNING", startTimeout);
+    }
+
+    /// <summary>
+    /// Stage the test service in a VERSIONED ("blue-green") layout and start it: the
+    /// service tree lives at versions\&lt;version&gt; selected by a `current` junction,
+    /// and the SCM binPath runs through the junction
+    /// (<c>"{InstallDir}\current\SquidUpgradeE2ETestService.exe" --service</c>) — the
+    /// production versioned shape the upgrade script's blue-green path operates on.
+    /// Additive — the flat <see cref="InstallAndStart"/> is untouched.
+    /// </summary>
+    public void InstallVersionedAndStart(string testServiceExeSourcePath, string initialVersion, TimeSpan startTimeout)
+    {
+        if (!IsAvailable) throw new PlatformNotSupportedException("WindowsServiceFixture only runs on Windows");
+
+        TryDeleteService(_serviceName);
+
+        // Copy the ENTIRE source tree into versions\<v1> (a framework-dependent .NET
+        // exe needs its siblings co-located — same reason as the flat path).
+        var v1Dir = VersionDir(initialVersion);
+        Directory.CreateDirectory(v1Dir);
+
+        var sourceDir = Path.GetDirectoryName(testServiceExeSourcePath)
+            ?? throw new InvalidOperationException($"Test service source path has no directory: {testServiceExeSourcePath}");
+        foreach (var sourceFile in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDir, sourceFile);
+            var destFile = Path.Combine(v1Dir, relativePath);
+            var destDir = Path.GetDirectoryName(destFile);
+            if (!string.IsNullOrEmpty(destDir)) Directory.CreateDirectory(destDir);
+            File.Copy(sourceFile, destFile, overwrite: true);
+        }
+
+        // version.txt lives inside the version dir; the test service reads it relative
+        // to its own exe, so each version reports its own version.
+        File.WriteAllText(Path.Combine(v1Dir, "version.txt"), initialVersion);
+
+        // current -> versions\<v1> (junction, unprivileged — matches install-tentacle.ps1
+        // and what the upgrade script repoints to).
+        CreateJunction(CurrentPointer, v1Dir);
+
+        // SCM binPath runs through the junction, so an upgrade activates a new version
+        // by repointing `current` without re-registering the service.
+        RunScExpectingSuccess(
+            "/Create failed",
+            "create", _serviceName,
+            "binPath=", $"\"{Path.Combine(CurrentPointer, "SquidUpgradeE2ETestService.exe")}\" --service",
+            "type=", "own",
+            "start=", "demand"
+        );
+        _installed = true;
+
+        RunScExpectingSuccess("/Start failed", "start", _serviceName);
+
+        WaitForState("RUNNING", startTimeout);
+    }
+
+    /// <summary>Creates a directory junction via <c>mklink /J</c> (a cmd builtin) — unprivileged, unlike symlinks.</summary>
+    private static void CreateJunction(string link, string target)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "cmd.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("/c");
+        psi.ArgumentList.Add("mklink");
+        psi.ArgumentList.Add("/J");
+        psi.ArgumentList.Add(link);
+        psi.ArgumentList.Add(target);
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch cmd.exe for mklink");
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+
+        if (!p.WaitForExit(15_000))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("mklink did not exit within 15s");
+        }
+
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"mklink /J '{link}' -> '{target}' failed (exit {p.ExitCode}).\nstdout: {stdoutTask.Result}\nstderr: {stderrTask.Result}");
     }
 
     /// <summary>

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -1099,6 +1099,166 @@ public sealed class TentacleUpgradeLifecycleE2ETests
     }
 
     // ========================================================================
+    // Versioned (blue-green) upgrade — real SCM, junction repoint.
+    // Proves the failure-isolation guarantee on Windows: the running version's
+    // directory is never touched; rollback is a junction flip back to it.
+    // ========================================================================
+
+    [Fact]
+    public void Versioned_HappyPath_RepointsCurrentToV2_AndLeavesV1Intact()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running (per-version marker) before the versioned upgrade can be validated");
+
+        var v1Exe = ctx.Fixture.VersionedServiceExePath("1.0.0");
+        var v1HashBefore = Sha256Hex(v1Exe);
+
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0-test"));
+        var (exitCode, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0-test"));
+
+        exitCode.ShouldBe(0, customMessage: $"versioned happy-path upgrade MUST exit 0. Got {exitCode}.\nstdout:\n{stdout}");
+
+        var status = ctx.ReadLastUpgradeStatus();
+        status.ShouldNotBeNull(customMessage: $"last-upgrade.json MUST be written. Path: {ctx.StatusFilePath}");
+        status.Status.ShouldBe("SUCCESS", customMessage: $"status MUST be SUCCESS. Got '{status.Status}'. Detail: {status.Detail}");
+
+        // current now resolves to versions\2.0.0-test (junction repointed).
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("2.0.0-test",
+            customMessage: "current\\version.txt MUST be V2 — the `current` junction was repointed to versions\\2.0.0-test");
+
+        // versions\1.0.0 untouched: blue-green staged V2 into a SEPARATE dir and
+        // repointed the junction; it never moved/overwrote/deleted the prior version.
+        Directory.Exists(ctx.Fixture.VersionDir("1.0.0")).ShouldBeTrue(
+            "versions\\1.0.0 MUST remain after a blue-green upgrade (failure isolation — old version preserved)");
+        Sha256Hex(v1Exe).ShouldBe(v1HashBefore,
+            "the previous version's exe MUST be byte-for-byte unchanged — the upgrade never touches the running version's directory");
+
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("2.0.0-test"), "2.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            "after junction repoint + restart, the V2 service MUST write its per-version marker (started on the new version through `current`)");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void Versioned_CrashOnStart_RollsBackByRepointingCurrentToV1()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running before the rollback scenario can be validated");
+
+        var v1Exe = ctx.Fixture.VersionedServiceExePath("1.0.0");
+        var v1HashBefore = Sha256Hex(v1Exe);
+
+        // crashOnStart=true → v2's OnStart throws → SCM start fails → Invoke-Rollback.
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0-test", crashOnStart: true));
+        var (exitCode, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0-test"));
+
+        // Exit 8 = Start-Service post-swap failed → rollback fired.
+        exitCode.ShouldBe(8, customMessage: $"crashing OnStart MUST trigger the versioned rollback (exit 8). Got {exitCode}.\nstdout:\n{stdout}");
+
+        var status = ctx.ReadLastUpgradeStatus();
+        status.ShouldNotBeNull(customMessage: $"last-upgrade.json MUST be written on the rollback path. Path: {ctx.StatusFilePath}");
+        status.Status.ShouldBe("ROLLED_BACK",
+            customMessage: $"status MUST be ROLLED_BACK after a successful versioned rollback. Got '{status.Status}'. Detail: {status.Detail}");
+
+        // current repointed BACK to versions\1.0.0.
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("1.0.0",
+            customMessage: "current\\version.txt MUST be back to V1 — rollback repointed `current` to the previous version");
+
+        // v1 exe byte-unchanged: the rollback is a junction flip, and the v1 dir was
+        // never touched during the (failed) upgrade attempt.
+        Sha256Hex(v1Exe).ShouldBe(v1HashBefore,
+            "the previous version's exe MUST be byte-for-byte unchanged through a failed upgrade + rollback");
+
+        // The broken v2 is preserved in its own version dir for post-mortem (the
+        // versioned equivalent of the flat .failed archive — not silently deleted).
+        Directory.Exists(ctx.Fixture.VersionDir("2.0.0-test")).ShouldBeTrue(
+            "the broken V2 MUST remain at versions\\2.0.0-test for post-mortem");
+
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            "the V1 service MUST be running again after rollback (current repointed back + restart)");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void Versioned_MultiUpgrade_PreservesEveryPriorVersion()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue("v1 must be running");
+
+        var v1Hash = Sha256Hex(ctx.Fixture.VersionedServiceExePath("1.0.0"));
+
+        // Upgrade 1.0.0 -> 2.0.0-test
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0-test"));
+        var (exit2, _) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0-test"));
+        exit2.ShouldBe(0, customMessage: "first upgrade (v1->v2) must succeed");
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("2.0.0-test"), "2.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue("v2 must run after the first upgrade");
+
+        var v2Hash = Sha256Hex(ctx.Fixture.VersionedServiceExePath("2.0.0-test"));
+
+        // Upgrade 2.0.0-test -> 3.0.0-test
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "3.0.0-test"));
+        var (exit3, _) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("3.0.0-test"));
+        exit3.ShouldBe(0, customMessage: "second upgrade (v2->v3) must succeed");
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("3.0.0-test"), "3.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue("v3 must run after the second upgrade");
+
+        // All three version dirs coexist (no GC yet); current -> v3; v1 & v2 byte-unchanged.
+        Directory.Exists(ctx.Fixture.VersionDir("1.0.0")).ShouldBeTrue("v1 dir MUST be preserved across two upgrades");
+        Directory.Exists(ctx.Fixture.VersionDir("2.0.0-test")).ShouldBeTrue("v2 dir MUST be preserved");
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("3.0.0-test", customMessage: "current MUST point at v3 after two upgrades");
+        Sha256Hex(ctx.Fixture.VersionedServiceExePath("1.0.0")).ShouldBe(v1Hash, "v1 exe MUST be byte-unchanged across two upgrades");
+        Sha256Hex(ctx.Fixture.VersionedServiceExePath("2.0.0-test")).ShouldBe(v2Hash, "v2 exe MUST be byte-unchanged after the v3 upgrade");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void FlatInstall_DoesNotCreateVersionedLayout()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        // Non-breaking guard: the flat install path MUST NOT create the versioned
+        // layout — versions\ / current only appear via InstallVersionedAndStart.
+        ctx.Fixture.InstallAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue("flat v1 must be running");
+
+        Directory.Exists(ctx.Fixture.VersionsRoot).ShouldBeFalse(
+            "flat InstallAndStart MUST NOT create a versions\\ dir — the versioned layout is opt-in");
+        Directory.Exists(ctx.Fixture.CurrentPointer).ShouldBeFalse(
+            "flat InstallAndStart MUST NOT create a `current` junction");
+
+        ctx.MarkClean();
+    }
+
+    private static string ReadThroughCurrent(UpgradeLifecycleContext ctx, string fileName)
+    {
+        var path = Path.Combine(ctx.Fixture.CurrentPointer, fileName);
+        return File.Exists(path) ? File.ReadAllText(path).Trim() : "(absent)";
+    }
+
+    private static string Sha256Hex(string path)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(File.ReadAllBytes(path)));
+    }
+
+    // ========================================================================
     // Per-test context — owns every OS resource the test stages. IDisposable
     // best-effort cleanup runs on every exit path (Rule 12.3) so a failed
     // assertion mid-test doesn't leak SCM entries / scheduled tasks / temp dirs.

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -1118,8 +1118,13 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         var v1Exe = ctx.Fixture.VersionedServiceExePath("1.0.0");
         var v1HashBefore = Sha256Hex(v1Exe);
 
-        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0-test"));
-        var (exitCode, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0-test"));
+        // Release-style target versions (no pre-release suffix): BuildV2BundleZip on
+        // Windows writes a stripped version.txt, so a "2.0.0-test" target would land
+        // version.txt="2.0.0" — a dir-name-vs-content mismatch. Using "2.0.0" keeps the
+        // version dir, version.txt, and marker all consistent (the suffix-handling
+        // pre-release case is covered on the Linux side, whose bundle preserves it).
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0"));
+        var (exitCode, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0"));
 
         exitCode.ShouldBe(0, customMessage: $"versioned happy-path upgrade MUST exit 0. Got {exitCode}.\nstdout:\n{stdout}");
 
@@ -1127,9 +1132,9 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         status.ShouldNotBeNull(customMessage: $"last-upgrade.json MUST be written. Path: {ctx.StatusFilePath}");
         status.Status.ShouldBe("SUCCESS", customMessage: $"status MUST be SUCCESS. Got '{status.Status}'. Detail: {status.Detail}");
 
-        // current now resolves to versions\2.0.0-test (junction repointed).
-        ReadThroughCurrent(ctx, "version.txt").ShouldBe("2.0.0-test",
-            customMessage: "current\\version.txt MUST be V2 — the `current` junction was repointed to versions\\2.0.0-test");
+        // current now resolves to versions\2.0.0 (junction repointed).
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("2.0.0",
+            customMessage: "current\\version.txt MUST be V2 — the `current` junction was repointed to versions\\2.0.0");
 
         // versions\1.0.0 untouched: blue-green staged V2 into a SEPARATE dir and
         // repointed the junction; it never moved/overwrote/deleted the prior version.
@@ -1138,7 +1143,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         Sha256Hex(v1Exe).ShouldBe(v1HashBefore,
             "the previous version's exe MUST be byte-for-byte unchanged — the upgrade never touches the running version's directory");
 
-        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("2.0.0-test"), "2.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("2.0.0"), "2.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
             "after junction repoint + restart, the V2 service MUST write its per-version marker (started on the new version through `current`)");
 
         ctx.MarkClean();
@@ -1159,8 +1164,9 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         var v1HashBefore = Sha256Hex(v1Exe);
 
         // crashOnStart=true → v2's OnStart throws → SCM start fails → Invoke-Rollback.
-        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0-test", crashOnStart: true));
-        var (exitCode, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0-test"));
+        // Release-style version (no suffix) — see the happy-path note.
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0", crashOnStart: true));
+        var (exitCode, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0"));
 
         // Exit 8 = Start-Service post-swap failed → rollback fired.
         exitCode.ShouldBe(8, customMessage: $"crashing OnStart MUST trigger the versioned rollback (exit 8). Got {exitCode}.\nstdout:\n{stdout}");
@@ -1181,8 +1187,8 @@ public sealed class TentacleUpgradeLifecycleE2ETests
 
         // The broken v2 is preserved in its own version dir for post-mortem (the
         // versioned equivalent of the flat .failed archive — not silently deleted).
-        Directory.Exists(ctx.Fixture.VersionDir("2.0.0-test")).ShouldBeTrue(
-            "the broken V2 MUST remain at versions\\2.0.0-test for post-mortem");
+        Directory.Exists(ctx.Fixture.VersionDir("2.0.0")).ShouldBeTrue(
+            "the broken V2 MUST remain at versions\\2.0.0 for post-mortem");
 
         WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
             "the V1 service MUST be running again after rollback (current repointed back + restart)");
@@ -1202,26 +1208,28 @@ public sealed class TentacleUpgradeLifecycleE2ETests
 
         var v1Hash = Sha256Hex(ctx.Fixture.VersionedServiceExePath("1.0.0"));
 
-        // Upgrade 1.0.0 -> 2.0.0-test
-        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0-test"));
-        var (exit2, _) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0-test"));
+        // Release-style versions (no pre-release suffix) — see the happy-path note;
+        // the Windows bundle strips suffixes, so suffix-free keeps dir == version.txt.
+        // Upgrade 1.0.0 -> 2.0.0
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "2.0.0"));
+        var (exit2, _) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("2.0.0"));
         exit2.ShouldBe(0, customMessage: "first upgrade (v1->v2) must succeed");
-        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("2.0.0-test"), "2.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue("v2 must run after the first upgrade");
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("2.0.0"), "2.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue("v2 must run after the first upgrade");
 
-        var v2Hash = Sha256Hex(ctx.Fixture.VersionedServiceExePath("2.0.0-test"));
+        var v2Hash = Sha256Hex(ctx.Fixture.VersionedServiceExePath("2.0.0"));
 
-        // Upgrade 2.0.0-test -> 3.0.0-test
-        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "3.0.0-test"));
-        var (exit3, _) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("3.0.0-test"));
+        // Upgrade 2.0.0 -> 3.0.0
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "3.0.0"));
+        var (exit3, _) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("3.0.0"));
         exit3.ShouldBe(0, customMessage: "second upgrade (v2->v3) must succeed");
-        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("3.0.0-test"), "3.0.0-test", TimeSpan.FromSeconds(30)).ShouldBeTrue("v3 must run after the second upgrade");
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("3.0.0"), "3.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue("v3 must run after the second upgrade");
 
         // All three version dirs coexist (no GC yet); current -> v3; v1 & v2 byte-unchanged.
         Directory.Exists(ctx.Fixture.VersionDir("1.0.0")).ShouldBeTrue("v1 dir MUST be preserved across two upgrades");
-        Directory.Exists(ctx.Fixture.VersionDir("2.0.0-test")).ShouldBeTrue("v2 dir MUST be preserved");
-        ReadThroughCurrent(ctx, "version.txt").ShouldBe("3.0.0-test", customMessage: "current MUST point at v3 after two upgrades");
+        Directory.Exists(ctx.Fixture.VersionDir("2.0.0")).ShouldBeTrue("v2 dir MUST be preserved");
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("3.0.0", customMessage: "current MUST point at v3 after two upgrades");
         Sha256Hex(ctx.Fixture.VersionedServiceExePath("1.0.0")).ShouldBe(v1Hash, "v1 exe MUST be byte-unchanged across two upgrades");
-        Sha256Hex(ctx.Fixture.VersionedServiceExePath("2.0.0-test")).ShouldBe(v2Hash, "v2 exe MUST be byte-unchanged after the v3 upgrade");
+        Sha256Hex(ctx.Fixture.VersionedServiceExePath("2.0.0")).ShouldBe(v2Hash, "v2 exe MUST be byte-unchanged after the v3 upgrade");
 
         ctx.MarkClean();
     }


### PR DESCRIPTION
## Summary

Windows real-SCM E2E parity with the Linux versioned-upgrade coverage (#404) — proves the blue-green guarantee on Windows: the running version's directory is never touched; rollback is a `current` junction flip back to it.

- `WindowsServiceFixture.InstallVersionedAndStart` — stages a v1 service in the versioned layout (copy tree → `versions\<v1>`, `mklink /J current → versions\<v1>`, `sc create` binPath through the junction). **Additive** — the flat `InstallAndStart` is untouched.
- Four tests on the existing `UpgradeLifecycleContext`:
  - **happy**: `current` junction repoints v1→v2, `versions\<v1>` exe **SHA256 byte-unchanged**, v2 per-version marker, status `SUCCESS`.
  - **crashOnStart rollback**: exit 8 / `ROLLED_BACK`, `current` repointed back to v1, v1 **byte-unchanged**, broken v2 preserved at `versions\<v2>` for post-mortem, service running v1 again.
  - **multi-upgrade v1→v2→v3**: all three version dirs coexist (no GC yet), `current`→v3, v1 & v2 exes byte-unchanged.
  - **flat-install guard**: flat `InstallAndStart` creates no `versions\` / `current` (non-breaking — versioned layout is opt-in).

## Test plan

- [x] Windows E2E project compiles on mac (additions: fixture method + 4 tests + helpers).
- [ ] Real Windows runner via `workflow_dispatch` on `tentacle-windows-e2e.yml` (Category=TentacleUpgradeLifecycleE2E) — dispatched on this branch.

## Notes
- Non-breaking: pure test-infrastructure + 4 new tests; no production code. The Windows `TestService` is already self-relative (reads version.txt next to its exe), so per-version semantics work with no service change.