### PR TITLE
Emit document-audit events on SaveChanges

### DIFF
--- a/src/Squid.Core/Persistence/SquidDbContext.Audit.cs
+++ b/src/Squid.Core/Persistence/SquidDbContext.Audit.cs
@@ -1,0 +1,100 @@
+using Squid.Core.Persistence.Entities.Events;
+using Squid.Core.Services.Events;
+using Squid.Message.Enums.Events;
+using Squid.Message.Models.Events;
+
+namespace Squid.Core.Persistence;
+
+/// <summary>
+/// Generic document-audit emission — the second of the two central, generic emission points
+/// for the Event history (the other being the deployment lifecycle handler). Any persisted
+/// entity registered in <see cref="IAuditDocumentRegistry"/> produces a
+/// DocumentCreated/Modified/Deleted event on save, with no per-entity or per-handler code.
+///
+/// <para>Changes are captured before the real save and the audit rows are written in a
+/// second save afterwards (so server-generated ids on inserts are populated). The audit
+/// write is best-effort: a failure is logged and swallowed so it can never roll back or
+/// fail the originating document change. Provenance comes from the same ICurrentUser the
+/// context already uses, so a portal/API edit is attributed to the editing user.</para>
+/// </summary>
+public partial class SquidDbContext
+{
+    private List<(object Entity, EventCategory Category)> CaptureDocumentAudits()
+    {
+        var captures = new List<(object, EventCategory)>();
+
+        if (_auditDocuments == null) return captures;
+
+        foreach (var entry in ChangeTracker.Entries())
+        {
+            var category = ToDocumentCategory(entry.State);
+
+            if (category == null) continue;
+            if (!_auditDocuments.TryDescribe(entry.Entity, out _, out _)) continue;
+
+            captures.Add((entry.Entity, category.Value));
+        }
+
+        return captures;
+    }
+
+    private async Task EmitDocumentAuditsAsync(List<(object Entity, EventCategory Category)> captures, CancellationToken ct)
+    {
+        if (captures.Count == 0) return;
+
+        var events = BuildAuditEvents(captures);
+
+        if (events.Count == 0) return;
+
+        try
+        {
+            await Set<Event>().AddRangeAsync(events, ct).ConfigureAwait(false);
+            await base.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            DetachAll(events);
+            Log.Warning(ex, "[Audit] Failed to persist {Count} document audit event(s); the originating change was already committed", events.Count);
+        }
+    }
+
+    private List<Event> BuildAuditEvents(List<(object Entity, EventCategory Category)> captures)
+    {
+        var events = new List<Event>(captures.Count);
+
+        foreach (var (entity, category) in captures)
+        {
+            // Re-describe AFTER the save so insert-generated ids are populated on the entity.
+            if (!_auditDocuments.TryDescribe(entity, out var documentType, out var keys)) continue;
+
+            events.Add(EventFactory.Build(BuildRequest(category, documentType, keys), _currentUser));
+        }
+
+        return events;
+    }
+
+    private static RecordEventRequest BuildRequest(EventCategory category, string documentType, AuditDocumentKeys keys) => new()
+    {
+        Category = category,
+        SpaceId = keys.SpaceId,
+        ProjectId = keys.ProjectId,
+        ReleaseId = keys.ReleaseId,
+        EnvironmentId = keys.EnvironmentId,
+        MachineId = keys.MachineId,
+        References = new DocumentEventReferences { DocumentType = documentType, Name = keys.Name }
+    };
+
+    private void DetachAll(IEnumerable<Event> events)
+    {
+        foreach (var @event in events)
+            Entry(@event).State = EntityState.Detached;
+    }
+
+    private static EventCategory? ToDocumentCategory(EntityState state) => state switch
+    {
+        EntityState.Added => EventCategory.DocumentCreated,
+        EntityState.Modified => EventCategory.DocumentModified,
+        EntityState.Deleted => EventCategory.DocumentDeleted,
+        _ => null
+    };
+}

