### PR TITLE
Resolve $RID in the Windows upgrade download URL before fetching

### DIFF
--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -104,6 +104,12 @@ switch -Regex ($arch) {
 # ── Placeholders filled by WindowsTentacleUpgradeStrategy before transmission ─
 $TARGET_VERSION   = '{{TARGET_VERSION}}'
 $DOWNLOAD_URL     = '{{DOWNLOAD_URL}}'
+# The server can't know the agent's architecture, so it emits the URL with a literal
+# '$RID' token. The single-quoted assignment above keeps it literal (PowerShell never
+# re-expands a stored value at use time), so resolve it now that arch detection has set
+# $RID. A targeted Replace — not a double-quoted re-assignment — leaves any other '$' or
+# backtick in an operator-overridden base URL untouched.
+$DOWNLOAD_URL     = $DOWNLOAD_URL.Replace('$RID', $RID)
 $EXPECTED_SHA256  = '{{EXPECTED_SHA256}}'
 $INSTALL_DIR      = '{{INSTALL_DIR}}'
 $SERVICE_NAME     = '{{SERVICE_NAME}}'

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
@@ -306,6 +306,17 @@ public sealed class LocalReleaseMirror : IDisposable
             _receivedRequests.Add(path);
         }
 
+        // Real GitHub returns 404 for an asset whose name still carries an UNEXPANDED token
+        // — a script that failed to resolve $RID, or a {{PLACEHOLDER}} the server forgot to
+        // substitute. A permissive "serve any archive" mirror masks that class of bug; mirror
+        // the real contract so an unresolved-token path does not exist.
+        if (ContainsUnresolvedToken(path))
+        {
+            ctx.Response.StatusCode = 404;
+            ctx.Response.OutputStream.Close();
+            return;
+        }
+
         // 404 if the path mentions any of the configured "not found" versions
         // OR matches any of the path-substring "not found" entries. Versions
         // are coarse (substring of any URL); paths are surgical (used to 404
@@ -345,6 +356,15 @@ public sealed class LocalReleaseMirror : IDisposable
         ctx.Response.StatusCode = 404;
         ctx.Response.OutputStream.Close();
     }
+
+    // A well-formed release asset path never contains a server placeholder or an unexpanded
+    // shell/PowerShell variable. If one is present the agent failed to resolve it, and real
+    // GitHub would 404 — so we do too, instead of papering over it by serving any archive.
+    private static bool ContainsUnresolvedToken(string path) =>
+        path.Contains("$RID", StringComparison.Ordinal) ||
+        path.Contains("$TARGET_VERSION", StringComparison.Ordinal) ||
+        path.Contains("{{", StringComparison.Ordinal) ||
+        path.Contains("{RID}", StringComparison.Ordinal);
 
     /// <summary>
     /// Serves the SHA256 companion for the underlying archive. Production

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -560,8 +560,9 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
         // stale placeholder. The script's header comment contains the
         // literal sequence `{{...}}` (three dots) as documentation about
         // the placeholder convention — that's NOT a placeholder, so the
-        // ALL-CAPS regex skips it cleanly.
-        var stalePlaceholderPattern = new System.Text.RegularExpressions.Regex(@"\{\{[A-Z_]+\}\}");
+        // token regex skips it cleanly. Digits are included so a forgotten
+        // digit-bearing placeholder (e.g. {{EXPECTED_SHA256}}) is also caught.
+        var stalePlaceholderPattern = new System.Text.RegularExpressions.Regex(@"\{\{[A-Z0-9_]+\}\}");
         stalePlaceholderPattern.IsMatch(script).ShouldBeFalse(
             customMessage: "an unsubstituted '{{ALL_CAPS}}' placeholder ships a broken script — add a per-placeholder check above when introducing new placeholders");
     }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeReleaseAssetContractTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/UpgradeReleaseAssetContractTests.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Squid.Core.Services.Machines.Upgrade;
