### PR TITLE
Default unavailable deployment targets to fail-fast

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
@@ -22,10 +22,13 @@ public sealed record TransientTargetResult(
 /// Single source of truth for the project "Transient Deployment Targets" behaviour.
 /// Pure + deterministic so it can be unit-tested exhaustively.
 ///
-/// <para>Defaults (<see cref="UnavailableDeploymentTargetBehavior.SkipAndContinue"/> +
-/// <see cref="UnhealthyDeploymentTargetBehavior.Exclude"/>) reproduce Squid's historical
-/// unconditional exclusion of unavailable + unhealthy targets, so honouring the setting
-/// is non-breaking for projects that haven't configured it.</para>
+/// <para>For an unconfigured project the defaults are
+/// <see cref="UnavailableDeploymentTargetBehavior.FailDeployment"/> (an unavailable target
+/// fails the deployment up front rather than being silently skipped while the task reports
+/// success) and <see cref="UnhealthyDeploymentTargetBehavior.Exclude"/> (unhealthy targets
+/// are dropped). Explicit <see cref="UnavailableDeploymentTargetBehavior.SkipAndContinue"/> /
+/// <see cref="UnhealthyDeploymentTargetBehavior.DoNotExclude"/> opt back into the lenient
+/// behaviour. The default is applied at the settings DTO, not by enum ordinal.</para>
 /// </summary>
 public static class TransientDeploymentTargetEvaluator
 {

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
@@ -98,10 +98,11 @@ public sealed class PrepareDeploymentPhase(
         Log.Information("[Deploy] Found {Count} target machines for deployment {DeploymentId}", ctx.AllTargets.Count, ctx.Deployment.Id);
     }
 
-    // Honour the project's "Transient Deployment Targets" setting. Defaults
-    // (SkipAndContinue + Exclude) reproduce the historical unconditional exclusion of
-    // unavailable + unhealthy targets, so an unconfigured project behaves exactly as
-    // before. FailDeployment on an unavailable target aborts the deployment up front.
+    // Honour the project's "Transient Deployment Targets" setting. For an
+    // unconfigured project the defaults are FailDeployment (an unavailable target
+    // aborts the deployment up front rather than being silently skipped) + Exclude
+    // (unhealthy targets are dropped). Explicit SkipAndContinue is the opt-out that
+    // restores the lenient skip behaviour for unavailable targets.
     internal static void ApplyTransientTargetPolicy(DeploymentTaskContext ctx)
     {
         var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(ctx.AllTargets, ctx.Project?.DeploymentSettingsJson);

--- a/src/Squid.Core/Services/Deployments/Project/DeploymentSettingsSerializer.cs
+++ b/src/Squid.Core/Services/Deployments/Project/DeploymentSettingsSerializer.cs
@@ -6,8 +6,8 @@ namespace Squid.Core.Services.Deployments.Project;
 /// <summary>
 /// Shared (de)serialisation for the project's <see cref="DeploymentSettingsDto"/> JSON
 /// blob. A null / blank / malformed blob deserialises to a default-constructed DTO so
-/// every consumer (the deploy pipeline + the get/save service) sees "all defaults" =
-/// today's behaviour rather than throwing.
+/// every consumer (the deploy pipeline + the get/save service) sees the all-defaults DTO
+/// rather than throwing.
 /// </summary>
 public static class DeploymentSettingsSerializer
 {

--- a/src/Squid.Message/Enums/Deployments/DeploymentSettingsEnums.cs
+++ b/src/Squid.Message/Enums/Deployments/DeploymentSettingsEnums.cs
@@ -4,9 +4,11 @@ namespace Squid.Message.Enums.Deployments;
 
 /// <summary>
 /// What to do when a deployment target is UNAVAILABLE at the start of, or becomes
-/// unavailable during, a deployment. Default (value 0) = <see cref="SkipAndContinue"/>,
-/// which preserves Squid's historical behaviour (unavailable targets are skipped and
-/// removed from the deployment) — so wiring this is non-breaking.
+/// unavailable during, a deployment. The project default for an unconfigured project is
+/// <see cref="FailDeployment"/> (fail fast rather than silently skip an unreachable target
+/// and report success — see <c>TransientDeploymentTargetsDto</c>). <see cref="SkipAndContinue"/>
+/// is the opt-in lenient mode. Note value 0 remains <see cref="SkipAndContinue"/> as the
+/// stable wire encoding; the default is applied at the settings DTO, not by enum ordinal.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UnavailableDeploymentTargetBehavior

--- a/src/Squid.Message/Models/Deployments/Project/DeploymentSettingsDto.cs
+++ b/src/Squid.Message/Models/Deployments/Project/DeploymentSettingsDto.cs
@@ -6,8 +6,9 @@ namespace Squid.Message.Models.Deployments.Project;
 /// Project-level deployment settings. Persisted as a JSON blob on the project so the
 /// shape can grow (release versioning, default failure mode, default package download,
 /// etc.) without a migration per setting. Today it carries the transient-target
-/// behaviour; an absent / null blob means "all defaults", which preserve today's
-/// runtime behaviour.
+/// behaviour; an absent / null blob means "all defaults" — see
+/// <see cref="TransientDeploymentTargetsDto"/> for what each default resolves to (the
+/// unavailable-target default is fail-fast).
 /// </summary>
 public class DeploymentSettingsDto
 {
@@ -20,7 +21,16 @@ public class DeploymentSettingsDto
 /// </summary>
 public class TransientDeploymentTargetsDto
 {
-    public UnavailableDeploymentTargetBehavior UnavailableDeploymentTargets { get; set; }
+    /// <summary>
+    /// Default <see cref="UnavailableDeploymentTargetBehavior.FailDeployment"/>: an
+    /// unconfigured project fails fast on an unreachable target rather than silently
+    /// skipping it and reporting success. A project opts back into the lenient behaviour by
+    /// explicitly setting <see cref="UnavailableDeploymentTargetBehavior.SkipAndContinue"/>.
+    /// System.Text.Json keeps this initializer when the field is absent, so an explicitly
+    /// persisted <c>SkipAndContinue</c> is preserved and only never-configured projects pick
+    /// up the fail-fast default.
+    /// </summary>
+    public UnavailableDeploymentTargetBehavior UnavailableDeploymentTargets { get; set; } = UnavailableDeploymentTargetBehavior.FailDeployment;
 
     public UnhealthyDeploymentTargetBehavior UnhealthyDeploymentTargets { get; set; }
 }

--- a/tests/Squid.IntegrationTests/Services/Deployments/ProjectSettings/ProjectDeploymentSettingsServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/ProjectSettings/ProjectDeploymentSettingsServiceTests.cs
@@ -27,7 +27,7 @@ public class ProjectDeploymentSettingsServiceTests : TestBase
 
         var settings = await Run<IProjectDeploymentSettingsService, DeploymentSettingsDto>(s => s.GetAsync(projectId)).ConfigureAwait(false);
 
-        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.SkipAndContinue);
+        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.FailDeployment);
         settings.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.Exclude);
     }
 

--- a/tests/Squid.UnitTests/Services/Deployments/ProjectSettings/DeploymentSettingsSerializerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ProjectSettings/DeploymentSettingsSerializerTests.cs
@@ -6,8 +6,14 @@ namespace Squid.UnitTests.Services.Deployments.ProjectSettings;
 
 /// <summary>
 /// Pins the project DeploymentSettings (de)serialisation: null / blank / malformed JSON
-/// degrade to "all defaults" (today's behaviour) rather than throwing, and a configured
-/// blob round-trips with enums as stable string values.
+/// degrade to "all defaults" rather than throwing, and a configured blob round-trips with
+/// enums as stable string values.
+///
+/// <para>The unavailable-target default is <see cref="UnavailableDeploymentTargetBehavior.FailDeployment"/>
+/// (fail-fast) so an unconfigured project does not silently skip an unreachable target and
+/// report success. A project opts back into the lenient skip behaviour by explicitly
+/// configuring <see cref="UnavailableDeploymentTargetBehavior.SkipAndContinue"/>, which the
+/// round-trip test proves is preserved.</para>
 /// </summary>
 public class DeploymentSettingsSerializerTests
 {
@@ -21,8 +27,37 @@ public class DeploymentSettingsSerializerTests
         var settings = DeploymentSettingsSerializer.Deserialize(json);
 
         settings.ShouldNotBeNull();
-        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.SkipAndContinue);
+        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.FailDeployment);
         settings.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.Exclude);
