### PR TITLE
Pause and preserve checkpoint on deployment timeout, add manual resume

### DIFF
--- a/src/Squid.Api/Controllers/ServerTaskController.cs
+++ b/src/Squid.Api/Controllers/ServerTaskController.cs
@@ -93,4 +93,14 @@ public class ServerTaskController : ControllerBase
 
         return Ok(response);
     }
+
+    [HttpPost("{taskId:int}/resume")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ResumeServerTaskResponse))]
+    public async Task<IActionResult> ResumeTaskAsync(int taskId)
+    {
+        var response = await _mediator.SendAsync<ResumeServerTaskCommand, ResumeServerTaskResponse>(
+            new ResumeServerTaskCommand { TaskId = taskId }).ConfigureAwait(false);
+
+        return Ok(response);
+    }
 }

--- a/src/Squid.Core/Handlers/CommandHandlers/Deployments/ServerTask/ResumeServerTaskCommandHandler.cs
+++ b/src/Squid.Core/Handlers/CommandHandlers/Deployments/ServerTask/ResumeServerTaskCommandHandler.cs
@@ -1,0 +1,14 @@
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Message.Commands.Deployments.ServerTask;
+
+namespace Squid.Core.Handlers.CommandHandlers.Deployments.ServerTask;
+
+public class ResumeServerTaskCommandHandler(IServerTaskControlService controlService) : ICommandHandler<ResumeServerTaskCommand, ResumeServerTaskResponse>
+{
+    public async Task<ResumeServerTaskResponse> Handle(IReceiveContext<ResumeServerTaskCommand> context, CancellationToken cancellationToken)
+    {
+        await controlService.ResumeTaskAsync(context.Message.TaskId, cancellationToken).ConfigureAwait(false);
+
+        return new ResumeServerTaskResponse();
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
@@ -69,6 +69,31 @@ public sealed class DeploymentCompletionHandler(
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// A deployment that exceeds the wall-clock timeout is treated as a pause,
+    /// not a failure: the task transitions to <see cref="TaskState.Paused"/> and
+    /// its checkpoint is left intact so an operator can resume it (POST
+    /// tasks/{id}/resume) once the cause is understood, rather than losing every
+    /// already-completed batch and restarting from scratch. We deliberately do
+    /// NOT delete the checkpoint (it is the resume point) and do NOT write a
+    /// <c>DeploymentCompletion</c> record (a paused deployment has not completed
+    /// — the completion is recorded when it later succeeds or fails). The
+    /// historical fail-fast behaviour (Failed + checkpoint deleted) remains
+    /// available via the <c>SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE</c> escape hatch,
+    /// which routes timeouts back through <see cref="OnFailureAsync"/>.
+    /// </summary>
+    public async Task OnTimedOutAsync(DeploymentTaskContext ctx, Exception ex, CancellationToken ct)
+    {
+        Log.Warning(ex, "[Deploy] Task {TaskId} timed out; pausing for resume, checkpoint preserved", ctx.ServerTaskId);
+
+        var fromState = await ResolveCurrentActiveStateAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
+
+        await genericDataProvider.ExecuteInTransactionAsync(async cancellationToken =>
+        {
+            await serverTaskService.TransitionStateAsync(ctx.ServerTaskId, fromState, TaskState.Paused, cancellationToken).ConfigureAwait(false);
+        }, ct).ConfigureAwait(false);
+    }
+
     private async Task<string> ResolveCurrentActiveStateAsync(int serverTaskId, CancellationToken ct)
     {
         var task = await serverTaskService.GetTaskAsync(serverTaskId, ct).ConfigureAwait(false);

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentPipelineRunner.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentPipelineRunner.cs
@@ -25,7 +25,24 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
     internal const int DefaultDeploymentTimeoutMinutes = 60;
     private static readonly TimeSpan DefaultDeploymentTimeout = TimeSpan.FromMinutes(DefaultDeploymentTimeoutMinutes);
 
+    /// <summary>
+    /// Operator escape hatch (Rule 8): controls what happens when a deployment
+    /// exceeds <see cref="DeploymentTimeoutMinutesEnvVar"/>. The safe default
+    /// (unset / blank / unrecognised) is <c>true</c> — the task is paused and
+    /// its checkpoint preserved so it can be resumed (POST tasks/{id}/resume)
+    /// instead of failing irrecoverably. Set this env var to a falsey value
+    /// (<c>false</c>/<c>0</c>/<c>no</c>/<c>off</c>, case-insensitive) to restore
+    /// the historical fail-fast behaviour: a timed-out deployment transitions to
+    /// Failed and its checkpoint is deleted. Operators who key alerting off the
+    /// terminal Failed state (rather than the resumable Paused state) can opt out
+    /// here without a code change.
+    /// </summary>
+    public const string DeploymentTimeoutResumableEnvVar = "SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE";
+
+    internal const bool DefaultDeploymentTimeoutResumable = true;
+
     internal TimeSpan DeploymentTimeout { get; init; } = ResolveDeploymentTimeout();
+    internal bool TimeoutResumable { get; init; } = ResolveTimeoutResumable();
     internal TimeSpan ConcurrencyMaxWait { get; init; } = DefaultConcurrencyMaxWait;
     internal TimeSpan ConcurrencyPollInterval { get; init; } = DefaultConcurrencyPollInterval;
 
@@ -86,7 +103,12 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !registryCts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
             var ex = new DeploymentTimeoutException(serverTaskId, DeploymentTimeout);
-            await SafeCompleteAsync(ctx, () => completion.OnFailureAsync(ctx, ex, CancellationToken.None), new DeploymentTimedOutEvent(new DeploymentEventContext { Exception = ex }));
+
+            Func<Task> onTimeout = TimeoutResumable
+                ? () => completion.OnTimedOutAsync(ctx, ex, CancellationToken.None)
+                : () => completion.OnFailureAsync(ctx, ex, CancellationToken.None);
+
+            await SafeCompleteAsync(ctx, onTimeout, new DeploymentTimedOutEvent(new DeploymentEventContext { Exception = ex }));
         }
         catch (OperationCanceledException) when (linkedCts.IsCancellationRequested)
         {
@@ -180,4 +202,30 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
 
     private static TimeSpan ResolveDeploymentTimeout()
         => ParseDeploymentTimeout(Environment.GetEnvironmentVariable(DeploymentTimeoutMinutesEnvVar));
+
+    /// <summary>
+    /// Parses the operator-supplied resumable-timeout flag. The safe default is
+    /// <c>true</c> (pause + preserve checkpoint on timeout) — only an explicit
+    /// falsey token (<c>false</c>/<c>0</c>/<c>no</c>/<c>off</c>, case-insensitive,
+    /// surrounding whitespace tolerated) opts back into fail-fast. Anything
+    /// unrecognised falls back to the safe resumable default so a typo can never
+    /// silently throw away a deployment's progress. Pure + static (surfaced to
+    /// the unit suite via InternalsVisibleTo) so the full input matrix is
+    /// testable without the pipeline.
+    /// </summary>
+    internal static bool ParseTimeoutResumable(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultDeploymentTimeoutResumable;
+
+        var value = raw.Trim();
+
+        if (value.Equals("false", StringComparison.OrdinalIgnoreCase) || value == "0"
+            || value.Equals("no", StringComparison.OrdinalIgnoreCase) || value.Equals("off", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return DefaultDeploymentTimeoutResumable;
+    }
+
+    private static bool ResolveTimeoutResumable()
+        => ParseTimeoutResumable(Environment.GetEnvironmentVariable(DeploymentTimeoutResumableEnvVar));
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/IDeploymentPipelinePhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/IDeploymentPipelinePhase.cs
@@ -12,4 +12,5 @@ public interface IDeploymentCompletionHandler : IScopedDependency
     Task OnFailureAsync(DeploymentTaskContext ctx, Exception ex, CancellationToken ct);
     Task OnCancelledAsync(DeploymentTaskContext ctx, CancellationToken ct);
     Task OnPausedAsync(DeploymentTaskContext ctx, CancellationToken ct);
+    Task OnTimedOutAsync(DeploymentTaskContext ctx, Exception ex, CancellationToken ct);
 }

--- a/src/Squid.Core/Services/Deployments/ServerTask/Exceptions/ServerTaskAwaitingInterruptionException.cs
+++ b/src/Squid.Core/Services/Deployments/ServerTask/Exceptions/ServerTaskAwaitingInterruptionException.cs
@@ -1,0 +1,12 @@
+namespace Squid.Core.Services.Deployments.ServerTask.Exceptions;
+
+public class ServerTaskAwaitingInterruptionException : InvalidOperationException
+{
+    public int TaskId { get; }
+
+    public ServerTaskAwaitingInterruptionException(int taskId)
+        : base($"ServerTask {taskId} is paused awaiting a manual interruption response; submit the interruption to resume rather than resuming directly")
+    {
+        TaskId = taskId;
+    }
+}

--- a/src/Squid.Core/Services/Deployments/ServerTask/ServerTaskControlService.cs
+++ b/src/Squid.Core/Services/Deployments/ServerTask/ServerTaskControlService.cs
@@ -10,6 +10,7 @@ namespace Squid.Core.Services.Deployments.ServerTask;
 public interface IServerTaskControlService : IScopedDependency
 {
     Task CancelTaskAsync(int serverTaskId, CancellationToken ct = default);
+    Task ResumeTaskAsync(int serverTaskId, CancellationToken ct = default);
     Task TryAutoResumeAsync(int serverTaskId, CancellationToken ct = default);
 }
 
@@ -52,6 +53,33 @@ public class ServerTaskControlService(
         }
     }
 
+    /// <summary>
+    /// Operator-initiated resume of a paused deployment (e.g. one paused by the
+    /// timeout-resumable path). Unlike <see cref="TryAutoResumeAsync"/>, which
+    /// silently no-ops on an ineligible task because it fires opportunistically
+    /// after an interruption response, this is an explicit request and surfaces
+    /// every precondition failure as a typed exception so the API can return an
+    /// actionable error instead of a misleading 200. A task awaiting a manual
+    /// interruption must be resumed by submitting that interruption — not here.
+    /// </summary>
+    public async Task ResumeTaskAsync(int serverTaskId, CancellationToken ct = default)
+    {
+        var task = await serverTaskDataProvider.GetServerTaskByIdAsync(serverTaskId, ct).ConfigureAwait(false);
+
+        if (task == null)
+            throw new ServerTaskNotFoundException(serverTaskId);
+
+        if (!string.Equals(task.State, TaskState.Paused, StringComparison.OrdinalIgnoreCase))
+            throw new ServerTaskStateTransitionException(task.State, TaskState.Executing);
+
+        if (task.HasPendingInterruptions)
+            throw new ServerTaskAwaitingInterruptionException(serverTaskId);
+
+        var jobId = await EnqueueResumeAsync(task, ct).ConfigureAwait(false);
+
+        Log.Information("Manually resumed task {TaskId} with new job {JobId}", serverTaskId, jobId);
+    }
+
     public async Task TryAutoResumeAsync(int serverTaskId, CancellationToken ct = default)
     {
         var task = await serverTaskDataProvider.GetServerTaskByIdAsync(serverTaskId, ct).ConfigureAwait(false);
@@ -60,7 +88,14 @@ public class ServerTaskControlService(
         if (!string.Equals(task.State, TaskState.Paused, StringComparison.OrdinalIgnoreCase)) return;
         if (task.HasPendingInterruptions) return;
 
-        var jobId = backgroundJobClient.Enqueue<IDeploymentTaskExecutor>(executor => executor.ProcessAsync(serverTaskId, CancellationToken.None));
+        var jobId = await EnqueueResumeAsync(task, ct).ConfigureAwait(false);
+
+        Log.Information("Auto-resumed task {TaskId} with new job {JobId}", serverTaskId, jobId);
+    }
+
+    private async Task<string> EnqueueResumeAsync(Persistence.Entities.Deployments.ServerTask task, CancellationToken ct)
+    {
+        var jobId = backgroundJobClient.Enqueue<IDeploymentTaskExecutor>(executor => executor.ProcessAsync(task.Id, CancellationToken.None));
 
         if (!string.IsNullOrEmpty(jobId))
         {
@@ -68,7 +103,7 @@ public class ServerTaskControlService(
             await serverTaskDataProvider.UpdateServerTaskStateAsync(task.Id, task.State, cancellationToken: ct).ConfigureAwait(false);
         }
 
-        Log.Information("Auto-resumed task {TaskId} with new job {JobId}", serverTaskId, jobId);
+        return jobId;
     }
 
     private async Task CancelPendingTaskAsync(Persistence.Entities.Deployments.ServerTask task, CancellationToken ct)

--- a/src/Squid.Message/Commands/Deployments/ServerTask/ResumeServerTaskCommand.cs
+++ b/src/Squid.Message/Commands/Deployments/ServerTask/ResumeServerTaskCommand.cs
@@ -1,0 +1,13 @@
+using Squid.Message.Attributes;
+using Squid.Message.Enums;
+using Squid.Message.Response;
+
+namespace Squid.Message.Commands.Deployments.ServerTask;
+
+[RequiresPermission(Permission.TaskCreate)]
+public class ResumeServerTaskCommand : ICommand
+{
+    public int TaskId { get; set; }
+}
+
+public class ResumeServerTaskResponse : SquidResponse;

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesResumeCheckpointE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesResumeCheckpointE2ETests.cs
@@ -358,6 +358,43 @@ public class KubernetesResumeCheckpointE2ETests
     }
 
     // ────────────────────────────────────────────────────────────────────────
+    // 5. RESUME-AFTER-TIMEOUT — the full loop, end to end
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResumeAfterTimeoutPause_CompletesDeploymentFromCheckpoint()
+    {
+        // The post-timeout state the resumable-timeout feature produces: the
+        // deployment completed batch 0, then exceeded the wall-clock timeout and
+        // was PAUSED with its checkpoint preserved (LastCompletedBatchIndex=0).
+        // Resuming it (what ServerTaskControlService.ResumeTaskAsync re-dispatches
+        // — ProcessAsync on the same task) must finish batches 1+2 WITHOUT
+        // re-running batch 0, end in Success, and clean up the checkpoint. This
+        // proves the work done before the timeout is never thrown away.
+        ExecutionCapture.Clear();
+        ExecutionCapture.ResultFactory = _ => new ScriptExecutionResult { Success = true, ExitCode = 0 };
+
+        var serverTaskId = await SeedThreeStepDeployAsync();
+
+        await PlantCheckpointAsync(serverTaskId, outputVariablesJson: "[]", lastCompletedBatchIndex: 0);
+        await SetTaskStateAsync(serverTaskId, TaskState.Paused);
+
+        await ExecutePipelineAsync(serverTaskId);
+
+        ExecutionCapture.CapturedRequests.Count.ShouldBe(2,
+            customMessage: "Resume after a timeout-pause must skip the already-completed batch 0 and run only " +
+                          $"batches 1+2 (2 requests). Got {ExecutionCapture.CapturedRequests.Count}. " +
+                          "3 = the pre-timeout work was thrown away (the regression this feature fixes).");
+
+        await AssertTaskSuccessAsync(serverTaskId);
+
+        var checkpoint = await LoadCheckpointAsync(serverTaskId);
+        checkpoint.ShouldBeNull(
+            customMessage: "After a successful resume the checkpoint MUST be cleaned up — the deployment is now " +
+                          "terminally Success and the resume point is no longer needed.");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
     // Helpers
     // ────────────────────────────────────────────────────────────────────────
 

--- a/tests/Squid.IntegrationTests/Deployments/ServerTasks/IntegrationTimeoutResume.cs
+++ b/tests/Squid.IntegrationTests/Deployments/ServerTasks/IntegrationTimeoutResume.cs
@@ -1,0 +1,136 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Pipeline;
+using Squid.Core.Services.Deployments.Checkpoints;
+using Squid.Core.Services.Deployments.ServerTask;
+
+namespace Squid.IntegrationTests.Deployments.ServerTasks;
+
+/// <summary>
+/// Integration coverage for the resumable-timeout completion path against a REAL
+/// Postgres DB. <c>DeploymentCompletionHandlerTests</c> proves the branch logic
+/// with mocks; this proves the persistence truth that matters operationally:
+/// a timed-out deployment ends <see cref="TaskState.Paused"/> (a resumable,
+/// non-terminal state) with its checkpoint row INTACT, so the deployment can be
+/// resumed from the last completed batch instead of restarting from scratch.
+/// The contrast test pins the fail-fast escape-hatch behaviour
+/// (<c>OnFailureAsync</c>): Failed + checkpoint deleted = unrecoverable.
+/// </summary>
+public class IntegrationTimeoutResume : ServerTaskFixtureBase
+{
+    [Fact]
+    public async Task OnTimedOut_PausesTask_AndPreservesCheckpoint()
+    {
+        var taskId = await SeedExecutingTaskAsync();
+
+        await Run<IDeploymentCheckpointService>(async checkpointService =>
+        {
+            await checkpointService.SaveAsync(new DeploymentExecutionCheckpoint
+            {
+                ServerTaskId = taskId,
+                DeploymentId = 1,
+                LastCompletedBatchIndex = 1,
+                FailureEncountered = false
+            });
+        });
+
+        await Run<IDeploymentCompletionHandler>(async handler =>
+        {
+            var ctx = new DeploymentTaskContext { ServerTaskId = taskId };
+            await handler.OnTimedOutAsync(ctx, new DeploymentTimeoutException(taskId, TimeSpan.FromMinutes(60)), CancellationToken.None);
+        });
+
+        await Run<IRepository, IDeploymentCheckpointService>(async (repository, checkpointService) =>
+        {
+            var task = await repository.QueryNoTracking<ServerTask>(t => t.Id == taskId).FirstOrDefaultAsync();
+            task.ShouldNotBeNull();
+            task.State.ShouldBe(TaskState.Paused,
+                customMessage: "A timed-out deployment must end Paused (resumable), not Failed. " +
+                              "If Failed, the timeout routed through OnFailureAsync instead of OnTimedOutAsync.");
+
+            var checkpoint = await checkpointService.LoadAsync(taskId);
+            checkpoint.ShouldNotBeNull(
+                customMessage: "Checkpoint MUST survive a timeout-pause — it is the resume point. " +
+                              "If null, OnTimedOutAsync wrongly deleted it (the unrecoverable regression this fixes).");
+            checkpoint.LastCompletedBatchIndex.ShouldBe(1,
+                customMessage: "Preserved checkpoint must retain its progress so resume skips completed batches.");
+        });
+    }
+
+    [Fact]
+    public async Task OnFailure_FailsTask_AndDeletesCheckpoint()
+    {
+        // Pins the fail-fast escape hatch (SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE=false
+        // routes timeouts here): the historical Failed + checkpoint-deleted
+        // behaviour, intentionally unrecoverable.
+        var taskId = await SeedExecutingTaskAsync();
+
+        await Run<IDeploymentCheckpointService>(async checkpointService =>
+        {
+            await checkpointService.SaveAsync(new DeploymentExecutionCheckpoint
+            {
+                ServerTaskId = taskId,
+                DeploymentId = 1,
+                LastCompletedBatchIndex = 1,
+                FailureEncountered = false
+            });
+        });
+
+        await Run<IDeploymentCompletionHandler>(async handler =>
+        {
+            var ctx = new DeploymentTaskContext { ServerTaskId = taskId };
+            await handler.OnFailureAsync(ctx, new DeploymentTimeoutException(taskId, TimeSpan.FromMinutes(60)), CancellationToken.None);
+        });
+
+        await Run<IRepository, IDeploymentCheckpointService>(async (repository, checkpointService) =>
+        {
+            var task = await repository.QueryNoTracking<ServerTask>(t => t.Id == taskId).FirstOrDefaultAsync();
+            task.ShouldNotBeNull();
+            task.State.ShouldBe(TaskState.Failed);
+
+            var checkpoint = await checkpointService.LoadAsync(taskId);
+            checkpoint.ShouldBeNull("Fail-fast path must delete the checkpoint (historical behaviour).");
+        });
+    }
+
+    private async Task<int> SeedExecutingTaskAsync()
+    {
+        var taskId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var task = new ServerTask
+            {
+                Name = "Timeout Resume Test Task",
+                Description = "Task for timeout-resume integration test",
+                QueueTime = DateTimeOffset.UtcNow,
+                State = TaskState.Executing,
+                StartTime = DateTimeOffset.UtcNow,
+                ServerTaskType = "Deploy",
+                ProjectId = 1,
+                EnvironmentId = 1,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                BusinessProcessState = "Executing",
+                StateOrder = 1,
+                Weight = 1,
+                BatchId = 0,
+                JSON = string.Empty,
+                HasWarningsOrErrors = false,
+                ServerNodeId = Guid.NewGuid(),
+                DurationSeconds = 0,
+                DataVersion = Guid.NewGuid().ToByteArray()
+            };
+
+            await repository.InsertAsync(task);
+            await unitOfWork.SaveChangesAsync();
+            taskId = task.Id;
+        });
+
+        return taskId;
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerTests.cs
@@ -137,6 +137,64 @@ public class DeploymentCompletionHandlerTests
         _completionDataProvider.Verify(c => c.AddDeploymentCompletionAsync(It.IsAny<DeploymentCompletion>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ========== OnTimedOutAsync ==========
+    // Timeout is treated as a resumable pause: transition to Paused, KEEP the
+    // checkpoint (it's the resume point), and write NO completion record (the
+    // deployment hasn't completed — it's suspended).
+
+    [Fact]
+    public async Task OnTimedOut_TransitionsExecutingToPaused()
+    {
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Executing });
+
+        await _sut.OnTimedOutAsync(ctx, new Exception("timed out"), CancellationToken.None);
+
+        _serverTaskService.Verify(s => s.TransitionStateAsync(ctx.ServerTaskId, TaskState.Executing, TaskState.Paused, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnTimedOut_DoesNotCleanupCheckpoint()
+    {
+        // The headline behaviour: the checkpoint is the resume point. Deleting it
+        // (as OnFailure does) would make the timed-out deployment unrecoverable —
+        // exactly the regression this feature fixes.
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Executing });
+
+        await _sut.OnTimedOutAsync(ctx, new Exception("timed out"), CancellationToken.None);
+
+        _checkpointService.Verify(c => c.DeleteAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnTimedOut_DoesNotRecordCompletion()
+    {
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Executing });
+
+        await _sut.OnTimedOutAsync(ctx, new Exception("timed out"), CancellationToken.None);
+
+        _completionDataProvider.Verify(c => c.AddDeploymentCompletionAsync(It.IsAny<DeploymentCompletion>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnTimedOut_DoesNotTriggerAutoDeployments()
+    {
+        // Auto-deploy chaining only happens on a genuine success. A paused/timed-out
+        // deployment hasn't produced a result, so nothing downstream should fire.
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Executing });
+
+        await _sut.OnTimedOutAsync(ctx, new Exception("timed out"), CancellationToken.None);
+
+        _autoDeployService.Verify(a => a.TriggerAutoDeploymentsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // ========== Helpers ==========
 
     private static DeploymentTaskContext CreateContext()

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTimeoutTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTimeoutTests.cs
@@ -16,22 +16,47 @@ public class DeploymentPipelineRunnerTimeoutTests
     private readonly Mock<IServerTaskDataProvider> _taskDataProvider = new();
 
     [Fact]
-    public async Task Timeout_CallsOnFailure_WithDeploymentTimeoutException()
+    public async Task Timeout_Default_CallsOnTimedOut_WithDeploymentTimeoutException()
     {
+        // Default (resumable) behaviour: a timeout pauses + preserves the
+        // checkpoint via OnTimedOutAsync, NOT OnFailureAsync (which would delete
+        // the checkpoint and fail the task irrecoverably).
         var phase = CreateHangingPhase();
         var runner = CreateRunner(phase);
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
-        _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Once);
+        _completion.Verify(c => c.OnTimedOutAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Once);
+        _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Never);
         _completion.Verify(c => c.OnCancelledAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task Timeout_EmitsDeploymentTimedOutEvent()
+    public async Task Timeout_FailFast_CallsOnFailure_NotOnTimedOut()
     {
+        // Escape hatch (SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE=false): restore the
+        // historical fail-fast behaviour — a timeout routes through OnFailureAsync
+        // (Failed + checkpoint deleted), never OnTimedOutAsync.
         var phase = CreateHangingPhase();
-        var runner = CreateRunner(phase);
+        var runner = CreateFailFastRunner(phase);
+
+        await runner.ProcessAsync(1, CancellationToken.None);
+
+        _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Once);
+        _completion.Verify(c => c.OnTimedOutAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Never);
+        _completion.Verify(c => c.OnCancelledAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(true)]    // resumable (default)
+    [InlineData(false)]   // fail-fast (escape hatch)
+    public async Task Timeout_AlwaysEmitsDeploymentTimedOutEvent(bool resumable)
+    {
+        // The lifecycle signal "this deployment timed out" must fire regardless of
+        // how the terminal/pause state is recorded — observers keying off the
+        // event see the timeout in both modes.
+        var phase = CreateHangingPhase();
+        var runner = resumable ? CreateRunner(phase) : CreateFailFastRunner(phase);
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
@@ -76,6 +101,7 @@ public class DeploymentPipelineRunnerTimeoutTests
 
         _completion.Verify(c => c.OnCancelledAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
         _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Never);
+        _completion.Verify(c => c.OnTimedOutAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<DeploymentTimeoutException>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── Configurable deployment timeout (Rule 8 env-var escape hatch) ─────────
@@ -159,6 +185,84 @@ public class DeploymentPipelineRunnerTimeoutTests
         }
     }
 
+    // ── Resumable-timeout flag (Rule 8 env-var escape hatch) ──────────────────
+    // On timeout the safe default pauses + preserves the checkpoint (resumable).
+    // Operators who alert on the terminal Failed state can opt back into the
+    // historical fail-fast behaviour via this env var. Default (unset) is
+    // resumable; only an explicit falsey token disables it.
+
+    [Fact]
+    public void DeploymentTimeoutResumableEnvVar_ConstantNamePinned()
+    {
+        // Operators set this in Helm overrides / container env. Renaming it
+        // silently flips every opted-out tenant back to resumable pausing.
+        DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar
+            .ShouldBe("SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE");
+    }
+
+    [Fact]
+    public void DefaultDeploymentTimeoutResumable_IsTrue()
+    {
+        DeploymentPipelineRunner.DefaultDeploymentTimeoutResumable.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(null,    true)]    // unset → resumable default
+    [InlineData("",      true)]    // empty → default
+    [InlineData("   ",   true)]    // whitespace → default
+    [InlineData("false", false)]   // explicit opt-out
+    [InlineData("False", false)]   // case-insensitive
+    [InlineData("FALSE", false)]   // case-insensitive
+    [InlineData(" false ", false)] // surrounding whitespace trimmed
+    [InlineData("0",     false)]   // numeric opt-out
+    [InlineData("no",    false)]   // common falsey token
+    [InlineData("off",   false)]   // common falsey token
+    [InlineData("OFF",   false)]   // case-insensitive
+    [InlineData("true",  true)]    // explicit resumable
+    [InlineData("1",     true)]    // numeric truthy
+    [InlineData("yes",   true)]    // truthy token
+    [InlineData("garbage", true)]  // unrecognised → safe resumable default
+    public void ParseTimeoutResumable_HandlesAllInputs(string raw, bool expected)
+    {
+        DeploymentPipelineRunner.ParseTimeoutResumable(raw).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ResumableEnvVar_Unset_TimeoutResumableIsTrue()
+    {
+        var original = Environment.GetEnvironmentVariable(DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar);
+        Environment.SetEnvironmentVariable(DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar, null);
+
+        try
+        {
+            var runner = CreateRunnerWithoutTimeoutOverride();
+
+            runner.TimeoutResumable.ShouldBeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar, original);
+        }
+    }
+
+    [Fact]
+    public void ResumableEnvVar_SetFalse_DrivesTimeoutResumableProperty()
+    {
+        var original = Environment.GetEnvironmentVariable(DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar);
+        Environment.SetEnvironmentVariable(DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar, "false");
+
+        try
+        {
+            var runner = CreateRunnerWithoutTimeoutOverride();
+
+            runner.TimeoutResumable.ShouldBeFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(DeploymentPipelineRunner.DeploymentTimeoutResumableEnvVar, original);
+        }
+    }
+
     private DeploymentPipelineRunner CreateRunnerWithoutTimeoutOverride()
     {
         return new DeploymentPipelineRunner(Array.Empty<IDeploymentPipelinePhase>(), _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object);
@@ -181,7 +285,17 @@ public class DeploymentPipelineRunnerTimeoutTests
     {
         return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
         {
-            DeploymentTimeout = TimeSpan.FromMilliseconds(50)
+            DeploymentTimeout = TimeSpan.FromMilliseconds(50),
+            TimeoutResumable = true
+        };
+    }
+
+    private DeploymentPipelineRunner CreateFailFastRunner(params IDeploymentPipelinePhase[] phases)
+    {
+        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
+        {
+            DeploymentTimeout = TimeSpan.FromMilliseconds(50),
+            TimeoutResumable = false
         };
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/ServerTask/ServerTaskControlServiceResumeTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ServerTask/ServerTaskControlServiceResumeTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Linq.Expressions;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.Deployments.Checkpoints;
+using Squid.Core.Services.Deployments.Interruptions;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Deployments.ServerTask.Exceptions;
+using Squid.Core.Services.Jobs;
+using ServerTaskEntity = Squid.Core.Persistence.Entities.Deployments.ServerTask;
+
+namespace Squid.UnitTests.Services.Deployments.ServerTask;
+
+/// <summary>
+/// Manual resume of a paused deployment — the operator-facing trigger that
+/// re-dispatches a deployment paused by the timeout-resumable path (or any other
+/// pause without a pending interruption). Unlike <c>TryAutoResumeAsync</c>, which
+/// silently no-ops, <c>ResumeTaskAsync</c> surfaces every precondition failure as
+/// a typed exception so the API returns an actionable error instead of a
+/// misleading 200.
+/// </summary>
+public class ServerTaskControlServiceResumeTests
+{
+    private readonly Mock<IServerTaskDataProvider> _dataProvider = new();
+    private readonly Mock<IServerTaskService> _serverTaskService = new();
+    private readonly Mock<ITaskCancellationRegistry> _registry = new();
+    private readonly Mock<IDeploymentInterruptionService> _interruptionService = new();
+    private readonly Mock<IDeploymentCheckpointService> _checkpointService = new();
+    private readonly Mock<ISquidBackgroundJobClient> _jobClient = new();
+    private readonly ServerTaskControlService _sut;
+
+    public ServerTaskControlServiceResumeTests()
+    {
+        _sut = new ServerTaskControlService(_dataProvider.Object, _serverTaskService.Object, _registry.Object, _interruptionService.Object, _checkpointService.Object, _jobClient.Object);
+    }
+
+    private static Expression<Func<ISquidBackgroundJobClient, string>> AnyEnqueue() =>
+        j => j.Enqueue(It.IsAny<Expression<Func<IDeploymentTaskExecutor, Task>>>(), It.IsAny<string>());
+
+    [Fact]
+    public async Task Resume_PausedNoPendingInterruptions_EnqueuesProcessAsync()
+    {
+        var task = new ServerTaskEntity { Id = 7, State = TaskState.Paused, HasPendingInterruptions = false };
+        _dataProvider.Setup(d => d.GetServerTaskByIdAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(task);
+        _jobClient.Setup(AnyEnqueue()).Returns("resume-job-1");
+
+        await _sut.ResumeTaskAsync(7, CancellationToken.None);
+
+        _jobClient.Verify(AnyEnqueue(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Resume_EnqueueReturnsJobId_PersistsNewJobId()
+    {
+        // The new Hangfire job id must be written back so a subsequent cancel can
+        // delete the right job. Mirrors TryAutoResume's persistence.
+        var task = new ServerTaskEntity { Id = 7, State = TaskState.Paused, HasPendingInterruptions = false };
+        _dataProvider.Setup(d => d.GetServerTaskByIdAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(task);
+        _jobClient.Setup(AnyEnqueue()).Returns("resume-job-1");
+
+        await _sut.ResumeTaskAsync(7, CancellationToken.None);
+
+        task.JobId.ShouldBe("resume-job-1");
+        _dataProvider.Verify(d => d.UpdateServerTaskStateAsync(7, TaskState.Paused, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Resume_NotFound_ThrowsNotFound()
+    {
+        _dataProvider.Setup(d => d.GetServerTaskByIdAsync(99, It.IsAny<CancellationToken>())).ReturnsAsync((ServerTaskEntity)null);
+
+        await Should.ThrowAsync<ServerTaskNotFoundException>(() => _sut.ResumeTaskAsync(99, CancellationToken.None));
+
+        _jobClient.Verify(AnyEnqueue(), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(TaskState.Executing)]
+    [InlineData(TaskState.Pending)]
+    [InlineData(TaskState.Cancelling)]
+    [InlineData(TaskState.Success)]
+    [InlineData(TaskState.Failed)]
+    [InlineData(TaskState.Cancelled)]
+    [InlineData(TaskState.TimedOut)]
+    public async Task Resume_NotPaused_ThrowsStateTransition(string state)
+    {
+        // Only a Paused task can be resumed (Paused→Executing is the lone valid
+        // transition). Every other state is rejected up-front, never enqueued.
+        var task = new ServerTaskEntity { Id = 7, State = state };
+        _dataProvider.Setup(d => d.GetServerTaskByIdAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(task);
+
+        await Should.ThrowAsync<ServerTaskStateTransitionException>(() => _sut.ResumeTaskAsync(7, CancellationToken.None));
+
+        _jobClient.Verify(AnyEnqueue(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Resume_PausedWithPendingInterruption_ThrowsAwaitingInterruption()
+    {
+        // A task paused for a guided-failure / manual-intervention prompt must be
+        // resumed by SUBMITTING the interruption, not by a blind re-dispatch.
+        var task = new ServerTaskEntity { Id = 7, State = TaskState.Paused, HasPendingInterruptions = true };
+        _dataProvider.Setup(d => d.GetServerTaskByIdAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(task);
+
+        await Should.ThrowAsync<ServerTaskAwaitingInterruptionException>(() => _sut.ResumeTaskAsync(7, CancellationToken.None));
+
+        _jobClient.Verify(AnyEnqueue(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryAutoResume_StillEnqueues_AfterSharedEnqueueRefactor()
+    {
+        // Regression: ResumeTaskAsync + TryAutoResumeAsync now share EnqueueResumeAsync.
+        // Prove the auto path still dispatches for an eligible paused task.
+        var task = new ServerTaskEntity { Id = 7, State = TaskState.Paused, HasPendingInterruptions = false };
+        _dataProvider.Setup(d => d.GetServerTaskByIdAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(task);
+        _jobClient.Setup(AnyEnqueue()).Returns("auto-job-1");
+
+        await _sut.TryAutoResumeAsync(7, CancellationToken.None);
+
+        _jobClient.Verify(AnyEnqueue(), Times.Once);
+        task.JobId.ShouldBe("auto-job-1");
+    }
+}


### PR DESCRIPTION
## Summary

- On wall-clock timeout, a deployment now **pauses** (`Paused`) with its checkpoint **preserved** instead of transitioning to `Failed` and deleting the checkpoint. The already-completed batches are no longer thrown away.
- Adds a manual resume trigger — `POST /api/tasks/{id}/resume` → `ResumeServerTaskCommand` → `ServerTaskControlService.ResumeTaskAsync` — that re-dispatches the paused deployment. It reuses the existing, proven resume machinery: `StartExecutingAsync` already transitions `Paused → Executing` (`IsResumed`), and the state-agnostic `ResumeCheckpointPhase` (Order 50) restores progress, so resume skips completed batches.
- New default is the safe behaviour. The historical fail-fast path (`Failed` + checkpoint deleted) stays available behind `SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE=false` for operators who alert on the terminal `Failed` state.

## Design notes

- `Paused` is the only resumable state (`Paused → Executing` is the lone valid resume transition; `Failed`/`TimedOut` are terminal). So a resumable timeout *must* land in `Paused` — hence `OnTimedOutAsync` transitions `Executing → Paused`, keeps the checkpoint (it is the resume point), and writes **no** `DeploymentCompletion` record (a paused deployment hasn't completed).
- `ResumeTaskAsync` is the strict, operator-facing sibling of the opportunistic `TryAutoResumeAsync` (which fires after an interruption response). Both now share one `EnqueueResumeAsync`. Unlike the auto path, `ResumeTaskAsync` surfaces every precondition failure as a typed exception — `ServerTaskNotFoundException`, `ServerTaskStateTransitionException` (task not paused), `ServerTaskAwaitingInterruptionException` (resume a guided-failure pause by submitting the interruption, not here) — so the API returns an actionable error rather than a silent 200.
- Non-breaking surface: the new completion-handler method has a single implementer (updated); the endpoint/command/exception are purely additive. The one intentional behaviour change (timeout terminal-state `Failed → Paused`) is the requested safe-default flip and is reversible via the env var.

## Test plan

- [x] Unit — `DeploymentCompletionHandlerTests`: `OnTimedOutAsync` transitions `Executing → Paused`, does **not** delete the checkpoint, does **not** record a completion, does **not** trigger auto-deploys.
- [x] Unit — `DeploymentPipelineRunnerTimeoutTests`: timeout routes to `OnTimedOutAsync` by default and `OnFailureAsync` when fail-fast; `DeploymentTimedOutEvent` emitted in both modes; cancel still wins over timeout; `SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE` const pinned + 15-case parse matrix + env→property wiring.
- [x] Unit — `ServerTaskControlServiceResumeTests`: paused+no-interruption enqueues + persists new job id; not-found / not-paused (7 states) / pending-interruption all throw and never enqueue; `TryAutoResumeAsync` regression after the shared-enqueue refactor.
- [x] Integration (real Postgres) — `IntegrationTimeoutResume`: `OnTimedOutAsync` → task `Paused` + checkpoint row preserved (with progress); fail-fast contrast → `Failed` + checkpoint deleted.
- [x] E2E — `KubernetesResumeCheckpointE2ETests.ResumeAfterTimeoutPause_CompletesDeploymentFromCheckpoint`: plant checkpoint at batch 0 + set `Paused` (post-timeout state) → `ProcessAsync` runs only batches 1+2, ends `Success`, checkpoint cleaned up. (Runs on the CI Kind-cluster E2E gate.)
- [x] Full DeploymentExecution + Deployments + Handlers unit sweep: 4355 passed, 0 failed.

## Follow-up (out of scope)

- A timeout currently records the `DeploymentFailed` audit-event category (pre-existing mapping; `EventCategory` has no `TimedOut`/`Paused` value). With the resumable default this is mildly imprecise — a dedicated category + the operator-facing "Resume" button belong with the frontend Events work.