--- a/src/Squid.Core/Persistence/SquidDbContext.cs
+++ b/src/Squid.Core/Persistence/SquidDbContext.cs
@@ -1,18 +1,21 @@
 using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities;
 using Squid.Core.Persistence.EntityConfigurations;
+using Squid.Core.Services.Events;
 using Squid.Core.Services.Identity;
 using Squid.Message.Constants;
 
 namespace Squid.Core.Persistence;
 
-public class SquidDbContext : DbContext, IUnitOfWork
+public partial class SquidDbContext : DbContext, IUnitOfWork
 {
     private readonly ICurrentUser _currentUser;
+    private readonly IAuditDocumentRegistry _auditDocuments;
 
-    public SquidDbContext(DbContextOptions<SquidDbContext> options, ICurrentUser currentUser = null) : base(options)
+    public SquidDbContext(DbContextOptions<SquidDbContext> options, ICurrentUser currentUser = null, IAuditDocumentRegistry auditDocuments = null) : base(options)
     {
         _currentUser = currentUser;
+        _auditDocuments = auditDocuments;
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -27,7 +30,13 @@ public class SquidDbContext : DbContext, IUnitOfWork
         ChangeTracker.DetectChanges();
         ApplyAuditFields();
 
-        return await base.SaveChangesAsync(cancellationToken);
+        var documentAudits = CaptureDocumentAudits();
+
+        var result = await base.SaveChangesAsync(cancellationToken);
+
+        await EmitDocumentAuditsAsync(documentAudits, cancellationToken);
+
+        return result;
     }
 
     private void ApplyAuditFields()

--- a/src/Squid.Core/Services/Events/AuditDocumentKeys.cs
+++ b/src/Squid.Core/Services/Events/AuditDocumentKeys.cs
@@ -1,0 +1,19 @@
+namespace Squid.Core.Services.Events;
+
+/// <summary>
+/// The audit identity of a persisted document: which space it lives in, which first-class
+/// Event FK columns it populates (so the event appears under the right document feeds),
+/// and a human display name for the references blob. Produced by
+/// <see cref="IAuditDocumentRegistry"/> per document type.
+/// </summary>
+public sealed record AuditDocumentKeys
+{
+    public required int SpaceId { get; init; }
+
+    public int? ProjectId { get; init; }
+    public int? ReleaseId { get; init; }
+    public int? EnvironmentId { get; init; }
+    public int? MachineId { get; init; }
+
+    public string Name { get; init; }
+}

--- a/src/Squid.Core/Services/Events/EventFactory.cs
+++ b/src/Squid.Core/Services/Events/EventFactory.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Entities.Events;
+using Squid.Core.Services.Identity;
+using Squid.Message.Enums.Events;
+using Squid.Message.Models.Events;
+
+namespace Squid.Core.Services.Events;
+
+/// <summary>
+/// Builds an <see cref="Event"/> row from a <see cref="RecordEventRequest"/>, resolving
+/// provenance from the ambient <see cref="ICurrentUser"/>. Shared by the two central
+/// emission points — <c>EventService.RecordAsync</c> and the SaveChanges document-audit
+/// path in <c>SquidDbContext</c> — so provenance + reference serialization stay identical
+/// and in one place. Pure and stateless.
+/// </summary>
+public static class EventFactory
+{
+    public static Event Build(RecordEventRequest request, ICurrentUser currentUser) => new()
+    {
+        Category = request.Category,
+        ReferencesJson = Serialize(request.References),
+        SpaceId = request.SpaceId,
+        ProjectId = request.ProjectId,
+        ReleaseId = request.ReleaseId,
+        DeploymentId = request.DeploymentId,
+        EnvironmentId = request.EnvironmentId,
+        MachineId = request.MachineId,
+        ServerTaskId = request.ServerTaskId,
+        UserId = ResolveUserId(currentUser),
+        Username = ResolveUsername(currentUser),
+        // established-with + user-agent need the HTTP auth scheme / request headers;
+        // PR-4 (provenance polish) resolves those via a dedicated resolver. A real
+        // portal/API actor is still attributed via ICurrentUser (ResolveUserId/Name).
+        EstablishedWith = currentUser is { IsInternal: false } ? EventIdentityEstablishedWith.SessionCookie : EventIdentityEstablishedWith.Server,
+        UserAgent = null,
+        Occurred = DateTimeOffset.UtcNow
+    };
+
+    public static string Serialize(object references) => references is null ? "{}" : JsonSerializer.Serialize(references);
+
+    private static int? ResolveUserId(ICurrentUser currentUser) => currentUser is { IsInternal: false } ? currentUser.Id : null;
+
+    private static string ResolveUsername(ICurrentUser currentUser) =>
+        currentUser is null || currentUser.IsInternal || string.IsNullOrWhiteSpace(currentUser.Name) ? "system" : currentUser.Name;
+}

--- a/src/Squid.Core/Services/Events/EventService.cs
+++ b/src/Squid.Core/Services/Events/EventService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities.Events;
 using Squid.Core.Services.Identity;
@@ -27,7 +26,7 @@ public class EventService : IEventService
         // Document snapshots (the EventDocumentSnapshot side table) are written by
         // the document-audit path in a later step, where the saved event id is
         // available to link them. PR-1 records the event itself.
-        await _repository.InsertAsync(BuildEvent(request), cancellationToken).ConfigureAwait(false);
+        await _repository.InsertAsync(EventFactory.Build(request, _currentUser), cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<GetEventsResponseData> GetEventsAsync(GetEventsRequest request, CancellationToken cancellationToken = default)
@@ -44,27 +43,6 @@ public class EventService : IEventService
 
         return BuildPage(rows, take);
     }
-
-    private Event BuildEvent(RecordEventRequest request) => new()
-    {
-        Category = request.Category,
-        ReferencesJson = Serialize(request.References),
-        SpaceId = request.SpaceId,
-        ProjectId = request.ProjectId,
-        ReleaseId = request.ReleaseId,
-        DeploymentId = request.DeploymentId,
-        EnvironmentId = request.EnvironmentId,
-        MachineId = request.MachineId,
-        ServerTaskId = request.ServerTaskId,
-        UserId = ResolveUserId(),
-        Username = ResolveUsername(),
-        // established-with + user-agent need the HTTP auth scheme / request headers;
-        // PR-4 (provenance polish) resolves those via a dedicated resolver. A real
-        // portal/API actor is still attributed via ICurrentUser (ResolveUserId/Name).
-        EstablishedWith = _currentUser.IsInternal ? EventIdentityEstablishedWith.Server : EventIdentityEstablishedWith.SessionCookie,
-        UserAgent = null,
-        Occurred = DateTimeOffset.UtcNow
-    };
 
     private IQueryable<Event> BuildFilteredQuery(GetEventsRequest request)
     {
@@ -119,14 +97,6 @@ public class EventService : IEventService
             Occurred = e.Occurred
         };
     }
