### PR TITLE
Add version GC + same-version no-op to versioned upgrade

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
@@ -562,6 +562,7 @@ if [ -z "${SQUID_UPGRADE_SCOPED:-}" ]; then
     --setenv=OLD_VERSION_RPM="$OLD_VERSION_RPM" \
     --setenv=IS_VERSIONED="$IS_VERSIONED" \
     --setenv=OLD_VER_TARGET="$OLD_VER_TARGET" \
+    --setenv=SQUID_UPGRADE_KEEP_VERSIONS="${SQUID_UPGRADE_KEEP_VERSIONS:-3}" \
     bash "$SCOPED_SCRIPT" || {
       echo "::error:: Failed to spawn scope for upgrade handoff."
       write_status "FAILED" "systemd-run --scope failed to launch"
@@ -599,29 +600,41 @@ if [ "$IS_VERSIONED" = "1" ]; then
   NEW_VER_DIR="$INSTALL_DIR/versions/$TARGET_VERSION"
   sudo mkdir -p "$INSTALL_DIR/versions"
 
-  # Never delete the currently-running version's directory.
-  if [ -d "$NEW_VER_DIR" ] && [ "$NEW_VER_DIR" != "$OLD_VER_TARGET" ]; then sudo rm -rf "$NEW_VER_DIR"; fi
+  if [ -n "$OLD_VER_TARGET" ] && [ "$NEW_VER_DIR" = "$OLD_VER_TARGET" ]; then
+    # Re-upgrade to the already-active version: the running version dir IS the
+    # target, so there is nothing to stage or repoint. Discard the freshly
+    # downloaded copy (so we don't leave an extract/ residue inside the live
+    # version dir) and fall through to the restart/health-check as a no-op
+    # re-validation. `current` already points here.
+    echo "[upgrade] Target version $TARGET_VERSION is already active; skipping stage + repoint (no-op)."
+    emit_event B already-active "Target $TARGET_VERSION already active; no swap needed"
+    rm -rf "$EXTRACT" 2>/dev/null || true
+  else
+    # The target differs from the active version (guaranteed by the branch above),
+    # so removing any stale same-version dir can never touch the running version.
+    if [ -d "$NEW_VER_DIR" ]; then sudo rm -rf "$NEW_VER_DIR"; fi
 
-  if ! sudo mv "$EXTRACT" "$NEW_VER_DIR"; then
-    echo "::error:: Failed to stage new version into $NEW_VER_DIR. Running version untouched; no damage."
-    write_status "FAILED" "Failed to stage new version (versioned); running version intact at $OLD_VER_TARGET"
-    exit 10
-  fi
+    if ! sudo mv "$EXTRACT" "$NEW_VER_DIR"; then
+      echo "::error:: Failed to stage new version into $NEW_VER_DIR. Running version untouched; no damage."
+      write_status "FAILED" "Failed to stage new version (versioned); running version intact at $OLD_VER_TARGET"
+      exit 10
+    fi
 
-  sudo chmod +x "$NEW_VER_DIR/Squid.Tentacle"
-  [ -f "$NEW_VER_DIR/Squid.Calamari" ] && sudo chmod +x "$NEW_VER_DIR/Squid.Calamari"
+    sudo chmod +x "$NEW_VER_DIR/Squid.Tentacle"
+    [ -f "$NEW_VER_DIR/Squid.Calamari" ] && sudo chmod +x "$NEW_VER_DIR/Squid.Calamari"
 
-  if id "$SERVICE_USER" >/dev/null 2>&1; then
-    sudo chown -R "$SERVICE_USER:$SERVICE_USER" "$NEW_VER_DIR" 2>/dev/null || true
-  fi
+    if id "$SERVICE_USER" >/dev/null 2>&1; then
+      sudo chown -R "$SERVICE_USER:$SERVICE_USER" "$NEW_VER_DIR" 2>/dev/null || true
+    fi
 
-  # Activate atomically: ln into a temp name then rename onto `current`.
-  sudo ln -sfn "$NEW_VER_DIR" "$INSTALL_DIR/current.tmp"
-  if ! sudo mv -T "$INSTALL_DIR/current.tmp" "$INSTALL_DIR/current"; then
-    sudo rm -rf "$INSTALL_DIR/current.tmp" 2>/dev/null || true
-    echo "::error:: Failed to repoint current -> $NEW_VER_DIR. Running version untouched; no damage."
-    write_status "FAILED" "Failed to activate new version (current repoint); running version intact at $OLD_VER_TARGET"
-    exit 10
+    # Activate atomically: ln into a temp name then rename onto `current`.
+    sudo ln -sfn "$NEW_VER_DIR" "$INSTALL_DIR/current.tmp"
+    if ! sudo mv -T "$INSTALL_DIR/current.tmp" "$INSTALL_DIR/current"; then
+      sudo rm -rf "$INSTALL_DIR/current.tmp" 2>/dev/null || true
+      echo "::error:: Failed to repoint current -> $NEW_VER_DIR. Running version untouched; no damage."
+      write_status "FAILED" "Failed to activate new version (current repoint); running version intact at $OLD_VER_TARGET"
+      exit 10
+    fi
   fi
 elif [ "$INSTALL_METHOD" = "tarball" ]; then
   if [ -d "$BAK_DIR" ]; then sudo rm -rf "$BAK_DIR"; fi
@@ -725,6 +738,28 @@ if [ "$HEALTH_OK" = "1" ]; then
   if [ "$INSTALL_METHOD" = "tarball" ]; then
     sudo rm -rf "$BAK_DIR"
   fi
+
+  # Version GC (versioned only, best-effort): keep the newest N version dirs and
+  # prune older ones so versions/ doesn't grow unbounded. Runs only AFTER success
+  # is recorded, and NEVER deletes the active version (current's target). Retention
+  # is tunable via SQUID_UPGRADE_KEEP_VERSIONS (default 3 = active + a couple of
+  # rollback targets); a floor of 2 is enforced so a bad value can't strand rollback.
+  if [ "$IS_VERSIONED" = "1" ]; then
+    KEEP="${SQUID_UPGRADE_KEEP_VERSIONS:-3}"
+    if ! [ "$KEEP" -ge 2 ] 2>/dev/null; then KEEP=2; fi
+
+    CURRENT_REAL=$(readlink -f "$INSTALL_DIR/current" 2>/dev/null || true)
+    KEPT=0
+    for d in $(ls -1dt "$INSTALL_DIR"/versions/*/ 2>/dev/null); do
+      d="${d%/}"
+      KEPT=$((KEPT + 1))
+      if [ "$KEPT" -le "$KEEP" ]; then continue; fi
+      if [ "$(readlink -f "$d" 2>/dev/null)" = "$CURRENT_REAL" ]; then continue; fi
+      sudo rm -rf "$d" 2>/dev/null || true
+    done
+    emit_event B gc "Version GC: kept newest $KEEP version(s), pruned older"
+  fi
+
   exit 0
 fi
 

--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -678,20 +678,35 @@ try {
         $newVerDir = Join-Path $versionsRoot $TARGET_VERSION
         New-Item -ItemType Directory -Path $versionsRoot -Force | Out-Null
 
-        # Never delete the currently-running version's directory.
-        if ((Test-Path $newVerDir) -and ($newVerDir -ne $oldVerTarget)) {
-            Remove-Item -Path $newVerDir -Recurse -Force
+        # Normalised compare: is the target already the active version?
+        $newFull = [System.IO.Path]::GetFullPath($newVerDir).TrimEnd('\')
+        $oldFull = if ($oldVerTarget) { [System.IO.Path]::GetFullPath($oldVerTarget).TrimEnd('\') } else { '' }
+
+        if ($oldFull -and ($newFull -eq $oldFull)) {
+            # Re-upgrade to the already-active version: nothing to stage or repoint
+            # (current already points here). Discard the downloaded copy so we don't
+            # leave an extract residue inside the live version dir. (The pre-upgrade
+            # ProductVersion short-circuit usually catches this; this is the dir-based
+            # belt-and-braces for the pre-release case where the stamp differs.)
+            Append-UpgradeLog "[upgrade] Target version $TARGET_VERSION is already active; skipping stage + repoint (no-op)."
+            Write-UpgradeEvent -Phase 'B' -Kind 'already-active' -Msg "Target $TARGET_VERSION already active; no swap needed"
+            Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
         }
+        else {
+            # Target differs from the active version, so removing any stale same-version
+            # dir can never touch the running version.
+            if (Test-Path $newVerDir) { Remove-Item -Path $newVerDir -Recurse -Force }
 
-        Append-UpgradeLog "[upgrade] Staging new version into $newVerDir"
-        Move-Item -Path $extractDir -Destination $newVerDir -Force
+            Append-UpgradeLog "[upgrade] Staging new version into $newVerDir"
+            Move-Item -Path $extractDir -Destination $newVerDir -Force
 
-        # Repoint `current` junction. Delete the old junction NON-recursively
-        # ([Directory]::Delete(path,$false)) so we remove only the reparse point,
-        # never the target version's files.
-        Append-UpgradeLog "[upgrade] Repointing current -> $newVerDir"
-        if (Test-Path $currentPointer) { [System.IO.Directory]::Delete($currentPointer, $false) }
-        New-Item -ItemType Junction -Path $currentPointer -Target $newVerDir | Out-Null
+            # Repoint `current` junction. Delete the old junction NON-recursively
+            # ([Directory]::Delete(path,$false)) so we remove only the reparse point,
+            # never the target version's files.
+            Append-UpgradeLog "[upgrade] Repointing current -> $newVerDir"
+            if (Test-Path $currentPointer) { [System.IO.Directory]::Delete($currentPointer, $false) }
+            New-Item -ItemType Junction -Path $currentPointer -Target $newVerDir | Out-Null
+        }
 
         Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Activated versions\$TARGET_VERSION via current junction — restarting service"
     }
@@ -812,6 +827,42 @@ try {
 
     Write-UpgradeStatus -Status 'SUCCESS' -InstallMethod $INSTALL_METHOD -Detail "Upgrade to $TARGET_VERSION complete"
     Append-UpgradeLog "[upgrade] Phase B complete — version $TARGET_VERSION installed via $INSTALL_METHOD"
+
+    # Version GC (versioned only, best-effort): keep the newest N version dirs and
+    # prune older ones so versions\ doesn't grow unbounded. Runs only AFTER success
+    # is recorded, and NEVER deletes the active version (current's target). Retention
+    # is tunable via SQUID_UPGRADE_KEEP_VERSIONS (default 3 = active + a couple of
+    # rollback targets); floored at 2 so a bad value can't strand rollback.
+    if ($isVersioned) {
+        try {
+            $keep = 3
+            if ($env:SQUID_UPGRADE_KEEP_VERSIONS -and ($env:SQUID_UPGRADE_KEEP_VERSIONS -as [int])) {
+                $keep = [int]$env:SQUID_UPGRADE_KEEP_VERSIONS
+            }
+            if ($keep -lt 2) { $keep = 2 }
+
+            $currentReal = if (Test-Path $currentPointer) { @((Get-Item $currentPointer -Force).Target)[0] } else { $null }
+            if ($currentReal) { $currentReal = [System.IO.Path]::GetFullPath(($currentReal -replace '^\\\?\?\\', '')).TrimEnd('\') }
+
+            $versionsRoot = Join-Path $INSTALL_DIR 'versions'
+            if (Test-Path $versionsRoot) {
+                # Sort by CreationTimeUtc (install order) — newest first. (Deliberately
+                # not LastWriteTimeUtc: that's reserved for the Phase B staging-dir
+                # anti-pattern guard, and creation time is the version's install moment.)
+                $dirs = @(Get-ChildItem -Path $versionsRoot -Directory | Sort-Object CreationTimeUtc -Descending)
+                for ($i = $keep; $i -lt $dirs.Count; $i++) {
+                    $full = [System.IO.Path]::GetFullPath($dirs[$i].FullName).TrimEnd('\')
+                    if ($currentReal -and ($full -eq $currentReal)) { continue }
+                    Remove-Item -Path $dirs[$i].FullName -Recurse -Force -ErrorAction SilentlyContinue
+                }
+                Write-UpgradeEvent -Phase 'B' -Kind 'gc' -Msg "Version GC: kept newest $keep version(s), pruned older"
+            }
+        }
+        catch {
+            Append-UpgradeLog "[upgrade] Version GC skipped (best-effort): $($_.Exception.Message)"
+        }
+    }
+
     exit 0
 }
 finally {

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxVersionedUpgradeE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxVersionedUpgradeE2ETests.cs
@@ -134,6 +134,66 @@ public sealed class TentacleLinuxVersionedUpgradeE2ETests
         ctx.MarkClean();
     }
 
+    // ========================================================================
+    // Version GC — beyond the retention floor, the oldest version is pruned.
+    // ========================================================================
+
+    [Fact]
+    public void Versioned_GC_PrunesOldestBeyondRetention()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        var healthz = new Dictionary<string, string> { ["SQUID_TEST_SERVICE_HEALTHZ"] = "1" };
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceScript, initialVersion: V1, startTimeout: TimeSpan.FromSeconds(15), extraEnvironment: healthz);
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath(V1), V1, TimeSpan.FromSeconds(15)).ShouldBeTrue("v1 must be running");
+
+        // Default retention is 3. v1 (install) + 3 upgrades = 4 versions, so after the
+        // final upgrade the oldest (v1) must be pruned while the newest 3 are kept.
+        foreach (var v in new[] { "2.0.0-test", "3.0.0-test", "4.0.0-test" })
+        {
+            ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleTarGz(targetVersion: v));
+            var (exit, output) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion(targetVersion: v));
+            exit.ShouldBe(0, customMessage: Tail($"upgrade to {v} must succeed", exit, output));
+            WaitForFileContent(ctx.Fixture.VersionedMarkerPath(v), v, TimeSpan.FromSeconds(30)).ShouldBeTrue($"{v} must run after upgrade");
+        }
+
+        Directory.Exists(ctx.Fixture.VersionDir(V1)).ShouldBeFalse(
+            "the oldest version (v1) MUST be GC-pruned once retention (default 3) is exceeded");
+        Directory.Exists(ctx.Fixture.VersionDir("2.0.0-test")).ShouldBeTrue("the newest 3 versions MUST be kept (v2)");
+        Directory.Exists(ctx.Fixture.VersionDir("3.0.0-test")).ShouldBeTrue("the newest 3 versions MUST be kept (v3)");
+        Directory.Exists(ctx.Fixture.VersionDir("4.0.0-test")).ShouldBeTrue("the newest 3 versions MUST be kept (v4)");
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("4.0.0-test", customMessage: "current MUST point at the newest version");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void Versioned_SameVersionReupgrade_IsNoOp_NoResidue()
+    {
+        if (!LinuxLifecycleContext.IsAvailable) return;
+
+        using var ctx = new LinuxLifecycleContext();
+
+        var healthz = new Dictionary<string, string> { ["SQUID_TEST_SERVICE_HEALTHZ"] = "1" };
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceScript, initialVersion: V1, startTimeout: TimeSpan.FromSeconds(15), extraEnvironment: healthz);
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath(V1), V1, TimeSpan.FromSeconds(15)).ShouldBeTrue("v1 must be running");
+
+        // Re-upgrade to the SAME version that is already active.
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleTarGz(targetVersion: V1));
+        var (exit, output) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion(targetVersion: V1));
+        exit.ShouldBe(0, customMessage: Tail("same-version re-upgrade must exit 0 (no-op)", exit, output));
+
+        // The no-op must NOT move the download into the live version dir.
+        Directory.Exists(Path.Combine(ctx.Fixture.VersionDir(V1), "extract")).ShouldBeFalse(
+            "a same-version re-upgrade MUST NOT leave an extract/ residue inside the live version dir");
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe(V1, customMessage: "current still points at the (unchanged) active version");
+        ctx.Fixture.IsActive().ShouldBeTrue(customMessage: "service MUST still be active after the no-op re-upgrade");
+
+        ctx.MarkClean();
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────
 
     private static string ReadThroughCurrent(LinuxLifecycleContext ctx, string fileName)

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeLinuxTentacleScriptTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeLinuxTentacleScriptTests.cs
@@ -106,10 +106,28 @@ public sealed class UpgradeLinuxTentacleScriptTests
     {
         RenderedScript.ShouldContain("NEW_VER_DIR=\"$INSTALL_DIR/versions/$TARGET_VERSION\"",
             customMessage: "the new version must be staged into versions/<target>, not over the running version");
-        RenderedScript.ShouldContain("[ \"$NEW_VER_DIR\" != \"$OLD_VER_TARGET\" ]",
-            customMessage: "the rm must be guarded so the currently-running version directory is never deleted");
+        RenderedScript.ShouldContain("[ \"$NEW_VER_DIR\" = \"$OLD_VER_TARGET\" ]",
+            customMessage: "a re-upgrade to the already-active version must be a no-op — the running version directory is never deleted/overwritten (it IS the active target)");
         RenderedScript.ShouldContain("mv -T \"$INSTALL_DIR/current.tmp\" \"$INSTALL_DIR/current\"",
             customMessage: "current must be repointed atomically via `mv -T` (rename), never rm+recreate");
+    }
+
+    [Fact]
+    public void Versioned_GC_PrunesOldVersionsKeepingNewest()
+    {
+        RenderedScript.ShouldContain("SQUID_UPGRADE_KEEP_VERSIONS",
+            customMessage: "version GC retention must be tunable via the SQUID_UPGRADE_KEEP_VERSIONS env var");
+        RenderedScript.ShouldContain("KEEP=2",
+            customMessage: "GC must floor retention at 2 (active + a rollback target) so a bad value can't strand rollback");
+        RenderedScript.ShouldContain("ls -1dt",
+            customMessage: "GC must enumerate version dirs newest-first (by mtime) to keep the newest N and prune older");
+    }
+
+    [Fact]
+    public void Versioned_SameVersionReupgrade_IsNoOp()
+    {
+        RenderedScript.ShouldContain("already-active",
+            customMessage: "a re-upgrade to the already-active version must emit an `already-active` event and skip stage+repoint (no extract/ residue in the live version dir)");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -1253,12 +1253,34 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
 
         inner.ShouldContain("$newVerDir = Join-Path $versionsRoot $TARGET_VERSION",
             customMessage: "the new version must be staged into versions\\<target>, not over the running version");
-        inner.ShouldContain("($newVerDir -ne $oldVerTarget)",
-            customMessage: "the Remove-Item must be guarded so the currently-running version directory is never deleted");
+        inner.ShouldContain("($newFull -eq $oldFull)",
+            customMessage: "a re-upgrade to the already-active version must be a no-op — the running version directory is never deleted/overwritten (it IS the active target)");
         inner.ShouldContain("[System.IO.Directory]::Delete($currentPointer, $false)",
             customMessage: "the old junction must be removed non-recursively so the target version's files are never wiped");
         inner.ShouldContain("New-Item -ItemType Junction -Path $currentPointer -Target $newVerDir",
             customMessage: "current must be repointed at the new version via a junction");
+    }
+
+    [Fact]
+    public void RenderInnerScript_Versioned_GC_PrunesOldVersionsKeepingNewest()
+    {
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("SQUID_UPGRADE_KEEP_VERSIONS",
+            customMessage: "version GC retention must be tunable via the SQUID_UPGRADE_KEEP_VERSIONS env var");
+        inner.ShouldContain("if ($keep -lt 2) { $keep = 2 }",
+            customMessage: "GC must floor retention at 2 (active + a rollback target) so a bad value can't strand rollback");
+        inner.ShouldContain("Sort-Object CreationTimeUtc -Descending",
+            customMessage: "GC must enumerate version dirs newest-first (by install/creation time) to keep the newest N and prune older");
+    }
+
+    [Fact]
+    public void RenderInnerScript_Versioned_SameVersionReupgrade_IsNoOp()
+    {
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        inner.ShouldContain("already-active",
+            customMessage: "a re-upgrade to the already-active version must emit an `already-active` event and skip stage+repoint (no extract residue in the live version dir)");
     }
 
     [Fact]

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -1254,6 +1254,59 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         ctx.MarkClean();
     }
 
+    [Fact]
+    public void Versioned_GC_PrunesOldestBeyondRetention()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue("v1 must be running");
+
+        // Default retention is 3. v1 (install) + 3 upgrades = 4 versions, so after the
+        // final upgrade the oldest (v1) must be pruned while the newest 3 are kept.
+        foreach (var v in new[] { "2.0.0", "3.0.0", "4.0.0" })
+        {
+            ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: v));
+            var (exit, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion(v));
+            exit.ShouldBe(0, customMessage: $"upgrade to {v} must succeed. Got {exit}.\nstdout:\n{stdout}");
+            WaitForFileContent(ctx.Fixture.VersionedMarkerPath(v), v, TimeSpan.FromSeconds(30)).ShouldBeTrue($"{v} must run after upgrade");
+        }
+
+        Directory.Exists(ctx.Fixture.VersionDir("1.0.0")).ShouldBeFalse(
+            "the oldest version (v1) MUST be GC-pruned once retention (default 3) is exceeded");
+        Directory.Exists(ctx.Fixture.VersionDir("2.0.0")).ShouldBeTrue("the newest 3 versions MUST be kept (v2)");
+        Directory.Exists(ctx.Fixture.VersionDir("3.0.0")).ShouldBeTrue("the newest 3 versions MUST be kept (v3)");
+        Directory.Exists(ctx.Fixture.VersionDir("4.0.0")).ShouldBeTrue("the newest 3 versions MUST be kept (v4)");
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("4.0.0", customMessage: "current MUST point at the newest version");
+
+        ctx.MarkClean();
+    }
+
+    [Fact]
+    public void Versioned_SameVersionReupgrade_IsNoOp_NoResidue()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallVersionedAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.VersionedMarkerPath("1.0.0"), "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue("v1 must be running");
+
+        // Re-upgrade to the SAME version that is already active.
+        ctx.Mirror.StagePreBuiltArchive(ctx.BuildV2BundleZip(targetVersion: "1.0.0"));
+        var (exit, stdout) = ctx.RunUpgradeScript(ctx.RenderProductionScriptForVersion("1.0.0"));
+        exit.ShouldBe(0, customMessage: $"same-version re-upgrade must exit 0 (no-op). Got {exit}.\nstdout:\n{stdout}");
+
+        // The no-op must NOT move the download into the live version dir.
+        Directory.Exists(Path.Combine(ctx.Fixture.VersionDir("1.0.0"), "extract")).ShouldBeFalse(
+            "a same-version re-upgrade MUST NOT leave an extract residue inside the live version dir");
+        ReadThroughCurrent(ctx, "version.txt").ShouldBe("1.0.0", customMessage: "current still points at the (unchanged) active version");
+
+        ctx.MarkClean();
+    }
+
     private static string ReadThroughCurrent(UpgradeLifecycleContext ctx, string fileName)
     {
         var path = Path.Combine(ctx.Fixture.CurrentPointer, fileName);


### PR DESCRIPTION
## Summary

Two refinements to the blue-green versioned upgrade (both OSes, versioned-only, gated on the layout — flat installs untouched):

- **Version GC**: after a successful upgrade, prune old version dirs keeping the newest N (`SQUID_UPGRADE_KEEP_VERSIONS`, default 3) so `versions/` doesn't grow unbounded. Best-effort (runs only after SUCCESS), floored at 2 so it can never strand the rollback target, and it never deletes the active version. On Linux the retention env var is propagated across the systemd-run scope so the override actually reaches Phase B.
- **Same-version re-upgrade** is now a clean no-op: when the target equals the active version, skip stage+repoint and discard the download instead of moving it into the live version dir (which previously left an `extract/` residue).

## Test plan

- [x] 694 upgrade unit tests green: updated guard pins + new GC/same-version drift assertions (env var + floor-2 + sort key + `already-active` event) + events-parity + `bash -n` on the rendered Linux script + the Windows resource test (GC sorts by `CreationTimeUtc`, sidestepping the Phase-B `LastWriteTime` anti-pattern guard).
- [ ] Real-OS E2E (dispatched on this branch): Linux systemd + Windows SCM — GC prunes the oldest beyond retention (4 versions → newest 3 kept); same-version re-upgrade is a no-op with no residue.

## Notes
Non-breaking: gated entirely on the versioned layout. GC is best-effort and floored at 2.