### PR TITLE
Fix install-script E2E flakiness and re-add to Windows gate

### DIFF
--- a/.github/workflows/tentacle-windows-smoke-e2e.yml
+++ b/.github/workflows/tentacle-windows-smoke-e2e.yml
@@ -22,17 +22,15 @@ name: Tentacle Windows Smoke E2E
 # unrelated PRs, so they get stuck "Expected -- waiting for status". The sentinel
 # always reports, so "Windows Lifecycle Smoke (PR gate)" is a safe required check.
 #
-# Smoke scope = the agent's service + upgrade lifecycle on a real Windows host:
+# Smoke scope = the agent's install + service + upgrade lifecycle on a real
+# Windows host: install-tentacle.ps1 (extract + discovery + UAC elevation) ->
 # sc.exe service install/start/stop/uninstall -> blue-green versioned upgrade
 # (download + SHA256 verify + extract + swap + health-check + rollback + GC +
 # last-upgrade.json) -> Task Scheduler detach. Deliberately EXCLUDED and left to
 # the nightly suite: IISDeployE2E (66 tests; needs a ~1m IIS feature install +
-# XDT engine), the real-binary publish path, deploy/register/capabilities/
-# diagnostic (cross-platform logic already exercised by unit + Linux E2E), and
-# TentacleInstallScriptE2E -- install-tentacle.ps1's UAC + install-info tests
-# have pre-existing test-quality issues (fragile cmdlet mock + a shared-
-# %ProgramData% parallel race) being fixed separately; re-added once
-# deterministic. Skipping IIS lets the tests job skip the slow IIS+XDT setup.
+# XDT engine), the real-binary publish path, and deploy/register/capabilities/
+# diagnostic (cross-platform logic already exercised by unit + Linux E2E).
+# Skipping IIS lets the tests job skip the slow IIS+XDT setup.
 
 on:
   pull_request:
@@ -41,7 +39,7 @@ on:
       test_filter:
         description: "xUnit --filter override for the smoke subset"
         required: false
-        default: "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E"
+        default: "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E"
 
 permissions:
   contents: read
@@ -78,7 +76,7 @@ jobs:
           # Same path set the gate cares about (Tentacle source, the Windows
           # upgrade script, the server-side upgrade strategy, the Windows E2E
           # project, and this workflow itself).
-          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
+          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "-> relevant=true (Tentacle paths changed)"
           else
