### PR TITLE
Record the in-flight ScriptTicket before the StartScript RPC

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -215,9 +215,10 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
     /// Dispatch a script to the agent and observe it to completion — or, on a
     /// resumed deployment, re-attach to a still-running script from a prior
     /// (crashed) run instead of launching a duplicate. The in-flight ScriptTicket
-    /// is recorded right after <c>StartScript</c> and cleared once observation
-    /// completes, so a server crash mid-script leaves a durable pointer the next
-    /// run can re-attach to.
+    /// is recorded <b>before</b> <c>StartScript</c> and cleared once observation
+    /// completes, so a server crash (or a lost RPC response) anywhere from the
+    /// moment the agent launches the script leaves a durable pointer the next run
+    /// can re-attach to — never a duplicate dispatch.
     /// </summary>
     private async Task<ScriptExecutionResult> DispatchOrReattachAsync(
         ScriptExecutionRequest request, IAsyncScriptService scriptClient, ServiceEndPoint endpoint,
@@ -226,10 +227,20 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         var reattached = await TryReattachAsync(request, scriptClient, endpoint, scriptTimeout, ct).ConfigureAwait(false);
         if (reattached != null) return reattached;
 
-        var startResponse = await scriptClient.StartScriptAsync(command).ConfigureAwait(false);
-
+        // Record-before-RPC: persist the ticket we are about to dispatch BEFORE
+        // firing StartScript. If the server crashes (or the response is lost) in
+        // the window where the agent has launched the script but the server has
+        // not yet recorded the ticket, a resume would otherwise find no pointer and
+        // dispatch a fresh ticket — running the (non-idempotent) script a SECOND
+        // time. With the record first, resume always knows a ticket to re-probe:
+        // TryReattachAsync re-attaches if the agent has it, and falls through to a
+        // clean fresh dispatch (via the Complete+UnknownResult sentinel) if the
+        // script never actually started. The agent is idempotent for a known
+        // ticket, so even a retried StartScript returns status, not a second run.
         if (_inFlightStore != null)
             await _inFlightStore.RecordDispatchedAsync(request.ServerTaskId, request.Machine.Id, scriptTicket.TaskId, ct).ConfigureAwait(false);
+
+        var startResponse = await scriptClient.StartScriptAsync(command).ConfigureAwait(false);
 
         Log.Information("[Deploy] Dispatching script to agent {MachineName} with ticket {Ticket}",
             request.Machine.Name, scriptTicket);

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
@@ -146,6 +146,40 @@ public class HalibutResumeReattachTests : TestBase
         result.Success.ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task FreshDispatch_RecordsInFlightTicket_BeforeStartScriptRpc()
+    {
+        // The record-before-RPC guarantee (P1, server-side StartScript idempotency):
+        // the in-flight ticket MUST be durably persisted BEFORE the StartScript RPC
+        // fires. Otherwise a crash / lost response in the window between the agent
+        // launching the script and the server recording the ticket leaves no pointer,
+        // and the resumed run re-dispatches a fresh ticket → the script runs twice.
+        const int taskId = 810005, machineId = 15;
+
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        // Capture, at the instant StartScript fires, what the store has COMMITTED —
+        // read through a fresh DI scope, exactly as a resumed server would see it.
+        string recordedWhenStartScriptFired = null;
+
+        var agent = new RecordingScriptService(
+            getStatusScript: new[] { (ProcessState.Complete, 0) },
+            completeResult: (ProcessState.Complete, 0))
+        {
+            OnStartScript = async _ => recordedWhenStartScriptFired = await GetTicketAsync(taskId, machineId).ConfigureAwait(false)
+        };
+
+        var result = await ExecuteWithAgentAsync(taskId, machineId, agent).ConfigureAwait(false);
+
+        result.Success.ShouldBeTrue();
+        agent.StartScriptCalls.ShouldBe(1);
+
+        recordedWhenStartScriptFired.ShouldBe(agent.StartedTickets.Single(),
+            customMessage: "record-before-RPC violated: the in-flight ticket must be durably persisted BEFORE StartScript fires. " +
+                          "If it is only recorded after the RPC returns, a crash / lost response in that window leaves no pointer " +
+                          "and the resumed run re-dispatches a duplicate (the exact double-run this ordering prevents).");
+    }
+
     // ── Drive the real strategy with a fake agent (per-scope IHalibutClientFactory override) ──
 
     private async Task<ScriptExecutionResult> ExecuteWithAgentAsync(int taskId, int machineId, RecordingScriptService agent)
@@ -213,11 +247,20 @@ public class HalibutResumeReattachTests : TestBase
         public List<string> StartedTickets { get; } = new();
         public List<string> ProbedTickets { get; } = new();
 
-        public Task<ScriptStatusResponse> StartScriptAsync(StartScriptCommand command)
+        /// <summary>Hook invoked WHILE StartScript is executing on the agent — lets a test
+        /// observe server-side state (e.g. the durably-recorded in-flight ticket) at the exact
+        /// instant the dispatch RPC is in flight.</summary>
+        public Func<StartScriptCommand, Task> OnStartScript { get; set; }
+
+        public async Task<ScriptStatusResponse> StartScriptAsync(StartScriptCommand command)
         {
             StartScriptCalls++;
             StartedTickets.Add(command.ScriptTicket.TaskId);
-            return Task.FromResult(Resp(command.ScriptTicket, ProcessState.Running, 0));
+
+            if (OnStartScript != null)
+                await OnStartScript(command).ConfigureAwait(false);
+
+            return Resp(command.ScriptTicket, ProcessState.Running, 0);
         }
 
         public Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request)