+
+namespace Squid.UnitTests.Services.Machines.Upgrade;
+
+/// <summary>
+/// Producer ⇿ consumer contract for the tentacle self-upgrade download.
+///
+/// <para>The release workflow (PRODUCER) publishes the upgrade artifact under a
+/// specific name; the upgrade strategy (CONSUMER) builds the URL it fetches from
+/// the same name. Nothing in the type system links them, so a rename on either
+/// side 404s every self-upgrade — exactly the class of bug that shipped when the
+/// Windows upgrade URL left <c>$RID</c> unexpanded. These tests pin the coupling
+/// so a divergence fails at PR-review time, on every platform, without needing a
+/// real agent or a real GitHub release.</para>
+///
+/// <para>Same pattern as <c>YumUpgradeMethodTests.PackagingRelease_PinnedToWorkflowContract</c>,
+/// extended to the zip/tarball GitHub-release artifacts the blue-green upgrade uses.</para>
+/// </summary>
+public sealed class UpgradeReleaseAssetContractTests
+{
+    [Fact]
+    public void WindowsUpgradeDownloadName_MatchesReleaseWorkflowZipArtifact()
+    {
+        var workflow = ReadWorkflow("build-publish-windows-tentacle.yml");
+
+        // Producer: the archive name `zip -r -q "../<name>"` publishes, with the
+        // version + rid interpolations normalised to {V}/{R}.
+        var producer = ExtractArchiveName(workflow, @"squid-tentacle-\$\{IMAGE_TAG\}-\$\{\{\s*matrix\.rid\s*\}\}\.zip");
+
+        // Consumer: the filename the upgrade strategy actually downloads.
+        var consumer = FileNameOf(WindowsTentacleUpgradeStrategy.BuildDownloadUrl("{V}", "{R}"));
+
+        producer.ShouldBe(consumer,
+            customMessage: $"build-publish-windows-tentacle.yml publishes '{producer}' but " +
+                           $"WindowsTentacleUpgradeStrategy.BuildDownloadUrl downloads '{consumer}'. " +
+                           "A mismatch 404s every Windows self-upgrade — keep the two in lockstep.");
+    }
+
+    [Fact]
+    public void LinuxUpgradeDownloadName_MatchesReleaseWorkflowTarballArtifact()
+    {
+        var workflow = ReadWorkflow("build-publish-linux-tentacle.yml");
+
+        var producer = ExtractArchiveName(workflow, @"squid-tentacle-\$\{IMAGE_TAG\}-\$\{\{\s*matrix\.rid\s*\}\}\.tar\.gz");
+
+        var consumer = FileNameOf(LinuxTentacleUpgradeStrategy.BuildDownloadUrl("{V}", "{R}"));
+
+        producer.ShouldBe(consumer,
+            customMessage: $"build-publish-linux-tentacle.yml publishes '{producer}' but " +
+                           $"LinuxTentacleUpgradeStrategy.BuildDownloadUrl downloads '{consumer}'. " +
+                           "A mismatch 404s every Linux tarball self-upgrade — keep the two in lockstep.");
+    }
+
+    private static string ExtractArchiveName(string workflow, string pattern)
+    {
+        var match = Regex.Match(workflow, pattern);
+
+        match.Success.ShouldBeTrue(
+            $"could not find the release archive name (pattern: {pattern}) in the workflow — " +
+            "the artifact naming changed. Update this contract AND the upgrade strategy together.");
+
+        return Normalize(match.Value);
+    }
+
+    // Reduce a release-artifact name to {V}-version / {R}-rid placeholders so it can be
+    // compared structurally to the strategy's BuildDownloadUrl output.
+    private static string Normalize(string name) =>
+        Regex.Replace(name.Replace("${IMAGE_TAG}", "{V}"), @"\$\{\{\s*matrix\.rid\s*\}\}", "{R}");
+
+    private static string FileNameOf(string url) => url.Split('/').Last();
+
+    private static string ReadWorkflow(string fileName) =>
+        File.ReadAllText(Path.Combine(FindRepoRoot(), ".github", "workflows", fileName));
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid working tree");
+    }
+}

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -280,6 +280,35 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
             customMessage: "Stop-Service WaitForStatus REGRESSED — must use $SERVICE_TIMEOUT_SPAN");
     }
 