-
-    private static string Serialize(object? references) =>
-        references is null ? "{}" : JsonSerializer.Serialize(references);
-
-    private int? ResolveUserId() => _currentUser.IsInternal ? null : _currentUser.Id;
-
-    private string ResolveUsername() =>
-        _currentUser.IsInternal || string.IsNullOrWhiteSpace(_currentUser.Name) ? "system" : _currentUser.Name;
 
     private static string DescribeEstablishedWith(EventIdentityEstablishedWith value) => value switch
     {

--- a/src/Squid.Core/Services/Events/IAuditDocumentRegistry.cs
+++ b/src/Squid.Core/Services/Events/IAuditDocumentRegistry.cs
@@ -1,0 +1,60 @@
+using Squid.Core.Persistence.Entities.Deployments;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.Core.Services.Events;
+
+/// <summary>
+/// Single source of truth for which persisted entities are user-facing "documents" worth
+/// auditing, and how to derive each one's audit identity (space + feed FKs + display name).
+///
+/// <para>Decoupled from the entities themselves (matching Squid's external-contributor
+/// philosophy — entities carry no audit concern). The SaveChanges document-audit path in
+/// <c>SquidDbContext</c> consults this registry: an entity type that is NOT registered is
+/// simply not audited. Adding a new audited document = one entry here; no other change.</para>
+/// </summary>
+public interface IAuditDocumentRegistry : ISingletonDependency
+{
+    /// <summary>
+    /// True when <paramref name="entity"/> is an audited document type, yielding its
+    /// display type name and audit keys; false otherwise (the entity is skipped).
+    /// </summary>
+    bool TryDescribe(object entity, out string documentType, out AuditDocumentKeys keys);
+}
+
+public sealed class AuditDocumentRegistry : IAuditDocumentRegistry
+{
+    private sealed record Mapping(string DocumentType, Func<object, AuditDocumentKeys> Extract);
+
+    // One glanceable table of every audited document. The extractor maps the entity to the
+    // first-class Event FK columns so the event surfaces under that document's feed
+    // (a Release event under both the release AND its project, etc.).
+    private static readonly Dictionary<Type, Mapping> Mappings = new()
+    {
+        [typeof(Project)] = new("Project", e => { var p = (Project)e; return new AuditDocumentKeys { SpaceId = p.SpaceId, ProjectId = p.Id, Name = p.Name }; }),
+        [typeof(Release)] = new("Release", e => { var r = (Release)e; return new AuditDocumentKeys { SpaceId = r.SpaceId, ProjectId = r.ProjectId, ReleaseId = r.Id, Name = r.Version }; }),
+        [typeof(Environment)] = new("Environment", e => { var x = (Environment)e; return new AuditDocumentKeys { SpaceId = x.SpaceId, EnvironmentId = x.Id, Name = x.Name }; }),
+        [typeof(Machine)] = new("Machine", e => { var m = (Machine)e; return new AuditDocumentKeys { SpaceId = m.SpaceId, MachineId = m.Id, Name = m.Name }; }),
+        [typeof(DeploymentAccount)] = new("DeploymentAccount", e => { var a = (DeploymentAccount)e; return new AuditDocumentKeys { SpaceId = a.SpaceId, Name = a.Name }; }),
+        [typeof(Channel)] = new("Channel", e => { var c = (Channel)e; return new AuditDocumentKeys { SpaceId = c.SpaceId, ProjectId = c.ProjectId, Name = c.Name }; }),
+        [typeof(VariableSet)] = new("VariableSet", e => { var v = (VariableSet)e; return new AuditDocumentKeys { SpaceId = v.SpaceId, Name = v.Name }; }),
+        [typeof(ProjectGroup)] = new("ProjectGroup", e => { var g = (ProjectGroup)e; return new AuditDocumentKeys { SpaceId = g.SpaceId, Name = g.Name }; }),
+        [typeof(ExternalFeed)] = new("ExternalFeed", e => { var f = (ExternalFeed)e; return new AuditDocumentKeys { SpaceId = f.SpaceId, Name = f.Name }; }),
+        [typeof(Certificate)] = new("Certificate", e => { var c = (Certificate)e; return new AuditDocumentKeys { SpaceId = c.SpaceId, Name = c.Name }; })
+    };
+
+    public bool TryDescribe(object entity, out string documentType, out AuditDocumentKeys keys)
+    {
+        documentType = null;
+        keys = null;
+
+        if (entity is null || !Mappings.TryGetValue(entity.GetType(), out var mapping)) return false;
+
+        documentType = mapping.DocumentType;
+        keys = mapping.Extract(entity);
+
+        return true;
+    }
+
+    /// <summary>The registered document type names — exposed for drift/coverage tests.</summary>
+    public static IReadOnlyCollection<string> RegisteredDocumentTypes => Mappings.Values.Select(m => m.DocumentType).ToList();
+}

--- a/src/Squid.Core/SquidModule.cs
+++ b/src/Squid.Core/SquidModule.cs
@@ -2,6 +2,7 @@ using Squid.Core.Caching;
 using Squid.Core.Halibut;
 using Squid.Core.Persistence.Db;
 using Squid.Core.Services.DataSeeding;
+using Squid.Core.Services.Events;
 using Squid.Core.Services.Identity;
 
 using Squid.Core.Settings.System;
@@ -120,7 +121,8 @@ public class SquidModule : Module
             {
                 var options = c.Resolve<DbContextOptions<SquidDbContext>>();
                 var currentUser = c.ResolveOptional<ICurrentUser>();
-                return new SquidDbContext(options, currentUser);
+                var auditDocuments = c.ResolveOptional<IAuditDocumentRegistry>();
+                return new SquidDbContext(options, currentUser, auditDocuments);
             })
             .AsSelf()
             .As<DbContext>()

