### PR TITLE
Audit deployment timeouts as DeploymentTimedOut, not DeploymentFailed

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentAuditEventHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Lifecycle/Handlers/DeploymentAuditEventHandler.cs
@@ -33,8 +33,10 @@ public sealed class DeploymentAuditEventHandler : DeploymentLifecycleHandlerBase
 
     protected override Task OnDeploymentFailedAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentFailed, ct);
 
-    // A timeout is a failure outcome for audit purposes.
-    protected override Task OnDeploymentTimedOutAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentFailed, ct);
+    // A wall-clock timeout is a distinct, recoverable outcome from a genuine
+    // failure — the deployment is paused and its checkpoint preserved for resume —
+    // so it is audited as DeploymentTimedOut rather than DeploymentFailed.
+    protected override Task OnDeploymentTimedOutAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentTimedOut, ct);
 
     protected override Task OnDeploymentCancelledAsync(DeploymentEventContext ctx, CancellationToken ct) => RecordAsync(EventCategory.DeploymentCanceled, ct);
 

--- a/src/Squid.Message/Constants/Events/EventCategoryRegistry.cs
+++ b/src/Squid.Message/Constants/Events/EventCategoryRegistry.cs
@@ -30,7 +30,8 @@ public static class EventCategoryRegistry
         [EventCategory.DeploymentResumed] = new("Deployment resumed", "Deploy to {Environment} resumed for {Release}"),
         [EventCategory.DeploymentSucceeded] = new("Deployment succeeded", "Deploy to {Environment} succeeded for {Release}"),
         [EventCategory.DeploymentFailed] = new("Deployment failed", "Deploy to {Environment} failed for {Release}"),
-        [EventCategory.DeploymentCanceled] = new("Deployment canceled", "Deploy to {Environment} canceled for {Release}")
+        [EventCategory.DeploymentCanceled] = new("Deployment canceled", "Deploy to {Environment} canceled for {Release}"),
+        [EventCategory.DeploymentTimedOut] = new("Deployment timed out", "Deploy to {Environment} timed out for {Release}")
     };
 
     public static Descriptor Describe(EventCategory category) =>

--- a/src/Squid.Message/Enums/Events/EventCategory.cs
+++ b/src/Squid.Message/Enums/Events/EventCategory.cs
@@ -24,5 +24,6 @@ public enum EventCategory : short
     DeploymentResumed = 15,
     DeploymentSucceeded = 16,
     DeploymentFailed = 17,
-    DeploymentCanceled = 18
+    DeploymentCanceled = 18,
+    DeploymentTimedOut = 19
 }

--- a/tests/Squid.IntegrationTests/Services/Events/DeploymentAuditEventHandlerTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Events/DeploymentAuditEventHandlerTests.cs
@@ -116,7 +116,7 @@ public class DeploymentAuditEventHandlerTests : TestBase
     }
 
     [Fact]
-    public async Task TimedOutEvent_IsAuditedAsFailure()
+    public async Task TimedOutEvent_IsAuditedAsDeploymentTimedOut()
     {
         const int spaceId = 730;
         const int deploymentId = 74;
@@ -127,7 +127,8 @@ public class DeploymentAuditEventHandlerTests : TestBase
         {
             var page = await events.GetEventsAsync(new GetEventsRequest { SpaceId = spaceId, DeploymentId = deploymentId });
 
-            page.Events.Single().Category.ShouldBe((int)EventCategory.DeploymentFailed, "a timeout is a failure outcome for audit purposes");
+            page.Events.Single().Category.ShouldBe((int)EventCategory.DeploymentTimedOut,
+                "a wall-clock timeout pauses + preserves the checkpoint for resume, so it is audited as DeploymentTimedOut — distinct from a genuine DeploymentFailed");
         }).ConfigureAwait(false);
     }
 

--- a/tests/Squid.UnitTests/Events/DeploymentAuditEventFactoryTests.cs
+++ b/tests/Squid.UnitTests/Events/DeploymentAuditEventFactoryTests.cs
@@ -51,6 +51,7 @@ public class DeploymentAuditEventFactoryTests
     [InlineData(EventCategory.DeploymentSucceeded)]
     [InlineData(EventCategory.DeploymentFailed)]
     [InlineData(EventCategory.DeploymentCanceled)]
