### PR TITLE
Emit deployment-lifecycle audit events

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleHandlerBase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/DeploymentLifecycleHandlerBase.cs
@@ -51,6 +51,7 @@ public abstract class DeploymentLifecycleHandlerBase : IDeploymentLifecycleHandl
         ManualInterventionResolvedEvent e => OnManualInterventionResolvedAsync(e.Context, ct),
         DeploymentCancelledEvent e => OnDeploymentCancelledAsync(e.Context, ct),
         DeploymentPausedEvent e => OnDeploymentPausedAsync(e.Context, ct),
+        DeploymentTimedOutEvent e => OnDeploymentTimedOutAsync(e.Context, ct),
         _ => Task.CompletedTask
     };
 
@@ -115,7 +116,8 @@ public abstract class DeploymentLifecycleHandlerBase : IDeploymentLifecycleHandl
     protected virtual Task OnManualInterventionPromptAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnManualInterventionResolvedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
 
-    // === Cancellation / Pause ===
+    // === Cancellation / Pause / Timeout ===
     protected virtual Task OnDeploymentCancelledAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
     protected virtual Task OnDeploymentPausedAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
+    protected virtual Task OnDeploymentTimedOutAsync(DeploymentEventContext ctx, CancellationToken ct) => Task.CompletedTask;
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentAuditEventHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentAuditEventHandler.cs
@@ -1,0 +1,61 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Events;
+using Squid.Message.Enums.Events;
+
+namespace Squid.Core.Services.DeploymentExecution.Lifecycle.Handlers;
+
+/// <summary>
+/// Records deployment-lifecycle audit events into the persisted Event stream — one of the
+/// two central, generic emission points for the audit history (the other being the EF
+/// SaveChanges document interceptor). It subscribes to the SAME lifecycle events the
+/// pipeline already emits, so there are NO scattered RecordAsync calls and no producer
+/// changes: each milestone maps to exactly one <see cref="EventCategory"/>.
+///
+/// <para>Audit writes run in a fresh DI scope so they persist independently of the
+/// deployment's own transaction (append-only audit semantics — a rolled-back step must
+/// not erase the fact that it ran). The lifecycle publisher already isolates handler
+/// exceptions, so an audit-write failure can never block or fail the deployment.</para>
+/// </summary>
+public sealed class DeploymentAuditEventHandler : DeploymentLifecycleHandlerBase
+{
+    // Runs after the activity logger (Order 0); audit is a terminal side-effect.
+    public override int Order => 1000;
+
+    private readonly ILifetimeScope _scope;
+
+    public DeploymentAuditEventHandler(ILifetimeScope scope) => _scope = scope;
+
+    protected override Task OnDeploymentStartingAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentStarted, ct);
+
+    protected override Task OnDeploymentResumingAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentResumed, ct);
+
+    protected override Task OnDeploymentSucceededAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentSucceeded, ct);
+
+    protected override Task OnDeploymentFailedAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentFailed, ct);
+
+    // A timeout is a failure outcome for audit purposes.
+    protected override Task OnDeploymentTimedOutAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentFailed, ct);
+
+    protected override Task OnDeploymentCancelledAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentCanceled, ct);
+
+    protected override Task OnManualInterventionPromptAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.ManualInterventionRaised, ct);
+
+    protected override Task OnManualInterventionResolvedAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.ManualInterventionSubmitted, ct);
+
+    protected override Task OnGuidedFailurePromptAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.GuidedFailureRaised, ct);
+
+    private async Task RecordAsync(EventCategory category, CancellationToken ct)
+    {
+        var request = DeploymentAuditEventFactory.Build(Ctx, category);
+
+        if (request == null) return;
+
+        await using var scope = _scope.BeginLifetimeScope();
+
+        var events = scope.Resolve<IEventService>();
+        var unitOfWork = scope.Resolve<IUnitOfWork>();
+
+        await events.RecordAsync(request, ct).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Squid.Core/Services/Events/DeploymentAuditEventFactory.cs
+++ b/src/Squid.Core/Services/Events/DeploymentAuditEventFactory.cs
@@ -1,0 +1,46 @@
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Message.Enums.Events;
+using Squid.Message.Models.Events;
+
+namespace Squid.Core.Services.Events;
+
+/// <summary>
+/// Pure projection from the deployment pipeline's shared <see cref="DeploymentTaskContext"/>
+/// to a <see cref="RecordEventRequest"/> for a given lifecycle <see cref="EventCategory"/>.
+/// Kept side-effect-free so the mapping (which document FKs + references an audit event
+/// carries) is unit-testable in isolation, with persistence handled separately by
+/// <c>DeploymentAuditEventHandler</c>.
+/// </summary>
+public static class DeploymentAuditEventFactory
+{
+    /// <summary>
+    /// Builds the audit request from the deployment context, or returns <c>null</c> when
+    /// the context has no resolved deployment yet (nothing meaningful to attribute the
+    /// event to — the caller skips recording).
+    /// </summary>
+    public static RecordEventRequest Build(DeploymentTaskContext ctx, EventCategory category)
+    {
+        var deployment = ctx?.Deployment;
+
+        if (deployment == null) return null;
+
+        return new RecordEventRequest
+        {
+            Category = category,
+            SpaceId = deployment.SpaceId,
+            ProjectId = deployment.ProjectId,
+            ReleaseId = deployment.ReleaseId,
+            EnvironmentId = deployment.EnvironmentId,
+            DeploymentId = deployment.Id,
+            ServerTaskId = ctx.ServerTaskId,
+            References = BuildReferences(ctx)
+        };
+    }
+
+    private static DeploymentEventReferences BuildReferences(DeploymentTaskContext ctx) => new()
+    {
+        Project = ctx.Project?.Name,
+        Release = ctx.Release?.Version,
+        Environment = ctx.Environment?.Name
+    };
+}

--- a/src/Squid.Core/Services/Events/IEventService.cs
+++ b/src/Squid.Core/Services/Events/IEventService.cs
@@ -17,8 +17,9 @@ public interface IEventService : IScopedDependency
     /// across handlers/services:
     /// <list type="bullet">
     ///   <item>the EF Core SaveChanges interceptor (document Created/Modified/Deleted), and</item>
-    ///   <item>the Mediator publish-pipe audit middleware that records any published
-    ///   domain event implementing the auditable marker (deployment lifecycle, etc.).</item>
+    ///   <item>the deployment lifecycle audit handler (one <c>IDeploymentLifecycleHandler</c>
+    ///   that subscribes to the pipeline's existing lifecycle events and maps each milestone
+    ///   to a category — no producer changes, no scattered calls).</item>
     /// </list>
     /// Keeping emission centralized is what makes the audit stream generic and
     /// maintainable; do not add ad-hoc RecordAsync calls in feature code.

--- a/src/Squid.Message/Models/Events/DeploymentEventReferences.cs
+++ b/src/Squid.Message/Models/Events/DeploymentEventReferences.cs
@@ -1,0 +1,15 @@
+namespace Squid.Message.Models.Events;
+
+/// <summary>
+/// Structured reference arguments for a deployment-lifecycle audit event, serialized
+/// to the Event's jsonb <c>references</c> column. Property names match the
+/// <c>{Placeholder}</c> tokens in the category message templates (e.g.
+/// "Deploy to {Environment} succeeded for {Release}") so the history UI can linkify
+/// and render without a pre-baked English string.
+/// </summary>
+public sealed record DeploymentEventReferences
+{
+    public string? Project { get; init; }
+    public string? Release { get; init; }
+    public string? Environment { get; init; }
+}

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/DeploymentHistoryE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/DeploymentHistoryE2ETests.cs
@@ -1,0 +1,118 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Events;
+using Squid.E2ETests.Helpers;
+using Squid.E2ETests.Infrastructure;
+using Squid.Message.Enums;
+using Squid.Message.Enums.Events;
+using Squid.Message.Requests.Events;
+using Shouldly;
+using Xunit;
+
+namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
+
+/// <summary>
+/// Full-pipeline E2E for the deployment-history audit stream. Drives the REAL
+/// <c>DeploymentPipelineRunner</c> end-to-end (real DI graph, real lifecycle publisher,
+/// real Postgres, real DbUp-migrated event table) through the in-process
+/// <c>CapturingExecutionStrategy</c> — so NO Kind cluster is needed and the test is
+/// deterministic. It proves the audit handler fires from inside <c>ProcessAsync</c> and
+/// the persisted Event feed reflects the lifecycle in newest-first order. Deliberately
+/// NOT in the "KindCluster" collection (no kubectl), so it cannot flake on cluster infra.
+/// </summary>
+[Trait("Category", "E2E")]
+public class DeploymentHistoryE2ETests : IClassFixture<DeploymentPipelineFixture<DeploymentHistoryE2ETests>>
+{
+    private const int SeededSpaceId = 1;   // K8sTestDataSeeder seeds everything in space 1
+
+    private readonly DeploymentPipelineFixture<DeploymentHistoryE2ETests> _fixture;
+
+    public DeploymentHistoryE2ETests(DeploymentPipelineFixture<DeploymentHistoryE2ETests> fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task SuccessfulPipeline_RecordsStartedThenSucceeded_InTheEventFeed()
+    {
+        _fixture.ExecutionCapture.Clear();
+
+        var serverTaskId = await SeedAsync();
+
+        await _fixture.Run<IDeploymentTaskExecutor>(executor => executor.ProcessAsync(serverTaskId, CancellationToken.None)).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(TaskState.Success);
+
+        await _fixture.Run<IEventService>(async events =>
+        {
+            var feed = await events.GetEventsAsync(new GetEventsRequest { SpaceId = SeededSpaceId });
+            var categories = feed.Events.Select(e => e.Category).ToList();
+
+            categories.Contains((int)EventCategory.DeploymentStarted).ShouldBeTrue("the pipeline must record that the deployment started");
+            categories.Contains((int)EventCategory.DeploymentSucceeded).ShouldBeTrue("and that it succeeded");
+            feed.Events[0].Category.ShouldBe((int)EventCategory.DeploymentSucceeded, "the terminal success is the newest event");
+
+            var succeeded = feed.Events.First(e => e.Category == (int)EventCategory.DeploymentSucceeded);
+            succeeded.ReleaseId.ShouldNotBeNull("the audit event links back to its release");
+            succeeded.DeploymentId.ShouldNotBeNull();
+            // references carry the seeded release version (1.0.0) for the history UI to render
+            succeeded.ReferencesJson.ShouldContain("1.0.0");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task FailedPipeline_RecordsDeploymentFailed_InTheEventFeed()
+    {
+        _fixture.ExecutionCapture.Clear();
+        _fixture.ExecutionCapture.ResultFactory = _ => new ScriptExecutionResult { Success = false, ExitCode = 1, LogLines = { "simulated step failure" } };
+
+        var serverTaskId = await SeedAsync();
+
+        // A hard step failure rethrows out of ProcessAsync — but only AFTER the runner has
+        // emitted DeploymentFailedEvent and recorded the terminal Failed state. The audit
+        // assertion below is the point: the failure is durably recorded despite the rethrow.
+        try
+        {
+            await _fixture.Run<IDeploymentTaskExecutor>(executor => executor.ProcessAsync(serverTaskId, CancellationToken.None)).ConfigureAwait(false);
+        }
+        catch (DeploymentScriptException)
+        {
+        }
+
+        await AssertTaskStateAsync(TaskState.Failed);
+
+        await _fixture.Run<IEventService>(async events =>
+        {
+            var feed = await events.GetEventsAsync(new GetEventsRequest { SpaceId = SeededSpaceId });
+
+            feed.Events.Select(e => e.Category).Contains((int)EventCategory.DeploymentFailed).ShouldBeTrue("a failed step must surface a DeploymentFailed audit event");
+        }).ConfigureAwait(false);
+    }
+
+    private async Task<int> SeedAsync()
+    {
+        var serverTaskId = 0;
+
+        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var seeder = new K8sTestDataSeeder(repository, unitOfWork);
+            await seeder.SeedAsync(createFeedSecrets: false).ConfigureAwait(false);
+            serverTaskId = seeder.ServerTaskId;
+        }).ConfigureAwait(false);
+
+        return serverTaskId;
+    }
+
+    private async Task AssertTaskStateAsync(string expected)
+    {
+        await _fixture.Run<IServerTaskDataProvider>(async taskDataProvider =>
+        {
+            var tasks = await taskDataProvider.GetAllServerTasksAsync(CancellationToken.None).ConfigureAwait(false);
+
+            tasks.ShouldContain(t => t.State == expected, $"the seeded deployment should reach {expected}");
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.IntegrationTests/Services/Events/DeploymentAuditEventHandlerTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/DeploymentAuditEventHandlerTests.cs
@@ -1,0 +1,192 @@
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.DeploymentExecution.Lifecycle.Handlers;
+using Squid.Core.Services.Events;
+using Squid.Message.Enums.Events;
+using Squid.Message.Requests.Events;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.IntegrationTests.Services.Events;
+
+/// <summary>
+/// Drives the real <see cref="DeploymentAuditEventHandler"/> against a real database via
+/// its real fresh-scope persistence path (ILifetimeScope → IEventService → IUnitOfWork),
+/// then reads the persisted audit row back through <see cref="IEventService"/>. Proves the
+/// lifecycle seam records the right category + document references + provenance, and that a
+/// pre-deployment-data event is skipped rather than persisted as an orphan.
+/// </summary>
+public class DeploymentAuditEventHandlerTests : TestBase
+{
+    public DeploymentAuditEventHandlerTests()
+        : base("Events", "squid_it_audit_handler")
+    {
+    }
+
+    private static DeploymentTaskContext Context(int spaceId, int deploymentId, int releaseId) => new()
+    {
+        ServerTaskId = deploymentId * 10,
+        Deployment = new Deployment { Id = deploymentId, SpaceId = spaceId, ProjectId = 3, ReleaseId = releaseId, EnvironmentId = 4 },
+        Project = new Project { Id = 3, Name = "Checkout" },
+        Release = new Release { Id = releaseId, Version = "6.6.2" },
+        Environment = new Environment { Id = 4, Name = "Production" }
+    };
+
+    private async Task EmitAsync(DeploymentTaskContext ctx, DeploymentLifecycleEvent @event)
+    {
+        await Run<ILifetimeScope>(async scope =>
+        {
+            var handler = new DeploymentAuditEventHandler(scope);
+            handler.Initialize(ctx);
+
+            await handler.HandleAsync(@event, CancellationToken.None);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SucceededEvent_PersistsDeploymentSucceeded_WithDocumentRefsAndProvenance()
+    {
+        const int spaceId = 700;
+        const int deploymentId = 71;
+        const int releaseId = 7001;
+
+        await EmitAsync(Context(spaceId, deploymentId, releaseId), new DeploymentSucceededEvent(new DeploymentEventContext()));
+
+        await Run<IEventService>(async events =>
+        {
+            var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId });
+
+            page.Events.Count.ShouldBe(1);
+
+            var dto = page.Events[0];
+            dto.Category.ShouldBe((int)EventCategory.DeploymentSucceeded);
+            dto.DeploymentId.ShouldBe(deploymentId);
+            dto.ReleaseId.ShouldBe(releaseId);
+            dto.ProjectId.ShouldBe(3);
+            dto.EnvironmentId.ShouldBe(4);
+            dto.ServerTaskId.ShouldBe(deploymentId * 10);
+            dto.ReferencesJson.ShouldContain("6.6.2");
+            dto.ReferencesJson.ShouldContain("Production");
+            dto.Username.ShouldBe("system");                                       // background pipeline => system actor
+            dto.EstablishedWith.ShouldBe((int)EventIdentityEstablishedWith.Server);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task FullLifecycle_EmitsOrderedAuditTrail_NewestFirst()
+    {
+        const int spaceId = 710;
+        const int deploymentId = 72;
+        var ctx = Context(spaceId, deploymentId, 7201);
+
+        await EmitAsync(ctx, new DeploymentStartingEvent(new DeploymentEventContext()));
+        await EmitAsync(ctx, new ManualInterventionPromptEvent(new DeploymentEventContext()));
+        await EmitAsync(ctx, new ManualInterventionResolvedEvent(new DeploymentEventContext()));
+        await EmitAsync(ctx, new DeploymentSucceededEvent(new DeploymentEventContext()));
+
+        await Run<IEventService>(async events =>
+        {
+            var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId });
+
+            page.Events.Select(e => e.Category).ShouldBe(new[]
+            {
+                (int)EventCategory.DeploymentSucceeded,
+                (int)EventCategory.ManualInterventionSubmitted,
+                (int)EventCategory.ManualInterventionRaised,
+                (int)EventCategory.DeploymentStarted
+            }, "the audit feed is newest-first and covers the full lifecycle");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task FailedEvent_PersistsDeploymentFailed()
+    {
+        const int spaceId = 720;
+        const int deploymentId = 73;
+
+        await EmitAsync(Context(spaceId, deploymentId, 7301), new DeploymentFailedEvent(new DeploymentEventContext { Exception = new InvalidOperationException("boom") }));
+
+        await Run<IEventService>(async events =>
+        {
+            var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId });
+
+            page.Events.Single().Category.ShouldBe((int)EventCategory.DeploymentFailed);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task TimedOutEvent_IsAuditedAsFailure()
+    {
+        const int spaceId = 730;
+        const int deploymentId = 74;
+
+        await EmitAsync(Context(spaceId, deploymentId, 7401), new DeploymentTimedOutEvent(new DeploymentEventContext()));
+
+        await Run<IEventService>(async events =>
+        {
+            var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId });
+
+            page.Events.Single().Category.ShouldBe((int)EventCategory.DeploymentFailed, "a timeout is a failure outcome for audit purposes");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task RecordedEvent_IsVisibleUnderEveryRelatedDocumentFeed()
+    {
+        const int spaceId = 740;
+        const int deploymentId = 75;
+        const int releaseId = 7501;
+
+        await EmitAsync(Context(spaceId, deploymentId, releaseId), new DeploymentSucceededEvent(new DeploymentEventContext()));
+
+        await Run<IEventService>(async events =>
+        {
+            (await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, ReleaseId = releaseId })).Events.Count.ShouldBe(1, "release feed");
+            (await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, ProjectId = 3 })).Events.Count.ShouldBe(1, "project feed");
+            (await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, EnvironmentId = 4 })).Events.Count.ShouldBe(1, "environment feed");
+            (await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId })).Events.Count.ShouldBe(1, "deployment feed");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task RealLifecyclePublisher_DispatchesEmittedEvent_ToTheAutoRegisteredAuditHandler()
+    {
+        // The strongest seam proof short of the full pipeline: resolve the REAL
+        // IDeploymentLifecycle publisher (which injects every auto-discovered
+        // IDeploymentLifecycleHandler). If the audit handler is correctly registered via
+        // IScopedDependency, emitting an event through the publisher persists an audit row —
+        // with NO explicit wiring. This is exactly how the deployment pipeline emits.
+        const int spaceId = 760;
+        const int deploymentId = 76;
+        var ctx = Context(spaceId, deploymentId, 7601);
+
+        await Run<IDeploymentLifecycle>(async lifecycle =>
+        {
+            lifecycle.Initialize(ctx);
+
+            await lifecycle.EmitAsync(new DeploymentSucceededEvent(new DeploymentEventContext()), CancellationToken.None);
+        }).ConfigureAwait(false);
+
+        await Run<IEventService>(async events =>
+        {
+            var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId });
+
+            page.Events.Single().Category.ShouldBe((int)EventCategory.DeploymentSucceeded, "the auto-registered audit handler must fire through the real publisher");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task NoDeploymentResolvedYet_RecordsNothing_AndDoesNotThrow()
+    {
+        const int spaceId = 750;
+
+        // A lifecycle event firing before LoadDeploymentDataPhase has no deployment to
+        // attribute to. The handler must no-op (no orphan row, no exception).
+        await EmitAsync(new DeploymentTaskContext { ServerTaskId = 999 }, new DeploymentSucceededEvent(new DeploymentEventContext()));
+
+        await Run<IEventService>(async events =>
+        {
+            (await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId })).Events.ShouldBeEmpty();
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.UnitTests/Events/DeploymentAuditEventFactoryTests.cs
+++ b/tests/Squid.UnitTests/Events/DeploymentAuditEventFactoryTests.cs
@@ -1,0 +1,91 @@
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.Events;
+using Squid.Message.Enums.Events;
+using Squid.Message.Models.Events;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.UnitTests.Events;
+
+public class DeploymentAuditEventFactoryTests
+{
+    private static DeploymentTaskContext FullContext() => new()
+    {
+        ServerTaskId = 555,
+        Deployment = new Deployment { Id = 42, SpaceId = 7, ProjectId = 3, ReleaseId = 9, EnvironmentId = 4 },
+        Project = new Project { Id = 3, Name = "Checkout" },
+        Release = new Release { Id = 9, Version = "6.6.2" },
+        Environment = new Environment { Id = 4, Name = "Production" }
+    };
+
+    [Fact]
+    public void Build_ProjectsEveryDocumentReferenceFromTheDeployment()
+    {
+        var request = DeploymentAuditEventFactory.Build(FullContext(), EventCategory.DeploymentSucceeded);
+
+        request.ShouldNotBeNull();
+        request.Category.ShouldBe(EventCategory.DeploymentSucceeded);
+        request.SpaceId.ShouldBe(7);
+        request.ProjectId.ShouldBe(3);
+        request.ReleaseId.ShouldBe(9);
+        request.EnvironmentId.ShouldBe(4);
+        request.DeploymentId.ShouldBe(42);
+        request.ServerTaskId.ShouldBe(555);
+        request.MachineId.ShouldBeNull("a deployment-level event is not scoped to one machine");
+    }
+
+    [Fact]
+    public void Build_PopulatesReferencesWithDisplayNames_MatchingTemplateTokens()
+    {
+        var request = DeploymentAuditEventFactory.Build(FullContext(), EventCategory.DeploymentStarted);
+
+        var references = request.References.ShouldBeOfType<DeploymentEventReferences>();
+        references.Project.ShouldBe("Checkout");
+        references.Release.ShouldBe("6.6.2");
+        references.Environment.ShouldBe("Production");
+    }
+
+    [Theory]
+    [InlineData(EventCategory.DeploymentStarted)]
+    [InlineData(EventCategory.DeploymentResumed)]
+    [InlineData(EventCategory.DeploymentSucceeded)]
+    [InlineData(EventCategory.DeploymentFailed)]
+    [InlineData(EventCategory.DeploymentCanceled)]
+    [InlineData(EventCategory.ManualInterventionRaised)]
+    [InlineData(EventCategory.ManualInterventionSubmitted)]
+    [InlineData(EventCategory.GuidedFailureRaised)]
+    public void Build_CarriesTheRequestedCategoryVerbatim(EventCategory category)
+    {
+        DeploymentAuditEventFactory.Build(FullContext(), category).Category.ShouldBe(category);
+    }
+
+    [Fact]
+    public void Build_NoDeploymentResolvedYet_ReturnsNullSoTheHandlerSkips()
+    {
+        // Lifecycle events can fire before LoadDeploymentDataPhase populates ctx.Deployment.
+        // There is nothing to attribute the event to, so the factory returns null (the
+        // handler must skip recording rather than throw or persist an orphan).
+        DeploymentAuditEventFactory.Build(new DeploymentTaskContext { ServerTaskId = 1 }, EventCategory.DeploymentFailed).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Build_NullContext_ReturnsNull()
+    {
+        DeploymentAuditEventFactory.Build(null, EventCategory.DeploymentFailed).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Build_MissingDisplayNames_LeavesReferenceFieldsNullButStillRecords()
+    {
+        var ctx = new DeploymentTaskContext { ServerTaskId = 1, Deployment = new Deployment { Id = 1, SpaceId = 2, ProjectId = 3, ReleaseId = 4, EnvironmentId = 5 } };
+
+        var request = DeploymentAuditEventFactory.Build(ctx, EventCategory.DeploymentStarted);
+
+        request.ShouldNotBeNull();
+        request.SpaceId.ShouldBe(2);
+        var references = request.References.ShouldBeOfType<DeploymentEventReferences>();
+        references.Project.ShouldBeNull();
+        references.Release.ShouldBeNull();
+        references.Environment.ShouldBeNull();
+    }
+}

--- a/tests/Squid.UnitTests/Events/DeploymentLifecycleDispatchTests.cs
+++ b/tests/Squid.UnitTests/Events/DeploymentLifecycleDispatchTests.cs
@@ -1,0 +1,56 @@
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+
+namespace Squid.UnitTests.Events;
+
+public class DeploymentLifecycleDispatchTests
+{
+    private sealed class RecordingHandler : DeploymentLifecycleHandlerBase
+    {
+        public string Routed { get; private set; }
+
+        protected override Task OnDeploymentTimedOutAsync(DeploymentEventContext ctx, CancellationToken ct) => Route(nameof(OnDeploymentTimedOutAsync));
+        protected override Task OnDeploymentSucceededAsync(DeploymentEventContext ctx, CancellationToken ct) => Route(nameof(OnDeploymentSucceededAsync));
+        protected override Task OnManualInterventionResolvedAsync(DeploymentEventContext ctx, CancellationToken ct) => Route(nameof(OnManualInterventionResolvedAsync));
+
+        private Task Route(string method)
+        {
+            Routed = method;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Dispatch_TimedOutEvent_RoutesToTimedOutHook()
+    {
+        // Regression: DeploymentTimedOutEvent IS emitted by the pipeline runner but was
+        // previously dropped by the base switch (fell through to the default no-op), so a
+        // timed-out deployment was never audited. This pins the dispatch case that fixes it.
+        var handler = new RecordingHandler();
+
+        await handler.HandleAsync(new DeploymentTimedOutEvent(new DeploymentEventContext()), CancellationToken.None);
+
+        handler.Routed.ShouldBe("OnDeploymentTimedOutAsync");
+    }
+
+    [Fact]
+    public async Task Dispatch_SucceededEvent_RoutesToSucceededHook()
+    {
+        var handler = new RecordingHandler();
+
+        await handler.HandleAsync(new DeploymentSucceededEvent(new DeploymentEventContext()), CancellationToken.None);
+
+        handler.Routed.ShouldBe("OnDeploymentSucceededAsync");
+    }
+
+    [Fact]
+    public async Task Dispatch_UnhandledEvent_IsSilentNoOp()
+    {
+        // A handler that does not override a hook must silently ignore the event,
+        // never throw — the publisher relies on this to fan one event to many handlers.
+        var handler = new RecordingHandler();
+
+        await handler.HandleAsync(new StepStartingEvent(new DeploymentEventContext()), CancellationToken.None);
+
+        handler.Routed.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Record the deployment lifecycle into the persisted Event audit stream: started, resumed, manual-intervention raised/submitted, guided-failure raised, succeeded, failed, timed-out, canceled.
- Emission is generic and centralized — a single auto-discovered `IDeploymentLifecycleHandler` (`DeploymentAuditEventHandler`) subscribes to the lifecycle events the pipeline *already* emits and maps each milestone to one `EventCategory`. No scattered `RecordAsync` calls; no producer changes.
- Audit writes run in a fresh DI scope (`ILifetimeScope.BeginLifetimeScope`) so they persist independently of the deployment transaction. The lifecycle publisher already isolates handler exceptions, so an audit-write failure can never fail a deployment.
- Pure `DeploymentAuditEventFactory` projects the shared `DeploymentTaskContext` → `RecordEventRequest` (document FKs + display-name references), kept side-effect-free for unit testing.
- Dispatch the previously-dropped `DeploymentTimedOutEvent` in the lifecycle base (additive no-op hook) so timed-out deployments are audited as failures.

Purely additive — no existing signature or behavior changed. Builds on the Event foundation from #411.

## Test plan

- [x] Unit (16): `DeploymentAuditEventFactory` projection across all categories + null-context/no-deployment guards; lifecycle base dispatch including the new timeout hook.
- [x] Integration (real Postgres, 7): handler → DB via the real fresh-scope path; full ordered lifecycle trail; failed/timed-out → DeploymentFailed; cross-document feed visibility; pre-deployment-data no-op; **real `IDeploymentLifecycle` publisher dispatches to the auto-registered handler**.
- [x] E2E (full `ProcessAsync`, no Kind, 2): successful pipeline records Started→Succeeded with references; failed pipeline records DeploymentFailed.
- [x] Regression: full solution build clean; 268 lifecycle/activity-logger/events/pipeline unit tests green; verified in isolation (PR builds + passes on clean main).