+    [Fact]
+    public void RenderInnerScript_DownloadUrl_RewritesLiteralRidTokenBeforeDownload()
+    {
+        // PRODUCTION BUG GUARD (Windows upgrade "Download failed: (404)"):
+        // The server emits the download URL with a LITERAL '$RID' token
+        // ($DOWNLOAD_URL = '.../squid-tentacle-<ver>-$RID.zip'). PowerShell single-quoted
+        // assignment does NOT expand $RID, and PowerShell never re-expands a variable's
+        // stored value at use time — so the script MUST explicitly rewrite the '$RID' token
+        // to the architecture-resolved $RID BEFORE Invoke-WebRequest consumes $DOWNLOAD_URL.
+        // Without it the agent requests .../squid-tentacle-<ver>-$RID.zip → GitHub 404.
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        var literalUrlIdx = inner.IndexOf("-$RID.zip'", StringComparison.Ordinal);
+        var rewriteIdx = inner.IndexOf(".Replace('$RID', $RID)", StringComparison.Ordinal);
+        var downloadIdx = inner.IndexOf("Invoke-WebRequest -Uri $DOWNLOAD_URL", StringComparison.Ordinal);
+
+        literalUrlIdx.ShouldBeGreaterThan(-1,
+            customMessage: "Expected the server to emit the single-quoted URL with a literal $RID token.");
+
+        rewriteIdx.ShouldBeGreaterThan(literalUrlIdx,
+            customMessage: "Download URL must rewrite the literal '$RID' token to the resolved $RID. " +
+                           "PowerShell will NOT expand $RID inside a single-quoted value, so without " +
+                           "$DOWNLOAD_URL = $DOWNLOAD_URL.Replace('$RID', $RID) the agent downloads " +
+                           ".../squid-tentacle-<ver>-$RID.zip and GitHub returns 404.");
+
+        downloadIdx.ShouldBeGreaterThan(rewriteIdx,
+            customMessage: "The $RID rewrite MUST happen before Invoke-WebRequest consumes $DOWNLOAD_URL.");
+    }
+
     // ── J.E.7: HealthcheckFatalEnvVar pins ──────────────────────────────────
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -343,7 +343,9 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         // Any {{PLACEHOLDER}} left in the dispatched script is a substitution the strategy forgot
         // to fill; it reaches the agent verbatim and breaks at runtime (the $RID bug's cousin).
         // One invariant guards the entire server-side placeholder surface, not just the ones with
-        // bespoke tests.
+        // bespoke tests. The token pattern is [A-Z0-9_]+ (matches {{EXPECTED_SHA256}} and friends)
+        // — deliberately NOT a broad {{...}} match, which would false-positive on the script
+        // header's own `{{...}}` documentation comment.
         var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
 
         System.Text.RegularExpressions.Regex.Matches(inner, @"\{\{[A-Z0-9_]+\}\}").Count

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -309,6 +309,59 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
             customMessage: "The $RID rewrite MUST happen before Invoke-WebRequest consumes $DOWNLOAD_URL.");
     }
 
+    [Theory]
+    [InlineData("win-x64")]
+    [InlineData("win-arm64")]
+    public void RenderInnerScript_AgentResolvedDownloadUrl_EqualsBuilderForEachArch(string rid)
+    {
+        // Closes the gap that let the 404 ship: BuildDownloadUrl_DefaultsToGitHubReleasesZipPath
+        // passed a CONCRETE rid and proved the builder — but the real dispatch path embeds
+        // BuildDownloadUrl(version,"{RID}") → "$RID" into a single-quoted line and defers
+        // resolution to the agent, which the isolated test never exercised. Reproduce the
+        // agent's resolution from the rendered script and pin it to the canonical builder URL
+        // for EVERY supported arch. Fails if the rewrite is missing (URL keeps $RID ≠ builder)
+        // or if the embedded URL/extension/version ever diverges from the builder.
+        const string version = "1.6.0";
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript(version, WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        System.Text.RegularExpressions.Regex.IsMatch(inner, @"\$DOWNLOAD_URL\s*=\s*\$DOWNLOAD_URL\.Replace\('\$RID',\s*\$RID\)")
+            .ShouldBeTrue(customMessage: "the script must rewrite the literal $RID token — a single-quoted assignment never expands it.");
+
+        var embeddedLiteral = ExtractDownloadUrlLiteral(inner);
+        var agentResolved = embeddedLiteral.Replace("$RID", rid, StringComparison.Ordinal);
+
+        agentResolved.ShouldBe(WindowsTentacleUpgradeStrategy.BuildDownloadUrl(version, rid),
+            customMessage: $"agent-resolved download URL for {rid} diverged from BuildDownloadUrl — " +
+                           "the dispatched script and the builder must produce the same URL.");
+        agentResolved.ShouldNotContain("$RID", customMessage: "resolved URL still carries a literal $RID token.");
+        agentResolved.ShouldNotContain("{RID}", customMessage: "resolved URL still carries a {RID} placeholder.");
+    }
+
+    [Fact]
+    public void RenderInnerScript_NoUnsubstitutedServerPlaceholdersRemain()
+    {
+        // Any {{PLACEHOLDER}} left in the dispatched script is a substitution the strategy forgot
+        // to fill; it reaches the agent verbatim and breaks at runtime (the $RID bug's cousin).
+        // One invariant guards the entire server-side placeholder surface, not just the ones with
+        // bespoke tests.
+        var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
+
+        System.Text.RegularExpressions.Regex.Matches(inner, @"\{\{[A-Z0-9_]+\}\}").Count
+            .ShouldBe(0, customMessage: "an unsubstituted {{PLACEHOLDER}} survived into the dispatched script.");
+    }
+
+    // The URL the server embedded in `$DOWNLOAD_URL = '<url>'` (single-quoted → PowerShell stores
+    // it verbatim). The rewrite line below it carries no single-quoted URL, so the first match is
+    // the assignment.
+    private static string ExtractDownloadUrlLiteral(string renderedScript)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(renderedScript, @"\$DOWNLOAD_URL\s*=\s*'([^']*)'");
+
+        match.Success.ShouldBeTrue(customMessage: "could not find the $DOWNLOAD_URL single-quoted assignment in the rendered script.");
+
+        return match.Groups[1].Value;
+    }
+
     // ── J.E.7: HealthcheckFatalEnvVar pins ──────────────────────────────────
 
     [Fact]

