### PR TITLE
Create action-scoped namespace on KubernetesApi deploys

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesApiIntentRenderer.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Rendering/KubernetesApiIntentRenderer.cs
@@ -80,7 +80,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
         if (!ScriptSyntaxHelper.IsShellSyntax(intent.Syntax))
             return intent.ScriptBody;
 
-        return WrapWithKubectlContext(intent.ScriptBody, intent.Syntax, context);
+        return WrapWithKubectlContext(intent.ScriptBody, intent.Syntax, context, KubernetesTargetNamespaceResolver.Resolve(context));
     }
 
     private ScriptExecutionRequest RenderKubernetesApply(KubernetesApplyIntent intent, IntentRenderContext context)
@@ -118,7 +118,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
     {
         var deploymentFiles = HelmUpgradeScriptBuilder.BuildDeploymentFiles(intent);
         var rawScript = HelmUpgradeScriptBuilder.Build(intent, intent.Syntax);
-        var wrappedScript = WrapShellBody(rawScript, intent.Syntax, context);
+        var wrappedScript = WrapShellBody(rawScript, intent.Syntax, context, intent.Namespace);
 
         return new ScriptExecutionRequest
         {
@@ -144,7 +144,7 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
     private ScriptExecutionRequest RenderKustomize(KubernetesKustomizeIntent intent, IntentRenderContext context)
     {
         var rawScript = KubernetesKustomizeScriptBuilder.Build(intent, intent.Syntax);
-        var wrappedScript = WrapShellBody(rawScript, intent.Syntax, context);
+        var wrappedScript = WrapShellBody(rawScript, intent.Syntax, context, intent.Namespace);
 
         return new ScriptExecutionRequest
         {
@@ -171,24 +171,25 @@ public sealed class KubernetesApiIntentRenderer : IIntentRenderer
         if (!ScriptSyntaxHelper.IsShellSyntax(intent.Syntax))
             return scriptBody;
 
-        return WrapWithKubectlContext(scriptBody, intent.Syntax, context);
+        return WrapWithKubectlContext(scriptBody, intent.Syntax, context, intent.Namespace);
     }
 
-    private string WrapShellBody(string scriptBody, ScriptSyntax syntax, IntentRenderContext context)
+    private string WrapShellBody(string scriptBody, ScriptSyntax syntax, IntentRenderContext context, string targetNamespace)
     {
         if (!ScriptSyntaxHelper.IsShellSyntax(syntax))
             return scriptBody;
 
-        return WrapWithKubectlContext(scriptBody, syntax, context);
+        return WrapWithKubectlContext(scriptBody, syntax, context, targetNamespace);
     }
 
-    private string WrapWithKubectlContext(string scriptBody, ScriptSyntax syntax, IntentRenderContext context)
+    private string WrapWithKubectlContext(string scriptBody, ScriptSyntax syntax, IntentRenderContext context, string targetNamespace)
     {
         var scriptContext = new ScriptContext
         {
             Endpoint = context.Target.EndpointContext,
             Syntax = syntax,
-            Variables = context.EffectiveVariables.ToList()
+            Variables = context.EffectiveVariables.ToList(),
+            Namespace = targetNamespace
         };
 
         var customKubectl = context.EffectiveVariables

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Transport/KubernetesApiContextScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Kubernetes/Transport/KubernetesApiContextScriptBuilder.cs
@@ -130,6 +130,9 @@ public class KubernetesApiContextScriptBuilder : IKubernetesApiContextScriptBuil
 
     private static string ResolveNamespace(ScriptContext context, KubernetesApiEndpointDto endpoint)
     {
+        if (!string.IsNullOrWhiteSpace(context?.Namespace))
+            return context.Namespace;
+
         if (context?.ActionProperties != null && context.ActionProperties.Count > 0)
             return KubernetesPropertyParser.GetNamespace(context.ActionProperties);
 

--- a/src/Squid.Core/Services/DeploymentExecution/Transport/EndpointContext.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Transport/EndpointContext.cs
@@ -56,4 +56,13 @@ public class ScriptContext
     public ScriptSyntax Syntax { get; set; }
     public List<VariableDto> Variables { get; set; }
     public Dictionary<string, string> ActionProperties { get; set; }
+
+    // Resolved, already-expanded target namespace for this action (e.g. the
+    // "Deploy Kubernetes containers" step namespace). When set it is the authoritative
+    // source for the kubectl-context default namespace AND the namespace auto-create
+    // preamble — taking precedence over ActionProperties / endpoint namespace. This is
+    // what the Agent transport already does via intent.Namespace; carrying it here keeps
+    // the Api transport consistent so an action-scoped namespace is created on a fresh
+    // cluster instead of silently falling back to the endpoint/default namespace.
+    public string Namespace { get; set; }
 }

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesAgentNamespaceWrappingE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesAgentNamespaceWrappingE2ETests.cs
@@ -3,6 +3,7 @@ using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Deployments.Account;
 using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.Deployments.ServerTask;
 using Squid.E2ETests.Infrastructure;
 using Squid.IntegrationTests.Helpers;
@@ -124,6 +125,45 @@ data:
             // (full auth + namespace via KubectlContext.sh template)
             captured.ScriptBody.ShouldNotContain("kubectl config set-context --current --namespace=");
         }
+    }
+
+    [Fact]
+    public async Task Api_DeployRawYaml_ActionNamespace_DrivesNamespaceCreation_WhenEndpointHasNone()
+    {
+        // Regression (prd): namespace is declared on the action (e.g. Deploy Kubernetes
+        // containers with #{namespace}) while the EKS/endpoint has none. The KubernetesApi
+        // path MUST render the action namespace into the kubectl-context preamble so it is
+        // auto-created before `kubectl apply`. Pre-fix it fell back to the endpoint/default
+        // namespace, so a fresh prd namespace was never created and apply failed with
+        // namespaces "squid-web-prd" not found. Drives the real renderer + context builder
+        // through the full pipeline (no mocks).
+        var inlineYaml = @"apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configurations-squidweb
+  namespace: squid-web-prd
+data:
+  .env: hello";
+
+        var serverTaskId = await SeedActionAsync(
+            "Squid.KubernetesDeployRawYaml",
+            ns: "",                       // endpoint namespace empty — the exact prd shape
+            communicationStyle: "KubernetesApi",
+            ("Squid.Action.KubernetesYaml.InlineYaml", inlineYaml),
+            ("Squid.Action.Script.Syntax", "Bash"),
+            ("Squid.Action.KubernetesContainers.Namespace", "squid-web-prd"));
+
+        await ExecutePipelineAsync(serverTaskId);
+
+        ExecutionCapture.CapturedRequests.ShouldNotBeEmpty();
+
+        var captured = ExecutionCapture.CapturedRequests[0];
+
+        // KubernetesApi base64-encodes the namespace into the context template; the create
+        // block (KubectlContext.sh) then runs against it. base64("squid-web-prd") is the
+        // discriminator — pre-fix the template carried the empty endpoint namespace instead.
+        captured.ScriptBody.ShouldContain(ShellEscapeHelper.Base64Encode("squid-web-prd"));
+        captured.ScriptBody.ShouldContain("create namespace");
     }
 
     // ========================================================================

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesApiContextScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesApiContextScriptBuilderTests.cs
@@ -246,6 +246,101 @@ public class KubernetesApiContextScriptBuilderTests
         result.ShouldNotContain(ShellEscapeHelper.Base64Encode("endpoint-ns"));
     }
 
+    [Fact]
+    public void WrapWithContext_ContextNamespace_OverridesEndpointNamespace()
+    {
+        // Regression: the action/step namespace (e.g. "Deploy Kubernetes containers" with
+        // namespace #{namespace}) is carried on ScriptContext.Namespace by the renderer and
+        // MUST drive the kubectl context + namespace auto-create — taking precedence over the
+        // endpoint namespace. Previously the namespace fell back to the endpoint/default value
+        // so the target namespace was never created and `kubectl apply` failed on a fresh
+        // cluster with: namespaces "..." not found.
+        var ctx = CreateContext(ns: "endpoint-ns", accountType: AccountType.Token,
+            credentialsJson: JsonSerializer.Serialize(new TokenCredentials { Token = "t" }));
+        ctx.Namespace = "squid-web-prd";
+
+        var result = _builder.WrapWithContext("echo hi", ctx);
+
+        result.ShouldContain(ShellEscapeHelper.Base64Encode("squid-web-prd"));
+        result.ShouldNotContain(ShellEscapeHelper.Base64Encode("endpoint-ns"));
+    }
+
+    [Fact]
+    public void WrapWithContext_ContextNamespace_EmptyEndpointNamespace_StillDrivesNamespace()
+    {
+        // The exact prd failure shape: endpoint has no namespace, the namespace lives only on
+        // the action. Without the fix, {{Namespace}} resolved to "" -> the create block was
+        // skipped and apply targeted a non-existent namespace.
+        var ctx = CreateContext(ns: "", accountType: AccountType.Token,
+            credentialsJson: JsonSerializer.Serialize(new TokenCredentials { Token = "t" }));
+        ctx.Namespace = "squid-web-prd";
+
+        var result = _builder.WrapWithContext("kubectl apply -f configmap.yaml", ctx);
+
+        result.ShouldContain(ShellEscapeHelper.Base64Encode("squid-web-prd"));
+    }
+
+    [Fact]
+    public void WrapWithContext_NoContextNamespace_FallsBackToEndpointNamespace_Unchanged()
+    {
+        // Backward-compat: when the renderer does not set ScriptContext.Namespace (null), the
+        // existing ActionProperties -> endpoint -> default resolution is preserved verbatim.
+        var ctx = CreateContext(ns: "endpoint-ns", accountType: AccountType.Token,
+            credentialsJson: JsonSerializer.Serialize(new TokenCredentials { Token = "t" }));
+
+        var result = _builder.WrapWithContext("echo hi", ctx);
+
+        result.ShouldContain(ShellEscapeHelper.Base64Encode("endpoint-ns"));
+    }
+
+    [Fact]
+    public void WrapWithContext_ContextNamespaceWhitespace_FallsBackToEndpointNamespace()
+    {
+        // Whitespace-only must not win over the endpoint fallback (IsNullOrWhiteSpace guard).
+        var ctx = CreateContext(ns: "endpoint-ns", accountType: AccountType.Token,
+            credentialsJson: JsonSerializer.Serialize(new TokenCredentials { Token = "t" }));
+        ctx.Namespace = "   ";
+
+        var result = _builder.WrapWithContext("echo hi", ctx);
+
+        result.ShouldContain(ShellEscapeHelper.Base64Encode("endpoint-ns"));
+    }
+
+    [Fact]
+    public void WrapWithContext_ContextNamespace_TakesPrecedenceOverActionProperties()
+    {
+        // ScriptContext.Namespace (renderer-resolved, already expanded) is the most specific
+        // source and must win even over ActionProperties.
+        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Squid.Action.KubernetesContainers.Namespace"] = "action-props-ns"
+        };
+        var ctx = CreateContext(ns: "endpoint-ns", accountType: AccountType.Token,
+            credentialsJson: JsonSerializer.Serialize(new TokenCredentials { Token = "t" }),
+            actionProperties: props);
+        ctx.Namespace = "squid-web-prd";
+
+        var result = _builder.WrapWithContext("echo hi", ctx);
+
+        result.ShouldContain(ShellEscapeHelper.Base64Encode("squid-web-prd"));
+        result.ShouldNotContain(ShellEscapeHelper.Base64Encode("action-props-ns"));
+        result.ShouldNotContain(ShellEscapeHelper.Base64Encode("endpoint-ns"));
+    }
+
+    [Fact]
+    public void WrapWithContext_ContextNamespace_PowerShell_DrivesNamespace()
+    {
+        var ctx = CreateContext(ns: "endpoint-ns", accountType: AccountType.Token,
+            credentialsJson: JsonSerializer.Serialize(new TokenCredentials { Token = "t" }),
+            syntax: ScriptSyntax.PowerShell);
+        ctx.Namespace = "squid-web-prd";
+
+        var result = _builder.WrapWithContext("echo hi", ctx);
+
+        result.ShouldContain(ShellEscapeHelper.Base64Encode("squid-web-prd"));
+        result.ShouldNotContain(ShellEscapeHelper.Base64Encode("endpoint-ns"));
+    }
+
     // === TLS Skip Tests ===
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesApiIntentRendererTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/KubernetesApiIntentRendererTests.cs
@@ -147,6 +147,89 @@ public class KubernetesApiIntentRendererTests
         rendered.TargetNamespace.ShouldBe("kustomize-ns");
     }
 