+    }
+
+    [Fact]
+    public void Deserialize_ExplicitSkipAndContinue_IsPreservedOverDefault()
+    {
+        // The opt-out: a project that deliberately configured SkipAndContinue must keep it,
+        // NOT be silently upgraded to the new fail-fast default. Use a hand-written blob with
+        // the field PRESENT (not a round-trip) so the test fails if the default ever reverts
+        // to SkipAndContinue — the field-present path must win over whatever the default is.
+        const string json = """{"transientDeploymentTargets":{"unavailableDeploymentTargets":"SkipAndContinue","unhealthyDeploymentTargets":"Exclude"}}""";
+
+        var settings = DeploymentSettingsSerializer.Deserialize(json);
+
+        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.SkipAndContinue);
+    }
+
+    [Fact]
+    public void Deserialize_ValidJsonWithUnavailableFieldAbsent_UsesFailDeploymentDefault()
+    {
+        // The actual mechanism behind the new default: a valid blob that simply omits the
+        // unavailableDeploymentTargets field. System.Text.Json keeps the property initializer
+        // (FailDeployment) for the absent field while honouring the present unhealthy field.
+        // This is the path that catches a revert of the DTO initializer.
+        const string json = """{"transientDeploymentTargets":{"unhealthyDeploymentTargets":"DoNotExclude"}}""";
+
+        var settings = DeploymentSettingsSerializer.Deserialize(json);
+
+        settings.TransientDeploymentTargets.UnavailableDeploymentTargets.ShouldBe(UnavailableDeploymentTargetBehavior.FailDeployment);
+        settings.TransientDeploymentTargets.UnhealthyDeploymentTargets.ShouldBe(UnhealthyDeploymentTargetBehavior.DoNotExclude);
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/PrepareDeploymentPhaseTransientTargetTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/PrepareDeploymentPhaseTransientTargetTests.cs
@@ -14,8 +14,9 @@ namespace Squid.UnitTests.Services.Deployments.Targets;
 
 /// <summary>
 /// Pins how phase 4 applies the project "Transient Deployment Targets" setting to the
-/// candidate targets: default (no settings) reproduces today's unconditional exclusion;
-/// FailDeployment aborts on an unavailable target; DoNotExclude keeps unhealthy targets.
+/// candidate targets: default (no settings) fails fast on an unavailable target and still
+/// excludes unhealthy ones; explicit SkipAndContinue skips an unavailable target; DoNotExclude
+/// keeps unhealthy targets.
 /// </summary>
 public class PrepareDeploymentPhaseTransientTargetTests
 {
@@ -39,17 +40,31 @@ public class PrepareDeploymentPhaseTransientTargetTests
         });
 
     [Fact]
