### PR TITLE
Send the isolation mutex name on the wire's IsolationMutexName field

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -151,11 +151,13 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         };
 
         var scriptTimeout = request.Timeout ?? _defaultScriptTimeout;
-        // ARCH.7: ticket is fresh-per-attempt (Guid); mutex name is stable
-        // hash of the dispatch tuple so concurrent dispatches of the same
-        // action still serialise on the agent.
+        // Ticket is fresh-per-attempt (Guid) so a retry doesn't trap on agent-side
+        // state from the previous attempt. IsolationMutexName is MACHINE-SCOPED
+        // (the 5th ctor arg) so every FullIsolation script on this machine —
+        // deployments AND upgrades, all via ScriptIsolationMutexNames.ForMachine —
+        // serialises behind one writer lock. The server task id rides the 7th arg
+        // (taskId) purely for correlation.
         var ticketId = GenerateTicketId(request.ServerTaskId, request.StepName, request.ActionName, request.Machine.Id);
-        var mutexName = GenerateMutexName(request.ServerTaskId, request.StepName, request.ActionName, request.Machine.Id);
         var scriptTicket = new ScriptTicket(ticketId);
 
         var command = new StartScriptCommand(
@@ -163,9 +165,9 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
             scriptBody,
             ScriptIsolationLevel.FullIsolation,
             scriptTimeout,
-            null,
+            ScriptIsolationMutexNames.ForMachine(request.Machine.Id),
             Array.Empty<string>(),
-            mutexName,
+            request.ServerTaskId.ToString(),
             TimeSpan.Zero,
             scriptFiles)
         {
@@ -185,9 +187,10 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
 
         var scriptFiles = BuildDirectScriptFiles(request.DeploymentFiles, variableBytes, sensitiveBytes, password);
         var scriptTimeout = request.Timeout ?? _defaultScriptTimeout;
-        // ARCH.7: see ExecuteCalamariViaHalibutAsync above for the ticket-vs-mutex split rationale.
+        // See ExecuteCalamariViaHalibutAsync above for the ticket-vs-mutex-name
+        // rationale: ticket is Guid-per-attempt; IsolationMutexName (arg 5) is the
+        // machine-scoped name that serialises FullIsolation scripts on the agent.
         var ticketId = GenerateTicketId(request.ServerTaskId, request.StepName, request.ActionName, request.Machine.Id);
-        var mutexName = GenerateMutexName(request.ServerTaskId, request.StepName, request.ActionName, request.Machine.Id);
         var scriptTicket = new ScriptTicket(ticketId);
 
         var command = new StartScriptCommand(
@@ -195,9 +198,9 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
             request.ScriptBody,
             ScriptIsolationLevel.FullIsolation,
             scriptTimeout,
-            null,
+            ScriptIsolationMutexNames.ForMachine(request.Machine.Id),
             Array.Empty<string>(),
-            mutexName,
+            request.ServerTaskId.ToString(),
             TimeSpan.Zero,
             scriptFiles)
         {
@@ -351,43 +354,21 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
     }
 
     /// <summary>
-    /// ARCH.7: produces a fresh
-    /// <see cref="ScriptTicket"/> id per dispatch attempt. The
-    /// <paramref name="serverTaskId"/> / <paramref name="stepName"/> /
-    /// <paramref name="actionName"/> / <paramref name="machineId"/> tuple is
-    /// IGNORED for the ticket itself — kept on the signature for symmetry
-    /// with <see cref="GenerateMutexName"/>, which is the value that DOES
-    /// need stability across attempts.
-    ///
-    /// <para>Pre-fix this method derived the ticket from the tuple via SHA256.
-    /// Same-tuple retries (server-side double-dispatch, network-glitch
-    /// resend) reused the same ticket — agent-side state from the previous
-    /// attempt (workspace, mutex) could trap the retry. Octopus matches this
-    /// fix with <c>Guid.NewGuid()</c> per dispatch.</para>
+    /// Produces a fresh <see cref="ScriptTicket"/> id per dispatch attempt
+    /// (<c>Guid.NewGuid()</c>). The (<paramref name="serverTaskId"/>,
+    /// <paramref name="stepName"/>, <paramref name="actionName"/>,
+    /// <paramref name="machineId"/>) tuple is IGNORED — the ticket is deliberately
+    /// non-deterministic so a retry doesn't trap on agent-side state (workspace,
+    /// mutex) left by the previous attempt. The arguments are kept on the signature
+    /// for call-site readability and test pinning. Cross-dispatch serialisation is
+    /// handled separately by the machine-scoped
+    /// <see cref="ScriptIsolationMutexNames.ForMachine"/> on
+    /// <see cref="StartScriptCommand.IsolationMutexName"/>, NOT by the ticket.
     ///
     /// <para>Pinned by <c>HalibutMachineExecutionStrategyRoutingTests.GenerateTicketId_*</c>.</para>
     /// </summary>
     internal static string GenerateTicketId(int serverTaskId, string stepName, string actionName, int machineId)
         => Guid.NewGuid().ToString("N");
-
-    /// <summary>
-    /// Stable hash of the dispatch tuple — used as the agent-side
-    /// <c>ScriptIsolationMutexName</c> so two concurrent dispatches of the
-    /// SAME logical action (e.g. genuine retry overlapping with original)
-    /// serialise on the agent, even though they carry distinct tickets.
-    ///
-    /// <para>This is the part of the pre-fix <c>GenerateTicketId</c> that was
-    /// actually load-bearing; it survives unchanged after we split ticket
-    /// (Guid-per-attempt) from mutex name (deterministic).</para>
-    ///
-    /// <para>Pinned by <c>HalibutMachineExecutionStrategyRoutingTests.GenerateMutexName_*</c>.</para>
-    /// </summary>
-    internal static string GenerateMutexName(int serverTaskId, string stepName, string actionName, int machineId)
-    {
-        var input = $"{serverTaskId}|{stepName}|{actionName}|{machineId}";
-        var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(input));
-        return Convert.ToHexString(hash)[..32].ToLowerInvariant();
-    }
 
     /// <summary>
     /// P0-E.3: emit a structured log line naming which script-service protocol

