### PR TITLE
Fix and harden Windows tentacle upgrade download path

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -7,9 +7,14 @@ name: Tentacle Windows E2E
 #
 # Single-job, multi-step layout (vs tests.yml's one-job-per-project) is a
 # deliberate cost optimization — splitting into separate jobs would spin up an
-# additional windows-latest VM per project (2x billing applies per VM). The
-# trade-off is sequential execution + slightly muddier failure attribution;
-# the per-step name + per-step filter input are how we keep both clear.
+# additional VM per project (2x billing applies per VM). The trade-off is
+# sequential execution + slightly muddier failure attribution; the per-step
+# name + per-step filter input are how we keep both clear.
+#
+# OS matrix: the job fans out over windows-2019 AND windows-2022 to prove the
+# self-upgrade across Windows versions (older SCM / TLS defaults on 2019). This
+# multiplies the VM minutes by the matrix size — acceptable because the run is
+# nightly/dispatch-gated, not per-PR.
 
 on:
   schedule:
@@ -32,8 +37,14 @@ permissions:
 
 jobs:
   windows-tentacle-e2e:
-    name: Windows Tentacle End-to-End
-    runs-on: windows-latest
+    name: Windows Tentacle End-to-End (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Prove the upgrade across Windows versions: 2019 (older SCM / TLS defaults)
+      # AND 2022. fail-fast: false so one OS's failure doesn't mask the other's result.
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
     env:
       NUGET_CONFIG: ${{ github.workspace }}/NuGet.Config
 

--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -11,10 +11,11 @@ name: Tentacle Windows E2E
 # sequential execution + slightly muddier failure attribution; the per-step
 # name + per-step filter input are how we keep both clear.
 #
-# OS matrix: the job fans out over windows-2019 AND windows-2022 to prove the
-# self-upgrade across Windows versions (older SCM / TLS defaults on 2019). This
+# OS matrix: the job fans out over windows-2022 AND windows-2025 to prove the
+# self-upgrade across Windows versions (older SCM / TLS defaults on 2022). This
 # multiplies the VM minutes by the matrix size — acceptable because the run is
-# nightly/dispatch-gated, not per-PR.
+# nightly/dispatch-gated, not per-PR. (windows-2019 is retired from GitHub-hosted
+# runners — its label queues forever, so it is deliberately not in the matrix.)
 
 on:
   schedule:
@@ -40,11 +41,13 @@ jobs:
     name: Windows Tentacle End-to-End (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
-      # Prove the upgrade across Windows versions: 2019 (older SCM / TLS defaults)
-      # AND 2022. fail-fast: false so one OS's failure doesn't mask the other's result.
+      # Prove the upgrade across Windows versions: 2022 (older SCM / TLS defaults)
+      # AND 2025 (current windows-latest). windows-2019 is retired from GitHub-hosted
+      # runners, so its label queues forever — do not use it. fail-fast: false so one
+      # OS's failure doesn't mask the other's result.
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
     env:
       NUGET_CONFIG: ${{ github.workspace }}/NuGet.Config
 

--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -75,7 +75,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# ── Defaults (Rule 8 -- pinned literals) ─────────────────────────────────────
+# -- Defaults (Rule 8 -- pinned literals) -------------------------------------
 # Renaming any of these breaks operator runbooks, MDM playbooks, and the
 # in-UI script-generator's expectations.
 $DefaultVersion       = 'latest'
@@ -94,7 +94,7 @@ if ([string]::IsNullOrWhiteSpace($Version))      { $Version = $DefaultVersion }
 if ([string]::IsNullOrWhiteSpace($InstallDir))   { $InstallDir = $DefaultInstallDir }
 if ([string]::IsNullOrWhiteSpace($DownloadBase)) { $DownloadBase = $DefaultDownloadBase }
 
-# ── Arch detection ──────────────────────────────────────────────────────────
+# -- Arch detection ----------------------------------------------------------
 function Resolve-Rid {
     param([string] $Arch)
 
@@ -114,13 +114,13 @@ if ([string]::IsNullOrWhiteSpace($arch)) {
 
 $rid = Resolve-Rid -Arch $arch
 
-# ── UAC auto-elevation ──────────────────────────────────────────────────────
+# -- UAC auto-elevation ------------------------------------------------------
 # Default install dir (%ProgramFiles%) + writing %ProgramData%\Squid both
 # require Administrator. Rather than refuse to run for non-admin operators,
 # we re-launch this script under UAC.
 #
 # Two invocation modes need handling:
-#   1. File-invocation  (`.\install-tentacle.ps1 …`) -- $PSCommandPath is set;
+#   1. File-invocation  (`.\install-tentacle.ps1 ...`) -- $PSCommandPath is set;
 #                       we relaunch the same file.
 #   2. Pipe-invocation  (`irm <url> | iex`) -- $PSCommandPath is empty; the
 #                       script body lives in $MyInvocation.MyCommand.ScriptContents.
@@ -211,7 +211,7 @@ function Invoke-SelfElevation {
 UAC elevation failed: $($_.Exception.Message)
 
 Workarounds:
-  1. Right-click PowerShell → 'Run as Administrator', then re-run this script
+  1. Right-click PowerShell -> 'Run as Administrator', then re-run this script
   2. From an admin terminal: powershell -NoProfile -ExecutionPolicy Bypass -File '$scriptPath' $(($forwarded -join ' '))
   3. Install to a user-owned path (no admin needed):
        .\install-tentacle.ps1 -InstallDir "$env:USERPROFILE\squid-tentacle"
@@ -250,7 +250,7 @@ Write-Host "Arch:     $rid"
 Write-Host "Install:  $InstallDir"
 Write-Host ''
 
-# ── Download URL resolution ─────────────────────────────────────────────────
+# -- Download URL resolution -------------------------------------------------
 function Resolve-DownloadUrls {
     param(
         [string] $Version,
@@ -281,7 +281,13 @@ try {
         Write-Host "Downloading from $url..."
 
         try {
-            Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing -TimeoutSec 300
+            # System.Net.WebClient + forced TLS 1.2, NOT Invoke-WebRequest: PS 5.1's
+            # Invoke-WebRequest -OutFile corrupts large binary downloads on some hosts
+            # (truncated zip -> extraction "End of central directory not found"); WebClient
+            # streams the bytes verbatim. Same fix as upgrade-windows-tentacle.ps1.
+            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+            $wc = New-Object System.Net.WebClient
+            try { $wc.DownloadFile($url, $archivePath) } finally { $wc.Dispose() }
             $downloaded = $true
             break
         } catch {
@@ -302,7 +308,7 @@ Possible causes:
         exit 1
     }
 
-    # ── Extract into a versioned ("blue-green") layout ───────────────────────
+    # -- Extract into a versioned ("blue-green") layout -----------------------
     # Binary lives in versions\<v>; a stable `current` junction selects the active
     # version. A later upgrade repoints `current` without touching the running
     # version's directory, so any failure leaves the old version intact. Stage
@@ -316,7 +322,8 @@ Possible causes:
     New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
 
     Write-Host "Extracting..."
-    Expand-Archive -Path $archivePath -DestinationPath $stagingDir -Force
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $stagingDir)
 
     $stagedBinary = Join-Path $stagingDir $BinaryName
     if (-not (Test-Path $stagedBinary)) {
@@ -365,7 +372,7 @@ Possible causes:
     Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-# ── Discovery file ──────────────────────────────────────────────────────────
+# -- Discovery file ----------------------------------------------------------
 # Downstream scripts read %ProgramData%\Squid\Tentacle\install-info.json to
 # locate the binary. Without this, the server-generated register/service-install
 # snippet would have to hardcode the install path -- breaking custom InstallDir.
@@ -410,7 +417,7 @@ Write-InstallInfo `
     -InfoPath $InstallInfoPath `
     -Schema $InstallInfoSchema
 
-# ── Firewall rule for Listening Tentacle ────────────────────────────────────
+# -- Firewall rule for Listening Tentacle ------------------------------------
 function Add-ListeningFirewallRule {
     param(
         [string] $RuleName,
@@ -441,7 +448,7 @@ try {
     Write-Warning "Failed to add firewall rule: $($_.Exception.Message). For Listening Tentacle, manually run: New-NetFirewallRule -DisplayName 'Squid Tentacle' -Direction Inbound -Protocol TCP -LocalPort $ListeningPort -Action Allow"
 }
 
-# ── Service install ─────────────────────────────────────────────────────────
+# -- Service install ---------------------------------------------------------
 if ($NoServiceInstall) {
     Write-Host ''
     Write-Host '-NoServiceInstall set -- skipping service install.'
@@ -463,7 +470,7 @@ if ($NoServiceInstall) {
     Write-Host ''
 }
 
-# ── Next-step hints ─────────────────────────────────────────────────────────
+# -- Next-step hints ---------------------------------------------------------
 Write-Host '=== Next steps ==='
 Write-Host ''
 Write-Host 'Register the agent with your Squid server (the install-info.json above'

--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -268,6 +268,32 @@ function Resolve-DownloadUrls {
     )
 }
 
+# -- Generic retry helper -- retry transient failures (network blips, Defender
+# file locks) with linear backoff so a single hiccup doesn't fail the install.
+# Re-throws once attempts are exhausted so the caller's catch handles it.
+function Invoke-WithRetry {
+    param(
+        [scriptblock] $Action,
+        [string] $Label,
+        [int] $MaxAttempts = 3,
+        [int] $BaseDelaySeconds = 2
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            & $Action
+            return
+        }
+        catch {
+            if ($attempt -ge $MaxAttempts) { throw }
+
+            $delay = $BaseDelaySeconds * $attempt
+            Write-Host "  $Label attempt $attempt/$MaxAttempts failed: $($_.Exception.Message) -- retrying in ${delay}s"
+            Start-Sleep -Seconds $delay
+        }
+    }
+}
+
 $urls = Resolve-DownloadUrls -Version $Version -Rid $rid -DownloadBase $DownloadBase
 
 $tempDir = Join-Path $env:TEMP "squid-tentacle-install-$([guid]::NewGuid().ToString('N'))"
@@ -286,8 +312,26 @@ try {
             # (truncated zip -> extraction "End of central directory not found"); WebClient
             # streams the bytes verbatim. Same fix as upgrade-windows-tentacle.ps1.
             [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
-            $wc = New-Object System.Net.WebClient
-            try { $wc.DownloadFile($url, $archivePath) } finally { $wc.Dispose() }
+
+            # Retry each URL a few times before falling through to the next candidate,
+            # and route through the configured proxy with default creds (407 on
+            # authenticated corporate proxies).
+            Invoke-WithRetry -Label "download" -Action {
+                if (Test-Path $archivePath) { Remove-Item -Path $archivePath -Force -ErrorAction SilentlyContinue }
+
+                $wc = New-Object System.Net.WebClient
+                $wc.UseDefaultCredentials = $true
+                if ($wc.Proxy) { $wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials }
+                try { $wc.DownloadFile($url, $archivePath) } finally { $wc.Dispose() }
+            }
+
+            # Reject a 0-byte / truncated file (error page returned with HTTP 200) so it
+            # fails here with a clear message instead of an opaque extraction error.
+            $archiveSize = (Get-Item $archivePath).Length
+            if ($archiveSize -lt 1024) {
+                throw "Downloaded archive is only $archiveSize byte(s) -- expected a multi-MB zip (likely an error page returned with HTTP 200)."
+            }
+
             $downloaded = $true
             break
         } catch {
@@ -319,11 +363,17 @@ Possible causes:
     }
 
     $stagingDir = Join-Path $tempDir 'extract'
-    New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
 
     Write-Host "Extracting..."
     Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $stagingDir)
+
+    # Retry extraction: Defender can briefly lock a freshly-written file. Clear any
+    # partial output first since ExtractToDirectory has no overwrite overload on PS 5.1.
+    Invoke-WithRetry -Label "extraction" -Action {
+        if (Test-Path $stagingDir) { Remove-Item -Path $stagingDir -Recurse -Force -ErrorAction SilentlyContinue }
+        New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $stagingDir)
+    }
 
     $stagedBinary = Join-Path $stagingDir $BinaryName
     if (-not (Test-Path $stagedBinary)) {
@@ -342,7 +392,8 @@ Possible causes:
         $versionDir = Join-Path $versionsRoot $resolvedVersion
         if (-not (Test-Path $versionsRoot)) { New-Item -ItemType Directory -Path $versionsRoot -Force | Out-Null }
         if (Test-Path $versionDir) { Remove-Item -Path $versionDir -Recurse -Force }
-        Move-Item -Path $stagingDir -Destination $versionDir
+        # Retry the swap: Defender may briefly lock a freshly-extracted file.
+        Invoke-WithRetry -Label "version swap" -Action { Move-Item -Path $stagingDir -Destination $versionDir }
 
         # Repoint `current` at the new version. Delete the old junction
         # NON-recursively ([Directory]::Delete(path, $false)) so we remove only the

--- a/deploy/scripts/install-tentacle.ps1
+++ b/deploy/scripts/install-tentacle.ps1
@@ -325,11 +325,15 @@ try {
                 try { $wc.DownloadFile($url, $archivePath) } finally { $wc.Dispose() }
             }
 
-            # Reject a 0-byte / truncated file (error page returned with HTTP 200) so it
-            # fails here with a clear message instead of an opaque extraction error.
+            # Validate the download is actually a zip via its PK magic bytes (0x50 0x4B)
+            # so an error page returned with HTTP 200 / a truncated write fails here with
+            # a clear message instead of an opaque extraction error. Any valid zip passes
+            # regardless of size (a fixed size floor would wrongly reject small archives).
             $archiveSize = (Get-Item $archivePath).Length
-            if ($archiveSize -lt 1024) {
-                throw "Downloaded archive is only $archiveSize byte(s) -- expected a multi-MB zip (likely an error page returned with HTTP 200)."
+            $zipStream = [System.IO.File]::OpenRead($archivePath)
+            try { $zipB0 = $zipStream.ReadByte(); $zipB1 = $zipStream.ReadByte() } finally { $zipStream.Dispose() }
+            if ($zipB0 -ne 0x50 -or $zipB1 -ne 0x4B) {
+                throw "Downloaded file is not a zip archive (missing PK header, $archiveSize bytes) -- likely an error page returned with HTTP 200, or a truncated download."
             }
 
             $downloaded = $true

--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -579,14 +579,19 @@ try {
                     try { $downloadClient.DownloadFile($DOWNLOAD_URL, $archivePath) } finally { $downloadClient.Dispose() }
                 }
 
-                # Sanity-check the size: a 0-byte / truncated file (proxy error page
-                # returned with HTTP 200, disk full mid-write) would otherwise fail later
-                # at extraction with an opaque "central directory" error. Catch it here.
+                # Validate the download is actually a zip via its PK magic bytes
+                # (0x50 0x4B). A proxy error page returned with HTTP 200, a truncated /
+                # 0-byte write, or an HTML 404 would otherwise fail later at extraction
+                # with an opaque "central directory" error. A valid zip of ANY size
+                # passes (a fixed size floor would wrongly reject small archives);
+                # non-zip content (HTML '<', JSON '{', empty) is rejected here clearly.
                 $archiveSize = (Get-Item $archivePath).Length
-                if ($archiveSize -lt 1024) {
-                    throw "Downloaded archive is only $archiveSize byte(s) -- expected a multi-MB zip. The server likely returned an error page with HTTP 200, or the write was truncated."
+                $zipStream = [System.IO.File]::OpenRead($archivePath)
+                try { $zipB0 = $zipStream.ReadByte(); $zipB1 = $zipStream.ReadByte() } finally { $zipStream.Dispose() }
+                if ($zipB0 -ne 0x50 -or $zipB1 -ne 0x4B) {
+                    throw "Downloaded file is not a zip archive (missing PK header, $archiveSize bytes) -- the server likely returned an error page with HTTP 200, or the download was truncated."
                 }
-                Append-UpgradeLog "[upgrade-method:zip] Downloaded $archiveSize bytes"
+                Append-UpgradeLog "[upgrade-method:zip] Downloaded $archiveSize bytes (valid zip header)"
             }
             catch {
                 Append-UpgradeLog "[upgrade-method:zip] Download failed: $($_.Exception.Message)"

--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -3,36 +3,36 @@
 # ------------------------------------------------------------------------------
 # Sent over a Halibut polling RPC by the server's WindowsTentacleUpgradeStrategy
 # at ScriptIsolationLevel.FullIsolation, so the agent serialises
-# this behind any in-flight deployment scripts — we never restart a tentacle
+# this behind any in-flight deployment scripts -- we never restart a tentacle
 # mid-deploy.
 #
 # Placeholders ({{...}}) are filled by the server before transmission.
 #
 # Mirrors the Linux upgrade-linux-tentacle.sh structure for operator-readability
-# parity: same Phase A → Phase B split, same INSTALL_OK / INSTALL_METHOD
+# parity: same Phase A -> Phase B split, same INSTALL_OK / INSTALL_METHOD
 # variables, same status-file shape (WindowsUpgradeStatusStorage
 # layout: %ProgramData%\Squid\Tentacle\upgrade\last-upgrade.json).
 #
 # ARCHITECTURE:
 #   Phase A (in tentacle process / Halibut sees logs):
-#     • Pre-flight (arch, status file setup, idempotency lock).
-#     • INSTALL_METHODS block (server-injected): ordered chocolatey → MSI →
+#     * Pre-flight (arch, status file setup, idempotency lock).
+#     * INSTALL_METHODS block (server-injected): ordered chocolatey -> MSI ->
 #       zip-marker dispatch (ships chocolatey + MSI;
 #       ships zip-marker only). The first method whose detection branch matches
 #       sets $INSTALL_OK = $true.
-#     • If $INSTALL_METHOD = 'zip', the existing zip download/verify/extract
+#     * If $INSTALL_METHOD = 'zip', the existing zip download/verify/extract
 #       block runs (separate from the marker so its ~80 lines stay in the
 #       template, not in C#).
 #
-#   Phase B (after Phase A — see "Detach mechanism" note below):
-#     • Conditional swap: zip method requires Move-Item .\bak / Move-Item
+#   Phase B (after Phase A -- see "Detach mechanism" note below):
+#     * Conditional swap: zip method requires Move-Item .\bak / Move-Item
 #       .\staging; chocolatey/MSI methods are no-ops here (the package
 #       manager already wrote %ProgramFiles%\Squid Tentacle).
-#     • Stop-Service squid-tentacle.
-#     • Move-Item swap.
-#     • Start-Service squid-tentacle.
-#     • Health poll + version verify.
-#     • Status file at %ProgramData%\Squid\Tentacle\upgrade\last-upgrade.json
+#     * Stop-Service squid-tentacle.
+#     * Move-Item swap.
+#     * Start-Service squid-tentacle.
+#     * Health poll + version verify.
+#     * Status file at %ProgramData%\Squid\Tentacle\upgrade\last-upgrade.json
 #       (Octopus parity: server reads on next health check via
 #       Capabilities RPC).
 #
@@ -42,36 +42,36 @@
 #   restart, the WindowsTentacleUpgradeStrategy will wrap the
 #   template invocation in a detach mechanism (likely Task Scheduler one-shot
 #   task running as SYSTEM, equivalent to Linux's `systemd-run --scope`).
-#   This template is written ASSUMING the detach has already happened — it
+#   This template is written ASSUMING the detach has already happened -- it
 #   runs end-to-end synchronously without trying to self-detach.
 #
 # Status progression (matches Linux):
-#   IN_PROGRESS → SWAPPED → SUCCESS
-#                          → ROLLED_BACK
-#                          → ROLLBACK_NEEDED
-#                          → ROLLBACK_CRITICAL_FAILED
+#   IN_PROGRESS -> SWAPPED -> SUCCESS
+#                          -> ROLLED_BACK
+#                          -> ROLLBACK_NEEDED
+#                          -> ROLLBACK_CRITICAL_FAILED
 #
 # Exit codes (Halibut-visible from Phase A):
-#   0   — dispatched to Phase B OR no-op (already on target version)
-#   1   — unsupported architecture
-#   2   — download failure (zip method only)
-#   3   — missing binary in extracted archive
-#   5   — insufficient disk space
-#   7   — SHA256 mismatch (only when EXPECTED_SHA256 is non-empty)
-#   8   — Start-Service post-swap failed → rollback fired (J.E.6)
-#   9   — Healthcheck timeout in FATAL mode → rollback fired (J.E.7)
-#   12  — Windows version too old (PowerShell 5.0+ required, Server 2016+)
-#   13  — failed to acquire upgrade lock (concurrent upgrade in progress)
-#   14  — no install method succeeded (zip + future chocolatey/MSI all skipped or failed)
-#   15  — insufficient privileges (must run as Administrator or LocalSystem)
+#   0   -- dispatched to Phase B OR no-op (already on target version)
+#   1   -- unsupported architecture
+#   2   -- download failure (zip method only)
+#   3   -- missing binary in extracted archive
+#   5   -- insufficient disk space
+#   7   -- SHA256 mismatch (only when EXPECTED_SHA256 is non-empty)
+#   8   -- Start-Service post-swap failed -> rollback fired (J.E.6)
+#   9   -- Healthcheck timeout in FATAL mode -> rollback fired (J.E.7)
+#   12  -- Windows version too old (PowerShell 5.0+ required, Server 2016+)
+#   13  -- failed to acquire upgrade lock (concurrent upgrade in progress)
+#   14  -- no install method succeeded (zip + future chocolatey/MSI all skipped or failed)
+#   15  -- insufficient privileges (must run as Administrator or LocalSystem)
 # ==============================================================================
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-# ── Identity gate ──────────────────────────────────────────────
+# -- Identity gate ----------------------------------------------
 # The WindowsTentacleUpgradeStrategy wraps invocation in a
-# Task Scheduler one-shot task with `/RU SYSTEM` — equivalent to Linux's
+# Task Scheduler one-shot task with `/RU SYSTEM` -- equivalent to Linux's
 # `systemd-run --scope` running as root. If we see a non-elevated identity
 # here, the wrapper failed silently and Phase B's `Stop-Service` /
 # `Move-Item` will fail at a confusing layer. Fail fast with a clear message.
@@ -85,9 +85,9 @@ if (-not $isElevated -and -not $isSystem) {
     exit 15
 }
 
-# ── Arch detection MUST run before DOWNLOAD_URL is consumed ───────────────────
+# -- Arch detection MUST run before DOWNLOAD_URL is consumed -------------------
 # $env:PROCESSOR_ARCHITECTURE on a 64-bit OS is "AMD64" (x64) or "ARM64".
-# 32-bit Windows is NOT supported — docs analysis concluded
+# 32-bit Windows is NOT supported -- docs analysis concluded
 # x86 has no real audience in 2026 (Server 2012 R2 was the last 32-bit
 # Windows Server, EOL 2023).
 $arch = $env:PROCESSOR_ARCHITECTURE
@@ -101,25 +101,25 @@ switch -Regex ($arch) {
     }
 }
 
-# ── Placeholders filled by WindowsTentacleUpgradeStrategy before transmission ─
+# -- Placeholders filled by WindowsTentacleUpgradeStrategy before transmission -
 $TARGET_VERSION   = '{{TARGET_VERSION}}'
 $DOWNLOAD_URL     = '{{DOWNLOAD_URL}}'
 # The server can't know the agent's architecture, so it emits the URL with a literal
 # '$RID' token. The single-quoted assignment above keeps it literal (PowerShell never
 # re-expands a stored value at use time), so resolve it now that arch detection has set
-# $RID. A targeted Replace — not a double-quoted re-assignment — leaves any other '$' or
+# $RID. A targeted Replace -- not a double-quoted re-assignment -- leaves any other '$' or
 # backtick in an operator-overridden base URL untouched.
 $DOWNLOAD_URL     = $DOWNLOAD_URL.Replace('$RID', $RID)
 $EXPECTED_SHA256  = '{{EXPECTED_SHA256}}'
 $INSTALL_DIR      = '{{INSTALL_DIR}}'
 $SERVICE_NAME     = '{{SERVICE_NAME}}'
 $HEALTHCHECK_URL  = '{{HEALTHCHECK_URL}}'
-# Retry count substituted as a numeric literal (no quotes) — `[int]` cast
+# Retry count substituted as a numeric literal (no quotes) -- `[int]` cast
 # would fail on a quoted-and-cast empty string if the placeholder ever
 # defaults to empty.
 $HEALTHCHECK_RETRIES = {{HEALTHCHECK_RETRIES}}
 # Healthcheck failure mode. Substituted by the strategy as `$true` /
-# `$false` (PowerShell boolean literals — no quotes) so this assignment
+# `$false` (PowerShell boolean literals -- no quotes) so this assignment
 # is type-safe regardless of operator's env var format. Default `$false`
 # = warning + proceed (matches Octopus Tentacle); `$true` = strict =
 # rollback on timeout. See WindowsTentacleUpgradeStrategy.HealthcheckFatalEnvVar.
@@ -140,13 +140,13 @@ $STATUS_FILE = Join-Path $STATUS_DIR 'last-upgrade.json'
 $LOCK_FILE   = Join-Path $STATUS_DIR 'upgrade.lock'
 $LOG_FILE    = Join-Path $STATUS_DIR 'upgrade.log'
 
-# ── Layout detection (blue-green) ────────────────────────────────────────────
+# -- Layout detection (blue-green) --------------------------------------------
 # A versioned install selects its active version via the `current` junction
 # ({INSTALL_DIR}\current -> versions\<v>). When versioned, Phase B activates the
 # new version by repointing `current` and NEVER touches the running version's
 # directory, so any failure leaves the old version intact and instantly
 # restorable. Flat installs (no `current` junction) keep today's .bak swap
-# byte-for-byte — the entire blue-green path is gated on $isVersioned. We only
+# byte-for-byte -- the entire blue-green path is gated on $isVersioned. We only
 # treat the install as versioned when `current` is a reparse point AND its
 # target reads back cleanly; anything else falls back to the flat path.
 $isVersioned = $false
@@ -190,7 +190,7 @@ if (-not (Test-Path $STATUS_DIR)) {
 # corrupt the first JSON line the server parses). Best-effort.
 try { [System.IO.File]::WriteAllText($EVENTS_FILE, '', (New-Object System.Text.UTF8Encoding($false))) } catch { }
 
-# ── Status file helper — atomic write via temp+rename ────────────────────────
+# -- Status file helper -- atomic write via temp+rename ------------------------
 function Write-UpgradeStatus {
     param(
         [string] $Status,
@@ -210,7 +210,7 @@ function Write-UpgradeStatus {
         scriptPid     = $PID
     } | ConvertTo-Json -Depth 5
 
-    # Temp + rename for atomicity — readers (Squid server's
+    # Temp + rename for atomicity -- readers (Squid server's
     # WindowsUpgradeStatusStorage via Capabilities RPC) can never see a
     # half-written JSON.
     $temp = "$STATUS_FILE.tmp"
@@ -243,7 +243,7 @@ function Append-UpgradeLog {
     Write-Host $Line
 }
 
-# ── Event timeline helper — append one structured event (parity with the ─────
+# -- Event timeline helper -- append one structured event (parity with the -----
 # Linux script's emit_event). One JSON object per line:
 #   {"t":"2026-06-01T02:57:04Z","phase":"A","kind":"start","msg":"..."}
 function Write-UpgradeEvent {
@@ -253,7 +253,7 @@ function Write-UpgradeEvent {
         [string] $Msg = ''
     )
 
-    # Terminal-state events ALWAYS emit regardless of the cap — operators MUST
+    # Terminal-state events ALWAYS emit regardless of the cap -- operators MUST
     # see the final outcome. This set MUST stay in sync with the Linux script's
     # emit_event terminal list (drift-pinned by the cross-script parity test)
     # and the FE's UPGRADE_EVENTS_TERMINAL_KINDS.
@@ -265,14 +265,14 @@ function Write-UpgradeEvent {
     }
 
     # Minimal JSON-safe escaping: drop quotes and backslashes (events originate
-    # from our own controlled strings — versions, methods, exit codes). Matches
+    # from our own controlled strings -- versions, methods, exit codes). Matches
     # the Linux emit_event `tr -d '"\\'`.
     $safeMsg = $Msg -replace '["\\]', ''
 
     $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     $line = '{"t":"' + $now + '","phase":"' + $Phase + '","kind":"' + $Kind + '","msg":"' + $safeMsg + '"}'
 
-    # BOM-less UTF8 append — PS 5.1's Add-Content -Encoding UTF8 prepends a BOM
+    # BOM-less UTF8 append -- PS 5.1's Add-Content -Encoding UTF8 prepends a BOM
     # that would corrupt the first JSON line the server parses. Best-effort:
     # events are advisory, never fail the upgrade on an event-write hiccup.
     try {
@@ -280,14 +280,14 @@ function Write-UpgradeEvent {
     } catch { }
 }
 
-# ── Rollback helper (J.E.6) ──────────────────────────────────────────────────
+# -- Rollback helper (J.E.6) --------------------------------------------------
 # Restores the previous binary from .bak when Phase B can't bring the new
 # binary up. Three failure modes drive this:
-#   1. Start-Service throws (new binary's OnStart raised → SCM 1067 / "the
+#   1. Start-Service throws (new binary's OnStart raised -> SCM 1067 / "the
 #      service did not start in a timely fashion"). E.g., new binary has a
 #      broken DI graph that throws at construction time.
 #   2. Service start succeeded but new binary's healthcheck never returned
-#      200 within $HEALTHCHECK_RETRIES * 2 seconds — currently a warning
+#      200 within $HEALTHCHECK_RETRIES * 2 seconds -- currently a warning
 #      (matches Octopus Tentacle's behaviour: capabilities probe will detect
 #      a missing version on the next health probe). A future env-var-gated
 #      "fatal" mode will make this a rollback trigger.
@@ -299,9 +299,9 @@ function Write-UpgradeEvent {
 # $TARGET_VERSION are in scope (defined earlier in Phase A / Phase B).
 #
 # Status writes:
-#   - ROLLED_BACK              — clean restoration: old service is RUNNING again
-#   - ROLLBACK_NEEDED          — no .bak available (somehow), can't auto-restore
-#   - ROLLBACK_CRITICAL_FAILED — restored .bak but old service won't start either
+#   - ROLLED_BACK              -- clean restoration: old service is RUNNING again
+#   - ROLLBACK_NEEDED          -- no .bak available (somehow), can't auto-restore
+#   - ROLLBACK_CRITICAL_FAILED -- restored .bak but old service won't start either
 function Invoke-Rollback {
     param(
         [Parameter(Mandatory)] [string] $Reason,
@@ -311,7 +311,7 @@ function Invoke-Rollback {
     Append-UpgradeLog "::warning:: [rollback] Initiating rollback: $Reason"
 
     # Stop new service first if it managed to come up (degraded but running).
-    # Best-effort — SCM may already have force-killed it.
+    # Best-effort -- SCM may already have force-killed it.
     try {
         $svc = Get-Service -Name $SERVICE_NAME -ErrorAction SilentlyContinue
         if ($null -ne $svc -and $svc.Status -ne 'Stopped') {
@@ -320,12 +320,12 @@ function Invoke-Rollback {
             $svc.WaitForStatus('Stopped', $SERVICE_TIMEOUT_SPAN)
         }
     } catch {
-        Append-UpgradeLog "[rollback] Couldn't cleanly stop new service: $($_.Exception.Message). Proceeding with restore — Move-Item might still succeed if SCM has released the binary."
+        Append-UpgradeLog "[rollback] Couldn't cleanly stop new service: $($_.Exception.Message). Proceeding with restore -- Move-Item might still succeed if SCM has released the binary."
     }
 
-    # ── Versioned (blue-green) rollback ──────────────────────────────────────
+    # -- Versioned (blue-green) rollback --------------------------------------
     # Repoint `current` back to the previous version. The previous version
-    # directory was never touched during the swap, so this cannot lose it — even
+    # directory was never touched during the swap, so this cannot lose it -- even
     # if the repoint or the restart fails, the previous binaries remain intact at
     # $oldVerTarget. Flat installs fall through to the .bak restore below.
     if ($isVersioned) {
@@ -358,8 +358,8 @@ function Invoke-Rollback {
     $bakDir = Join-Path $installParent "$installLeaf.bak"
 
     if (-not (Test-Path $bakDir)) {
-        Append-UpgradeLog "::error:: [rollback] No .bak directory at $bakDir — cannot auto-restore. Operator must manually reinstall."
-        Write-UpgradeStatus -Status 'ROLLBACK_NEEDED' -InstallMethod $INSTALL_METHOD -Detail "Failure: $Reason. No .bak available — manual reinstall required." -ExitCode $ExitCode
+        Append-UpgradeLog "::error:: [rollback] No .bak directory at $bakDir -- cannot auto-restore. Operator must manually reinstall."
+        Write-UpgradeStatus -Status 'ROLLBACK_NEEDED' -InstallMethod $INSTALL_METHOD -Detail "Failure: $Reason. No .bak available -- manual reinstall required." -ExitCode $ExitCode
         exit $ExitCode
     }
 
@@ -372,16 +372,16 @@ function Invoke-Rollback {
             Remove-Item -Path $failedDir -Recurse -Force
         }
         if (Test-Path $INSTALL_DIR) {
-            Append-UpgradeLog "[rollback] Moving broken $INSTALL_DIR → $failedDir for post-mortem"
+            Append-UpgradeLog "[rollback] Moving broken $INSTALL_DIR -> $failedDir for post-mortem"
             Move-Item -Path $INSTALL_DIR -Destination $failedDir -Force
         }
     } catch {
         Append-UpgradeLog "::error:: [rollback] Couldn't archive broken binary: $($_.Exception.Message). Restore may fail next step."
     }
 
-    # Restore .bak → INSTALL_DIR.
+    # Restore .bak -> INSTALL_DIR.
     try {
-        Append-UpgradeLog "[rollback] Restoring $bakDir → $INSTALL_DIR"
+        Append-UpgradeLog "[rollback] Restoring $bakDir -> $INSTALL_DIR"
         Move-Item -Path $bakDir -Destination $INSTALL_DIR -Force
     } catch {
         Append-UpgradeLog "::error:: [rollback] Restore Move-Item failed: $($_.Exception.Message)"
@@ -394,7 +394,7 @@ function Invoke-Rollback {
         Append-UpgradeLog "[rollback] Starting service (old binary)"
         Start-Service -Name $SERVICE_NAME
 
-        # Wait for SCM to confirm RUNNING — synchronous proof that the old
+        # Wait for SCM to confirm RUNNING -- synchronous proof that the old
         # service is genuinely back up before we report ROLLED_BACK.
         $svc = Get-Service -Name $SERVICE_NAME
         $svc.WaitForStatus('Running', $SERVICE_TIMEOUT_SPAN)
@@ -409,7 +409,7 @@ function Invoke-Rollback {
     exit $ExitCode
 }
 
-# ── Idempotency: lock file ───────────────────────────────────────────────────
+# -- Idempotency: lock file ---------------------------------------------------
 # Single per-host lock (NOT per-target-version) so two concurrent operator
 # clicks targeting different versions can't race the SCM Stop-Service +
 # Move-Item swap + Start-Service sequence. Mirrors the Linux flock layout.
@@ -427,7 +427,7 @@ if (Test-Path $LOCK_FILE) {
 
     # Regex-parse PID. Avoids `[int]::TryParse([ref])` which has fragile
     # PowerShell binding behaviour. Empty / non-numeric / negative content
-    # leaves $existingPid at 0 → falls through the > 0 guard → treated
+    # leaves $existingPid at 0 -> falls through the > 0 guard -> treated
     # as stale (correct: a non-numeric lock file is corrupt and should
     # be broken).
     $existingPid = 0
@@ -447,13 +447,13 @@ if (Test-Path $LOCK_FILE) {
     }
 
     if ($holderAlive) {
-        Append-UpgradeLog "::error:: Upgrade lock $LOCK_FILE held by LIVE PID $existingPid — refusing concurrent upgrade dispatch"
+        Append-UpgradeLog "::error:: Upgrade lock $LOCK_FILE held by LIVE PID $existingPid -- refusing concurrent upgrade dispatch"
         exit 13
     }
 
-    # Stale lock — log + break + proceed. Operator-visible recovery from
+    # Stale lock -- log + break + proceed. Operator-visible recovery from
     # a previously-crashed dispatch that left the lock orphaned.
-    Append-UpgradeLog "::warning:: Upgrade lock $LOCK_FILE held by stale PID '$existing' (no live process) — breaking lock to recover from a previously-crashed dispatch"
+    Append-UpgradeLog "::warning:: Upgrade lock $LOCK_FILE held by stale PID '$existing' (no live process) -- breaking lock to recover from a previously-crashed dispatch"
     try { Remove-Item -Path $LOCK_FILE -Force -ErrorAction Stop } catch {
         # Couldn't break the lock (permissions / IO error). Operator must
         # intervene; surface the failure clearly.
@@ -465,34 +465,34 @@ if (Test-Path $LOCK_FILE) {
 Set-Content -Path $LOCK_FILE -Value "$PID" -Force
 
 try {
-    Append-UpgradeLog "[upgrade] Phase A starting — target version $TARGET_VERSION on $RID"
+    Append-UpgradeLog "[upgrade] Phase A starting -- target version $TARGET_VERSION on $RID"
     Write-UpgradeStatus -Status 'IN_PROGRESS' -Detail "Phase A starting (target $TARGET_VERSION)"
 
-    # ── Already-on-target short-circuit ─────────────────────────────────────
+    # -- Already-on-target short-circuit -------------------------------------
     # If the running binary is already at the target version, short-circuit.
     # The strategy would normally do this server-side via the
     # AlreadyUpToDate path, but a stale runtime-cache could let an upgrade
-    # dispatch through anyway — this is the agent-side defence-in-depth.
+    # dispatch through anyway -- this is the agent-side defence-in-depth.
     $tentacleExe = Join-Path $INSTALL_DIR 'Squid.Tentacle.exe'
 
     if (Test-Path $tentacleExe) {
         $currentVersion = (Get-Item $tentacleExe).VersionInfo.ProductVersion
 
         if ($currentVersion -eq $TARGET_VERSION) {
-            Append-UpgradeLog "[upgrade] Already on target version $TARGET_VERSION — no-op"
+            Append-UpgradeLog "[upgrade] Already on target version $TARGET_VERSION -- no-op"
             Write-UpgradeStatus -Status 'SUCCESS' -Detail "Already on target $TARGET_VERSION (no-op)"
             exit 0
         }
     }
 
-    # ── INSTALL_METHODS dispatch (server-injected) ──────────────────────────
+    # -- INSTALL_METHODS dispatch (server-injected) --------------------------
     # The server replaces the placeholder below with the concatenated snippets
     # from each IWindowsUpgradeMethod's RenderDetectAndInstall.
     # ships zip-marker only;  will add chocolatey + MSI.
     #
     # IMPORTANT: do NOT mention the placeholder name verbatim anywhere except
     # the actual substitution site below. WindowsTentacleUpgradeStrategy uses
-    # String.Replace which matches every occurrence — a comment-line mention
+    # String.Replace which matches every occurrence -- a comment-line mention
     # would be rewritten too, splicing multi-line PowerShell into a `#`-prefixed
     # line and producing parse errors that ONLY surface at agent-side Task
     # Scheduler invocation (operator sees Initiated, no upgrade actually runs).
@@ -502,7 +502,7 @@ try {
 
     {{INSTALL_METHODS}}
 
-    # ── Zip-method execution block ──────────────────────────────────────────
+    # -- Zip-method execution block ------------------------------------------
     # The marker emitted by ZipUpgradeMethod.RenderDetectAndInstall sets
     # $INSTALL_METHOD = 'zip'. This block does the actual work.
     if ($INSTALL_METHOD -eq 'zip' -and $INSTALL_OK -ne $true) {
@@ -512,13 +512,19 @@ try {
         try {
             New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
 
-            Append-UpgradeLog "[upgrade-method:zip] Downloading $DOWNLOAD_URL → $archivePath"
+            Append-UpgradeLog "[upgrade-method:zip] Downloading $DOWNLOAD_URL -> $archivePath"
 
             try {
-                # -UseBasicParsing avoids needing IE first-run config on
-                # stripped Server Core images. -TimeoutSec 600 = 10 min budget
-                # for the download (matches install-tentacle.ps1's pattern).
-                Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $archivePath -UseBasicParsing -TimeoutSec 600
+                # System.Net.WebClient, NOT Invoke-WebRequest: Windows PowerShell 5.1's
+                # Invoke-WebRequest -OutFile corrupts large binary downloads on some hosts
+                # (truncated zip -> "End of central directory record could not be found" at
+                # extract time, exit 14) while WebClient.DownloadFile streams the bytes
+                # verbatim. Force TLS 1.2 first -- 5.1 may still negotiate 1.0/1.1, which
+                # GitHub rejects. Verified on a real agent: WebClient returns the byte-exact
+                # archive where Invoke-WebRequest returned a corrupt one.
+                [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+                $downloadClient = New-Object System.Net.WebClient
+                try { $downloadClient.DownloadFile($DOWNLOAD_URL, $archivePath) } finally { $downloadClient.Dispose() }
             }
             catch {
                 Append-UpgradeLog "[upgrade-method:zip] Download failed: $($_.Exception.Message)"
@@ -530,7 +536,7 @@ try {
             # upgrade-linux-tentacle.sh:418-429 pattern. Resolution chain:
             #
             #   (1) Strategy-substituted EXPECTED_SHA256 (server-side override
-            #       — operator pinned a specific hash via env var, or strategy
+            #       -- operator pinned a specific hash via env var, or strategy
             #       in the future starts substituting from a manifest)
             #
             #   (2) <DOWNLOAD_URL>.sha256 companion file (has
@@ -539,33 +545,39 @@ try {
             #
             #   (3) Fall through with skip-with-warning (matches Linux's
             #       behaviour for older releases that don't have .sha256
-            #       companions yet — backward compat for in-the-wild artifacts)
+            #       companions yet -- backward compat for in-the-wild artifacts)
             #
             # Format expected: `sha256sum`'s default output (`<64-hex>  <filename>`).
             # We strip whitespace + tail and validate hex-only-64-chars before
-            # using — anything else is treated as "no valid SHA available"
+            # using -- anything else is treated as "no valid SHA available"
             # and falls through. Mirrors Linux's grep-and-validate guard.
             if ([string]::IsNullOrWhiteSpace($EXPECTED_SHA256)) {
                 $shaUrl = "$DOWNLOAD_URL.sha256"
-                Append-UpgradeLog "[upgrade-method:zip] EXPECTED_SHA256 empty — opportunistic fetch from $shaUrl"
+                Append-UpgradeLog "[upgrade-method:zip] EXPECTED_SHA256 empty -- opportunistic fetch from $shaUrl"
                 try {
-                    $shaResponse = Invoke-WebRequest -Uri $shaUrl -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
+                    # WebClient.DownloadString, NOT Invoke-WebRequest -- same PS 5.1 robustness
+                    # reason as the archive download above.
+                    $shaClient = New-Object System.Net.WebClient
+                    try { $shaContent = $shaClient.DownloadString($shaUrl) } finally { $shaClient.Dispose() }
                     # Take ONLY the first whitespace-delimited token (hex digest).
                     # `sha256sum file > file.sha256` writes "<hex>  <filename>".
-                    $fetched = ($shaResponse.Content -split '\s+', 2)[0].Trim().ToLower()
+                    $fetched = ($shaContent -split '\s+', 2)[0].Trim().ToLower()
                     if ($fetched -match '^[0-9a-f]{64}$') {
                         $EXPECTED_SHA256 = $fetched
                         Append-UpgradeLog "[upgrade-method:zip] Fetched expected SHA256 from $shaUrl"
                     }
                     else {
-                        Append-UpgradeLog "[upgrade-method:zip] Companion at $shaUrl returned non-hex / wrong-length content — skipping verification"
+                        # Log the actual content (ASCII-sanitised, truncated) so a malformed or
+                        # redirected companion is diagnosable from the web log without RDP.
+                        $shaSnippet = ($shaContent.Substring(0, [Math]::Min(80, $shaContent.Length))) -replace '[^\x20-\x7E]', '?'
+                        Append-UpgradeLog "[upgrade-method:zip] Companion at $shaUrl returned non-hex/wrong-length content (first 80 chars: '$shaSnippet') -- skipping verification"
                     }
                 }
                 catch {
                     # Common, expected case for older releases without .sha256
                     # companions OR for air-gap mirrors that haven't replicated
                     # the companion files yet. NOT a fatal error.
-                    Append-UpgradeLog "[upgrade-method:zip] No .sha256 companion at $shaUrl — skipping verification (release pipeline does not yet publish per-archive hashes for this version)"
+                    Append-UpgradeLog "[upgrade-method:zip] No .sha256 companion at $shaUrl -- skipping verification (release pipeline does not yet publish per-archive hashes for this version)"
                 }
             }
 
@@ -578,7 +590,7 @@ try {
                 # auto-loader; some Windows runner images + stripped-down
                 # PowerShell installations have observed the auto-loader fail
                 # with `CommandNotFoundException` for the SHA cmdlet even when
-                # `Invoke-WebRequest` (same module) loads fine — likely a
+                # `Invoke-WebRequest` (same module) loads fine -- likely a
                 # partial module-cache state under the combination of
                 # `$ErrorActionPreference = 'Stop'` and
                 # `Set-StrictMode -Version Latest`. Direct .NET avoids the
@@ -609,7 +621,12 @@ try {
             New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
 
             Append-UpgradeLog "[upgrade-method:zip] Extracting to $extractDir"
-            Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+            # [System.IO.Compression.ZipFile]::ExtractToDirectory, NOT Expand-Archive: the BCL
+            # API is more robust on large / Linux-`zip`-built archives and surfaces a clearer
+            # error than the cmdlet wrapper. Add-Type loads the assembly on PS 5.1 (already
+            # present in pwsh 7). Consistent with the direct-.NET SHA path above.
+            Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+            [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $extractDir)
 
             $extractedExe = Join-Path $extractDir 'Squid.Tentacle.exe'
 
@@ -620,7 +637,7 @@ try {
             }
 
             $INSTALL_OK = $true
-            Append-UpgradeLog "[upgrade-method:zip] Phase A complete — staging dir $extractDir ready for swap"
+            Append-UpgradeLog "[upgrade-method:zip] Phase A complete -- staging dir $extractDir ready for swap"
         }
         catch {
             Append-UpgradeLog "[upgrade-method:zip] Unexpected failure: $($_.Exception.Message)"
@@ -629,24 +646,24 @@ try {
         }
     }
 
-    # ── No method matched — operator must investigate ───────────────────────
+    # -- No method matched -- operator must investigate -----------------------
     if ($INSTALL_OK -ne $true) {
-        Append-UpgradeLog "::error:: No install method succeeded — INSTALL_METHOD='$INSTALL_METHOD'"
+        Append-UpgradeLog "::error:: No install method succeeded -- INSTALL_METHOD='$INSTALL_METHOD'"
         Write-UpgradeStatus -Status 'FAILED' -InstallMethod $INSTALL_METHOD -Detail "No install method succeeded" -ExitCode 14
         exit 14
     }
 
-    # ── Phase B: Stop service → swap → start service → health check ─────────
+    # -- Phase B: Stop service -> swap -> start service -> health check ---------
     # This block runs SYNCHRONOUSLY and assumes the strategy has
     # already detached the script process from the Tentacle service tree
     # (likely via a Task Scheduler one-shot wrapper, equivalent to Linux's
     # `systemd-run --scope`). If the script is invoked directly inside the
     # Tentacle process tree without a detach wrapper, Stop-Service will
-    # terminate this process before Phase B completes — an orchestration
+    # terminate this process before Phase B completes -- an orchestration
     # concern owned by E.3's strategy, not by this template.
-    Append-UpgradeLog "[upgrade] Phase B starting — stopping service '$SERVICE_NAME' and swapping binary"
+    Append-UpgradeLog "[upgrade] Phase B starting -- stopping service '$SERVICE_NAME' and swapping binary"
 
-    # Entering Phase B — events emitted from here are tagged phase 'B'.
+    # Entering Phase B -- events emitted from here are tagged phase 'B'.
     $script:CURRENT_PHASE = 'B'
 
     $serviceWasRunning = $false
@@ -666,10 +683,10 @@ try {
         }
     }
     else {
-        Append-UpgradeLog "[upgrade] Service $SERVICE_NAME not registered yet — first install path"
+        Append-UpgradeLog "[upgrade] Service $SERVICE_NAME not registered yet -- first install path"
     }
 
-    # ── Conditional swap ────────────────────────────────────────────────────
+    # -- Conditional swap ----------------------------------------------------
     # Versioned (blue-green): stage the new version into versions\<target> and
     # repoint the `current` junction; the running version directory is NEVER
     # touched, so any failure leaves it intact. Flat: legacy move-aside .bak swap.
@@ -714,7 +731,7 @@ try {
             New-Item -ItemType Junction -Path $currentPointer -Target $newVerDir | Out-Null
         }
 
-        Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Activated versions\$TARGET_VERSION via current junction — restarting service"
+        Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Activated versions\$TARGET_VERSION via current junction -- restarting service"
     }
     elseif ($INSTALL_METHOD -eq 'zip') {
         # Backup current install (zip method requires explicit swap).
@@ -722,7 +739,7 @@ try {
         # so a future operator setting INSTALL_DIR with a trailing backslash
         # ("C:\Squid\") doesn't produce a hidden ".bak" leaf inside the dir.
         # Linux side doesn't have this concern (no spaces, no trailing-slash
-        # convention drift) — Windows ProgramFiles paths often round-trip
+        # convention drift) -- Windows ProgramFiles paths often round-trip
         # through clipboards/CLIs that re-add separators, so guard for it.
         $installParent = Split-Path -Parent $INSTALL_DIR
         $installLeaf = Split-Path -Leaf $INSTALL_DIR
@@ -733,7 +750,7 @@ try {
         }
 
         if (Test-Path $INSTALL_DIR) {
-            Append-UpgradeLog "[upgrade] Backing up $INSTALL_DIR → $bakDir"
+            Append-UpgradeLog "[upgrade] Backing up $INSTALL_DIR -> $bakDir"
             Move-Item -Path $INSTALL_DIR -Destination $bakDir -Force
         }
 
@@ -751,17 +768,17 @@ try {
             exit 14
         }
 
-        Append-UpgradeLog "[upgrade] Moving $extractDir → $INSTALL_DIR"
+        Append-UpgradeLog "[upgrade] Moving $extractDir -> $INSTALL_DIR"
         Move-Item -Path $extractDir -Destination $INSTALL_DIR -Force
 
-        Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Binary swapped — restarting service"
+        Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Binary swapped -- restarting service"
     }
 
     # Start the service (may already be running for first-install path).
-    # Wrap in try/catch — if the new binary's OnStart throws (e.g. SCM 1067
+    # Wrap in try/catch -- if the new binary's OnStart throws (e.g. SCM 1067
     # "service did not start in a timely fashion"), call Invoke-Rollback so
     # the agent recovers to the old binary instead of being left in a half-
-    # swapped Stopped state. Wait for RUNNING state too — Start-Service
+    # swapped Stopped state. Wait for RUNNING state too -- Start-Service
     # returns when SCM accepts the start command, but the actual process
     # OnStart may still throw a few seconds later. WaitForStatus surfaces
     # that synchronously so the catch is reachable.
@@ -783,8 +800,8 @@ try {
         }
     }
 
-    # ── Health check ────────────────────────────────────────────────────────
-    # Retry count is server-substituted per dispatch (default 30 attempts ×
+    # -- Health check --------------------------------------------------------
+    # Retry count is server-substituted per dispatch (default 30 attempts x
     # 2s sleep = 60s wait window, see WindowsTentacleUpgradeStrategy.DefaultHealthcheckRetries).
     # Operator override via SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_RETRIES
     # env var on the SERVER side: deployments with slow-starting agents
@@ -794,7 +811,7 @@ try {
     # doesn't expose HTTP, so every poll attempt 404s and the wait is pure
     # cost). Pinned by `WindowsTentacleUpgradeStrategyTests.HealthcheckRetriesEnvVar_*`.
     $totalWaitSeconds = $HEALTHCHECK_RETRIES * 2
-    Append-UpgradeLog "[upgrade] Waiting for healthcheck $HEALTHCHECK_URL (max $HEALTHCHECK_RETRIES attempts × 2s = ${totalWaitSeconds}s)"
+    Append-UpgradeLog "[upgrade] Waiting for healthcheck $HEALTHCHECK_URL (max $HEALTHCHECK_RETRIES attempts x 2s = ${totalWaitSeconds}s)"
 
     $healthOk = $false
 
@@ -811,7 +828,7 @@ try {
             }
         }
         catch {
-            # Expected during the restart window — keep polling
+            # Expected during the restart window -- keep polling
         }
     }
 
@@ -822,17 +839,17 @@ try {
             # rather than leave the operator with a Stopped+swapped service
             # that the next capabilities probe will report as broken anyway.
             # Exit 9 is the documented "healthcheck timeout (FATAL mode)
-            # → rollback fired" code.
+            # -> rollback fired" code.
             Invoke-Rollback -Reason "Healthcheck didn't respond within ${totalWaitSeconds}s and SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true (strict mode)" -ExitCode 9
         }
 
         # Default mode (matches Octopus Tentacle): warning + proceed.
         # Capabilities probe will detect a dead agent on the next probe.
-        Append-UpgradeLog "::warning:: Healthcheck didn't respond within ${totalWaitSeconds}s — proceeding anyway, server will retry on next health probe (set SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true to roll back instead)"
+        Append-UpgradeLog "::warning:: Healthcheck didn't respond within ${totalWaitSeconds}s -- proceeding anyway, server will retry on next health probe (set SQUID_TARGET_WINDOWS_TENTACLE_HEALTHCHECK_FATAL=true to roll back instead)"
     }
 
     Write-UpgradeStatus -Status 'SUCCESS' -InstallMethod $INSTALL_METHOD -Detail "Upgrade to $TARGET_VERSION complete"
-    Append-UpgradeLog "[upgrade] Phase B complete — version $TARGET_VERSION installed via $INSTALL_METHOD"
+    Append-UpgradeLog "[upgrade] Phase B complete -- version $TARGET_VERSION installed via $INSTALL_METHOD"
 
     # Version GC (versioned only, best-effort): keep the newest N version dirs and
     # prune older ones so versions\ doesn't grow unbounded. Runs only AFTER success
@@ -852,7 +869,7 @@ try {
 
             $versionsRoot = Join-Path $INSTALL_DIR 'versions'
             if (Test-Path $versionsRoot) {
-                # Sort by CreationTimeUtc (install order) — newest first. (Deliberately
+                # Sort by CreationTimeUtc (install order) -- newest first. (Deliberately
                 # not LastWriteTimeUtc: that's reserved for the Phase B staging-dir
                 # anti-pattern guard, and creation time is the version's install moment.)
                 $dirs = @(Get-ChildItem -Path $versionsRoot -Directory | Sort-Object CreationTimeUtc -Descending)

--- a/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-windows-tentacle.ps1
@@ -243,6 +243,40 @@ function Append-UpgradeLog {
     Write-Host $Line
 }
 
+# -- Generic retry helper -- run an action, retrying transient failures with -----
+# linear backoff. Used for the network download, archive extraction, and the
+# binary swap: all three hit transient Windows failures (TCP resets / CDN 503s /
+# proxy hiccups on download; Defender holding a lock on a freshly-written file
+# during extract or Move-Item). Without retry a single transient blip fails the
+# whole upgrade -- the dominant cause of sub-100% upgrade success in the field.
+# Re-throws the last exception once attempts are exhausted so the caller's own
+# catch records the terminal status.
+function Invoke-WithRetry {
+    param(
+        [scriptblock] $Action,
+        [string] $Label,
+        [int] $MaxAttempts = 3,
+        [int] $BaseDelaySeconds = 2
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            & $Action
+            return
+        }
+        catch {
+            if ($attempt -ge $MaxAttempts) {
+                Append-UpgradeLog "[retry] $Label failed after $MaxAttempts attempt(s): $($_.Exception.Message)"
+                throw
+            }
+
+            $delay = $BaseDelaySeconds * $attempt
+            Append-UpgradeLog "[retry] $Label attempt $attempt/$MaxAttempts failed: $($_.Exception.Message) -- retrying in ${delay}s"
+            Start-Sleep -Seconds $delay
+        }
+    }
+}
+
 # -- Event timeline helper -- append one structured event (parity with the -----
 # Linux script's emit_event). One JSON object per line:
 #   {"t":"2026-06-01T02:57:04Z","phase":"A","kind":"start","msg":"..."}
@@ -523,8 +557,36 @@ try {
                 # GitHub rejects. Verified on a real agent: WebClient returns the byte-exact
                 # archive where Invoke-WebRequest returned a corrupt one.
                 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
-                $downloadClient = New-Object System.Net.WebClient
-                try { $downloadClient.DownloadFile($DOWNLOAD_URL, $archivePath) } finally { $downloadClient.Dispose() }
+
+                # Retry transient network failures (TCP reset / DNS blip / CDN 503 /
+                # proxy hiccup) -- a single blip must not fail the whole upgrade. Count is
+                # env-tunable for flaky or air-gapped links (floored at 1).
+                $downloadAttempts = 3
+                if ($env:SQUID_UPGRADE_DOWNLOAD_RETRIES -as [int]) { $downloadAttempts = [int]$env:SQUID_UPGRADE_DOWNLOAD_RETRIES }
+                if ($downloadAttempts -lt 1) { $downloadAttempts = 1 }
+
+                Invoke-WithRetry -Label 'archive download' -MaxAttempts $downloadAttempts -Action {
+                    # Clear any partial file from a prior failed attempt so a half-written
+                    # archive can't masquerade as a complete download.
+                    if (Test-Path $archivePath) { Remove-Item -Path $archivePath -Force -ErrorAction SilentlyContinue }
+
+                    $downloadClient = New-Object System.Net.WebClient
+                    # Route through the machine's configured proxy with the caller's
+                    # credentials so authenticated corporate proxies (407) don't block it.
+                    $downloadClient.UseDefaultCredentials = $true
+                    if ($downloadClient.Proxy) { $downloadClient.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials }
+
+                    try { $downloadClient.DownloadFile($DOWNLOAD_URL, $archivePath) } finally { $downloadClient.Dispose() }
+                }
+
+                # Sanity-check the size: a 0-byte / truncated file (proxy error page
+                # returned with HTTP 200, disk full mid-write) would otherwise fail later
+                # at extraction with an opaque "central directory" error. Catch it here.
+                $archiveSize = (Get-Item $archivePath).Length
+                if ($archiveSize -lt 1024) {
+                    throw "Downloaded archive is only $archiveSize byte(s) -- expected a multi-MB zip. The server likely returned an error page with HTTP 200, or the write was truncated."
+                }
+                Append-UpgradeLog "[upgrade-method:zip] Downloaded $archiveSize bytes"
             }
             catch {
                 Append-UpgradeLog "[upgrade-method:zip] Download failed: $($_.Exception.Message)"
@@ -618,7 +680,6 @@ try {
             }
 
             $extractDir = Join-Path $stagingDir 'extract'
-            New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
 
             Append-UpgradeLog "[upgrade-method:zip] Extracting to $extractDir"
             # [System.IO.Compression.ZipFile]::ExtractToDirectory, NOT Expand-Archive: the BCL
@@ -626,7 +687,15 @@ try {
             # error than the cmdlet wrapper. Add-Type loads the assembly on PS 5.1 (already
             # present in pwsh 7). Consistent with the direct-.NET SHA path above.
             Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-            [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $extractDir)
+
+            # Retry extraction: Defender can briefly lock a freshly-written file mid-extract.
+            # ExtractToDirectory has no overwrite overload on .NET Framework, so clear any
+            # partial output before each attempt (else a retry throws "file already exists").
+            Invoke-WithRetry -Label 'archive extraction' -Action {
+                if (Test-Path $extractDir) { Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue }
+                New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+                [System.IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $extractDir)
+            }
 
             $extractedExe = Join-Path $extractDir 'Squid.Tentacle.exe'
 
@@ -721,7 +790,8 @@ try {
             if (Test-Path $newVerDir) { Remove-Item -Path $newVerDir -Recurse -Force }
 
             Append-UpgradeLog "[upgrade] Staging new version into $newVerDir"
-            Move-Item -Path $extractDir -Destination $newVerDir -Force
+            # Retry the swap: Defender may briefly lock a freshly-extracted file.
+            Invoke-WithRetry -Label 'binary swap' -Action { Move-Item -Path $extractDir -Destination $newVerDir -Force }
 
             # Repoint `current` junction. Delete the old junction NON-recursively
             # ([Directory]::Delete(path,$false)) so we remove only the reparse point,
@@ -769,7 +839,8 @@ try {
         }
 
         Append-UpgradeLog "[upgrade] Moving $extractDir -> $INSTALL_DIR"
-        Move-Item -Path $extractDir -Destination $INSTALL_DIR -Force
+        # Retry the swap: Defender may briefly lock a freshly-extracted file.
+        Invoke-WithRetry -Label 'binary swap' -Action { Move-Item -Path $extractDir -Destination $INSTALL_DIR -Force }
 
         Write-UpgradeStatus -Status 'SWAPPED' -InstallMethod 'zip' -Detail "Binary swapped -- restarting service"
     }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -288,13 +288,13 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
         // ($DOWNLOAD_URL = '.../squid-tentacle-<ver>-$RID.zip'). PowerShell single-quoted
         // assignment does NOT expand $RID, and PowerShell never re-expands a variable's
         // stored value at use time — so the script MUST explicitly rewrite the '$RID' token
-        // to the architecture-resolved $RID BEFORE Invoke-WebRequest consumes $DOWNLOAD_URL.
+        // to the architecture-resolved $RID BEFORE WebClient.DownloadFile consumes $DOWNLOAD_URL.
         // Without it the agent requests .../squid-tentacle-<ver>-$RID.zip → GitHub 404.
         var inner = WindowsTentacleUpgradeStrategy.RenderInnerScript("1.6.0", WindowsTentacleUpgradeStrategy.DefaultMethodOrder);
 
         var literalUrlIdx = inner.IndexOf("-$RID.zip'", StringComparison.Ordinal);
         var rewriteIdx = inner.IndexOf(".Replace('$RID', $RID)", StringComparison.Ordinal);
-        var downloadIdx = inner.IndexOf("Invoke-WebRequest -Uri $DOWNLOAD_URL", StringComparison.Ordinal);
+        var downloadIdx = inner.IndexOf("DownloadFile($DOWNLOAD_URL", StringComparison.Ordinal);
 
         literalUrlIdx.ShouldBeGreaterThan(-1,
             customMessage: "Expected the server to emit the single-quoted URL with a literal $RID token.");
@@ -306,7 +306,7 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
                            ".../squid-tentacle-<ver>-$RID.zip and GitHub returns 404.");
 
         downloadIdx.ShouldBeGreaterThan(rewriteIdx,
-            customMessage: "The $RID rewrite MUST happen before Invoke-WebRequest consumes $DOWNLOAD_URL.");
+            customMessage: "The $RID rewrite MUST happen before WebClient.DownloadFile consumes $DOWNLOAD_URL.");
     }
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeScriptResourceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeScriptResourceTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Squid.Core.Services.Machines.Upgrade;
 
@@ -206,9 +207,9 @@ public sealed class WindowsUpgradeScriptResourceTests
         var content = LoadResource();
 
         content.ShouldContain("$DOWNLOAD_URL.sha256",
-            customMessage: "must construct .sha256 companion URL by appending '.sha256' to the download URL — same convention Linux uses + same convention 's release workflows publish");
-        content.ShouldContain("Invoke-WebRequest",
-            customMessage: "must use PowerShell's HTTP client (no external curl dep on Windows)");
+            customMessage: "must construct .sha256 companion URL by appending '.sha256' to the download URL — same convention Linux uses + same convention the release workflows publish");
+        content.ShouldContain("DownloadString",
+            customMessage: "SHA companion must be fetched via WebClient.DownloadString, NOT Invoke-WebRequest. PS 5.1's Invoke-WebRequest returns .Content as byte[] for application/octet-stream companions (GitHub Releases' default Content-Type), so the whitespace split yields garbage, the 64-hex regex fails, and verification is silently skipped — letting a corrupt download through. DownloadString always returns a string.");
         content.ShouldContain("'^[0-9a-f]{64}$'",
             customMessage: "must validate the fetched content is exactly 64 hex chars — guards against HTML 404 pages, partial bytes, etc. masquerading as a SHA");
     }
@@ -223,10 +224,10 @@ public sealed class WindowsUpgradeScriptResourceTests
         // Linux's "::info::" non-error log line.
         var content = LoadResource();
 
-        // The catch block must exist (Invoke-WebRequest with -ErrorAction Stop
-        // throws on 404 — must be caught + treated as "no SHA, fall through").
+        // The catch block must exist (WebClient.DownloadString throws a
+        // WebException on 404 — must be caught + treated as "no SHA, fall through").
         content.ShouldContain("catch",
-            customMessage: "Invoke-WebRequest 404 / network failure on .sha256 fetch MUST be caught — air-gap mirrors without companion files would otherwise fail every upgrade with a transport error");
+            customMessage: "WebClient.DownloadString 404 / network failure on .sha256 fetch MUST be caught — air-gap mirrors without companion files would otherwise fail every upgrade with a transport error");
         content.ShouldContain("No .sha256 companion at",
             customMessage: "fall-through log line must explain the absence — operators investigating a 'why didn't SHA verify' question see the absent-companion reason");
     }
@@ -294,5 +295,84 @@ public sealed class WindowsUpgradeScriptResourceTests
             customMessage: "Get-ChildItem | LastWriteTime racy search must be gone; Phase B reads $extractDir directly");
         content.ShouldContain("if (-not (Test-Path $extractDir))",
             customMessage: "Phase B must validate $extractDir exists (defense against Phase A leaving the variable empty / temp dir cleanup) and exit cleanly with a clear staging-disappeared message");
+    }
+
+    [Fact]
+    public void Resource_ZipDownload_UsesWebClient_ForcesTls12_NotInvokeWebRequestOutFile()
+    {
+        // Root cause of the field report (upgrade to 1.8.13 failed with
+        // "End of central directory record could not be found", exit 14):
+        // Windows PowerShell 5.1's `Invoke-WebRequest -OutFile` corrupts large
+        // binary downloads on some hosts (truncated/garbled bytes), so the
+        // downstream archive extraction can't find the central directory.
+        // WebClient.DownloadFile streams the bytes verbatim. Verified on the
+        // reporting operator's box: WebClient returned the byte-exact archive
+        // (size + SHA match) where Invoke-WebRequest had returned a corrupt one.
+        var content = LoadResource();
+
+        content.ShouldContain("System.Net.WebClient",
+            customMessage: "the zip archive MUST be downloaded via System.Net.WebClient — Invoke-WebRequest -OutFile corrupts large binaries on PS 5.1");
+        content.ShouldContain("DownloadFile",
+            customMessage: "WebClient.DownloadFile streams bytes verbatim, unlike Invoke-WebRequest -OutFile");
+        content.ShouldContain("SecurityProtocolType]::Tls12",
+            customMessage: "must force TLS 1.2 before the download — PS 5.1 may negotiate 1.0/1.1 by default, which GitHub rejects with a connection reset");
+
+        // -OutFile (the Invoke-WebRequest binary-download pattern that corrupts
+        // large archives) may appear in an explanatory comment, but must never
+        // be INVOKED. Scan non-comment lines only. The health-check probe uses
+        // Invoke-WebRequest legitimately but without -OutFile, so it's unaffected.
+        var executableLines = string.Join("\n", content
+            .Split('\n')
+            .Where(line => !line.TrimStart().StartsWith("#")));
+
+        executableLines.ShouldNotContain("-OutFile",
+            customMessage: "the binary archive download must NOT use Invoke-WebRequest -OutFile (the PS 5.1 large-binary corruption pattern that produced the 'End of central directory' failure). Use WebClient.DownloadFile.");
+    }
+
+    [Fact]
+    public void Resource_Extraction_UsesZipFileExtractToDirectory_NotExpandArchive()
+    {
+        // Companion to the WebClient fix: extraction uses the BCL
+        // [System.IO.Compression.ZipFile]::ExtractToDirectory rather than the
+        // Expand-Archive cmdlet. The BCL API is more robust on large /
+        // Linux-`zip`-built archives and surfaces a clearer error than the
+        // cmdlet wrapper. Add-Type loads the assembly on PS 5.1.
+        var content = LoadResource();
+
+        content.ShouldContain("ZipFile]::ExtractToDirectory",
+            customMessage: "extraction MUST use [System.IO.Compression.ZipFile]::ExtractToDirectory — more robust than Expand-Archive on large / cross-platform-built zips");
+
+        // Expand-Archive may legitimately appear in an explanatory comment
+        // ("...NOT Expand-Archive..."). What must NOT appear is an actual
+        // invocation — scan non-comment lines only.
+        var executableLines = string.Join("\n", content
+            .Split('\n')
+            .Where(line => !line.TrimStart().StartsWith("#")));
+
+        executableLines.ShouldNotContain("Expand-Archive",
+            customMessage: "Expand-Archive must not be INVOKED — it was flaky on the large agent archive and produced the opaque 'End of central directory' failure. (An explanatory comment mentioning it is fine.)");
+    }
+
+    [Fact]
+    public void Resource_ContainsNoNonAsciiCharacters_PreventsMojibakeInWebLog()
+    {
+        // The field report also showed mojibake in the web-surfaced upgrade log
+        // ("ʹ�á�3�...", box-drawing turned to "â??"). Windows PowerShell 5.1
+        // mis-decodes non-ASCII (em-dashes, arrows, box-drawing) under the OEM
+        // codepage, and those bytes flow into the upgrade log the server renders.
+        // The entire script must be pure ASCII so log lines stay legible without
+        // RDP. Mirrors the WindowsPowerShellScriptBuilder em-dash drift detector.
+        var content = LoadResource();
+
+        var offenders = content
+            .Select((ch, idx) => (ch, idx))
+            .Where(t => t.ch > '\x7F')
+            .Take(10)
+            .Select(t => $"U+{(int)t.ch:X4} at offset {t.idx}")
+            .ToList();
+
+        offenders.ShouldBeEmpty(
+            customMessage: "upgrade-windows-tentacle.ps1 must be pure ASCII so PS 5.1 + the web log don't mojibake it. " +
+                           $"Non-ASCII found: {string.Join(", ", offenders)}. Replace em-dashes/arrows/box-drawing with ASCII (--, ->, -).");
     }
 }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeScriptResourceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeScriptResourceTests.cs
@@ -375,4 +375,39 @@ public sealed class WindowsUpgradeScriptResourceTests
             customMessage: "upgrade-windows-tentacle.ps1 must be pure ASCII so PS 5.1 + the web log don't mojibake it. " +
                            $"Non-ASCII found: {string.Join(", ", offenders)}. Replace em-dashes/arrows/box-drawing with ASCII (--, ->, -).");
     }
+
+    [Fact]
+    public void Resource_DownloadPath_HardenedForReliability_RetryProxyAndExtractSwap()
+    {
+        // Near-100% upgrade success requires surviving the common transient
+        // Windows failures: a network blip on the download, an authenticated
+        // corporate proxy, and a Defender file-lock on extract / swap. Pin each
+        // hardening measure so a future edit can't silently drop it.
+        var content = LoadResource();
+
+        content.ShouldContain("function Invoke-WithRetry",
+            customMessage: "must define a generic retry helper so a single transient failure doesn't fail the whole upgrade");
+        content.ShouldContain("Invoke-WithRetry -Label 'archive download'",
+            customMessage: "the binary download MUST be wrapped in retry — a single TCP reset / CDN 503 / proxy blip is the #1 field cause of upgrade failure");
+        content.ShouldContain("UseDefaultCredentials",
+            customMessage: "WebClient MUST use default credentials so authenticated corporate proxies (407) don't block the download");
+        content.ShouldContain("DefaultNetworkCredentials",
+            customMessage: "the proxy MUST be given default network credentials for NTLM/Kerberos corporate proxies");
+        content.ShouldContain("Invoke-WithRetry -Label 'archive extraction'",
+            customMessage: "extraction MUST retry — Defender can briefly lock a freshly-written file mid-extract");
+        content.ShouldContain("Invoke-WithRetry -Label 'binary swap'",
+            customMessage: "the Move-Item swap MUST retry — Defender can briefly lock the freshly-extracted binary");
+    }
+
+    [Fact]
+    public void Resource_DownloadSizeSanityCheck_RejectsTruncatedArchive()
+    {
+        // A 0-byte / truncated download (proxy error page returned with HTTP 200,
+        // disk full mid-write) must fail with a clear message here, not an opaque
+        // "central directory" error at extraction time.
+        var content = LoadResource();
+
+        content.ShouldMatch(@"\$archiveSize\s*-lt\s*\d+",
+            customMessage: "must sanity-check the downloaded archive size and reject a clearly-too-small file before extraction");
+    }
 }

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeScriptResourceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsUpgradeScriptResourceTests.cs
@@ -400,14 +400,19 @@ public sealed class WindowsUpgradeScriptResourceTests
     }
 
     [Fact]
-    public void Resource_DownloadSizeSanityCheck_RejectsTruncatedArchive()
+    public void Resource_DownloadValidatedAsZip_RejectsNonZipContent()
     {
-        // A 0-byte / truncated download (proxy error page returned with HTTP 200,
-        // disk full mid-write) must fail with a clear message here, not an opaque
-        // "central directory" error at extraction time.
+        // A non-zip download (proxy error page returned with HTTP 200, an HTML 404,
+        // a 0-byte / truncated write) must fail with a clear message here, not an
+        // opaque "central directory" error at extraction time. The check validates
+        // the PK magic bytes (0x50 0x4B) rather than a size floor — a valid zip of
+        // ANY size passes (a fixed floor would wrongly reject small archives, and
+        // would miss large HTML error pages).
         var content = LoadResource();
 
-        content.ShouldMatch(@"\$archiveSize\s*-lt\s*\d+",
-            customMessage: "must sanity-check the downloaded archive size and reject a clearly-too-small file before extraction");
+        content.ShouldContain("0x50",
+            customMessage: "must validate the download starts with the zip 'PK' magic byte 0x50");
+        content.ShouldContain("0x4B",
+            customMessage: "must validate the download's second byte is the zip 'PK' magic byte 0x4B — rejects HTML/JSON error pages and truncated downloads of any size");
     }
 }

--- a/tests/Squid.WindowsTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/Infrastructure/LocalReleaseMirror.cs
@@ -105,6 +105,13 @@ public sealed class LocalReleaseMirror : IDisposable
     /// PR but the toggle is here for future use).
     /// </summary>
     private bool _suppressSha256;
+    /// <summary>
+    /// Number of upcoming archive (.zip / .tar.gz) requests to fail with HTTP
+    /// 503 before serving normally. Simulates a transient CDN / network blip so
+    /// the production script's download-retry loop can be proven to recover.
+    /// Decremented per injected failure; 0 = serve normally.
+    /// </summary>
+    private int _archiveFailuresRemaining;
     private bool _disposed;
 
     /// <summary>The mirror's base URL. Pass this as <c>--DownloadBase</c>
@@ -242,6 +249,18 @@ public sealed class LocalReleaseMirror : IDisposable
         _suppressSha256 = true;
     }
 
+    /// <summary>
+    /// Make the next <paramref name="count"/> archive (.zip / .tar.gz) requests
+    /// return HTTP 503, then serve normally. Simulates a transient CDN/network
+    /// failure so a test can prove the production script's download-retry loop
+    /// recovers — the upgrade still succeeds, and <see cref="ReceivedRequests"/>
+    /// shows more than one archive hit for the same URL.
+    /// </summary>
+    public void FailNextArchiveRequests(int count)
+    {
+        lock (_requestsLock) { _archiveFailuresRemaining = count; }
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -314,6 +333,27 @@ public sealed class LocalReleaseMirror : IDisposable
         {
             ServeSha256(ctx, path);
             return;
+        }
+
+        // Transient-failure injection (download-retry coverage): fail the first N
+        // archive requests with 503 so the production script's retry loop must
+        // recover. Applies only to the binary archive, never the .sha256 companion.
+        if (path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+        {
+            bool injectFailure;
+            lock (_requestsLock)
+            {
+                injectFailure = _archiveFailuresRemaining > 0;
+                if (injectFailure) _archiveFailuresRemaining--;
+            }
+
+            if (injectFailure)
+            {
+                ctx.Response.StatusCode = 503;
+                ctx.Response.OutputStream.Close();
+                return;
+            }
         }
 
         if (path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptResilienceE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptResilienceE2ETests.cs
@@ -319,9 +319,9 @@ public sealed class TentacleInstallScriptResilienceE2ETests : IDisposable
         for (var i = 0; i < iterations; i++)
         {
             // Each iteration stages a different binary content so we can verify
-            // the latest install actually overwrote the previous one. If
-            // Expand-Archive -Force broke and silently no-op'd, we'd see stale
-            // content here.
+            // the latest install actually overwrote the previous one. If the
+            // re-install overwrite (Copy-Item -Force on the flat fallback path)
+            // broke and silently no-op'd, we'd see stale content here.
             var marker = $"iter-{i}-{Guid.NewGuid():N}";
             mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes(marker));
 
@@ -341,7 +341,7 @@ public sealed class TentacleInstallScriptResilienceE2ETests : IDisposable
 
             var content = await File.ReadAllTextAsync(Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe"));
             if (!content.Contains(marker))
-                failures.Add($"iter {i}: binary content '{content}' missing marker '{marker}' -- Expand-Archive -Force did not overwrite.");
+                failures.Add($"iter {i}: binary content '{content}' missing marker '{marker}' -- re-install (Copy-Item -Force flat fallback) did not overwrite.");
         }
 
         failures.ShouldBeEmpty(

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptWindowsE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleInstallScriptWindowsE2ETests.cs
@@ -10,16 +10,16 @@ namespace Squid.WindowsTentacleE2ETests;
 /// <see cref="LocalReleaseMirror"/> serving fake zip downloads.
 ///
 /// <para><b>Tier</b>: 🟢 High-fidelity (Rule 12). Real powershell.exe
-/// running real install script, real Expand-Archive into a real install
+/// running real install script, real ZipFile extraction into a real install
 /// directory, real Test-Path verification. Only the upstream release CDN
 /// is replaced.</para>
 ///
 /// <para><b>Skip-on-non-Windows</b>: install-tentacle.ps1 uses
-/// <c>Expand-Archive</c>, <c>New-NetFirewallRule</c>, and <c>powershell.exe</c>
+/// <c>New-NetFirewallRule</c>, directory junctions, and <c>powershell.exe</c>
 /// — all Windows-specific. Tests no-op cleanly on macOS / Linux.</para>
 ///
 /// <para><b>What this catches</b>: a regression in the script's URL
-/// composition, arg parsing, fallback URL logic, Expand-Archive flag use,
+/// composition, arg parsing, fallback URL logic, extraction,
 /// or post-extract verification. Every install-tentacle.ps1 release
 /// hereafter MUST keep these tests green.</para>
 ///
@@ -152,7 +152,10 @@ public sealed class TentacleInstallScriptWindowsE2ETests : IDisposable
         firstResult.exitCode.ShouldBe(0,
             customMessage: $"first install MUST succeed. stdout:\n{firstResult.stdout}\nstderr:\n{firstResult.stderr}");
 
-        // Second install over the same dir — Expand-Archive -Force overwrites.
+        // Second install over the same dir overwrites. The fake text binary can't
+        // report a version, so the script takes the flat-layout fallback whose
+        // Copy-Item -Force overwrites the install dir (extraction itself goes into
+        // a fresh per-run staging dir, so ZipFile.ExtractToDirectory never collides).
         // Stage a different content so we can verify the second install took.
         mirror.StageBinary("Squid.Tentacle.exe", System.Text.Encoding.UTF8.GetBytes("# v2\n"));
 
@@ -166,11 +169,11 @@ public sealed class TentacleInstallScriptWindowsE2ETests : IDisposable
         secondResult.exitCode.ShouldBe(0,
             customMessage: $"second install over existing dir MUST succeed (idempotent). stdout:\n{secondResult.stdout}\nstderr:\n{secondResult.stderr}");
 
-        // Binary content was updated (proves Expand-Archive -Force overwrote).
+        // Binary content was updated (proves the re-install overwrote the install dir).
         var binaryPath = Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe");
         var contentAfterSecond = await File.ReadAllTextAsync(binaryPath);
         contentAfterSecond.ShouldContain("v2",
-            customMessage: $"after re-install with new content, binary MUST reflect the new version. Got: '{contentAfterSecond}'. Expand-Archive -Force isn't overwriting?");
+            customMessage: $"after re-install with new content, binary MUST reflect the new version. Got: '{contentAfterSecond}'. Copy-Item -Force (flat fallback) isn't overwriting the install dir?");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -122,7 +122,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
                 customMessage: "v2Bundle MUST contain Squid.Tentacle.exe at the top level. " +
                               "If null: BuildV2BundleZip dropped the placeholder OR the test wired the bundle through StageBinary " +
                               "(which auto-wraps content in a fresh zip — caller's pre-built zip becomes a single inner entry, " +
-                              "no top-level Squid.Tentacle.exe after Expand-Archive runs on the agent).");
+                              "no top-level Squid.Tentacle.exe after the agent extracts the bundle).");
         }
 
         // 3. Render production .ps1 with placeholders pointed at our fixtures.
@@ -831,7 +831,7 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         // ZERO download requests. If the .ps1 reached Phase A, it would
         // hit DOWNLOAD_URL → mirror would log the request.
         ctx.Mirror.ReceivedRequests.ShouldBeEmpty(
-            customMessage: $"short-circuit MUST fire BEFORE Phase A's Invoke-WebRequest. " +
+            customMessage: $"short-circuit MUST fire BEFORE Phase A's archive download. " +
                           $"Mirror received: [{string.Join(", ", ctx.Mirror.ReceivedRequests)}]. " +
                           "If non-empty: the short-circuit didn't fire → operator's no-op click triggered a download (waste of bandwidth + agent IO).");
 

--- a/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/TentacleUpgradeLifecycleE2ETests.cs
@@ -170,6 +170,51 @@ public sealed class TentacleUpgradeLifecycleE2ETests
         ctx.MarkClean();
     }
 
+    [Fact]
+    public void E1h_TransientDownloadFailure_RetryRecovers_UpgradeStillSucceeds()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new UpgradeLifecycleContext();
+
+        ctx.Fixture.InstallAndStart(ctx.TestServiceExe, initialVersion: "1.0.0", startTimeout: TimeSpan.FromSeconds(30));
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            "v1 service must be running before the retry test can validate recovery");
+
+        var v2Bundle = ctx.BuildV2BundleZip(targetVersion: "2.0.0-test");
+        ctx.Mirror.StagePreBuiltArchive(v2Bundle);
+
+        // Inject a transient failure: the FIRST archive download returns 503.
+        // The production download-retry loop must recover on the next attempt, so
+        // the upgrade still succeeds. Without the retry (pre-hardening) this single
+        // blip would fail the whole upgrade with exit 2 — the dominant field cause
+        // of sub-100% upgrade success. This is the behavioural proof of the retry.
+        ctx.Mirror.FailNextArchiveRequests(1);
+
+        var script = ctx.RenderProductionScriptForVersion(targetVersion: "2.0.0-test");
+        var (exitCode, stdout) = ctx.RunUpgradeScript(script);
+
+        exitCode.ShouldBe(0,
+            customMessage: $"a single transient 503 on the archive download MUST be recovered by the retry loop (upgrade still succeeds). " +
+                          $"If exit 2: the download isn't retrying. Logs at {ctx.StatusDir}\\upgrade.log; stdout:\n{stdout}");
+
+        var statusPayload = ctx.ReadLastUpgradeStatus();
+        statusPayload.ShouldNotBeNull("last-upgrade.json must be written after the retry-recovered upgrade");
+        statusPayload.Status.ShouldBe("SUCCESS",
+            customMessage: $"upgrade MUST report SUCCESS after recovering from the transient download failure. Got: '{statusPayload.Status}', detail: {statusPayload.Detail}");
+
+        // Prove the retry actually re-fetched: the mirror saw the archive requested
+        // more than once (the 503'd attempt + the successful retry).
+        var archiveRequests = ctx.Mirror.ReceivedRequests.Count(p => p.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+        archiveRequests.ShouldBeGreaterThan(1,
+            customMessage: $"the archive must have been requested >1 time (503 then retry). Saw {archiveRequests} .zip request(s) — the retry loop didn't re-fetch.");
+
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage: "after retry-recovered download + swap + restart, marker MUST show 2.0.0");
+
+        ctx.MarkClean();
+    }
+
     // ========================================================================
     // E1.u1 / E5.u1 — Download URL 404 → exit 2 + FAILED status with download detail
     //

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
@@ -36,7 +36,7 @@ public static class WindowsUpgradeE2ECategories
     /// companion-file fetch + verification logic in
     /// <c>upgrade-windows-tentacle.ps1</c>. Uses an in-process HTTP
     /// listener serving a known .sha256 + .zip pair so the .ps1's
-    /// <c>Invoke-WebRequest</c> + <c>Get-FileHash</c> path runs against
+    /// <c>WebClient.DownloadString</c> + <c>SHA256</c> verify path runs against
     /// a real local server (no GitHub Releases dependency for the test
     /// — the fixture controls EVERY response: 404, invalid body, valid
     /// match, valid mismatch).
@@ -117,11 +117,11 @@ public static class WindowsUpgradeE2ECategories
     /// against a <see cref="Infrastructure.LocalReleaseMirror"/> serving
     /// fake zip / tarball downloads. Tier 🟢 high-fidelity — every
     /// component except the upstream GitHub Releases CDN is real
-    /// (real shell, real script, real Expand-Archive / tar xzf, real
+    /// (real shell, real script, real ZipFile extraction / tar xzf, real
     /// install-dir IO).
     ///
     /// <para><b>OS scope</b>: install-tentacle.ps1 is Windows-only (uses
-    /// <c>Expand-Archive</c>, <c>New-NetFirewallRule</c>); install-tentacle.sh
+    /// <c>New-NetFirewallRule</c> + directory junctions); install-tentacle.sh
     /// is Linux-only (uses <c>apt</c>/<c>dnf</c>/<c>useradd</c>/<c>tar</c>).
     /// Each test method skip-guards on its target OS.</para>
     /// </summary>
@@ -162,8 +162,8 @@ public static class WindowsUpgradeE2ECategories
     /// — the round-trip operator UI relies on for post-upgrade status.
     ///
     /// <para><b>Tier</b>: 🟢 High-fidelity (Rule 12). Production .ps1
-    /// loaded from disk verbatim, real <c>Invoke-WebRequest</c> +
-    /// <c>Get-FileHash</c> + <c>Expand-Archive</c> + <c>Stop-Service</c> +
+    /// loaded from disk verbatim, real <c>WebClient.DownloadFile</c> +
+    /// <c>SHA256</c> verify + <c>ZipFile.ExtractToDirectory</c> + <c>Stop-Service</c> +
     /// <c>Move-Item</c> + <c>Start-Service</c> — only the upstream GitHub
     /// Releases CDN is replaced (LocalReleaseMirror) and <c>$env:ProgramData</c>
     /// is redirected to a test-isolated dir so <c>last-upgrade.json</c> /
@@ -179,12 +179,12 @@ public static class WindowsUpgradeE2ECategories
     /// restart sequence, AND asserts on the resulting
     /// <c>last-upgrade.json</c> payload (the operator-visible outcome).
     /// Catches regressions invisible to PhaseB tests: download URL
-    /// construction, SHA companion fetch, Expand-Archive layout
+    /// construction, SHA companion fetch, extraction layout
     /// assumptions, status JSON schema.</para>
     ///
     /// <para><b>Windows-only</b>: uses sc.exe-installed service +
-    /// PowerShell-only cmdlets (<c>Stop-Service</c>, <c>Start-Service</c>,
-    /// <c>Expand-Archive</c>, <c>Get-FileHash</c>). Skip-guards on
+    /// PowerShell service-control cmdlets (<c>Stop-Service</c>, <c>Start-Service</c>)
+    /// + directory junctions. Skip-guards on
     /// non-Windows dev hosts.</para>
     /// </summary>
     public const string TentacleUpgradeLifecycle = "TentacleUpgradeLifecycleE2E";

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeShaVerifyE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeShaVerifyE2ETests.cs
@@ -17,9 +17,10 @@ namespace Squid.WindowsTentacleE2ETests;
 /// dependency, fully deterministic, runs in seconds.
 ///
 /// <para><b>Why a fixture HTTP server (not a static-file path)</b>: the
-/// production .ps1 uses <c>Invoke-WebRequest</c> via a real URL, and the
-/// behaviour we want to pin is THE NETWORK FETCH (transport-error
-/// handling, 404 fall-through, content-type tolerance). A pure file://
+/// production .ps1 fetches the companion via <c>WebClient.DownloadString</c>
+/// over a real URL, and the behaviour we want to pin is THE NETWORK FETCH
+/// (transport-error handling, 404 fall-through, content-type tolerance —
+/// including the application/octet-stream case GitHub Releases serve). A pure file://
 /// or static-file approach would bypass the HTTP layer that's the actual
 /// cross-platform contract. <c>HttpListener</c> on a random localhost
 /// port matches production traffic shape minus TLS — sufficient for the
@@ -57,11 +58,11 @@ public sealed class WindowsUpgradeShaVerifyE2ETests
         var keyOperations = new[]
         {
             "$DOWNLOAD_URL.sha256",         // companion URL convention
-            "Invoke-WebRequest",            // PowerShell HTTP fetch
-            "-UseBasicParsing",             // no IE-engine dep on Server Core
-            "-TimeoutSec",                  // bounded fetch
+            "System.Net.WebClient",         // PS 5.1-robust fetch — Invoke-WebRequest returns .Content as byte[] for application/octet-stream companions (GitHub's default) → garbage split → false "non-hex" → silent skip
+            "DownloadString",               // companion fetched as a string regardless of Content-Type
+            "SecurityProtocolType]::Tls12", // force TLS 1.2 (PS 5.1 may negotiate 1.0/1.1, which GitHub rejects)
             "'^[0-9a-f]{64}$'",             // 64-hex validation regex
-            "[System.Security.Cryptography.SHA256]",  // direct .NET hash compute (Get-FileHash auto-loader was unreliable on some Windows runner images — see J.E.3.1 fix in upgrade-windows-tentacle.ps1)
+            "[System.Security.Cryptography.SHA256]",  // direct .NET hash compute (Get-FileHash auto-loader unreliable on some Windows runner images)
             "ComputeHash",                  // hash invocation
             "exit 7",                       // documented mismatch exit code
         };
@@ -92,7 +93,7 @@ public sealed class WindowsUpgradeShaVerifyE2ETests
     }
 
     // ========================================================================
-    // E2E: real Invoke-WebRequest against a localhost HTTP fixture.
+    // E2E: real WebClient.DownloadString against a localhost HTTP fixture.
     // Each test gets its own HttpListener on a fresh random port so they
     // can run in parallel without cross-pollution.
     // ========================================================================
@@ -115,6 +116,35 @@ public sealed class WindowsUpgradeShaVerifyE2ETests
             customMessage: $"fetch-and-extract script must exit 0 on valid 64-hex SHA companion. stdout:\n{stdout}");
         stdout.ShouldContain(expectedSha,
             customMessage: $"PowerShell must extract the 64-hex digest from the sha256sum-format response (got: {stdout})");
+    }
+
+    [Fact]
+    public void OpportunisticFetch_OctetStreamContentType_StillExtractsHex()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // Regression pin for the real-world SHA-skip seam: GitHub Releases serve
+        // .sha256 assets as application/octet-stream. PS 5.1's Invoke-WebRequest
+        // returns .Content as byte[] for octet-stream, so the -split produced
+        // garbage, the 64-hex regex failed, and verification was SILENTLY SKIPPED
+        // (so a corrupt download went uncaught — exactly the field-reported
+        // "returned non-hex / wrong-length content -- skipping verification").
+        // WebClient.DownloadString returns a string regardless of Content-Type,
+        // so the hex extracts correctly. This test would FAIL against the old
+        // Invoke-WebRequest implementation — it pins the fix to the real cause.
+        var archiveContent = Encoding.UTF8.GetBytes("octet-stream companion fixture");
+        var expectedSha = ComputeSha256Hex(archiveContent);
+
+        using var fixture = new ShaFixtureHttpServer();
+        fixture.Routes["/octet.zip.sha256"] = (status: 200, body: $"{expectedSha}  octet.zip\n");
+        fixture.ContentTypes["/octet.zip.sha256"] = "application/octet-stream";
+
+        var (exitCode, stdout) = RunFetchAndExtract(fixture.BaseUrl + "/octet.zip");
+
+        exitCode.ShouldBe(0,
+            customMessage: $"octet-stream SHA companion must still yield exit 0. stdout:\n{stdout}");
+        stdout.ShouldContain(expectedSha,
+            customMessage: "WebClient.DownloadString MUST extract the hex digest even when the companion is served as application/octet-stream (GitHub Releases' default). The old Invoke-WebRequest path returned byte[] here and silently skipped verification — this is the exact seam that let a corrupt 1.8.13 download through.");
     }
 
     [Fact]
@@ -178,11 +208,11 @@ public sealed class WindowsUpgradeShaVerifyE2ETests
     {
         if (!OperatingSystem.IsWindows()) return;
 
-        // Pin the timeout-handling path: -TimeoutSec 10 in the .ps1 means
-        // Invoke-WebRequest throws on >10s server delay. The catch must
-        // treat this as fall-through (NOT propagate). We test by pointing
-        // at a port nothing listens on — Invoke-WebRequest fails with
-        // connection refused, same catch path.
+        // Pin the transport-failure path: WebClient.DownloadString throws a
+        // WebException on connection failure / timeout. The catch must treat
+        // this as fall-through (NOT propagate). We test by pointing at a port
+        // nothing listens on — DownloadString fails with connection refused,
+        // same catch path the production .ps1 relies on.
         var (exitCode, stdout) = RunFetchAndExtract("http://127.0.0.1:1/squid-tentacle.zip");
 
         exitCode.ShouldBe(0,
@@ -212,17 +242,24 @@ if ([string]::IsNullOrWhiteSpace($EXPECTED_SHA256)) {{
     $shaUrl = ""$DOWNLOAD_URL.sha256""
     Write-Host ""[fetch] opportunistic fetch from $shaUrl""
     try {{
-        $shaResponse = Invoke-WebRequest -Uri $shaUrl -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop
-        $fetched = ($shaResponse.Content -split '\s+', 2)[0].Trim().ToLower()
+        # WebClient.DownloadString + forced TLS 1.2 -- mirrors production
+        # upgrade-windows-tentacle.ps1. Invoke-WebRequest in PS 5.1 returns
+        # .Content as byte[] for application/octet-stream companions (GitHub's
+        # default Content-Type), which breaks the -split and yields a false
+        # non-hex result. DownloadString always returns a string.
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+        $shaClient = New-Object System.Net.WebClient
+        try {{ $shaContent = $shaClient.DownloadString($shaUrl) }} finally {{ $shaClient.Dispose() }}
+        $fetched = ($shaContent -split '\s+', 2)[0].Trim().ToLower()
         if ($fetched -match '^[0-9a-f]{{64}}$') {{
             $EXPECTED_SHA256 = $fetched
             Write-Host ""[fetch] valid SHA256: $EXPECTED_SHA256""
         }} else {{
-            Write-Host ""[fetch] non-hex / wrong length — skipping verification""
+            Write-Host ""[fetch] non-hex / wrong length -- skipping verification""
         }}
     }}
     catch {{
-        Write-Host ""[fetch] No .sha256 companion at $shaUrl — skipping verification""
+        Write-Host ""[fetch] No .sha256 companion at $shaUrl -- skipping verification""
     }}
 }}
 
@@ -310,6 +347,15 @@ exit 0
     private sealed class ShaFixtureHttpServer : IDisposable
     {
         public Dictionary<string, (int status, string body)> Routes { get; } = new();
+
+        /// <summary>
+        /// Optional per-path Content-Type override. Defaults to
+        /// "text/plain; charset=utf-8" when a path is absent. The octet-stream
+        /// regression test uses this to reproduce GitHub Releases' default
+        /// application/octet-stream Content-Type on .sha256 assets.
+        /// </summary>
+        public Dictionary<string, string> ContentTypes { get; } = new();
+
         public string BaseUrl { get; }
 
         private readonly HttpListener _listener;
@@ -343,13 +389,17 @@ exit 0
                     if (Routes.TryGetValue(path, out var route))
                     {
                         ctx.Response.StatusCode = route.status;
-                        // CRITICAL: Set Content-Type explicitly. Without it, PowerShell 5.1's
-                        // Invoke-WebRequest may auto-detect octet-stream and return .Content
-                        // as byte[] instead of string. The .ps1's `-split '\s+'` then operates
-                        // on a byte[] and produces no usable hex token → the regex fails →
-                        // "non-hex / wrong length" path executes when the test expected the
-                        // valid-SHA path. text/plain forces string interpretation.
-                        ctx.Response.ContentType = "text/plain; charset=utf-8";
+                        // Content-Type: defaults to text/plain; per-path override via
+                        // ContentTypes. Production fetches the companion with
+                        // WebClient.DownloadString, which returns a string regardless of
+                        // Content-Type, so the octet-stream regression test (mimicking
+                        // GitHub Releases' default) still extracts the hex. The OLD
+                        // Invoke-WebRequest path returned .Content as byte[] for
+                        // octet-stream, the -split produced garbage, the regex failed,
+                        // and verification was silently skipped.
+                        ctx.Response.ContentType = ContentTypes.TryGetValue(path, out var contentType)
+                            ? contentType
+                            : "text/plain; charset=utf-8";
                         var bytes = Encoding.UTF8.GetBytes(route.body);
                         ctx.Response.OutputStream.Write(bytes, 0, bytes.Length);
                     }


### PR DESCRIPTION
## Summary

Make the Windows tentacle self-upgrade work, and work reliably across Windows versions and environments.

**Correctness fix** (the field report: upgrade to 1.8.13 failed with "End of central directory record could not be found", exit 14):

- `Invoke-WebRequest -OutFile` corrupted the large binary download on PS 5.1 → extraction failed. Switch to `System.Net.WebClient.DownloadFile` + forced TLS 1.2.
- The `.sha256` companion (served by GitHub as `application/octet-stream`) was fetched with `Invoke-WebRequest`, which returns `.Content` as a `byte[]` for octet-stream → the hex split failed → SHA verification was **silently skipped**, letting the corrupt download through. Switch to `WebClient.DownloadString` (always a string) + log an ASCII snippet of any malformed companion.
- Extract via `[System.IO.Compression.ZipFile]::ExtractToDirectory` instead of `Expand-Archive`.
- Script is now **pure ASCII** so PS 5.1 + the web log don't mojibake under non-Latin OEM codepages.

**Reliability hardening** (raise success rate toward 100%):

- Retry the download with backoff (3 attempts, env-tunable `SQUID_UPGRADE_DOWNLOAD_RETRIES`) — survives transient TCP reset / CDN 503 / proxy blips.
- Route through the configured proxy with default credentials — authenticated corporate proxies (407) no longer block it.
- Reject a 0-byte / truncated download with a clear message instead of an opaque extraction error.
- Retry extraction + binary swap — Defender briefly locking a freshly-written file no longer fails the upgrade.

Same fix + hardening applied to `install-tentacle.ps1`.

## Test plan

- [x] 705 upgrade unit tests + resource/strategy/parity drift detectors green (macOS)
- [x] Cross-platform drift detectors: WebClient+TLS12 download, ZipFile extraction, pure-ASCII script, retry/proxy/size hardening
- [x] Octet-stream SHA regression test — reproduces the real cause; fails the old `Invoke-WebRequest` code
- [x] Behavioural download-retry E2E — `LocalReleaseMirror.FailNextArchiveRequests(1)` injects a 503; the real `.ps1` retries and the upgrade still succeeds
- [x] **Windows E2E green on a real Windows runner** (run 26962192825, 10m): production `.ps1` end-to-end — WebClient download → SHA → ZipFile extract → swap → restart → `last-upgrade.json`
- [ ] Windows E2E matrix (windows-2019 + windows-2022) — re-dispatched on this branch with the hardening + retry test
- [ ] Manual confirmation on the reporting operator's box (already verified WebClient returns the byte-exact archive: size + SHA match)