@@ -121,7 +119,7 @@ jobs:
       - name: Run Windows lifecycle smoke subset
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E" }
+          $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E" }
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `

--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -134,10 +134,31 @@ $rid = Resolve-Rid -Arch $arch
 #   - Already admin (Test-IsAdministrator)
 #   - Installing to a user-owned path (InstallDir != default) -- admin not required
 #   - -NoAutoElevate switch was passed (CI, SYSTEM-context invocations)
-function Test-IsAdministrator {
-    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-    $principal = New-Object System.Security.Principal.WindowsPrincipal($identity)
-    return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+# Defined only when no ambient definition exists, so a test harness can inject a
+# mock via a parent-scope `function global:Test-IsAdministrator`. A plain
+# script-local `function` would shadow any global override (PowerShell resolves
+# the script-local definition first), so the mock would never fire. Normal
+# installs have no ambient definition and use the real principal check below.
+if (-not (Test-Path Function:\Test-IsAdministrator)) {
+    function Test-IsAdministrator {
+        $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object System.Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+}
+
+# The UAC re-launch itself, factored into an overridable seam (same guard
+# rationale as Test-IsAdministrator). A test harness overrides this via a
+# parent-scope `function global:Invoke-UacRelaunch` to capture the invocation
+# instead of spawning a real elevated process -- mocking the built-in
+# Start-Process cmdlet is unreliable for the -Verb RunAs / ShellExecute path
+# (the returned process often doesn't expose ExitCode). Returns the child exit code.
+if (-not (Test-Path Function:\Invoke-UacRelaunch)) {
+    function Invoke-UacRelaunch {
+        param([string] $FilePath, [string] $Verb, [string[]] $ArgumentList)
+        $proc = Start-Process -FilePath $FilePath -Verb $Verb -ArgumentList $ArgumentList -Wait -PassThru
+        return $proc.ExitCode
+    }
 }
 
 function Get-OriginalArgs {
@@ -184,8 +205,7 @@ function Invoke-SelfElevation {
     Write-Host ""
 
     try {
-        $proc = Start-Process powershell.exe -Verb RunAs -ArgumentList $childArgs -Wait -PassThru
-        $childExit = $proc.ExitCode
+        $childExit = Invoke-UacRelaunch -FilePath 'powershell.exe' -Verb 'RunAs' -ArgumentList $childArgs
     } catch {
         Write-Error @"
 UAC elevation failed: $($_.Exception.Message)

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptResilienceE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptResilienceE2ETests.cs
@@ -36,8 +36,27 @@ namespace Squid.WindowsTentacleE2ETests;
 /// <c>docs/windows-tentacle-install.md</c> as known operator workflows.</para>
 /// </summary>
 [Trait("Category", WindowsUpgradeE2ECategories.TentacleInstallScript)]
-public sealed class TentacleInstallScriptResilienceE2ETests
+public sealed class TentacleInstallScriptResilienceE2ETests : IDisposable
 {
+    // Test-isolated %ProgramData% so install-tentacle.ps1's install-info.json
+    // (written to $env:ProgramData\Squid\Tentacle\) cannot collide with other
+    // install-script test classes running in parallel -- the shared canonical
+    // path was a cross-class race (a sibling test's BinaryPath leaked in). xUnit
+    // news-up this class per test method, so each test gets a unique dir; the
+    // child process inherits it via EnvironmentVariables["ProgramData"] in
+    // RunInstallScriptAsync.
+    private readonly string _programData =
+        Path.Combine(Path.GetTempPath(), $"squid-install-pd-{Guid.NewGuid():N}");
+
+    private string InstallInfoPath =>
+        Path.Combine(_programData, "Squid", "Tentacle", "install-info.json");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_programData)) Directory.Delete(_programData, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
     // ========================================================================
     // Group 1 -- install-info.json discovery file
     // ========================================================================
@@ -62,9 +81,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
         exitCode.ShouldBe(0,
             customMessage: $"install MUST succeed. stdout:\n{stdout}\nstderr:\n{stderr}");
 
-        var infoPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Squid", "Tentacle", "install-info.json");
+        var infoPath = InstallInfoPath;
 
         File.Exists(infoPath).ShouldBeTrue(
             customMessage:
@@ -94,9 +111,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
 
         exitCode.ShouldBe(0, customMessage: $"install MUST succeed. stdout:\n{stdout}\nstderr:\n{stderr}");
 
-        var infoPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Squid", "Tentacle", "install-info.json");
+        var infoPath = InstallInfoPath;
         ctx.RegisterCleanupPath(infoPath);
 
         var raw = await File.ReadAllTextAsync(infoPath);
@@ -157,9 +172,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
 
         exitCode.ShouldBe(0, customMessage: $"deep-nested install dir must work. stderr:\n{stderr}");
 
-        var infoPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Squid", "Tentacle", "install-info.json");
+        var infoPath = InstallInfoPath;
         ctx.RegisterCleanupPath(infoPath);
 
         var info = JsonDocument.Parse(await File.ReadAllTextAsync(infoPath)).RootElement;
@@ -210,10 +223,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
             try { Directory.Delete(defaultInstallDir, recursive: true); } catch { }
             try
             {
-                var infoPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-                    "Squid", "Tentacle", "install-info.json");
-                File.Delete(infoPath);
+                File.Delete(InstallInfoPath);
             }
             catch { }
         }
@@ -358,9 +368,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
         using var ctx = new InstallScriptTestContext();
         mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# test\n"));
 
-        var infoDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Squid", "Tentacle");
+        var infoDir = Path.Combine(_programData, "Squid", "Tentacle");
         var infoPath = Path.Combine(infoDir, "install-info.json");
         ctx.RegisterCleanupPath(infoPath);
 
@@ -417,9 +425,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
         File.Exists(Path.Combine(pathWithSpaces, "Squid.Tentacle.exe")).ShouldBeTrue();
 
         // install-info.json must roundtrip the spaced path correctly.
-        var infoPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Squid", "Tentacle", "install-info.json");
+        var infoPath = InstallInfoPath;
         ctx.RegisterCleanupPath(infoPath);
 
         var info = JsonDocument.Parse(await File.ReadAllTextAsync(infoPath)).RootElement;
@@ -433,7 +439,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests
     // a cross-cutting fixture that two classes share state through).
     // ========================================================================
 
-    private static async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
+    private async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
     {
         var scriptPath = LocateInstallScript();
 
@@ -445,6 +451,10 @@ public sealed class TentacleInstallScriptResilienceE2ETests
             UseShellExecute = false,
             CreateNoWindow = true
         };
+
+        // Redirect the child's %ProgramData% so install-info.json lands in this
+        // test's isolated dir, never the shared canonical path (cross-class race).
+        psi.EnvironmentVariables["ProgramData"] = _programData;
 
         psi.ArgumentList.Add("-NoProfile");
         psi.ArgumentList.Add("-NonInteractive");

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptWindowsE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptWindowsE2ETests.cs
@@ -33,8 +33,21 @@ namespace Squid.WindowsTentacleE2ETests;
 /// </list>
 /// </summary>
 [Trait("Category", WindowsUpgradeE2ECategories.TentacleInstallScript)]
-public sealed class TentacleInstallScriptWindowsE2ETests
+public sealed class TentacleInstallScriptWindowsE2ETests : IDisposable
 {
+    // Test-isolated %ProgramData% so install-tentacle.ps1's install-info.json
+    // write doesn't collide with sibling install-script test classes running in
+    // parallel (shared canonical path = cross-class race) and doesn't litter the
+    // runner's real C:\ProgramData. xUnit news-up this class per test method.
+    private readonly string _programData =
+        Path.Combine(Path.GetTempPath(), $"squid-install-pd-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_programData)) Directory.Delete(_programData, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
     // ========================================================================
     // A1.h + A4.h + A7.h — Happy path: custom dir + DOWNLOAD_BASE override
     //                       + -NoServiceInstall extracts binary cleanly
@@ -170,7 +183,7 @@ public sealed class TentacleInstallScriptWindowsE2ETests
     /// in under 5s against a loopback mirror; if it hangs, that's a
     /// script-level regression worth surfacing.
     /// </summary>
-    private static async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
+    private async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
     {
         var scriptPath = LocateInstallScript();
 
@@ -182,6 +195,10 @@ public sealed class TentacleInstallScriptWindowsE2ETests
             UseShellExecute = false,
             CreateNoWindow = true
         };
+
+        // Redirect the child's %ProgramData% so install-info.json lands in this
+        // test's isolated dir, never the shared canonical path (cross-class race).
+        psi.EnvironmentVariables["ProgramData"] = _programData;
 
         psi.ArgumentList.Add("-NoProfile");
         psi.ArgumentList.Add("-NonInteractive");

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUacElevationE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUacElevationE2ETests.cs
@@ -10,10 +10,11 @@ namespace Squid.WindowsTentacleE2ETests;
 /// <para><b>Tier</b>: 🟢 High-fidelity for the structural invariants we CAN
 /// observe without a real UAC prompt (a real prompt would block the CI runner
 /// forever). Real <c>powershell.exe</c> running real <c>install-tentacle.ps1</c>
-/// from disk; <c>Test-IsAdministrator</c> + <c>Start-Process</c> are overridden
-/// at <c>global:</c> scope by a wrapper script, redirecting the would-be UAC
-/// re-launch into a JSON capture file. Skip-on-non-Windows guard keeps the
-/// rest of the dev fleet green.</para>
+/// from disk; <c>Test-IsAdministrator</c> + <c>Invoke-UacRelaunch</c> are
+/// overridden at <c>global:</c> scope by a wrapper script (install-tentacle.ps1
+/// guard-defines both with <c>if (-not (Test-Path Function:\...))</c> so an
+/// ambient override wins), redirecting the would-be UAC re-launch into a JSON
+/// capture file. Skip-on-non-Windows guard keeps the rest of the dev fleet green.</para>
 ///
 /// <para><b>Production gap closed</b>: <see cref="TentacleInstallScriptResilienceE2ETests"/>
 /// covers every SKIP-elevation path (already admin / user-owned dir / explicit
@@ -25,8 +26,8 @@ namespace Squid.WindowsTentacleE2ETests;
 ///
 /// <para><b>How the capture works</b>: the wrapper script defines
 /// <c>function global:Test-IsAdministrator { return $false }</c> (forcing the
-/// elevation branch) and <c>function global:Start-Process</c> (capturing
-/// <c>$ArgumentList</c> to a JSON file then returning a fake exit). It then
+/// elevation branch) and <c>function global:Invoke-UacRelaunch</c> (capturing
+/// <c>$ArgumentList</c> to a JSON file then returning 99). It then
 /// calls <c>install-tentacle.ps1</c> with <c>-InstallDir 'C:\Program Files\Squid Tentacle'</c>
 /// — the default — so <c>$needsElevation</c> evaluates to <c>$true</c> and the
 /// elevation branch fires.</para>
@@ -263,9 +264,9 @@ public sealed class TentacleUacElevationE2ETests
             // PowerShell wrapper that:
             //   1. Replaces Test-IsAdministrator with a stub returning $false
             //      (forcing the $needsElevation branch in install-tentacle.ps1)
-            //   2. Replaces Start-Process with a stub that captures $ArgumentList
-            //      (+ FilePath + Verb) to a JSON file and returns a fake proc with
-            //      ExitCode=99 (so we can confirm elevation actually fired)
+            //   2. Replaces Invoke-UacRelaunch (the overridable elevation seam) with
+            //      a stub that captures $ArgumentList (+ FilePath + Verb) to a JSON
+            //      file and returns 99 (so we can confirm elevation actually fired)
             //   3. Invokes install-tentacle.ps1 with -InstallDir set to the DEFAULT
             //      path ("C:\Program Files\Squid Tentacle") so $needsElevation is true.
             //
@@ -280,16 +281,16 @@ $ErrorActionPreference = 'Stop'
 function global:Test-IsAdministrator {{ return $false }}
 
 # Override 2: capture the elevation invocation instead of actually triggering UAC.
-# install-tentacle.ps1's Invoke-SelfElevation calls:
-#   Start-Process powershell.exe -Verb RunAs -ArgumentList $childArgs -Wait -PassThru
-function global:Start-Process {{
-    [CmdletBinding()]
+# install-tentacle.ps1's Invoke-SelfElevation calls the overridable seam:
+#   Invoke-UacRelaunch -FilePath powershell.exe -Verb RunAs -ArgumentList $childArgs
+# (Overriding this named function is reliable; overriding the built-in
+# Start-Process cmdlet is NOT -- the -Verb RunAs / ShellExecute path bypassed it,
+# so the real elevated process ran and the captured exit code came back 0.)
+function global:Invoke-UacRelaunch {{
     param(
-        [Parameter(Position = 0)] [string] $FilePath,
+        [string] $FilePath,
         [string] $Verb,
-        [object[]] $ArgumentList,
-        [switch] $Wait,
-        [switch] $PassThru
+        [string[]] $ArgumentList
     )
 
     $captured = @{{
@@ -299,18 +300,24 @@ function global:Start-Process {{
     }}
     $captured | ConvertTo-Json -Depth 5 | Out-File -FilePath '{ctx_CapturePathEscaped(CapturePath)}' -Encoding UTF8
 
-    # Return a fake process with ExitCode=99 so the wrapper test can confirm
-    # the elevation branch actually fired (not just no-op'd).
-    return [pscustomobject]@{{ ExitCode = 99 }}
+    # Return ExitCode 99 so the wrapper test can confirm the elevation branch
+    # actually fired (install-tentacle.ps1 does `exit $childExit`).
+    return 99
 }}
 
 # Drive install-tentacle.ps1 with -InstallDir pointed at the default path so
 # `$needsElevation` is $true. -DownloadBase is required but won't be used
-# because Start-Process is mocked + the script exits before download.
+# because Invoke-UacRelaunch is mocked + the script exits before download.
 & '{ctx_CapturePathEscaped(installScriptPath)}' `
     -Version '9.9.9-test' `
     -InstallDir 'C:\Program Files\Squid Tentacle' `
     -DownloadBase 'https://example.invalid/dl'
