### PR TITLE
Bound audit-event growth via retention pruning

### DIFF
--- a/src/Squid.Core/Persistence/DbUpFiles/20260604_add_event_servertask_index.sql
+++ b/src/Squid.Core/Persistence/DbUpFiles/20260604_add_event_servertask_index.sql
@@ -1,0 +1,11 @@
+-- Add the missing per-server-task index on the audit event stream.
+--
+-- Two access paths need it and had no supporting index in the original
+-- 20260603_add_event_audit_stream.sql:
+--   1. GetEvents filtered by ServerTaskId (the per-task audit feed).
+--   2. Retention pruning (DELETE FROM event WHERE server_task_id IN (...)) when the
+--      owning deployments age out — without this the prune scans the whole table.
+--
+-- Partial (WHERE ... IS NOT NULL) + keyset-ordered by id, matching the other
+-- per-document feed indexes.
+CREATE INDEX IF NOT EXISTS ix_event_server_task ON event (server_task_id, id) WHERE server_task_id IS NOT NULL;

--- a/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
+++ b/src/Squid.Core/Services/Deployments/LifeCycle/RetentionPolicyEnforcer.cs
@@ -4,6 +4,7 @@ using Squid.Core.Services.Deployments.DeploymentCompletions;
 using Squid.Core.Services.Deployments.Deployments;
 using Squid.Core.Services.Deployments.Project;
 using Squid.Core.Services.Deployments.Release;
+using Squid.Core.Services.Events;
 using Squid.Message.Enums.Deployments;
 using TaskState = Squid.Core.Services.Deployments.ServerTask.TaskState;
 
@@ -22,6 +23,7 @@ public class RetentionPolicyEnforcer(
     IReleaseDataProvider releaseDataProvider,
     IDeploymentCompletionDataProvider deploymentCompletionDataProvider,
     IDeploymentDataProvider deploymentDataProvider,
+    IEventService eventService,
     IRepository repository) : IRetentionPolicyEnforcer
 {
     private static readonly string[] NonTerminalTaskStates = { TaskState.Pending, TaskState.Executing, TaskState.Cancelling, TaskState.Paused };
@@ -116,6 +118,7 @@ public class RetentionPolicyEnforcer(
     {
         if (taskIds.Count == 0) return;
 
+        await eventService.PruneByServerTaskIdsAsync(taskIds, cancellationToken).ConfigureAwait(false);
         await repository.ExecuteDeleteAsync<ServerTaskLog>(l => taskIds.Contains(l.ServerTaskId), cancellationToken).ConfigureAwait(false);
         await repository.ExecuteDeleteAsync<DeploymentInterruption>(i => taskIds.Contains(i.ServerTaskId), cancellationToken).ConfigureAwait(false);
         await repository.ExecuteDeleteAsync<DeploymentExecutionCheckpoint>(c => taskIds.Contains(c.ServerTaskId), cancellationToken).ConfigureAwait(false);

--- a/src/Squid.Core/Services/Events/EventService.cs
+++ b/src/Squid.Core/Services/Events/EventService.cs
@@ -44,6 +44,14 @@ public class EventService : IEventService
         return BuildPage(rows, take);
     }
 
+    public async Task<int> PruneByServerTaskIdsAsync(IReadOnlyCollection<int> serverTaskIds, CancellationToken cancellationToken = default)
+    {
+        if (serverTaskIds is null || serverTaskIds.Count == 0) return 0;
+
+        // event_document_snapshot rows cascade via the FK (ON DELETE CASCADE).
+        return await _repository.ExecuteDeleteAsync<Event>(e => e.ServerTaskId != null && serverTaskIds.Contains(e.ServerTaskId.Value), cancellationToken).ConfigureAwait(false);
+    }
+
     private IQueryable<Event> BuildFilteredQuery(GetEventsRequest request)
     {
         var query = _repository.QueryNoTracking<Event>(e => e.SpaceId == request.SpaceId!.Value);

--- a/src/Squid.Core/Services/Events/IEventService.cs
+++ b/src/Squid.Core/Services/Events/IEventService.cs
@@ -27,4 +27,11 @@ public interface IEventService : IScopedDependency
     Task RecordAsync(RecordEventRequest request, CancellationToken cancellationToken = default);
 
     Task<GetEventsResponseData> GetEventsAsync(GetEventsRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Prunes audit events (and their snapshots, via FK cascade) for the given server-task
+    /// ids — invoked by retention when the owning deployments are pruned, so the audit
+    /// stream stays bounded alongside the deployments it describes. Returns rows deleted.
+    /// </summary>
+    Task<int> PruneByServerTaskIdsAsync(IReadOnlyCollection<int> serverTaskIds, CancellationToken cancellationToken = default);
 }

--- a/tests/Squid.IntegrationTests/Services/Events/EventServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/EventServiceTests.cs
@@ -223,4 +223,48 @@ public class EventServiceTests : TestBase
             page.Events.Count.ShouldBeGreaterThanOrEqualTo(1, "Take must be clamped to a sane range, never returning zero rows for a non-empty feed");
         }).ConfigureAwait(false);
     }
