### PR TITLE
Bind tentacle healthz to loopback on Windows to stop firewall prompt

### DIFF
--- a/deploy/helm/kubernetes-agent/templates/deployment.yaml
+++ b/deploy/helm/kubernetes-agent/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
           value: {{ join "," .Values.tentacle.roles | quote }}
         - name: Tentacle__Flavor
           value: "{{ .Values.tentacle.flavor }}"
+        # Bind the health-check server to all interfaces so kubelet's httpGet
+        # liveness/readiness probes reach it over the pod network. Service-based
+        # tentacles default to loopback (avoids a Windows Firewall prompt), so the
+        # Kubernetes agent must opt back in here.
+        - name: Tentacle__HealthCheckBindHost
+          value: "{{ .Values.tentacle.healthCheckBindHost | default "+" }}"
         - name: Tentacle__MachineName
           value: "{{ .Values.tentacle.machineName }}"
         - name: Tentacle__ReleaseName

--- a/deploy/helm/kubernetes-agent/values.yaml
+++ b/deploy/helm/kubernetes-agent/values.yaml
@@ -28,6 +28,10 @@ tentacle:
       cpu: "500m"
 
   healthCheckPort: 8080
+  # Host the in-pod health-check server binds. "+" = all interfaces so kubelet's
+  # httpGet liveness/readiness probes can reach it. (The tentacle binary defaults
+  # to loopback for service installs to avoid a Windows Firewall prompt.)
+  healthCheckBindHost: "+"
 
   startupProbe:
     failureThreshold: 100

--- a/src/Squid.Tentacle/Configuration/TentacleSettings.cs
+++ b/src/Squid.Tentacle/Configuration/TentacleSettings.cs
@@ -38,6 +38,16 @@ public class TentacleSettings
     public string WorkspacePath { get; set; } = string.Empty;
     public string CertsPath { get; set; } = string.Empty;
     public int HealthCheckPort { get; set; } = 8080;
+
+    // Host the local health-check HTTP server binds. On Windows it defaults to the
+    // loopback address so the listener is NOT network-exposed -- binding all
+    // interfaces pops a Defender Firewall "allow access" prompt on every
+    // versioned-path upgrade, and the only Windows consumer of healthz is the
+    // upgrade script (which probes 127.0.0.1). On non-Windows it keeps "*" (all
+    // interfaces) so Linux/docker localhost probes and the Kubernetes agent's
+    // kubelet httpGet liveness/readiness probes (over the pod network) still work.
+    public string HealthCheckBindHost { get; set; } = OperatingSystem.IsWindows() ? "127.0.0.1" : "*";
+
     public int ListeningPort { get; set; } = 10933;
     public string ListeningHostName { get; set; } = string.Empty;
 

--- a/src/Squid.Tentacle/Core/TentacleApp.cs
+++ b/src/Squid.Tentacle/Core/TentacleApp.cs
@@ -100,7 +100,7 @@ public sealed class TentacleApp
             return true;
         };
 
-        await using var healthServer = _dependencies.HealthCheckServerFactory(tentacleSettings.HealthCheckPort, readinessCheck);
+        await using var healthServer = _dependencies.HealthCheckServerFactory(tentacleSettings.HealthCheckPort, tentacleSettings.HealthCheckBindHost, readinessCheck);
 
         try
         {
@@ -213,8 +213,8 @@ public sealed class TentacleAppDependencies
     public Func<X509Certificate2, Squid.Message.Contracts.Tentacle.IScriptService, TentacleSettings, Squid.Message.Contracts.Tentacle.ICapabilitiesService, ITentacleHalibutHost> HalibutHostFactory { get; init; } =
         (cert, scriptService, settings, capabilitiesService) => new TentacleHalibutHost(cert, scriptService, settings, capabilitiesService);
 
-    public Func<int, Func<bool>, IHealthCheckServer> HealthCheckServerFactory { get; init; } =
-        (port, readiness) => new HealthCheckServer(port, readiness);
+    public Func<int, string, Func<bool>, IHealthCheckServer> HealthCheckServerFactory { get; init; } =
+        (port, bindHost, readiness) => new HealthCheckServer(port, readiness, bindHost);
 
     public static TentacleAppDependencies CreateDefault() => new();
 }

--- a/src/Squid.Tentacle/Health/HealthCheckServer.cs
+++ b/src/Squid.Tentacle/Health/HealthCheckServer.cs
@@ -10,11 +10,18 @@ public class HealthCheckServer : IHealthCheckServer
     private CancellationTokenSource _cts;
     private Task _listenTask;
 
-    public HealthCheckServer(int port, Func<bool> readinessCheck)
+    public HealthCheckServer(int port, Func<bool> readinessCheck, string? bindHost = null)
     {
         _readinessCheck = readinessCheck;
         _listener = new HttpListener();
-        _listener.Prefixes.Add($"http://*:{port}/");
+        // Default: loopback on Windows (firewall-exempt -- the only Windows consumer,
+        // the upgrade script, probes 127.0.0.1), all interfaces elsewhere (Linux /
+        // docker localhost probes + kubelet httpGet over the pod network). Mirrors
+        // TentacleSettings.HealthCheckBindHost; the Kubernetes agent passes "+".
+        var host = string.IsNullOrWhiteSpace(bindHost)
+            ? (OperatingSystem.IsWindows() ? "127.0.0.1" : "*")
+            : bindHost;
+        _listener.Prefixes.Add($"http://{host}:{port}/");
     }
 
     public void Start()
