### PR TITLE
Persist the tentacle agent log to a rotated file under the service

### DIFF
--- a/src/Squid.Tentacle/Core/TentacleLogging.cs
+++ b/src/Squid.Tentacle/Core/TentacleLogging.cs
@@ -1,0 +1,119 @@
+using Serilog;
+using Serilog.Events;
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Core;
+
+/// <summary>
+/// Builds the tentacle's Serilog logger. The console sink is ALWAYS present
+/// (stderr-routed — keeps stdout clean for CLI pipelines). A persistent,
+/// size-rotated FILE sink is added ONLY when the process runs as the
+/// long-lived managed service (Windows SCM): there the console is attached to
+/// NUL, so without a file sink the agent's entire runtime log is lost.
+///
+/// <para>Short-lived CLI commands (<c>version</c>, <c>show-thumbprint</c>,
+/// <c>register</c>, …) stay console-only so they don't litter a log file per
+/// invocation. On Linux/systemd the console is captured by journald, so the
+/// file sink isn't needed there — the gap this closes is specifically the
+/// Windows service, whose console output goes nowhere.</para>
+/// </summary>
+public static class TentacleLogging
+{
+    /// <summary>Per-file size cap before the rolling sink starts a new file.</summary>
+    public const long FileSizeLimitBytes = 50L * 1024 * 1024;   // 50 MB
+
+    /// <summary>Rolled files (including the active one) retained before the oldest is deleted.</summary>
+    public const int RetainedFileCountLimit = 5;
+
+    /// <summary>Subfolder (under the system config dir) the agent log lives in.</summary>
+    public const string LogsDirName = "logs";
+
+    /// <summary>Active agent log filename; Serilog appends a roll suffix to older files.</summary>
+    public const string AgentLogFileName = "tentacle.log";
+
+    /// <summary>Size cap for the SCM-startup diagnostic log — a separate append-only
+    /// writer that predates the host + rolling sink, so the rolling sink can't cap it.</summary>
+    public const long ScmDiagnosticMaxBytes = 1024 * 1024;   // 1 MB
+
+    /// <summary>
+    /// Best-effort single-generation rotation for a plain append-only log file:
+    /// if it exceeds <paramref name="maxBytes"/>, move it to <c>{path}.old</c>
+    /// (overwriting any prior <c>.old</c>) and start fresh. Never throws — a
+    /// diagnostic writer must never disrupt the path it instruments.
+    /// </summary>
+    public static void RotateIfOversized(string path, long maxBytes)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+
+            if (!info.Exists || info.Length < maxBytes) return;
+
+            File.Copy(path, path + ".old", overwrite: true);
+            File.WriteAllText(path, string.Empty);
+        }
+        catch
+        {
+            // Best-effort — rotation must never throw.
+        }
+    }
+
+    /// <summary>
+    /// The persistent agent-log path: <c>{system-config-dir}/logs/tentacle.log</c>
+    /// (e.g. <c>%ProgramData%\Squid\Tentacle\logs\tentacle.log</c> on Windows).
+    /// </summary>
+    public static string ResolveAgentLogPath()
+        => Path.Combine(PlatformPaths.GetSystemConfigDir(), LogsDirName, AgentLogFileName);
+
+    /// <summary>
+    /// Builds the logger. <paramref name="addPersistentFileSink"/> is true only
+    /// when running as the managed service. <paramref name="logPathOverride"/> is
+    /// a test seam — production passes null and the path resolves to
+    /// <see cref="ResolveAgentLogPath"/>.
+    /// </summary>
+    public static LoggerConfiguration BuildLoggerConfiguration(bool addPersistentFileSink, string logPathOverride = null, long? fileSizeLimitBytesOverride = null)
+    {
+        var config = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.Console(
+                standardErrorFromLevel: LogEventLevel.Verbose,
+                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}");
+
+        if (addPersistentFileSink && TryResolveWritableLogPath(logPathOverride, out var logPath))
+            config.WriteTo.File(
+                logPath,
+                rollOnFileSizeLimit: true,
+                fileSizeLimitBytes: fileSizeLimitBytesOverride ?? FileSizeLimitBytes,
+                retainedFileCountLimit: RetainedFileCountLimit,
+                shared: true,
+                outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3}] {Message:lj}{NewLine}{Exception}");
+
+        return config;
+    }
+
+    /// <summary>
+    /// Resolves the log path and ensures its directory exists. Best-effort: if
+    /// the directory can't be created (permission denied, read-only FS), returns
+    /// false so the caller stays console-only — a log file must NEVER block the
+    /// service from starting.
+    /// </summary>
+    private static bool TryResolveWritableLogPath(string logPathOverride, out string logPath)
+    {
+        logPath = null;
+
+        try
+        {
+            var resolved = string.IsNullOrWhiteSpace(logPathOverride) ? ResolveAgentLogPath() : logPathOverride;
+            var dir = Path.GetDirectoryName(resolved);
+
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+            logPath = resolved;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Squid.Tentacle/Program.cs
+++ b/src/Squid.Tentacle/Program.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.WindowsServices;
 using Squid.Tentacle.Core;
 using Serilog;
-using Serilog.Events;
 
 // Direct ALL Serilog output to stderr (Unix convention: diagnostic
 // log lines on stderr, command output on stdout). This keeps stdout
@@ -28,12 +27,13 @@ using Serilog.Events;
 // (`register`, `service install`) still emit their summary output
 // (MachineId, etc.) to stdout via Console.WriteLine — log noise just
 // moves to stderr where it belongs.
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Information()
-    .WriteTo.Console(
-        standardErrorFromLevel: LogEventLevel.Verbose,
-        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
-    .CreateLogger();
+// Resolve the launch mode ONCE: a Windows-SCM-launched service has its console
+// attached to NUL, so it gets a persistent rolling FILE sink (otherwise its
+// entire runtime log is lost). Short-lived CLI commands stay console-only.
+// Reused below to drive the SCM lifetime branch.
+var runsUnderScm = TentacleEntry.ShouldRunUnderScm(args, OperatingSystem.IsWindows(), WindowsServiceHelpers.IsWindowsService);
+
+Log.Logger = TentacleLogging.BuildLoggerConfiguration(addPersistentFileSink: runsUnderScm).CreateLogger();
 
 try
 {
@@ -48,7 +48,7 @@ try
     // Console mode (interactive CLI, register, service install, etc.)
     // — including SSH-launched `run` for systemd's ExecStart on Linux
     // — falls through to the existing Console-CT path below.
-    if (TentacleEntry.ShouldRunUnderScm(args, OperatingSystem.IsWindows(), WindowsServiceHelpers.IsWindowsService))
+    if (runsUnderScm)
         return await RunUnderScmLifetimeAsync(args).ConfigureAwait(false);
 
     // Console mode — existing flow. Console.CancelKeyPress + ProcessExit
@@ -191,6 +191,10 @@ static class ScmDiagnosticLog
         {
             lock (Lock)
             {
+                // Single-generation rotation so this append-only diagnostic can't
+                // grow unbounded across thousands of service restarts.
+                TentacleLogging.RotateIfOversized(LogPath, TentacleLogging.ScmDiagnosticMaxBytes);
+
                 System.IO.File.AppendAllText(
                     LogPath,
                     $"[{DateTimeOffset.UtcNow:HH:mm:ss.fff}] {line}{Environment.NewLine}");

--- a/src/Squid.Tentacle/Squid.Tentacle.csproj
+++ b/src/Squid.Tentacle/Squid.Tentacle.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <!--
       Phase 13 follow-up — SCM control-handler integration.

--- a/tests/Squid.Tentacle.Tests/Core/TentacleLoggingTests.cs
+++ b/tests/Squid.Tentacle.Tests/Core/TentacleLoggingTests.cs
@@ -1,0 +1,163 @@
+using Squid.Tentacle.Core;
+using Squid.Tentacle.Platform;
+
+namespace Squid.Tentacle.Tests.Core;
+
+/// <summary>
+/// Pins the tentacle's logging contract (audit P2): a persistent, size-rotated
+/// FILE sink is added ONLY when running as the managed service (Windows SCM,
+/// where the console goes to NUL); short-lived CLI commands stay console-only.
+/// Also pins the single-generation rotation of the separate append-only
+/// SCM-startup diagnostic log.
+/// </summary>
+public sealed class TentacleLoggingTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TentacleLoggingTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "squid-tentacle-log-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Operator-visible constants pinned ────────────────────────────────────
+
+    [Fact]
+    public void Defaults_Pinned()
+    {
+        TentacleLogging.FileSizeLimitBytes.ShouldBe(50L * 1024 * 1024);
+        TentacleLogging.RetainedFileCountLimit.ShouldBe(5);
+        TentacleLogging.AgentLogFileName.ShouldBe("tentacle.log");
+        TentacleLogging.LogsDirName.ShouldBe("logs");
+        TentacleLogging.ScmDiagnosticMaxBytes.ShouldBe(1024 * 1024);
+    }
+
+    [Fact]
+    public void ResolveAgentLogPath_IsUnderSystemConfigDir_InLogsSubdir()
+    {
+        var path = TentacleLogging.ResolveAgentLogPath();
+
+        path.ShouldStartWith(PlatformPaths.GetSystemConfigDir());
+        path.ShouldEndWith(Path.Combine("logs", "tentacle.log"));
+    }
+
+    // ── File-sink gating ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoFileSink_WritesNoFile()
+    {
+        // Short-lived CLI command path: console-only, must not litter a log file.
+        var logPath = Path.Combine(_tempDir, "should-not-appear.log");
+
+        var logger = TentacleLogging.BuildLoggerConfiguration(addPersistentFileSink: false, logPathOverride: logPath).CreateLogger();
+        logger.Information("a short-lived CLI command line");
+        logger.Dispose();
+
+        File.Exists(logPath).ShouldBeFalse();
+        Directory.GetFiles(_tempDir).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WithFileSink_WritesPersistentLog()
+    {
+        // Managed-service path: the runtime log MUST be persisted to disk.
+        var logPath = Path.Combine(_tempDir, "tentacle.log");
+
+        var logger = TentacleLogging.BuildLoggerConfiguration(addPersistentFileSink: true, logPathOverride: logPath).CreateLogger();
+        logger.Information("agent runtime line {N}", 42);
+        logger.Dispose();
+
+        File.Exists(logPath).ShouldBeTrue();
+        File.ReadAllText(logPath).ShouldContain("agent runtime line 42");
+    }
+
+    [Fact]
+    public void WithFileSink_RotatesWhenSizeLimitExceeded()
+    {
+        // Proves the rolling sink actually rotates (the "no rotation" gap). Tiny
+        // size override so a handful of lines roll the file without writing 50 MB.
+        var logPath = Path.Combine(_tempDir, "tentacle.log");
+
+        var logger = TentacleLogging.BuildLoggerConfiguration(
+            addPersistentFileSink: true, logPathOverride: logPath, fileSizeLimitBytesOverride: 512).CreateLogger();
+
+        for (var i = 0; i < 200; i++)
+            logger.Information("rotation probe line {I} with padding to grow the file quickly", i);
+
+        logger.Dispose();
+
+        var files = Directory.GetFiles(_tempDir, "tentacle*.log");
+        files.Length.ShouldBeGreaterThan(1,
+            customMessage: "rollOnFileSizeLimit should have produced multiple rolled files");
+        files.Length.ShouldBeLessThanOrEqualTo(TentacleLogging.RetainedFileCountLimit,
+            customMessage: "retainedFileCountLimit should cap how many rolled files are kept");
+    }
+
+    [Fact]
+    public void WithFileSink_LogDirCannotBeCreated_FallsBackToConsoleOnly_NeverThrows()
+    {
+        // The hard guarantee (TentacleLogging.TryResolveWritableLogPath): a log
+        // file must NEVER block the service from starting. Force
+        // Directory.CreateDirectory to throw by making the log path's parent a
+        // regular FILE, then assert building the logger neither throws nor leaves
+        // a file — it silently falls back to console-only.
+        var blockingFile = Path.Combine(_tempDir, "not-a-dir");
+        File.WriteAllText(blockingFile, "i am a file, not a directory");
+
+        // {_tempDir}/not-a-dir/logs/tentacle.log — the "logs" dir can't be created
+        // under a regular file, so TryResolveWritableLogPath catches + returns false.
+        var impossiblePath = Path.Combine(blockingFile, "logs", "tentacle.log");
+
+        Should.NotThrow(() =>
+        {
+            using var logger = TentacleLogging.BuildLoggerConfiguration(
+                addPersistentFileSink: true, logPathOverride: impossiblePath).CreateLogger();
+            logger.Information("the service must still start when the log dir can't be created");
+        });
+
+        File.Exists(impossiblePath).ShouldBeFalse(
+            customMessage: "fell back to console-only — no log file should be produced at the un-creatable path");
+    }
+
+    // ── SCM-diagnostic single-generation rotation ────────────────────────────
+
+    [Fact]
+    public void RotateIfOversized_UnderLimit_LeavesFileUntouched()
+    {
+        var path = Path.Combine(_tempDir, "scm.log");
+        File.WriteAllText(path, "small");
+
+        TentacleLogging.RotateIfOversized(path, maxBytes: 1024);
+
+        File.ReadAllText(path).ShouldBe("small");
+        File.Exists(path + ".old").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RotateIfOversized_OverLimit_MovesToOldAndTruncates()
+    {
+        var path = Path.Combine(_tempDir, "scm.log");
+        File.WriteAllText(path, new string('x', 2048));
+
+        TentacleLogging.RotateIfOversized(path, maxBytes: 1024);
+
+        File.Exists(path + ".old").ShouldBeTrue();
+        new FileInfo(path + ".old").Length.ShouldBe(2048);
+        new FileInfo(path).Length.ShouldBe(0,
+            customMessage: "active file must be truncated after rotation so it can't grow unbounded");
+    }
+
+    [Fact]
+    public void RotateIfOversized_MissingFile_DoesNotThrow()
+    {
+        var path = Path.Combine(_tempDir, "does-not-exist.log");
+
+        Should.NotThrow(() => TentacleLogging.RotateIfOversized(path, maxBytes: 1));
+        File.Exists(path + ".old").ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- The tentacle's Serilog logger wrote to the **console only**. A Windows-SCM-launched service has no console — writes go to NUL — so the agent's entire runtime log was **lost**, leaving operators nothing to inspect after a failure. The only Windows-persistent file (the SCM-startup diagnostic) was **append-only with no size cap**.
- Add a size-rotated Serilog **file sink** (50 MB × 5 retained files) via a new testable `TentacleLogging` helper, **gated to the managed-service launch** (`ShouldRunUnderScm`). Short-lived CLI commands (`version`, `register`, …) stay console-only so they don't litter a log file per invocation. On Linux/systemd the console is already captured by journald, so the sink targets the Windows-service gap specifically. Directory creation is best-effort — a log file can never block the service from starting.
- Bound the separate append-only **SCM-startup diagnostic** log with a single-generation size rotation (`RotateIfOversized`, 1 MB → `.old`).
- **Non-breaking / additive**: console behaviour (stderr routing, output template) is unchanged; the file sink is purely additive and only active for the running service. Adds the `Serilog.Sinks.File` package.

## Test plan

- [x] Unit: operator-visible constants pinned (50 MB / 5 files / `tentacle.log` / `logs` / 1 MB SCM cap); `ResolveAgentLogPath` under `{system-config-dir}/logs`
- [x] Unit: file-sink **off** → no file written (CLI path); file-sink **on** → persistent log written + contains the message
- [x] Unit: **real rolling-file rotation** proven (tiny size override → multiple rolled files, capped at the retained-count limit)
- [x] Unit: `RotateIfOversized` under-limit no-op / over-limit → `.old` + truncate / missing-file no-throw
- [x] Regression: `Squid.Tentacle.Tests` Core/Entry/Scm 102/102 green; full suite green except 5 disk-gated `RunningScriptReporterTests` that fail on a near-full **dev disk** (`DiskSpaceChecker` 10% floor — environmental, branch-independent, untouched by this change; passes on CI)
- [x] `dotnet build Squid.sln` 0 errors