+    // ========== Namespace flows from intent into the kubectl-context ScriptContext ==========
+    // Regression (prd): the namespace declared on the action (e.g. Deploy Kubernetes containers
+    // with #{namespace}) is carried on intent.Namespace (already variable-expanded). It MUST be
+    // threaded into the ScriptContext so the kubectl-context preamble creates the target
+    // namespace before `kubectl apply`. Previously the Api path dropped it and the auto-create
+    // fell back to the endpoint/default namespace, so a fresh prd namespace was never created
+    // and the deploy failed with: namespaces "..." not found. The Agent transport already uses
+    // intent.Namespace; these pin the Api transport to the same source.
+
+    [Fact]
+    public async Task RenderAsync_KubernetesApplyIntent_IntentNamespace_FlowsToScriptContext()
+    {
+        var captured = CaptureScriptContext();
+        var intent = NewKubernetesApplyIntent() with { Namespace = "squid-web-prd" };
+
+        await _renderer.RenderAsync(intent, NewContext(), CancellationToken.None);
+
+        captured().ShouldNotBeNull();
+        captured()!.Namespace.ShouldBe("squid-web-prd");
+    }
+
+    [Fact]
+    public async Task RenderAsync_HelmUpgradeIntent_IntentNamespace_FlowsToScriptContext()
+    {
+        var captured = CaptureScriptContext();
+        var intent = NewHelmUpgradeIntent() with { Namespace = "squid-web-prd" };
+
+        await _renderer.RenderAsync(intent, NewContext(), CancellationToken.None);
+
+        captured().ShouldNotBeNull();
+        captured()!.Namespace.ShouldBe("squid-web-prd");
+    }
+
+    [Fact]
+    public async Task RenderAsync_KustomizeIntent_IntentNamespace_FlowsToScriptContext()
+    {
+        var captured = CaptureScriptContext();
+        var intent = NewKustomizeIntent() with { Namespace = "squid-web-prd" };
+
+        await _renderer.RenderAsync(intent, NewContext(), CancellationToken.None);
+
+        captured().ShouldNotBeNull();
+        captured()!.Namespace.ShouldBe("squid-web-prd");
+    }
+
+    [Fact]
+    public async Task RenderAsync_RunScriptIntent_TargetNamespace_FlowsToScriptContext()
+    {
+        // RunScript carries no intent.Namespace; the renderer resolves it from the
+        // Squid.Action.Kubernetes.Namespace variable (same source as TargetNamespace) so the
+        // kubectl-context preamble still creates/sets the right namespace.
+        var captured = CaptureScriptContext();
+
+        await _renderer.RenderAsync(
+            NewRunScriptIntent(syntax: ScriptSyntax.Bash),
+            NewContext(targetNamespace: "rs-ns"),
+            CancellationToken.None);
+
+        captured().ShouldNotBeNull();
+        captured()!.Namespace.ShouldBe("rs-ns");
+    }
+
+    [Fact]
+    public async Task RenderAsync_RunScriptIntent_NamespaceVariableTemplate_ExpandedIntoScriptContext()
+    {
+        // The namespace variable may itself be a #{...} template — it must be expanded before
+        // reaching the context builder (a raw #{...} is not a valid namespace name).
+        var captured = CaptureScriptContext();
+        var variables = new List<VariableDto>
+        {
+            new() { Name = "Environment", Value = "prod" },
+            new() { Name = SpecialVariables.Kubernetes.Namespace, Value = "#{Environment}-app" }
+        };
+
+        await _renderer.RenderAsync(
+            NewRunScriptIntent(syntax: ScriptSyntax.Bash),
+            NewContext(variables: variables),
+            CancellationToken.None);
+
+        captured().ShouldNotBeNull();
+        captured()!.Namespace.ShouldBe("prod-app");
+    }
+
     // ========== RunScriptIntent: wrapping behaviour ==========
 
     [Fact]