@@ -29,7 +36,10 @@ public class HealthCheckServer : IHealthCheckServer
     private int GetPort()
     {
         var prefix = _listener.Prefixes.FirstOrDefault() ?? "";
-        var uri = new Uri(prefix.Replace("*", "localhost"));
+        // "*"/"+" are valid HttpListener wildcard hosts but not valid URI hosts,
+        // so normalise them to a parseable host before extracting the port.
+        var parseable = prefix.Replace("://*:", "://localhost:").Replace("://+:", "://localhost:");
+        var uri = new Uri(parseable);
         return uri.Port;
     }
 

--- a/tests/Squid.Tentacle.Tests/Core/TentacleAppTests.cs
+++ b/tests/Squid.Tentacle.Tests/Core/TentacleAppTests.cs
@@ -44,7 +44,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (_, _) => healthServer
+            HealthCheckServerFactory = (_, _, _) => healthServer
         });
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
@@ -93,7 +93,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (_, _) => healthServer
+            HealthCheckServerFactory = (_, _, _) => healthServer
         });
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
@@ -130,7 +130,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (_, _) => healthServer
+            HealthCheckServerFactory = (_, _, _) => healthServer
         });
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
@@ -163,7 +163,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (_, _) => healthServer
+            HealthCheckServerFactory = (_, _, _) => healthServer
         });
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
@@ -206,7 +206,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (_, _) => healthServer
+            HealthCheckServerFactory = (_, _, _) => healthServer
         });
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
@@ -242,7 +242,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (port, readiness) =>
+            HealthCheckServerFactory = (port, _, readiness) =>
             {
                 capturedReadiness = readiness;
                 return healthServer;
@@ -284,7 +284,7 @@ public class TentacleAppTests : TimedTestBase
             BuiltInFlavorsProvider = () => [flavor],
             FlavorResolverFactory = flavors => new TentacleFlavorResolver(flavors),
             HalibutHostFactory = (_, _, _, _) => halibutHost,
-            HealthCheckServerFactory = (_, _) => healthServer
+            HealthCheckServerFactory = (_, _, _) => healthServer
         });
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);

--- a/tests/Squid.Tentacle.Tests/Health/HealthCheckServerTests.cs
+++ b/tests/Squid.Tentacle.Tests/Health/HealthCheckServerTests.cs
@@ -27,6 +27,36 @@ public class HealthCheckServerTests : TimedTestBase
     }
 
     [Fact]
+    public void HealthCheckBindHost_DefaultsToLoopbackOnWindows_AllInterfacesElsewhere()
+    {
+        // Windows default = loopback so the healthz listener isn't network-exposed
+        // and doesn't pop a Defender Firewall prompt on each versioned-path upgrade
+        // (the only Windows consumer, the upgrade script, probes 127.0.0.1).
+        // Non-Windows keeps "*" so Linux/docker localhost probes + kubelet httpGet
+        // (over the pod network) still reach it.
+        var settings = new Squid.Tentacle.Configuration.TentacleSettings();
+
+        if (OperatingSystem.IsWindows())
+            settings.HealthCheckBindHost.ShouldBe("127.0.0.1");
+        else
+            settings.HealthCheckBindHost.ShouldBe("*");
+    }
+
+    [Fact]
+    public async Task ExplicitLoopbackBindHost_IsReachableViaIpv4Loopback()
+    {
+        // The firewall-fix path: an explicit loopback bind still serves the upgrade
+        // script's 127.0.0.1 health probe.
+        var port = TcpPortAllocator.GetEphemeralPort();
+        await using var server = new HealthCheckServer(port, () => true, "127.0.0.1");
+        server.Start();
+
+        using var client = new HttpClient();
+        var result = await GetAsync(client, port, "/healthz");
+        result.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task Readiness_Endpoints_Reflect_Callback_State()
     {
         var ready = false;


### PR DESCRIPTION
## Summary

Operator report: a Windows **Defender Firewall** "allow this app to communicate" prompt appears on **every** upgrade of a SYSTEM-service Polling Tentacle.

**Root cause:** the health-check server binds `http://*:{port}/` (all interfaces) — `HealthCheckServer.cs`. Windows prompts when an app opens a listening socket on a public interface, and the blue-green versioned layout gives each upgrade a **new binary path**, which the path-keyed firewall treats as a new app → fresh prompt every upgrade. For an unattended SYSTEM service, the prompt may even leave the new binary's listener blocked.

**Fix:** default the bind host to **loopback on Windows** (`127.0.0.1`) — firewall-exempt, and the only Windows consumer of healthz is the upgrade script, which probes `127.0.0.1`. Keep **`*` on non-Windows** so Linux/docker `localhost` health checks and the **Kubernetes agent's kubelet `httpGet` liveness/readiness probes** (over the pod network) still work — the agent's Helm chart sets `Tentacle__HealthCheckBindHost: "+"` explicitly. Configurable via `Tentacle__HealthCheckBindHost`.

Takes effect on the upgrade *to* 1.8.16 (the new binary binds loopback → no prompt).

## Test plan

- [x] `HealthCheckServer` + `TentacleApp` tests green; new pins: OS-conditional default (Win→`127.0.0.1`, else `*`) + explicit-loopback reachable via `127.0.0.1`
- [x] `helm template` renders `Tentacle__HealthCheckBindHost: "+"` for the K8s agent
- [ ] Windows E2E (dispatched on this branch)
- [ ] Manual: upgrade a Windows polling tentacle to 1.8.16 → no firewall prompt; healthz still passes