--- a/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategy.cs
@@ -403,7 +403,11 @@ public sealed class LinuxTentacleUpgradeStrategy : IMachineUpgradeStrategy
         var ticketId = $"upgrade-{machine.Id}-{Guid.NewGuid():N}";
         var scriptBody = BuildScript(targetVersion);
 
-        return new StartScriptCommand(new ScriptTicket(ticketId), scriptBody, ScriptIsolationLevel.FullIsolation, UpgradeScriptTimeout, null, Array.Empty<string>(), ticketId, TimeSpan.Zero)
+        // IsolationMutexName (arg 5) is the SAME machine-scoped name deployments
+        // use, so an upgrade (which restarts the Tentacle) serialises with any
+        // in-flight deployment FullIsolation script on this machine instead of
+        // running concurrently. ticketId rides arg 7 (taskId) for correlation.
+        return new StartScriptCommand(new ScriptTicket(ticketId), scriptBody, ScriptIsolationLevel.FullIsolation, UpgradeScriptTimeout, ScriptIsolationMutexNames.ForMachine(machine.Id), Array.Empty<string>(), ticketId, TimeSpan.Zero)
         {
             ScriptSyntax = ScriptType.Bash
         };

--- a/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategy.cs
@@ -393,7 +393,11 @@ public sealed class WindowsTentacleUpgradeStrategy : IMachineUpgradeStrategy
         var ticketId = $"upgrade-{machine.Id}-{Guid.NewGuid():N}";
         var scriptBody = BuildScript(targetVersion);
 