-    public void Default_NullSettings_ExcludesUnavailableAndUnhealthy()
+    public void Default_NullSettings_FailsOnUnavailable()
     {
+        // New fail-fast default: an unconfigured project with an unavailable target aborts
+        // the deployment up front instead of silently skipping it and reporting success.
         var ctx = Context(null,
             M("healthy", MachineHealthStatus.Healthy),
-            M("unhealthy", MachineHealthStatus.Unhealthy),
             M("unavailable", MachineHealthStatus.Unavailable));
+
+        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx))
+            .Message.ShouldContain("unavailable");
+    }
+
+    [Fact]
+    public void Default_NullSettings_NoUnavailable_ExcludesUnhealthy()
+    {
+        // The unhealthy default (Exclude) is unchanged: with no unavailable target present,
+        // unhealthy targets are still excluded and the deployment proceeds on the rest.
+        var ctx = Context(null,
+            M("healthy", MachineHealthStatus.Healthy),
+            M("unhealthy", MachineHealthStatus.Unhealthy));
 
         PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
 
         ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy" });
-        ctx.ExcludedByHealthTargets.Select(m => m.Name).ShouldBe(new[] { "unhealthy", "unavailable" });
+        ctx.ExcludedByHealthTargets.Select(m => m.Name).ShouldBe(new[] { "unhealthy" });
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
@@ -11,16 +11,19 @@ namespace Squid.UnitTests.Services.Deployments.Targets;
 
 /// <summary>
 /// Exhaustive matrix for the project "Transient Deployment Targets" evaluator.
-/// The default behaviours (SkipAndContinue + Exclude) MUST reproduce the historical
-/// unconditional exclusion of unavailable + unhealthy targets, so the wiring is
-/// non-breaking for unconfigured projects.
+/// The defaults for an unconfigured project are <see cref="UnavailableDeploymentTargetBehavior.FailDeployment"/>
+/// (fail-fast on an unreachable target rather than silently skipping it and reporting success)
+/// and <see cref="UnhealthyDeploymentTargetBehavior.Exclude"/>. Explicit SkipAndContinue /
+/// DoNotExclude opt back into the lenient behaviour.
 /// </summary>
 public class TransientDeploymentTargetEvaluatorTests
 {
     private static Machine M(string name, MachineHealthStatus status) => new() { Name = name, HealthStatus = status };
 
+    // The helper's default policy mirrors the production DTO default so `Apply(machines)`
+    // reflects what an unconfigured project gets.
     private static TransientTargetResult Apply(IReadOnlyList<Machine> candidates,
-        UnavailableDeploymentTargetBehavior unavailable = UnavailableDeploymentTargetBehavior.SkipAndContinue,
+        UnavailableDeploymentTargetBehavior unavailable = UnavailableDeploymentTargetBehavior.FailDeployment,
         UnhealthyDeploymentTargetBehavior unhealthy = UnhealthyDeploymentTargetBehavior.Exclude)
         => TransientDeploymentTargetEvaluator.Apply(candidates, unavailable, unhealthy);
 
@@ -38,11 +41,11 @@ public class TransientDeploymentTargetEvaluatorTests
     }
 
     [Fact]
-    public void Defaults_ReproduceHistoricalExclusion()
+    public void Defaults_FailUnavailable_ExcludeUnhealthy()
     {
-        // SkipAndContinue + Exclude (the defaults) reproduce the historical unconditional
-        // exclusion: unavailable + unhealthy are removed (skipped), everything else kept,
-        // nothing fails. This is the single health gate shared by deploy and preview.
+        // Fail-fast defaults: an unavailable target fails the deployment; unhealthy is excluded
+        // (skipped); healthy / unknown / warnings proceed. This is the single health gate shared
+        // by deploy and preview.
         var machines = new[]
         {
             M("healthy", MachineHealthStatus.Healthy),
@@ -55,8 +58,8 @@ public class TransientDeploymentTargetEvaluatorTests
         var result = Apply(machines);
 
         result.Kept.Select(m => m.Name).ShouldBe(new[] { "healthy", "unknown", "warnings" });
-        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "unhealthy", "unavailable" });
-        result.FailedUnavailable.ShouldBeEmpty();
+        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "unhealthy" });
+        result.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "unavailable" });
     }
 
     [Fact]