--- a/src/Squid.Message/Models/Events/DocumentEventReferences.cs
+++ b/src/Squid.Message/Models/Events/DocumentEventReferences.cs
@@ -1,0 +1,13 @@
+namespace Squid.Message.Models.Events;
+
+/// <summary>
+/// Structured reference arguments for a document-audit event (created / modified / deleted),
+/// serialized to the Event's jsonb <c>references</c> column. The history UI renders the
+/// document type + name from these without a pre-baked English string.
+/// </summary>
+public sealed record DocumentEventReferences
+{
+    public required string DocumentType { get; init; }
+
+    public string Name { get; init; }
+}

--- a/tests/Squid.IntegrationTests/Base/TestBase.Initial.cs
+++ b/tests/Squid.IntegrationTests/Base/TestBase.Initial.cs
@@ -6,6 +6,7 @@ using Npgsql;
 using Serilog;
 using Microsoft.AspNetCore.Http;
 using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Events;
 using Squid.Core.Services.Identity;
 using Squid.Core.Services.Jobs;
 using Squid.Core.Settings.SelfCert;
@@ -48,11 +49,11 @@ public partial class TestBase
             .As<IHttpContextAccessor>()
             .SingleInstance();
 
-        containerBuilder.Register(_ =>
+        containerBuilder.Register(c =>
             {
                 var dbContextBuilder = new DbContextOptionsBuilder<SquidDbContext>();
                 dbContextBuilder.UseNpgsql(isolatedConnectionString).UseSnakeCaseNamingConvention();
-                return new SquidDbContext(dbContextBuilder.Options, new InternalUser());
+                return new SquidDbContext(dbContextBuilder.Options, new InternalUser(), c.Resolve<IAuditDocumentRegistry>());
             })
             .AsSelf()
             .As<DbContext>()

--- a/tests/Squid.IntegrationTests/Services/Events/DeploymentAuditEventHandlerTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/DeploymentAuditEventHandlerTests.cs
@@ -16,6 +16,7 @@ namespace Squid.IntegrationTests.Services.Events;
 /// lifecycle seam records the right category + document references + provenance, and that a
 /// pre-deployment-data event is skipped rather than persisted as an orphan.
 /// </summary>
+[Collection("EventsAudit")]
 public class DeploymentAuditEventHandlerTests : TestBase
 {
     public DeploymentAuditEventHandlerTests()

--- a/tests/Squid.IntegrationTests/Services/Events/DocumentAuditInterceptorTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/DocumentAuditInterceptorTests.cs
@@ -1,0 +1,158 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Events;
+using Squid.Message.Enums.Events;
+using Squid.Message.Requests.Events;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.IntegrationTests.Services.Events;
+
+/// <summary>
+/// Drives the real <c>SquidDbContext.SaveChangesAsync</c> document-audit interceptor against
+/// a real database: persisting / modifying / deleting a registered document emits the
+/// matching DocumentCreated/Modified/Deleted event with the document's feed keys + name,
+/// and an unregistered entity emits nothing. Best-effort by design — the originating change
+/// is always committed regardless of the audit write.
+/// </summary>
+[Collection("EventsAudit")]
+public class DocumentAuditInterceptorTests : TestBase
+{
+    public DocumentAuditInterceptorTests()
+        : base("Events", "squid_it_doc_audit")
+    {
+    }
+
+    private static ProjectGroup Group(string name, int spaceId) => new() { Name = name, Slug = name.ToLowerInvariant(), Description = "", SpaceId = spaceId };
+
+    private static Environment EnvironmentDoc(string name, int spaceId) => new() { Name = name, Slug = name.ToLowerInvariant(), Description = "", SpaceId = spaceId };
+
+    private static async Task<List<EventDto>> DocumentEventsAsync(IEventService events, int spaceId)
+    {
+        var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, Take = 100 });
+
+        return page.Events;
+    }
+
+    [Fact]
+    public async Task InsertingADocument_RecordsDocumentCreated_WithFeedKeysAndName()
+    {
+        const int spaceId = 800;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            await repository.InsertAsync(Group("Payments", spaceId));
+            await unitOfWork.SaveChangesAsync();
+        }).ConfigureAwait(false);
+
+        await Run<IEventService>(async events =>
+        {
+            var created = (await DocumentEventsAsync(events, spaceId)).Where(e => e.Category == (int)EventCategory.DocumentCreated).ToList();
+
+            created.Count.ShouldBe(1);
+            created[0].ReferencesJson.ShouldContain("ProjectGroup");
+            created[0].ReferencesJson.ShouldContain("Payments");
+            created[0].Username.ShouldBe("system");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task ModifyingADocument_RecordsDocumentModified()
+    {
+        const int spaceId = 801;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var group = Group("Original", spaceId);
+            await repository.InsertAsync(group);
+            await unitOfWork.SaveChangesAsync();   // DocumentCreated
+
+            group.Name = "Renamed";
+            await unitOfWork.SaveChangesAsync();   // DocumentModified
+        }).ConfigureAwait(false);
+
+        await Run<IEventService>(async events =>
+        {
+            var categories = (await DocumentEventsAsync(events, spaceId)).Select(e => e.Category).ToList();
+
+            categories.Count(c => c == (int)EventCategory.DocumentCreated).ShouldBe(1);
+            categories.Count(c => c == (int)EventCategory.DocumentModified).ShouldBe(1);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task DeletingADocument_RecordsDocumentDeleted()
+    {
+        const int spaceId = 802;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var group = Group("Doomed", spaceId);
+            await repository.InsertAsync(group);
+            await unitOfWork.SaveChangesAsync();
+
+            await repository.DeleteAsync(group);
+            await unitOfWork.SaveChangesAsync();   // DocumentDeleted (entity object keeps its id post-delete)
+        }).ConfigureAwait(false);
+
+        await Run<IEventService>(async events =>
+        {
+            (await DocumentEventsAsync(events, spaceId)).Count(e => e.Category == (int)EventCategory.DocumentDeleted).ShouldBe(1);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SavingTwoDocumentsInOneSave_RecordsOneEventEach_OnTheirOwnFeeds()
+    {
+        const int spaceId = 803;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            await repository.InsertAsync(Group("Group", spaceId));
+            await repository.InsertAsync(EnvironmentDoc("Staging", spaceId));
+            await unitOfWork.SaveChangesAsync();
+        }).ConfigureAwait(false);
+
+        await Run<IEventService>(async events =>
+        {
+            var created = (await DocumentEventsAsync(events, spaceId)).Where(e => e.Category == (int)EventCategory.DocumentCreated).ToList();
+
+            created.Count.ShouldBe(2, "each document in a multi-entity save gets its own audit event — and nothing else does");
+            created.ShouldContain(e => e.ReferencesJson.Contains("ProjectGroup"));
+
+            var environmentEvent = created.Single(e => e.ReferencesJson.Contains("Environment"));
+            environmentEvent.EnvironmentId.ShouldNotBeNull("an environment audit event surfaces on the environment feed");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SavingAnUnregisteredEntity_RecordsNothing()
+    {
+        const int spaceId = 804;
+
+        // ServerTask is persisted but is NOT a user-facing document → not in the registry →
+        // no audit noise. Guards against "audit every entity / every IAuditable" creep.
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            await repository.InsertAsync(new ServerTask
+            {
+                Name = "unaudited-task",
+                Description = "",
+                ErrorMessage = "",
+                ConcurrencyTag = "",
+                State = "Pending",
+                JSON = "{}",
+                BusinessProcessState = "",
+                ServerTaskType = "Deploy",
+                JobId = "",
+                DataVersion = Array.Empty<byte>(),
+                SpaceId = spaceId
+            });
+            await unitOfWork.SaveChangesAsync();
+        }).ConfigureAwait(false);
+
+        await Run<IEventService>(async events =>
+        {
+            (await DocumentEventsAsync(events, spaceId)).ShouldBeEmpty("non-document entities must not enter the audit stream");
+        }).ConfigureAwait(false);
+    }
+}

--- a/tests/Squid.IntegrationTests/Services/Events/EventServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/EventServiceTests.cs
@@ -6,6 +6,7 @@ using Squid.Message.Requests.Events;
 
 namespace Squid.IntegrationTests.Services.Events;
 
+[Collection("EventsAudit")]
 public class EventServiceTests : TestBase
 {
     public EventServiceTests()

--- a/tests/Squid.IntegrationTests/Services/Events/EventsAuditCollection.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/EventsAuditCollection.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace Squid.IntegrationTests.Services.Events;
+
+/// <summary>
+/// Serializes the Event-audit integration test classes (EventService, lifecycle handler,
+/// document interceptor). They each exercise the audit stream against a real database and
+/// the shared test-host infrastructure; running them in one collection makes xUnit execute
+/// them sequentially, so concurrent DB setup / shared static fixture state cannot race.
+/// </summary>
+[CollectionDefinition("EventsAudit")]
+public sealed class EventsAuditCollection
+{
+}

--- a/tests/Squid.UnitTests/Events/AuditDocumentRegistryTests.cs
+++ b/tests/Squid.UnitTests/Events/AuditDocumentRegistryTests.cs
@@ -1,0 +1,79 @@
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Events;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.UnitTests.Events;
+
+public class AuditDocumentRegistryTests
+{
+    private readonly AuditDocumentRegistry _registry = new();
+
+    [Fact]
+    public void Project_MapsToProjectFeedKey_NameIsProjectName()
+    {
+        _registry.TryDescribe(new Project { Id = 5, SpaceId = 2, Name = "Checkout" }, out var type, out var keys).ShouldBeTrue();
+
+        type.ShouldBe("Project");
+        keys.SpaceId.ShouldBe(2);
+        keys.ProjectId.ShouldBe(5);
+        keys.ReleaseId.ShouldBeNull();
+        keys.Name.ShouldBe("Checkout");
+    }
+
+    [Fact]
+    public void Release_AlsoCarriesProjectId_SoItShowsOnTheProjectFeed_NameIsVersion()
+    {
+        _registry.TryDescribe(new Release { Id = 9, ProjectId = 5, SpaceId = 2, Version = "6.6.2" }, out var type, out var keys).ShouldBeTrue();
+
+        type.ShouldBe("Release");
+        keys.ReleaseId.ShouldBe(9);
+        keys.ProjectId.ShouldBe(5);
+        keys.Name.ShouldBe("6.6.2");
+    }
+
+    [Fact]
+    public void Machine_MapsToMachineFeedKey()
+    {
+        _registry.TryDescribe(new Machine { Id = 7, SpaceId = 2, Name = "web-01" }, out var type, out var keys).ShouldBeTrue();
+
+        type.ShouldBe("Machine");
+        keys.MachineId.ShouldBe(7);
+        keys.Name.ShouldBe("web-01");
+    }
+
+    [Fact]
+    public void Environment_MapsToEnvironmentFeedKey()
+    {
+        _registry.TryDescribe(new Environment { Id = 3, SpaceId = 2, Name = "Production" }, out var type, out var keys).ShouldBeTrue();
+
+        type.ShouldBe("Environment");
+        keys.EnvironmentId.ShouldBe(3);
+        keys.Name.ShouldBe("Production");
+    }
+
+    [Fact]
+    public void UnregisteredEntity_IsNotAudited()
+    {
+        // The registry is a deliberate allowlist of user-facing documents — being IAuditable
+        // or just any object must NOT make an entity part of the audit stream.
+        _registry.TryDescribe(new object(), out var type, out var keys).ShouldBeFalse();
+        type.ShouldBeNull();
+        keys.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Null_IsNotAudited()
+    {
+        _registry.TryDescribe(null, out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RegisteredDocumentTypes_CoverTheUserFacingDocumentSurface()
+    {
+        AuditDocumentRegistry.RegisteredDocumentTypes.ShouldBe(new[]
+        {
+            "Project", "Release", "Environment", "Machine", "DeploymentAccount",
+            "Channel", "VariableSet", "ProjectGroup", "ExternalFeed", "Certificate"
+        }, ignoreOrder: true);
+    }
+}


### PR DESCRIPTION
## Summary

- Record DocumentCreated/Modified/Deleted audit events for user-facing documents (project, release, environment, machine, account, channel, variable set, project group, feed, certificate) whenever they are persisted — the **second of the two central, generic emission points** for the Event history (the first being PR #412's deployment lifecycle handler).
- Emission hooks the existing `SquidDbContext.SaveChangesAsync` and scans the `ChangeTracker` for entities registered in `IAuditDocumentRegistry` — a single decoupled allowlist (entities carry no audit concern, matching Squid's external-contributor philosophy). Adding a new audited document = one registry entry; no other change.
- Audit rows are written in a **second save** afterwards so insert-generated ids are populated. The write is **best-effort**: a failure is logged and swallowed so it can never roll back or fail the originating change. Provenance comes from the context's `ICurrentUser`, so a portal/API edit is attributed to the editing user.
- Extract a shared `EventFactory` so `EventService` and the interceptor build events identically (provenance + reference serialization in one place).
- Serialize the Event-audit integration test classes into one xUnit collection to remove cross-class DB races (a latent flakiness the third class exposed).

Purely additive — no existing signature or behavior changed; the audit write is swallowed on failure. Builds on #411 (foundation) + #412 (lifecycle).

## Test plan

- [x] Unit (7): `AuditDocumentRegistry` maps each document type to the right feed keys + name; unregistered/null entities are not audited; the registered-type allowlist is pinned.
- [x] Integration (real Postgres, 5): insert/modify/delete a document → DocumentCreated/Modified/Deleted with feed keys + name; two documents in one save → one event each on their own feeds; an unregistered entity (`ServerTask`) → nothing.
- [x] Non-breaking sweep: 144 doc-saving integration tests (Retention, Snapshot, Certificate, Variable, ServerTask) green with the interceptor active on every save.
- [x] Regression: full solution build clean; 62 Events unit + 22 Events integration green; verified in isolation (PR builds + passes on clean main).