-        return new StartScriptCommand(new ScriptTicket(ticketId), scriptBody, ScriptIsolationLevel.FullIsolation, UpgradeScriptTimeout, null, Array.Empty<string>(), ticketId, TimeSpan.Zero)
+        // IsolationMutexName (arg 5) is the SAME machine-scoped name deployments
+        // use, so an upgrade (which restarts the Tentacle) serialises with any
+        // in-flight deployment FullIsolation script on this machine instead of
+        // running concurrently. ticketId rides arg 7 (taskId) for correlation.
+        return new StartScriptCommand(new ScriptTicket(ticketId), scriptBody, ScriptIsolationLevel.FullIsolation, UpgradeScriptTimeout, ScriptIsolationMutexNames.ForMachine(machine.Id), Array.Empty<string>(), ticketId, TimeSpan.Zero)
         {
             ScriptSyntax = ScriptType.PowerShell
         };

--- a/src/Squid.Message/Contracts/Tentacle/ScriptIsolationMutexNames.cs
+++ b/src/Squid.Message/Contracts/Tentacle/ScriptIsolationMutexNames.cs
@@ -1,0 +1,26 @@
+namespace Squid.Message.Contracts.Tentacle;
+
+/// <summary>
+/// Single source of truth for the agent-side script-isolation mutex name passed
+/// as <see cref="StartScriptCommand.IsolationMutexName"/>.
+///
+/// <para>On the Tentacle, FullIsolation scripts that share a mutex name serialise
+/// behind one writer lock; scripts with different names can run concurrently.
+/// Squid uses a <b>machine-scoped</b> name so EVERY FullIsolation dispatch to a
+/// machine — deployment OR upgrade — serialises on that machine, preventing two
+/// scripts from stomping the same target (the safe per-machine default).
+/// Because one Tentacle process serves exactly one machine, this is equivalent to
+/// a single per-agent lock, but the explicit, shared name makes the
+/// cross-deployment and deploy-vs-upgrade serialisation intentional and visible
+/// in agent logs — versus the implicit <c>null → "default"</c> fallback that the
+/// dispatch code previously relied on by accident.</para>
+/// </summary>
+public static class ScriptIsolationMutexNames
+{
+    /// <summary>
+    /// The machine-scoped isolation mutex name. Every deployment / upgrade script
+    /// dispatched to <paramref name="machineId"/> uses this exact value, so they
+    /// all serialise behind one writer lock on that machine's Tentacle.
+    /// </summary>
+    public static string ForMachine(int machineId) => $"squid/machine/{machineId}";
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/HalibutMachineExecutionStrategyRoutingTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/HalibutMachineExecutionStrategyRoutingTests.cs
@@ -127,23 +127,13 @@ public class HalibutMachineExecutionStrategyRoutingTests
                 .Message.ShouldContain("Unsupported script syntax");
     }
 
-    // ── ARCH.7 (Phase-6, post-Phase-5 deep audit) ─────────────────────────────
+    // ── Ticket id — fresh per dispatch attempt ────────────────────────────────
     //
-    // Pre-fix: GenerateTicketId derived BOTH the ScriptTicket AND the
-    // IsolationMutexName from `SHA256(taskId|step|action|machineId)[..32]`.
-    // Two consecutive dispatches of the same logical action (e.g. retry after
-    // a network glitch on the original StartScript RPC) produced IDENTICAL
-    // tickets — so agent-side state from the first attempt (mutex, workspace)
-    // could trap the retry; the agent couldn't distinguish "redelivery" from
-    // "fresh attempt". Octopus matches this by using `Guid.NewGuid()` per
-    // dispatch.
-    //
-    // Post-fix:
-    //   - ScriptTicket: Guid.NewGuid() (32-char "N" form) per call → distinct
-    //     attempts get distinct tickets → no agent-side state trap.
-    //   - IsolationMutexName: stable SHA256 derivation kept → concurrent
-    //     dispatches of the same action still serialise on the agent (the
-    //     thing the original derivation was actually trying to do).
+    // The ScriptTicket is Guid.NewGuid() per call so a retry doesn't trap on
+    // agent-side state (workspace, mutex) left by the previous attempt. Cross-
+    // dispatch serialisation is NOT the ticket's job — it's handled by the
+    // machine-scoped IsolationMutexName (ScriptIsolationMutexNames.ForMachine,
+    // pinned in ScriptIsolationMutexNamesTests + the strategy wire-pin test).
 
     [Fact]
     public void GenerateTicketId_TwoCalls_ProduceDifferentTickets()