+    [InlineData(EventCategory.DeploymentTimedOut)]
     [InlineData(EventCategory.ManualInterventionRaised)]
     [InlineData(EventCategory.ManualInterventionSubmitted)]
     [InlineData(EventCategory.GuidedFailureRaised)]

--- a/tests/Squid.UnitTests/Events/EventCategoryRegistryTests.cs
+++ b/tests/Squid.UnitTests/Events/EventCategoryRegistryTests.cs
@@ -29,6 +29,7 @@ public class EventCategoryRegistryTests
     [InlineData(EventCategory.ManualInterventionRaised, "Manual intervention interruption raised")]
     [InlineData(EventCategory.DeploymentSucceeded, "Deployment succeeded")]
     [InlineData(EventCategory.DeploymentFailed, "Deployment failed")]
+    [InlineData(EventCategory.DeploymentTimedOut, "Deployment timed out")]
     public void Describe_ReturnsExpectedDisplayName(EventCategory category, string expectedDisplayName)
     {
         EventCategoryRegistry.Describe(category).DisplayName.ShouldBe(expectedDisplayName);
@@ -43,5 +44,6 @@ public class EventCategoryRegistryTests
         ((short)EventCategory.DeploymentSucceeded).ShouldBe((short)16);
         ((short)EventCategory.DeploymentFailed).ShouldBe((short)17);
         ((short)EventCategory.DeploymentCanceled).ShouldBe((short)18);
+        ((short)EventCategory.DeploymentTimedOut).ShouldBe((short)19);
     }
 }


### PR DESCRIPTION
## Summary

- A wall-clock deployment timeout now pauses the deployment and preserves its checkpoint for resume (shipped in the resumable-timeout change). Recording its audit event as `DeploymentFailed` misrepresented this recoverable outcome, so a timed-out deployment showed up in the audit feed as a failure.
- Adds `EventCategory.DeploymentTimedOut = 19` and repoints `DeploymentAuditEventHandler.OnDeploymentTimedOutAsync` to it, so the audit feed distinguishes a timeout (paused/resumable) from a genuine failure.

## Why it's non-breaking

- `19` is **additive** — no existing value (1–18) is renumbered, and `EventCategory` stays `short`-backed. The `event.category` column is a plain `smallint` with no CHECK constraint / enum type, so **no migration** is needed.
- The new `EventCategoryRegistry` descriptor is **mandatory**, not optional: the read path (`EventService.ToDto` → `EventCategoryRegistry.Describe`) throws on an unmapped category, and the `EveryEventCategory_HasANonEmptyDescriptor` drift test enforces it. Both are satisfied by the added descriptor.
- No `switch`/exhaustive match over `EventCategory` anywhere in `src/` lacks a default. The handler diff is surgical — only `OnDeploymentTimedOutAsync` changed; `OnDeploymentFailedAsync` and the other 8 mappings are untouched.

## Pairs with

The resumable-timeout change (separate PR on this milestone) is what makes a timeout *paused/resumable*. This PR is independently correct — the `DeploymentTimedOutEvent` is emitted on timeout regardless — and the two together make task state and audit category fully consistent.

## Test plan

- [x] Unit: `EventCategoryRegistryTests` — display-name `InlineData` + `19` numbering pin; `DeploymentAuditEventFactoryTests` — passthrough `InlineData`. (23/23)
- [x] Integration (real Postgres): `DeploymentAuditEventHandlerTests.TimedOutEvent_IsAuditedAsDeploymentTimedOut` asserts the timeout records `DeploymentTimedOut`; `FailedEvent_PersistsDeploymentFailed` retained as the contrast proving genuine failures are unaffected. (7/7)
- [x] `dotnet build src/Squid.Core` — 0 errors.
- [x] Adversarial review (independent agent): `ship`, no blocking issues.

## Follow-up (frontend, separate repo)

SquidWeb [feat/deployment-timedout-event-tone](https://github.com/SolarifyDev/SquidWeb/tree/feat/deployment-timedout-event-tone) tones the new category as `warning` (orange) — opened alongside.