+
+# Propagate install-tentacle.ps1's exit code. `exit N` inside a script invoked
+# via the call operator (&) sets $LASTEXITCODE but does NOT set the wrapper
+# process's exit code -- without this the elevation exit (99) is lost and the
+# test reads 0. This (not mock interception) was why the assertion saw 0.
+exit $LASTEXITCODE
 ";
 
             File.WriteAllText(WrapperPath, script);


### PR DESCRIPTION
## Summary

Fix two pre-existing test-quality bugs that kept `TentacleInstallScriptE2E` red on the `windows-latest` (Administrator) runner — surfaced by the new Windows smoke gate (#407/#408), and red on every push to `main` before that.

- **UAC tests (3 `TentacleUacElevationE2ETests`)** — two compounding causes:
  1. `install-tentacle.ps1` defined its own script-local `Test-IsAdministrator`, which **shadowed** the test's parent-scope `function global:` mock → on an admin host the real check returned `$true` and elevation was skipped. Fix: guard the definition (`if (-not (Test-Path Function:\...))`) so an ambient mock wins.
  2. **Root cause of the exit-99 mismatch** (verified locally with PowerShell): the wrapper invokes the script via the call operator (`& script.ps1`), and **`exit N` inside a `&`-invoked script sets `$LASTEXITCODE` but not the wrapper process's exit code** — so the mocked elevation exit (99) was lost and the assertion read 0. The mock was working; this was never a mock-interception problem. Fix: the wrapper ends with `exit $LASTEXITCODE`.
  - Also factor the elevation launch into a guard-defined `Invoke-UacRelaunch` seam the test overrides, instead of mocking the built-in `Start-Process` cmdlet — a cleaner, less fragile seam.
- **install-info parallel race (`TentacleInstallScript*E2ETests`)** — the script writes `install-info.json` to the shared canonical `%ProgramData%\Squid\Tentacle\`, so install-script test classes running in parallel clobbered each other's file. Fix: redirect the child's `%ProgramData%` to a per-test temp dir via `ProcessStartInfo`, mirroring `TentacleUpgradeLifecycleE2ETests`.
- **Re-add `TentacleInstallScriptE2E` to the Windows smoke gate** (`tentacle-windows-smoke-e2e.yml`): both filter defaults + the detect job's path match.

Production change (`install-tentacle.ps1`) is non-breaking: normal installs have no ambient function override and behave identically. The versioned-layout drift detector is unaffected (it pins the extract/swap region, not the elevation path).

## Test plan

- [x] Root cause reproduced + fix verified locally on PowerShell (`exit $LASTEXITCODE` propagates the `&`-invoked script's exit)
- [x] `Category=TentacleInstallScriptE2E` dispatched on `windows-latest`: **15/15 green** (was 12/15, then 3 UAC failing)
- [x] C# compiles clean; brace balance + drift detector verified
- [ ] This PR's gate run exercises the full **6-category** default filter (69 tests) on `windows-latest` and goes green
- [ ] `tests.yml` (unit + Tentacle drift detector + integration) green