### PR TITLE
Apply transient-target health policy in deployment preview

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.Deployments.Project;
 using Squid.Message.Enums;
 using Squid.Message.Enums.Deployments;
 using Machine = Squid.Core.Persistence.Entities.Deployments.Machine;
@@ -28,6 +29,19 @@ public sealed record TransientTargetResult(
 /// </summary>
 public static class TransientDeploymentTargetEvaluator
 {
+    /// <summary>
+    /// Resolves the project's "Transient Deployment Targets" policy from its
+    /// deployment-settings JSON and applies it. This is the single entry point both the
+    /// deployment pipeline (phase 4) and the deployment preview call, so the two cannot
+    /// disagree about which targets are eligible.
+    /// </summary>
+    public static TransientTargetResult ApplyProjectPolicy(IReadOnlyList<Machine> candidates, string deploymentSettingsJson)
+    {
+        var transient = DeploymentSettingsSerializer.Deserialize(deploymentSettingsJson).TransientDeploymentTargets;
+
+        return Apply(candidates, transient.UnavailableDeploymentTargets, transient.UnhealthyDeploymentTargets);
+    }
+
     public static TransientTargetResult Apply(
         IReadOnlyList<Machine> candidates,
         UnavailableDeploymentTargetBehavior unavailableBehavior,

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
@@ -1,6 +1,5 @@
 using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.Deployments.Deployments;
-using Squid.Core.Services.Deployments.Project;
 using Squid.Core.Services.Deployments.Snapshots;
 using Squid.Message.Models.Deployments.Variable;
 using Squid.Core.Services.DeploymentExecution.Variables;
@@ -105,10 +104,7 @@ public sealed class PrepareDeploymentPhase(
     // before. FailDeployment on an unavailable target aborts the deployment up front.
     internal static void ApplyTransientTargetPolicy(DeploymentTaskContext ctx)
     {
-        var transient = DeploymentSettingsSerializer.Deserialize(ctx.Project?.DeploymentSettingsJson).TransientDeploymentTargets;
-
-        var result = TransientDeploymentTargetEvaluator.Apply(
-            ctx.AllTargets, transient.UnavailableDeploymentTargets, transient.UnhealthyDeploymentTargets);
+        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(ctx.AllTargets, ctx.Project?.DeploymentSettingsJson);
 
         if (result.FailedUnavailable.Count > 0)
         {

--- a/src/Squid.Core/Services/Deployments/Deployments/DeploymentService.Preview.cs
+++ b/src/Squid.Core/Services/Deployments/Deployments/DeploymentService.Preview.cs
@@ -1,4 +1,5 @@
 using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.Services.DeploymentExecution.Transport;
@@ -47,13 +48,25 @@ public partial class DeploymentService
 
         var selectedMachines = ApplyMachineSelection(machines, context.SpecificMachineIds, context.ExcludedMachineIds);
 
+        // Apply the SAME transient-target eligibility the deployment pipeline applies
+        // (phase 4 -> TransientDeploymentTargetEvaluator), so preview's available targets are
+        // exactly the targets a real deployment would keep. Unavailable/unhealthy machines are
+        // excluded here, never counted as "available".
+        var project = await _projectDataProvider.GetProjectByIdAsync(release.ProjectId, cancellationToken).ConfigureAwait(false);
+        var eligibility = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(selectedMachines, project?.DeploymentSettingsJson);
+
+        result.ExcludedTargets = eligibility.Skipped.Concat(eligibility.FailedUnavailable).Select(MapMachineTarget).ToList();
+
+        if (eligibility.FailedUnavailable.Count > 0)
+            blockingReasons.Add($"{eligibility.FailedUnavailable.Count} deployment target(s) are unavailable and the project's Transient Deployment Targets policy is 'Fail deployment': {string.Join(", ", eligibility.FailedUnavailable.Select(m => m.Name))}.");
+
         await PopulateLifecycleValidationAsync(result, release, context, blockingReasons, cancellationToken).ConfigureAwait(false);
 
         var ruleReport = await _deploymentValidationOrchestrator.ValidateAsync(stage, context, cancellationToken).ConfigureAwait(false);
 
         blockingReasons.AddRange(ruleReport.Issues.Where(issue => issue.IsBlocking).Select(issue => issue.Message));
 
-        await PopulateStepsAndBlockersFromPlanAsync(result, release, context, selectedMachines, blockingReasons, cancellationToken).ConfigureAwait(false);
+        await PopulateStepsAndBlockersFromPlanAsync(result, release, context, eligibility.Kept, blockingReasons, cancellationToken).ConfigureAwait(false);
 
         return FinalizePreview(result, blockingReasons);
     }
@@ -64,7 +77,7 @@ public partial class DeploymentService
         DeploymentPreviewResult result,
         Persistence.Entities.Deployments.Release release,
         DeploymentValidationContext context,
-        List<Persistence.Entities.Deployments.Machine> selectedMachines,
+        List<Persistence.Entities.Deployments.Machine> eligibleMachines,
         List<string> blockingReasons,
         CancellationToken cancellationToken)
     {
@@ -72,7 +85,7 @@ public partial class DeploymentService
 
         try
         {
-            plan = await BuildPlanAsync(release, context, selectedMachines, cancellationToken).ConfigureAwait(false);
+            plan = await BuildPlanAsync(release, context, eligibleMachines, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -81,12 +94,44 @@ public partial class DeploymentService
             return;
         }
 
+        var healthByMachineId = eligibleMachines.ToDictionary(m => m.Id, m => m.HealthStatus.ToString());
+
         result.Steps = plan.Steps.Select(MapPlannedStep).ToList();
-        result.CandidateTargets = plan.CandidateTargets.Select(MapPlannedTarget).ToList();
+        result.CandidateTargets = plan.CandidateTargets.Select(target => MapPlannedTargetWithHealth(target, healthByMachineId)).ToList();
         result.AvailableMachineCount = result.CandidateTargets.Count;
 
         blockingReasons.AddRange(plan.BlockingReasons.Select(reason => reason.Message));
+
+        AddNoHealthyTargetsBlockerIfNeeded(result, blockingReasons);
     }
+
+    // Mirrors the deployment pipeline's "No target machines found" failure (phase 4): if a step
+    // genuinely needs targets (has roles, not run-on-server/step-level) but matched none, AND
+    // targets were excluded by health, the real deployment would fail — so the preview blocks too.
+    internal static void AddNoHealthyTargetsBlockerIfNeeded(DeploymentPreviewResult result, List<string> blockingReasons)
+    {
+        var stepNeedsTargetsButHasNone = result.Steps.Any(step =>
+            step.IsApplicable && !step.IsRunOnServer && !step.IsStepLevelOnly && step.RequiredRoles.Count > 0 && step.MatchedTargets.Count == 0);
+
+        if (stepNeedsTargetsButHasNone && result.ExcludedTargets.Count > 0)
+            blockingReasons.Add($"No healthy deployment targets are available — {result.ExcludedTargets.Count} matching target(s) were excluded as unavailable or unhealthy.");
+    }
+
+    private static DeploymentPreviewTargetResult MapPlannedTargetWithHealth(PlannedTarget target, IReadOnlyDictionary<int, string> healthByMachineId) => new()
+    {
+        MachineId = target.MachineId,
+        MachineName = target.MachineName,
+        Roles = target.Roles.ToList(),
+        HealthStatus = healthByMachineId.TryGetValue(target.MachineId, out var health) ? health : string.Empty
+    };
+
+    private static DeploymentPreviewTargetResult MapMachineTarget(Persistence.Entities.Deployments.Machine machine) => new()
+    {
+        MachineId = machine.Id,
+        MachineName = machine.Name,
+        Roles = DeploymentTargetFinder.ParseRoles(machine.Roles).ToList(),
+        HealthStatus = machine.HealthStatus.ToString()
+    };
 
     private async Task<DeploymentPlan> BuildPlanAsync(
         Persistence.Entities.Deployments.Release release,

--- a/src/Squid.Message/Models/Deployments/Deployment/DeploymentPreviewResult.cs
+++ b/src/Squid.Message/Models/Deployments/Deployment/DeploymentPreviewResult.cs
@@ -14,6 +14,14 @@ public class DeploymentPreviewResult
 
     public List<DeploymentPreviewTargetResult> CandidateTargets { get; set; } = [];
 
+    /// <summary>
+    /// Targets that matched the environment but were excluded by the project's Transient
+    /// Deployment Targets policy (unavailable / unhealthy) — the same exclusion the real
+    /// deployment applies. Surfaced so the UI can explain why the available count is lower
+    /// than the number of machines in the environment.
+    /// </summary>
+    public List<DeploymentPreviewTargetResult> ExcludedTargets { get; set; } = [];
+
     public List<DeploymentPreviewStepResult> Steps { get; set; } = [];
 
     public string Message => CanDeploy
@@ -28,6 +36,9 @@ public class DeploymentPreviewTargetResult
     public string MachineName { get; set; }
 
     public List<string> Roles { get; set; } = [];
+
+    /// <summary>Machine health at preview time (e.g. Healthy / Unavailable / Unhealthy / Unknown).</summary>
+    public string HealthStatus { get; set; } = string.Empty;
 }
 
 public class DeploymentPreviewStepResult

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/PreviewNoHealthyTargetsBlockerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/PreviewNoHealthyTargetsBlockerTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using Squid.Core.Services.Deployments.Deployments;
+using Squid.Message.Models.Deployments.Deployment;
+
+namespace Squid.UnitTests.Services.Deployments.Targets;
+
+/// <summary>
+/// The preview-side blocker that mirrors the deployment pipeline's "No target machines found"
+/// failure: when a step genuinely needs targets but every matching target was excluded by the
+/// transient-target health policy, the real deployment would fail — so the preview must block
+/// (CanDeploy = false) rather than show the step as runnable.
+/// </summary>
+public class PreviewNoHealthyTargetsBlockerTests
+{
+    private static DeploymentPreviewStepResult NeedsTargets(int matched = 0) => new()
+    {
+        IsApplicable = true,
+        IsRunOnServer = false,
+        IsStepLevelOnly = false,
+        RequiredRoles = ["web"],
+        MatchedTargets = matched > 0 ? [new DeploymentPreviewTargetResult { MachineId = 1, MachineName = "ok" }] : [],
+    };
+
+    private static DeploymentPreviewTargetResult Excluded() => new() { MachineId = 9, MachineName = "down", HealthStatus = "Unavailable" };
+
+    [Fact]
+    public void StepNeedsTargets_AllExcludedByHealth_AddsBlocker()
+    {
+        var result = new DeploymentPreviewResult { Steps = [NeedsTargets()], ExcludedTargets = [Excluded()] };
+        var blockers = new List<string>();
+
+        DeploymentService.AddNoHealthyTargetsBlockerIfNeeded(result, blockers);
+
+        blockers.Count.ShouldBe(1);
+        blockers[0].ShouldContain("No healthy deployment targets");
+    }
+
+    [Fact]
+    public void NoTargetsExcluded_DoesNotBlock()
+    {
+        // No health exclusion → a zero-target step is a role-mismatch concern, handled elsewhere.
+        var result = new DeploymentPreviewResult { Steps = [NeedsTargets()], ExcludedTargets = [] };
+        var blockers = new List<string>();
+
+        DeploymentService.AddNoHealthyTargetsBlockerIfNeeded(result, blockers);
+
+        blockers.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RunOnServerStep_DoesNotBlock_EvenWithExcludedTargets()
+    {
+        var result = new DeploymentPreviewResult
+        {
+            Steps = [new DeploymentPreviewStepResult { IsApplicable = true, IsRunOnServer = true, RequiredRoles = [] }],
+            ExcludedTargets = [Excluded()],
+        };
+        var blockers = new List<string>();
+
+        DeploymentService.AddNoHealthyTargetsBlockerIfNeeded(result, blockers);
+
+        blockers.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void StepStillHasHealthyTargets_DoesNotBlock()
+    {
+        var result = new DeploymentPreviewResult { Steps = [NeedsTargets(matched: 1)], ExcludedTargets = [Excluded()] };
+        var blockers = new List<string>();
+
+        DeploymentService.AddNoHealthyTargetsBlockerIfNeeded(result, blockers);
+
+        blockers.ShouldBeEmpty();
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.Deployments.Project;
 using Squid.Message.Enums;
 using Squid.Message.Enums.Deployments;
+using Squid.Message.Models.Deployments.Project;
 
 namespace Squid.UnitTests.Services.Deployments.Targets;
 
@@ -125,5 +127,68 @@ public class TransientDeploymentTargetEvaluatorTests
         result.Kept.ShouldBeEmpty();
         result.Skipped.ShouldBeEmpty();
         result.FailedUnavailable.ShouldBeEmpty();
+    }
+
+    // ── ApplyProjectPolicy: the single entry point BOTH the deployment pipeline (phase 4)
+    //    and the deployment preview call, so the two cannot disagree about eligibility. ──
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-json")]
+    public void ApplyProjectPolicy_NoOrInvalidSettings_UsesHistoricalDefaults(string settingsJson)
+    {
+        var machines = new[]
+        {
+            M("healthy", MachineHealthStatus.Healthy),
+            M("unhealthy", MachineHealthStatus.Unhealthy),
+            M("unavailable", MachineHealthStatus.Unavailable)
+        };
+
+        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(machines, settingsJson);
+
+        result.Kept.Select(m => m.Name).ShouldBe(new[] { "healthy" });
+        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "unhealthy", "unavailable" });
+        result.FailedUnavailable.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ApplyProjectPolicy_FailDeploymentSetting_FailsOnUnavailable()
+    {
+        var json = DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto
+        {
+            TransientDeploymentTargets = new TransientDeploymentTargetsDto
+            {
+                UnavailableDeploymentTargets = UnavailableDeploymentTargetBehavior.FailDeployment,
+                UnhealthyDeploymentTargets = UnhealthyDeploymentTargetBehavior.Exclude
+            }
+        });
+
+        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(new[] { M("down", MachineHealthStatus.Unavailable) }, json);
+
+        result.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "down" });
+        result.Kept.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ApplyProjectPolicy_IsApplyWithPolicyFromJson_SoPreviewAndDeployConverge()
+    {
+        // Convergence guarantee: ApplyProjectPolicy == Apply with the policy resolved from the
+        // project settings JSON. Preview and the deploy pipeline both route through it, so for
+        // the same machines + settings they produce identical Kept / Skipped / Failed sets.
+        var machines = new[]
+        {
+            M("healthy", MachineHealthStatus.Healthy),
+            M("unhealthy", MachineHealthStatus.Unhealthy),
+            M("unavailable", MachineHealthStatus.Unavailable)
+        };
+        var defaultsJson = DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto());
+
+        var viaProjectPolicy = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(machines, defaultsJson);
+        var viaApply = Apply(machines);
+
+        viaProjectPolicy.Kept.Select(m => m.Name).ShouldBe(viaApply.Kept.Select(m => m.Name));
+        viaProjectPolicy.Skipped.Select(m => m.Name).ShouldBe(viaApply.Skipped.Select(m => m.Name));
+        viaProjectPolicy.FailedUnavailable.Select(m => m.Name).ShouldBe(viaApply.FailedUnavailable.Select(m => m.Name));
     }
 }


### PR DESCRIPTION
## Summary

Fixes a Preview/Deploy inconsistency: the deploy **preview** counted targets as available using only environment + role + `!IsDisabled`, while the deployment **pipeline** (phase 4) additionally excludes unavailable/unhealthy targets via the project's *Transient Deployment Targets* policy. Result: preview could show "N available" for targets a real deployment skips — and with all targets unavailable, preview showed them green/available while the deployment fails up front with "No target machines found".

**Root cause:** the `DeploymentPlanner` is the shared source of truth for *role/step matching* (both Preview and Execute call it), but the *health/availability* pre-filter (`TransientDeploymentTargetEvaluator`, added with the Machine-Policy / Transient-Targets work) was wired only into the deploy pipeline — the preview path never called it.

**Fix — converge on one source of truth:**
- Extract `TransientDeploymentTargetEvaluator.ApplyProjectPolicy(machines, settingsJson)` (resolve the project policy, then evaluate) and call it from **both** phase 4 and the preview.
- Preview now feeds only the **kept** (eligible) targets to the planner, so `AvailableMachineCount`/`CandidateTargets` equal what a deployment would actually keep.
- New `ExcludedTargets` (with `HealthStatus`) surfaces the unavailable/unhealthy machines so the UI can explain the lower count.
- Preview **blocks** (`CanDeploy = false`) when a step needs targets but all matching targets were health-excluded, mirroring the pipeline's failure.

Non-breaking: phase-4 refactor is behavior-preserving (same evaluator); DTO additions are additive; default policy still reproduces the historical unavailable+unhealthy exclusion.

## Test plan

- [x] Unit (evaluator): `ApplyProjectPolicy` with no/invalid settings → historical defaults; FailDeployment policy → fails on unavailable; **convergence test** asserting `ApplyProjectPolicy` == `Apply` with policy-from-JSON (so Preview and Deploy cannot disagree).
- [x] Unit (preview blocker): step-needs-targets + all-health-excluded → blocks; no exclusion / run-on-server / still-has-healthy-targets → does not block.
- [x] Regression: phase-4 transient-target tests, planner, and preview-handler tests green; full solution build clean; 588 deployment/target unit tests pass.

Frontend (SquidWeb) consumes the new `ExcludedTargets`/`HealthStatus` + fixes the targets-page "Disabled" label in a companion PR.