@@ -155,8 +145,8 @@ public class HalibutMachineExecutionStrategyRoutingTests
 
         t1.ShouldNotBe(t2,
             customMessage:
-                "ARCH.7 — same dispatch tuple must produce DIFFERENT tickets across calls. " +
-                "SHA256-derived tickets caused agent-side state from a previous attempt to trap retries.");
+                "Same dispatch tuple must produce DIFFERENT tickets across calls. " +
+                "A deterministic ticket caused agent-side state from a previous attempt to trap retries.");
     }
 
     [Fact]
@@ -169,36 +159,5 @@ public class HalibutMachineExecutionStrategyRoutingTests
         ticket.Length.ShouldBe(32);
         ticket.ShouldMatch("^[a-f0-9]{32}$",
             customMessage: "ticket must be lowercase hex (Guid 'N' format) — agent's TicketIdWhitelist regex pins this.");
-    }
-
-    [Fact]
-    public void GenerateMutexName_StableForSameActionTuple()
-    {
-        // The IsolationMutexName MUST stay deterministic so two concurrent
-        // dispatches of the same logical action (e.g. server-side double-send
-        // bug, or genuine retry overlapping with original) serialise on the
-        // agent. Different tickets, same mutex name = correct agent behaviour.
-        var m1 = HalibutMachineExecutionStrategy.GenerateMutexName(123, "Deploy", "Apply", 7);
-        var m2 = HalibutMachineExecutionStrategy.GenerateMutexName(123, "Deploy", "Apply", 7);
-
-        m1.ShouldBe(m2);
-        m1.Length.ShouldBe(32);
-        m1.ShouldMatch("^[a-f0-9]{32}$");
-    }
-
-    [Theory]
-    [InlineData(1, "step", "action", 1, 2, "step", "action", 1)]    // taskId differs
-    [InlineData(1, "step", "action", 1, 1, "STEP", "action", 1)]    // step differs
-    [InlineData(1, "step", "action", 1, 1, "step", "ACTION", 1)]    // action differs
-    [InlineData(1, "step", "action", 1, 1, "step", "action", 2)]    // machineId differs
-    public void GenerateMutexName_DifferentTuple_DifferentMutex(
-        int t1, string s1, string a1, int m1,
-        int t2, string s2, string a2, int m2)
-    {
-        var n1 = HalibutMachineExecutionStrategy.GenerateMutexName(t1, s1, a1, m1);
-        var n2 = HalibutMachineExecutionStrategy.GenerateMutexName(t2, s2, a2, m2);
-
-        n1.ShouldNotBe(n2,
-            customMessage: "different (taskId, step, action, machineId) tuples must hash to different mutex names so unrelated dispatches don't serialise.");
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/ScriptIsolationMutexNamesTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/ScriptIsolationMutexNamesTests.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using Squid.Message.Contracts.Tentacle;
+using Xunit;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+/// <summary>
+/// Pins the machine-scoped isolation mutex name — the single source of truth
+/// shared by deployment dispatch (<c>HalibutMachineExecutionStrategy</c>) and
+/// upgrade dispatch (<c>Linux/WindowsTentacleUpgradeStrategy</c>). Every
+/// FullIsolation script dispatched to a machine carries this exact value as
+/// <see cref="StartScriptCommand.IsolationMutexName"/>, so they all serialise
+/// behind one writer lock on that machine's Tentacle.
+/// </summary>
+public sealed class ScriptIsolationMutexNamesTests
+{
+    [Fact]
+    public void ForMachine_SameMachine_ProducesSameName()
+    {
+        // Same machine → identical name → every FullIsolation script on it
+        // (deployment or upgrade) serialises on one lock.
+        ScriptIsolationMutexNames.ForMachine(42)
+            .ShouldBe(ScriptIsolationMutexNames.ForMachine(42));
+    }
+
+    [Fact]
+    public void ForMachine_DifferentMachines_ProduceDifferentNames()
+    {
+        // Different machines → different names → separate machines don't
+        // serialise against each other (they're separate agents anyway).
+        ScriptIsolationMutexNames.ForMachine(42)
+            .ShouldNotBe(ScriptIsolationMutexNames.ForMachine(43));
+    }
+
+    [Theory]
+    [InlineData(0, "squid/machine/0")]
+    [InlineData(7, "squid/machine/7")]
+    [InlineData(1234567890, "squid/machine/1234567890")]
+    public void ForMachine_FormatPinned(int machineId, string expected)
+    {
+        // Deployment + upgrade dispatch BOTH call this; deploy<->upgrade
+        // serialisation only holds if they produce the byte-identical string.
+        // Pin the literal so a "harmless" format tweak can't silently split the
+        // two onto different mutexes.
+        ScriptIsolationMutexNames.ForMachine(machineId).ShouldBe(expected);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
@@ -311,48 +311,64 @@ public class HalibutMachineExecutionStrategyTests
             CreateRequest(machine, calamariCommand: calamariCommand), CancellationToken.None);
 
         capturedCommand.ShouldNotBeNull();
-        capturedCommand.TaskId.ShouldNotBeNullOrEmpty();
-        capturedCommand.TaskId.Length.ShouldBe(32); // Guid without hyphens
+        // The ScriptTicket carries the Guid-per-attempt id; TaskId carries the
+        // server task id (correlation), NOT the ticket.
+        capturedCommand.ScriptTicket.TaskId.Length.ShouldBe(32); // Guid 'N' form
+        capturedCommand.ScriptTicket.TaskId.ShouldMatch("^[a-f0-9]{32}$");
     }
 
-    // === Ticket ID — fresh-per-attempt (ARCH.7) ===
-    //
-    //  these tests pinned `GenerateTicketId` as a pure function of
-    // the (taskId, step, action, machineId) tuple — same input, same output.
-    // ARCH.7 deliberately broke that property: ticket is now Guid-per-attempt
-    // so retries don't trap on agent-side state from the previous attempt.
-    // The stable-derivation half (used as the IsolationMutexName so concurrent
-    // dispatches still serialise on the agent) lives in `GenerateMutexName`,
-    // which IS pinned by these tests instead.
-
-    [Fact]
-    public void GenerateMutexName_SameInputs_ProducesSameResult()
+    [Theory]
+    [InlineData(null)]                   // direct-script dispatch site
+    [InlineData("calamari-run-script")]  // packaged / Calamari dispatch site
+    public async Task ExecuteScriptAsync_PassesMachineScopedMutexNameAsIsolationMutexName_NotTaskId(string calamariCommand)
     {
-        // The mutex-name MUST stay deterministic — that's what makes
-        // concurrent same-action dispatches serialise on the agent.
-        var n1 = HalibutMachineExecutionStrategy.GenerateMutexName(1, "Deploy", "RunScript", 42);
-        var n2 = HalibutMachineExecutionStrategy.GenerateMutexName(1, "Deploy", "RunScript", 42);
+        // Regression pin for the ctor-arg-position bug: the generated isolation
+        // mutex name MUST reach the wire as IsolationMutexName (arg 5) — the field
+        // the agent uses to serialise FullIsolation scripts. Before the fix it was
+        // misassigned to TaskId (arg 7), leaving IsolationMutexName null, which
+        // silently falls back to the global "default" mutex. No prior test captured
+        // this wire field, so the bug survived.
+        //
+        // Covers BOTH dispatch sites (direct + Calamari) since the bug existed in
+        // both. Uses DISTINCT machine.Id (42) and ServerTaskId (777) so the
+        // assertions prove WHICH field carries WHICH value — with a single shared 0
+        // the test couldn't distinguish ForMachine(machine.Id) from
+        // ForMachine(serverTaskId), nor TaskId=machineId from TaskId=serverTaskId.
+        var machine = new Machine
+        {
+            Id = 42,
+            Name = "test-agent",
+            Endpoint = """{"CommunicationStyle":"KubernetesAgent","SubscriptionId":"sub-test","Thumbprint":"AABBCCDD"}"""
+        };
+        StartScriptCommand captured = null;
+        var scriptClient = SetupScriptClient("poll://sub-test/");
+        scriptClient.Setup(s => s.StartScriptAsync(It.IsAny<StartScriptCommand>()))
+            .Callback<StartScriptCommand>(cmd => captured = cmd)
+            .ReturnsAsync(NewStartResponse("ticket"));
 
-        n1.ShouldBe(n2);
+        var request = CreateRequest(machine, calamariCommand: calamariCommand);
+        request.ServerTaskId = 777;
+
+        await _strategy.ExecuteScriptAsync(request, CancellationToken.None);
+
+        captured.ShouldNotBeNull();
+        captured.Isolation.ShouldBe(ScriptIsolationLevel.FullIsolation);
+        captured.IsolationMutexName.ShouldBe(ScriptIsolationMutexNames.ForMachine(42),
+            customMessage: "IsolationMutexName (arg 5) must be ForMachine(machine.Id=42) — keyed on machine id, " +
+                           "reaching the wire — not null (the global 'default' fallback) and not serverTaskId");
+        captured.IsolationMutexName.ShouldBe("squid/machine/42");
+        captured.TaskId.ShouldBe("777",
+            customMessage: "TaskId (arg 7) must carry the server task id (777), not the machine id or the mutex name");
     }
 
-    [Fact]
-    public void GenerateMutexName_DifferentMachineId_ProducesDifferentResult()
-    {
-        var n1 = HalibutMachineExecutionStrategy.GenerateMutexName(1, "Deploy", "RunScript", 42);
-        var n2 = HalibutMachineExecutionStrategy.GenerateMutexName(1, "Deploy", "RunScript", 43);
-
-        n1.ShouldNotBe(n2);
-    }
-
-    [Fact]
-    public void GenerateMutexName_DifferentStepName_ProducesDifferentResult()
-    {
-        var n1 = HalibutMachineExecutionStrategy.GenerateMutexName(1, "Deploy", "RunScript", 42);
-        var n2 = HalibutMachineExecutionStrategy.GenerateMutexName(1, "Rollback", "RunScript", 42);
-
-        n1.ShouldNotBe(n2);
-    }
+    // Isolation mutex name is now machine-scoped: the strategy sends
+    // ScriptIsolationMutexNames.ForMachine(machineId) on IsolationMutexName so
+    // EVERY FullIsolation script on a machine serialises behind one writer lock
+    // (the earlier per-action SHA keyed by serverTaskId would have let two
+    // deployments to the same machine run concurrently — the opposite of
+    // FullIsolation's purpose). The strategy's use of it is pinned by
+    // ExecuteScriptAsync_PassesMachineScopedMutexNameAsIsolationMutexName_NotTaskId
+    // above; the name's own contract is pinned by ScriptIsolationMutexNamesTests.
 
     // === Helpers ===
 

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/LinuxTentacleUpgradeStrategyTests.cs
@@ -682,6 +682,9 @@ public sealed class LinuxTentacleUpgradeStrategyTests : IDisposable
 
         cmd.Isolation.ShouldBe(ScriptIsolationLevel.FullIsolation);
         cmd.ScriptSyntax.ShouldBe(ScriptType.Bash);
+        cmd.IsolationMutexName.ShouldBe(ScriptIsolationMutexNames.ForMachine(7),
+            customMessage: "upgrade must share the machine-scoped mutex name deployments use, so the agent " +
+                           "serializes the (service-restarting) upgrade behind any in-flight deployment script");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/WindowsTentacleUpgradeStrategyTests.cs
@@ -1077,6 +1077,9 @@ public sealed class WindowsTentacleUpgradeStrategyTests : IDisposable
             "FullIsolation lets the agent's ScriptIsolationMutex serialize upgrades behind active deployments");
         cmd.ScriptSyntax.ShouldBe(ScriptType.PowerShell,
             "Windows must dispatch as PowerShell — Bash would be silently rejected by the agent's executor");