--- a/tests/Squid.WindowsTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
@@ -284,6 +284,19 @@ public sealed class LocalReleaseMirror : IDisposable
             _receivedRequests.Add(path);
         }
 
+        // Real GitHub returns 404 for an asset whose name still carries an UNEXPANDED token
+        // — e.g. a script that failed to resolve PowerShell's $RID, or a {{PLACEHOLDER}} the
+        // server forgot to substitute. A permissive "serve any .zip" mirror masks that class
+        // of bug: the Windows "$RID not expanded → 404" outage shipped precisely because this
+        // stub served the literal ".../squid-tentacle-<ver>-$RID.zip" path with a 200. Mirror
+        // the real contract — an unresolved-token path does not exist.
+        if (ContainsUnresolvedToken(path))
+        {
+            ctx.Response.StatusCode = 404;
+            ctx.Response.OutputStream.Close();
+            return;
+        }
+
         // 404 if the path mentions any of the configured "not found" versions.
         if (_notFoundVersions.Any(v => path.Contains(v, StringComparison.OrdinalIgnoreCase)))
         {
@@ -319,6 +332,15 @@ public sealed class LocalReleaseMirror : IDisposable
         ctx.Response.StatusCode = 404;
         ctx.Response.OutputStream.Close();
     }
+
+    // A well-formed release asset path never contains a server placeholder or an unexpanded
+    // PowerShell variable. If one is present the agent failed to resolve it, and real GitHub
+    // would 404 — so we do too, instead of papering over it by serving any .zip.
+    private static bool ContainsUnresolvedToken(string path) =>
+        path.Contains("$RID", StringComparison.Ordinal) ||
+        path.Contains("$TARGET_VERSION", StringComparison.Ordinal) ||
+        path.Contains("{{", StringComparison.Ordinal) ||
+        path.Contains("{RID}", StringComparison.Ordinal);
 
     /// <summary>
     /// Serves the SHA256 companion for the underlying archive. Production


### PR DESCRIPTION
## Summary

Windows tentacle upgrades fail at the download step with `Download failed: (404)`. The server emits the upgrade URL with a literal `$RID` placeholder (it can't know the agent's architecture), but `upgrade-windows-tentacle.ps1` assigned it with **single quotes** — `$DOWNLOAD_URL = '...-$RID.zip'` — so PowerShell never expanded `$RID`. The agent then requested `.../squid-tentacle-<ver>-$RID.zip`, which doesn't exist → GitHub 404.

Fix: rewrite the `$RID` token to the architecture-resolved value right after arch detection, before `Invoke-WebRequest` consumes the URL. A targeted `.Replace('$RID', $RID)` — not a double-quoted re-assignment — so an operator-overridden base URL with other `$`/backtick characters is left intact.

## Impact

- Zip is the **only** Windows upgrade method, so this broke **every** Windows tentacle upgrade at the download step since the feature shipped — it is a latent bug, not a regression in any recent release.
- Linux is unaffected: its `DOWNLOAD_URL="..."` is double-quoted and `$RID` is set before the assignment, so bash expands it.
- Why CI missed it: the Windows lifecycle E2E reads the real `.ps1` but its `LocalReleaseMirror` serves any `.zip` path, so the literal-`$RID` URL got a 200 there while real GitHub returns 404.

## Test plan

- [x] `RenderInnerScript_DownloadUrl_RewritesLiteralRidTokenBeforeDownload` — written test-first (RED before the fix, GREEN after); asserts the script rewrites the literal `$RID` token before `Invoke-WebRequest` consumes `$DOWNLOAD_URL`
- [x] Full unit suite green (5905/5905)
- [x] Full solution build (0 errors)
- [x] Resolved URL `.../squid-tentacle-1.8.11-win-x64.zip` confirmed to exist as a published release asset