### PR DESCRIPTION
## Summary

- `DispatchOrReattachAsync` recorded the in-flight ScriptTicket **after** `StartScriptAsync` returned (`HalibutMachineExecutionStrategy.cs`). A server crash — or a lost RPC response — in the window between the agent **launching** the script and the server **committing** the ticket left no durable pointer, so the resumed run dispatched a *fresh* ticket and ran the (non-idempotent) deployment script a **second time**.
- Fix: record the ticket **before** firing StartScript (a one-statement reorder). A resume then always knows a ticket to re-probe — `TryReattachAsync` re-attaches if the agent still holds the script, or falls through to a clean fresh dispatch (via the agent's `Complete+UnknownResult` unknown-ticket sentinel) if it never started.

This is the StartScript half of the SOTA-audit **P1** (server-side idempotency, aligning with Octopus ScriptServiceV2). The RPC-retry + observe-loop pointer-preservation half (`GetStatus`/`CompleteScript`) follows in a separate PR.

## Why it's non-breaking + generic

- Pure reorder of two adjacent calls that already exist; reuses the same `IInFlightScriptStore` and checkpoint column. No new state, no signature change.
- It only ever **avoids** a duplicate — the agent is idempotent for a known ticket (`LocalScriptService`/`ScriptPodService` dedupe by ticket), so a retried/known StartScript returns status, not a second launch.
- Composes with the existing reattach (#430 stripe-locking), checkpoint-preserving timeout (#428), and circuit breaker — it makes the reattach path the *recovery* mechanism, not a victim. If `RecordDispatchedAsync` itself fails, the dispatch now aborts cleanly **before** any agent-side launch (strictly safer than the old order).

## Test plan

- [x] Integration regression `HalibutResumeReattachTests.FreshDispatch_RecordsInFlightTicket_BeforeStartScriptRpc` — a hook captures, at the instant StartScript fires, what the store has durably committed (read through a fresh DI scope, as a resumed server would). **Verified red→green**: fails with "record-before-RPC violated" before the reorder, passes after.
- [x] Checkpoints integration sweep: 12/12. Halibut/reattach unit: 158/158. `dotnet build` 0 errors.