+        cmd.IsolationMutexName.ShouldBe(ScriptIsolationMutexNames.ForMachine(7),
+            customMessage: "upgrade must share the machine-scoped mutex name deployments use, so the agent " +
+                           "serializes the (service-restarting) upgrade behind any in-flight deployment script");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **Bug**: `HalibutMachineExecutionStrategy` (both dispatch sites) built the agent isolation mutex name but passed it into `StartScriptCommand`'s **`taskId`** parameter (arg 7) instead of **`isolationMutexName`** (arg 5), leaving the wire field `null`. The agent (`ScriptIsolationMutex`) then fell back to its single `"default"` mutex — so the per-action name the code + ARCH.7 docs + tests claimed to send **never reached the wire**, and the SHA hash polluted the correlation field. `Linux/WindowsTentacleUpgradeStrategy` passed `null` + the ticket id the same way.
- **Decision (semantics)**: serialise FullIsolation scripts **per machine** — the safe default — made **explicit** via a shared `ScriptIsolationMutexNames.ForMachine(machineId)` used by **both** deployment dispatch and the upgrade strategies. So every FullIsolation script dispatched to a machine (deployment *or* upgrade) serialises behind one writer lock, instead of relying on the accidental `null → "default"` fallback. Crucially, deployments and upgrades now share the **identical** name, preserving the deploy⇄upgrade agent-level serialisation (they were both on `"default"` before; a one-sided change would have split them onto different mutexes).
- Removed the per-action `GenerateMutexName` (keyed by `serverTaskId`, which actually *defeated* cross-deployment serialisation — FullIsolation's whole purpose). `taskId` now carries the server task id for correlation; `ResolveParentTraceId` ignores it, so this is behaviour-neutral on the agent.
- **Non-breaking**: on a single-machine agent the global lock stays global — serialisation behaviour is unchanged. Only the wire field, the doc comments, and the tests now reflect it. No agent-side change required (it already reads `IsolationMutexName`, null-falling-back to `"default"`); old-server↔new-agent and new-server↔old-agent both still serialise.

## Test plan

- [x] Unit (red→green): new `ExecuteScriptAsync_PassesMachineScopedMutexNameAsIsolationMutexName_NotTaskId` captures the dispatched `StartScriptCommand` and asserts `IsolationMutexName == ForMachine(machineId)` + `TaskId == ServerTaskId` — the wire field **no prior test pinned**, which is why the mis-wiring survived (confirmed RED before the fix)
- [x] Unit: `ScriptIsolationMutexNamesTests` pins the format literal + same-machine-same-name / different-machine-different-name (the shared-string invariant deploy⇄upgrade serialisation depends on)
- [x] Unit: both upgrade strategies' isolation-pin tests now assert `IsolationMutexName == ForMachine(machineId)`
- [x] Removed the stale per-action `GenerateMutexName` tests + ARCH.7 comments; corrected the ticket test to check `ScriptTicket.TaskId` (the actual Guid) not the SHA-in-`TaskId`
- [x] 251 affected tests green; broad `DeploymentExecution` + `Deployments` + `Machines.Upgrade` sweep 5017/5017 green; `dotnet build Squid.sln` 0 errors
- [ ] Tentacle `ScriptExecution` suite: 30 `LocalScriptServiceTests` fail **only** on a near-full dev disk (`DiskSpaceChecker` 10% floor in `StartScript` — environmental, agent code untouched by this change, branch-independent; all 30 confirmed disk-space `IOException`, zero mutex-related; pass on CI)