@@ -1157,6 +1240,18 @@ public class KubernetesApiIntentRendererTests
         _builderMock
             .Setup(b => b.WrapWithContext(It.IsAny<string>(), It.IsAny<ScriptContext>(), It.IsAny<string>()))
             .Returns(returnValue);
+    }
+
+    private Func<ScriptContext?> CaptureScriptContext()
+    {
+        ScriptContext? captured = null;
+
+        _builderMock
+            .Setup(b => b.WrapWithContext(It.IsAny<string>(), It.IsAny<ScriptContext>(), It.IsAny<string>()))
+            .Callback<string, ScriptContext, string>((_, ctx, _) => captured = ctx)
+            .Returns("wrapped");
+
+        return () => captured;
     }
 
     private static RunScriptIntent NewRunScriptIntent(string scriptBody = "echo default", ScriptSyntax syntax = ScriptSyntax.Bash)


### PR DESCRIPTION
## Summary

- KubernetesApi deploys to a not-yet-existing namespace failed with `namespaces "<ns>" not found`. The renderer never passed the action/step namespace into the kubectl-context builder, so `ResolveNamespace` fell back to the endpoint namespace (empty on most cloud targets) and the auto-create preamble in `KubectlContext.sh` was gated off — the first deploy to a fresh namespace never created it.
- Carry the resolved, already-expanded namespace on `ScriptContext.Namespace` and have the Api context builder prefer it, so the target namespace is created before `kubectl apply`. This matches the Agent transport, which already used `intent.Namespace`. Applies to every Api apply intent (containers, raw YAML, Helm, Kustomize) plus RunScript.
- Additive only: a new optional `ScriptContext.Namespace`, no interface or public-signature changes. When unset, the prior `ActionProperties -> endpoint -> default` resolution is preserved verbatim, so existing deploys are unaffected.

## Test plan

- [x] Unit — `KubernetesApiIntentRendererTests`: apply / Helm / Kustomize / RunScript thread the resolved namespace into `ScriptContext`; `#{...}` namespace templates are expanded before reaching the builder.
- [x] Unit — `KubernetesApiContextScriptBuilderTests`: `ScriptContext.Namespace` drives the kubectl context + create-namespace on both bash and PowerShell; takes precedence over endpoint and ActionProperties; null / whitespace falls back to the prior resolution unchanged.
- [x] E2E — `KubernetesAgentNamespaceWrappingE2ETests`: full pipeline (real renderer + context builder via `ProcessAsync`) renders `create namespace "<ns>"` for an action-scoped namespace when the endpoint has none.
- [x] Regression: 1121 Kubernetes unit tests green; full solution builds with 0 errors. New tests verified against the exact branch content (base `main` + this fix only).

Note: this is pure rendering logic (no persistence), so the applicable tiers are Unit + pipeline E2E; there is no DB behaviour to cover at the integration tier.