@@ -137,7 +140,7 @@ public class TransientDeploymentTargetEvaluatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("not-json")]
-    public void ApplyProjectPolicy_NoOrInvalidSettings_UsesHistoricalDefaults(string settingsJson)
+    public void ApplyProjectPolicy_NoOrInvalidSettings_FailUnavailable_ExcludeUnhealthy(string settingsJson)
     {
         var machines = new[]
         {
@@ -149,8 +152,8 @@ public class TransientDeploymentTargetEvaluatorTests
         var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(machines, settingsJson);
 
         result.Kept.Select(m => m.Name).ShouldBe(new[] { "healthy" });
-        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "unhealthy", "unavailable" });
-        result.FailedUnavailable.ShouldBeEmpty();
+        result.Skipped.Select(m => m.Name).ShouldBe(new[] { "unhealthy" });
+        result.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "unavailable" });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- An unconfigured project's "Transient Deployment Targets" policy defaulted to `SkipAndContinue`: an unavailable target at deployment start was silently dropped and the deployment still reported **success**. A failed target masquerading as a green deploy is a dangerous default.
- Flip the unconfigured default to `FailDeployment` (`TransientDeploymentTargetsDto.UnavailableDeploymentTargets` initializer) so an unreachable target aborts the deployment up front. The fail-fast plumbing already existed in phase 4 (`PrepareDeploymentPhase`) and the preview path — only the default value changes.
- **Behavioural change, deliberately scoped**: System.Text.Json keeps the property initializer when the field is absent, so a project that explicitly persisted `SkipAndContinue` is preserved; only never-configured projects pick up fail-fast. The per-project "Transient Deployment Targets" setting remains the opt-out for operators who want the lenient behaviour.
- The unhealthy-target default (`Exclude`) is unchanged. The enum wire encoding is unchanged (value 0 stays `SkipAndContinue`); the default is applied at the DTO, not by enum ordinal, so persisted blobs are unaffected.

## Test plan

- [x] Unit: serializer default → `FailDeployment`; explicit `SkipAndContinue` preserved over the default (opt-out)
- [x] Unit: evaluator `ApplyProjectPolicy(null/empty/invalid)` → unavailable → `FailedUnavailable`, unhealthy still excluded; preview⇿deploy convergence still holds
- [x] Unit: phase 4 — null settings + unavailable target throws `DeploymentTargetException`; null settings + only-unhealthy still excludes (no throw)
- [x] Integration (real DB): `GetAsync` on an unconfigured project returns `FailDeployment`
- [x] Regression: full `Services.Deployments` unit namespace 3983/3983 green; `dotnet build Squid.sln` 0 errors
- [ ] E2E: not added — only the default *value* changed (a serializer/persistence concern, covered by unit + integration); the `FailDeployment` *behaviour* and its phase-4/preview plumbing are unchanged and already covered

## Operator note

The frontend Deployment Settings UI renders the enum value the API returns, so an unconfigured project now shows "Fail deployment" preselected (the accurate new default) — no frontend change required.