+
+    [Fact]
+    public async Task PruneByServerTaskIdsAsync_DeletesOnlyTheTargetedTasksEvents_KeepingOthersAndOrphans()
+    {
+        const int spaceId = 40;
+        const int prunedTask = 5001;
+        const int keptTask = 5002;
+
+        await Run<IEventService, IUnitOfWork>(async (events, uow) =>
+        {
+            await events.RecordAsync(new RecordEventRequest { Category = EventCategory.DeploymentStarted, SpaceId = spaceId, ServerTaskId = prunedTask });
+            await events.RecordAsync(new RecordEventRequest { Category = EventCategory.DeploymentSucceeded, SpaceId = spaceId, ServerTaskId = prunedTask });
+            await events.RecordAsync(new RecordEventRequest { Category = EventCategory.DeploymentSucceeded, SpaceId = spaceId, ServerTaskId = keptTask });
+            await events.RecordAsync(new RecordEventRequest { Category = EventCategory.DocumentModified, SpaceId = spaceId, ProjectId = 9 }); // no server task — a config-audit orphan
+            await uow.SaveChangesAsync();
+        }).ConfigureAwait(false);
+
+        var deleted = 0;
+        await Run<IEventService>(async events => deleted = await events.PruneByServerTaskIdsAsync(new[] { prunedTask })).ConfigureAwait(false);
+
+        deleted.ShouldBe(2, "exactly the two events for the pruned task");
+
+        await Run<IEventService>(async events =>
+        {
+            var remaining = (await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, Take = 100 })).Events;
+
+            remaining.ShouldNotContain(e => e.ServerTaskId == prunedTask, "the pruned task's events are gone");
+            remaining.Count(e => e.ServerTaskId == keptTask).ShouldBe(1, "another task's events survive");
+            remaining.Count(e => e.Category == (int)EventCategory.DocumentModified).ShouldBe(1, "config-audit events without a server task are not touched");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task PruneByServerTaskIdsAsync_EmptyInput_IsANoOp()
+    {
+        (await RunResult<IEventService, int>(events => events.PruneByServerTaskIdsAsync(Array.Empty<int>()))).ShouldBe(0);
+    }
+
+    private async Task<TResult> RunResult<T, TResult>(Func<T, Task<TResult>> action)
+    {
+        var result = default(TResult);
+        await Run<T>(async svc => result = await action(svc)).ConfigureAwait(false);
+        return result;
+    }
 }


### PR DESCRIPTION
## Summary

Closes the one critical scaling gap found in a full review of the merged audit stream (#411/#412/#413): **the `event` table had no retention** — audit events outlived the deployments they describe and grew without limit.

- `RetentionPolicyEnforcer` now prunes audit events (snapshots cascade via FK) for the server tasks it cleans up, via `IEventService.PruneByServerTaskIdsAsync`. The stream stays bounded under the same deployment-centric policy that already governs logs/tasks/checkpoints.
- Add the missing partial index `event(server_task_id, id) WHERE server_task_id IS NOT NULL` — the original migration had none, and both the per-task audit feed and this prune need it.

Non-breaking: additive method + one prune call placed beside the existing server-task child deletes + a new index. Document-audit events (config edits, no server task) are deliberately **not** pruned here — they are low-volume; a time-based/partitioned sweep for them is the next step.

## Test plan

- [x] Integration: `PruneByServerTaskIdsAsync` deletes exactly the targeted task's events, leaving other tasks' events AND config-audit orphans (no server task) intact; empty input is a no-op.
- [x] Non-breaking: 26 Retention integration tests green with the enforcer now pruning events; 24 Events integration green; full solution build clean.
- [x] The new index migration applies cleanly (verified against real Postgres in the integration run).

## Review context (gaps found, scoped as follow-ups)

A deep audit confirmed the architecture is generic/simple and the implemented paths well-tested. Remaining items, specced in `memory/history_parity_plan.md`: generic `(document_type, document_id)` self-reference to per-doc-filter the long-tail documents (lifecycle, library variable set, machine policy, team) + register them; time-based/partition prune for config-audit events; bulk-op (`ExecuteUpdate/Delete`) bypass is by-design (audit-worthy mutations must use tracked SaveChanges); provenance polish; frontend.