### PR TITLE
Scope the transient-target policy to role-matched targets

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Filtering/TransientDeploymentTargetEvaluator.cs
@@ -45,6 +45,24 @@ public static class TransientDeploymentTargetEvaluator
         return Apply(candidates, transient.UnavailableDeploymentTargets, transient.UnhealthyDeploymentTargets);
     }
 
+    /// <summary>
+    /// Role-scoped policy application: the candidate set is first narrowed to the
+    /// targets that match at least one of the deployment's step roles. A target that
+    /// matches NO step role is not a deployment target for this release, so it must
+    /// neither fail the deployment (under the 'Fail deployment' policy) nor be
+    /// reported as excluded — it is simply irrelevant. An empty
+    /// <paramref name="requiredRoles"/> means some enabled step targets all machines,
+    /// so every candidate is relevant (no narrowing). Both the pipeline (phase 4) and
+    /// the preview call THIS overload, so neither can apply the policy to targets the
+    /// deployment would never touch.
+    /// </summary>
+    public static TransientTargetResult ApplyProjectPolicy(IReadOnlyList<Machine> candidates, HashSet<string> requiredRoles, string deploymentSettingsJson)
+    {
+        var relevant = DeploymentTargetFinder.FilterByRoles(candidates.ToList(), requiredRoles);
+
+        return ApplyProjectPolicy(relevant, deploymentSettingsJson);
+    }
+
     public static TransientTargetResult Apply(
         IReadOnlyList<Machine> candidates,
         UnavailableDeploymentTargetBehavior unavailableBehavior,

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/4_PrepareDeploymentPhase.cs
@@ -91,21 +91,28 @@ public sealed class PrepareDeploymentPhase(
     {
         ctx.AllTargets = await targetFinder.FindTargetsAsync(ctx.Deployment, ct).ConfigureAwait(false);
 
-        ApplyTransientTargetPolicy(ctx);
+        // Scope the transient-target policy to the targets the deployment would
+        // actually use (matching at least one step role). An unavailable target in
+        // the environment that no step targets must NOT fail the deployment — it is
+        // not a deployment target for this release. Same role set PreFilterTargetsByRoles uses.
+        var requiredRoles = DeploymentTargetFinder.CollectAllTargetRoles(ctx.Steps, actionHandlerRegistry.ResolveScope);
+
+        ApplyTransientTargetPolicy(ctx, requiredRoles);
 
         if (ctx.AllTargets.Count == 0) throw new DeploymentTargetException($"No target machines found for deployment {ctx.Deployment.Id}", ctx.Deployment.Id);
 
         Log.Information("[Deploy] Found {Count} target machines for deployment {DeploymentId}", ctx.AllTargets.Count, ctx.Deployment.Id);
     }
 
-    // Honour the project's "Transient Deployment Targets" setting. For an
-    // unconfigured project the defaults are FailDeployment (an unavailable target
-    // aborts the deployment up front rather than being silently skipped) + Exclude
-    // (unhealthy targets are dropped). Explicit SkipAndContinue is the opt-out that
-    // restores the lenient skip behaviour for unavailable targets.
-    internal static void ApplyTransientTargetPolicy(DeploymentTaskContext ctx)
+    // Honour the project's "Transient Deployment Targets" setting, scoped to the
+    // deployment's role-matched targets (see requiredRoles). For an unconfigured
+    // project the defaults are FailDeployment (an unavailable target aborts the
+    // deployment up front rather than being silently skipped) + Exclude (unhealthy
+    // targets are dropped). Explicit SkipAndContinue is the opt-out that restores the
+    // lenient skip behaviour for unavailable targets.
+    internal static void ApplyTransientTargetPolicy(DeploymentTaskContext ctx, HashSet<string> requiredRoles)
     {
-        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(ctx.AllTargets, ctx.Project?.DeploymentSettingsJson);
+        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(ctx.AllTargets, requiredRoles, ctx.Project?.DeploymentSettingsJson);
 
         if (result.FailedUnavailable.Count > 0)
         {

--- a/src/Squid.Core/Services/Deployments/Deployments/DeploymentService.Preview.cs
+++ b/src/Squid.Core/Services/Deployments/Deployments/DeploymentService.Preview.cs
@@ -61,7 +61,14 @@ public partial class DeploymentService
         // exactly the targets a real deployment would keep. Unavailable/unhealthy machines are
         // excluded here, never counted as "available".
         var project = await _projectDataProvider.GetProjectByIdAsync(release.ProjectId, cancellationToken).ConfigureAwait(false);
-        var eligibility = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(selectedMachines, project?.DeploymentSettingsJson);
+
+        // Scope the transient-target policy to the targets the deployment's steps would
+        // actually use (matching at least one step role), exactly as the pipeline does.
+        // An unavailable target in the environment that no step targets must NOT block the
+        // deployment — it is not a deployment target for this release. (The plan built
+        // below role-matches per step; this applies the same gate up front.)
+        var requiredRoles = await GetRequiredRolesAsync(release, cancellationToken).ConfigureAwait(false);
+        var eligibility = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(selectedMachines, requiredRoles, project?.DeploymentSettingsJson);
 
         result.ExcludedTargets = eligibility.Skipped.Concat(eligibility.FailedUnavailable).Select(MapMachineTarget).ToList();
 
@@ -140,6 +147,23 @@ public partial class DeploymentService
         Roles = DeploymentTargetFinder.ParseRoles(machine.Roles).ToList(),
         HealthStatus = machine.HealthStatus.ToString()
     };
+
+    // The union of all step target-roles for the release's process — the same set the
+    // pipeline's PreFilterTargetsByRoles uses. Empty means an enabled step targets all
+    // machines (no role narrowing). Used to scope the transient-target policy to the
+    // deployment's real targets so unrelated unavailable machines can't block it.
+    private async Task<HashSet<string>> GetRequiredRolesAsync(Persistence.Entities.Deployments.Release release, CancellationToken cancellationToken)
+    {
+        if (release.ProjectDeploymentProcessSnapshotId <= 0)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var processSnapshot = await _deploymentSnapshotService
+            .LoadProcessSnapshotAsync(release.ProjectDeploymentProcessSnapshotId, cancellationToken).ConfigureAwait(false);
+
+        var steps = ProcessSnapshotStepConverter.Convert(processSnapshot);
+
+        return DeploymentTargetFinder.CollectAllTargetRoles(steps, _actionHandlerRegistry.ResolveScope);
+    }
 
     private async Task<DeploymentPlan> BuildPlanAsync(
         Persistence.Entities.Deployments.Release release,

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/PrepareDeploymentPhaseTransientTargetTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/PrepareDeploymentPhaseTransientTargetTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Exceptions;
+using Squid.Core.Services.DeploymentExecution.Filtering;
 using Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
 using Squid.Core.Services.Deployments.Project;
 using Squid.Message.Enums;
@@ -48,7 +49,7 @@ public class PrepareDeploymentPhaseTransientTargetTests
             M("healthy", MachineHealthStatus.Healthy),
             M("unavailable", MachineHealthStatus.Unavailable));
 
-        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx))
+        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, []))
             .Message.ShouldContain("unavailable");
     }
 
@@ -61,7 +62,7 @@ public class PrepareDeploymentPhaseTransientTargetTests
             M("healthy", MachineHealthStatus.Healthy),
             M("unhealthy", MachineHealthStatus.Unhealthy));
 
-        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, []);
 
         ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy" });
         ctx.ExcludedByHealthTargets.Select(m => m.Name).ShouldBe(new[] { "unhealthy" });
@@ -75,7 +76,7 @@ public class PrepareDeploymentPhaseTransientTargetTests
             M("healthy", MachineHealthStatus.Healthy),
             M("down", MachineHealthStatus.Unavailable));
 
-        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx))
+        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, []))
             .Message.ShouldContain("down");
     }
 
@@ -87,7 +88,7 @@ public class PrepareDeploymentPhaseTransientTargetTests
             M("healthy", MachineHealthStatus.Healthy),
             M("sick", MachineHealthStatus.Unhealthy));
 
-        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, []);
 
         ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy", "sick" });
     }
@@ -100,9 +101,49 @@ public class PrepareDeploymentPhaseTransientTargetTests
             M("healthy", MachineHealthStatus.Healthy),
             M("down", MachineHealthStatus.Unavailable));
 
-        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx);
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, []);
 
         ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "healthy" });
         ctx.ExcludedByHealthTargets.Select(m => m.Name).ShouldBe(new[] { "down" });
+    }
+
+    // ── Role scoping: the policy applies only to targets the deployment would use ──
+
+    [Fact]
+    public void FailDeployment_UnavailableTargetWithUnmatchedRole_DoesNotFail()
+    {
+        // The reported bug: an unavailable target in the environment whose role NO step
+        // targets must not trigger 'Fail deployment' — it is not a deployment target for
+        // this release. The deployment below only targets the "web" role.
+        var web = M("web-01", MachineHealthStatus.Healthy);
+        web.Roles = DeploymentTargetFinder.SerializeRoles(new[] { "web" });
+
+        var unrelatedDown = M("db-down", MachineHealthStatus.Unavailable);
+        unrelatedDown.Roles = DeploymentTargetFinder.SerializeRoles(new[] { "db" });
+
+        var ctx = Context(
+            Json(UnavailableDeploymentTargetBehavior.FailDeployment, UnhealthyDeploymentTargetBehavior.Exclude),
+            web, unrelatedDown);
+
+        PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, ["web"]);
+
+        ctx.AllTargets.Select(m => m.Name).ShouldBe(new[] { "web-01" },
+            customMessage: "An unavailable target whose role no step targets must be ignored by the policy, not fail the deployment.");
+    }
+
+    [Fact]
+    public void FailDeployment_UnavailableTargetWithMatchedRole_StillFails()
+    {
+        // The policy MUST still fire when the unavailable target IS a deployment target
+        // (its role matches a step) — role scoping narrows the set, it doesn't disable the policy.
+        var webDown = M("web-down", MachineHealthStatus.Unavailable);
+        webDown.Roles = DeploymentTargetFinder.SerializeRoles(new[] { "web" });
+
+        var ctx = Context(
+            Json(UnavailableDeploymentTargetBehavior.FailDeployment, UnhealthyDeploymentTargetBehavior.Exclude),
+            webDown);
+
+        Should.Throw<DeploymentTargetException>(() => PrepareDeploymentPhase.ApplyTransientTargetPolicy(ctx, ["web"]))
+            .Message.ShouldContain("web-down");
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Targets/TransientDeploymentTargetEvaluatorTests.cs
@@ -195,4 +195,58 @@ public class TransientDeploymentTargetEvaluatorTests
         viaProjectPolicy.Skipped.Select(m => m.Name).ShouldBe(viaApply.Skipped.Select(m => m.Name));
         viaProjectPolicy.FailedUnavailable.Select(m => m.Name).ShouldBe(viaApply.FailedUnavailable.Select(m => m.Name));
     }
+
+    // ── Role scoping: the role-aware overload narrows the candidate set to the
+    //    deployment's step roles BEFORE applying the policy, so an unavailable target
+    //    that no step targets cannot fail the deployment. Both the pipeline (phase 4)
+    //    and the preview call THIS overload, so the role scoping is shared too. ──
+
+    private static Machine Role(Machine m, params string[] roles)
+    {
+        m.Roles = DeploymentTargetFinder.SerializeRoles(roles);
+        return m;
+    }
+
+    [Fact]
+    public void ApplyProjectPolicy_RoleScoped_IgnoresUnavailableTargetWithUnmatchedRole()
+    {
+        // The reported bug: an unavailable target whose role no step targets must NOT
+        // appear in FailedUnavailable — it is not a deployment target for this release.
+        var web = Role(M("web-01", MachineHealthStatus.Healthy), "web");
+        var dbDown = Role(M("db-down", MachineHealthStatus.Unavailable), "db");
+        var defaultsJson = DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto());
+
+        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(new[] { web, dbDown }, ["web"], defaultsJson);
+
+        result.FailedUnavailable.ShouldBeEmpty();
+        result.Kept.Select(m => m.Name).ShouldBe(new[] { "web-01" });
+    }
+
+    [Fact]
+    public void ApplyProjectPolicy_RoleScoped_StillFailsOnUnavailableMatchedRole()
+    {
+        // Role scoping NARROWS the set; it does not disable the policy. An unavailable
+        // target that IS a deployment target (matches a step role) still fails.
+        var webDown = Role(M("web-down", MachineHealthStatus.Unavailable), "web");
+        var defaultsJson = DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto());
+
+        var result = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(new[] { webDown }, ["web"], defaultsJson);
+
+        result.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "web-down" });
+    }
+
+    [Fact]
+    public void ApplyProjectPolicy_RoleScoped_EmptyRoles_EvaluatesAllTargets_LikeUnscoped()
+    {
+        // A step targeting all machines (no roles) → no narrowing → identical to the
+        // role-unaware overload, so existing role-less processes behave exactly as before.
+        var down = Role(M("down", MachineHealthStatus.Unavailable), "db");
+        var defaultsJson = DeploymentSettingsSerializer.Serialize(new DeploymentSettingsDto());
+
+        var scoped = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(new[] { down }, [], defaultsJson);
+        var unscoped = TransientDeploymentTargetEvaluator.ApplyProjectPolicy(new[] { down }, defaultsJson);
+
+        scoped.FailedUnavailable.Select(m => m.Name).ShouldBe(unscoped.FailedUnavailable.Select(m => m.Name));
+        scoped.FailedUnavailable.Select(m => m.Name).ShouldBe(new[] { "down" });
+    }
 }


### PR DESCRIPTION
## Summary

- The project **"Transient Deployment Targets"** policy (unavailable target → fail or skip the deployment) was applied to **every** target in the environment, **before** any role filtering. An unavailable target whose role no step targets — i.e. not a deployment target for this release — wrongly triggered **"Fail deployment"** and blocked an otherwise-valid deployment.
- Reproduced from the release preview: the steps preview correctly showed `1 target(s) matched` (the role-matched target was available), yet the banner read `2 deployment target(s) are unavailable … 'Fail deployment'` listing two machines with **unrelated roles**.
- The bug affected **both** the preview (`DeploymentService.Preview`) and the **real pipeline** (`4_PrepareDeploymentPhase` applied the policy in `FindTargetsAsync`, *before* `PreFilterTargetsByRoles`).

## Fix

- Add a shared role-aware overload `TransientDeploymentTargetEvaluator.ApplyProjectPolicy(candidates, requiredRoles, settingsJson)` that narrows the candidate set to targets matching at least one step role (the same `DeploymentTargetFinder.CollectAllTargetRoles` the pipeline already uses) before applying the policy. Both call sites now use it, so preview and pipeline stay converged.
- A target matching **no** step role is ignored by the policy (neither fails the deployment nor is reported excluded). A target matching a step role still fails the deployment when unavailable. An empty role set (some step targets all machines) means no narrowing — unchanged behaviour.

## Non-breaking + generic

- `FilterByRoles` with an empty role set returns all candidates, so projects/processes without explicit step roles behave exactly as before.
- Pure narrowing of the policy's input; no policy semantics changed. The convergence guard (preview ⇄ deploy) is preserved — both compute roles via the same `CollectAllTargetRoles` + `ResolveScope`.

## Test plan

- [x] Unit `PrepareDeploymentPhaseTransientTargetTests` — new: `FailDeployment_UnavailableTargetWithUnmatchedRole_DoesNotFail` (the reported bug) + `FailDeployment_UnavailableTargetWithMatchedRole_StillFails` (policy still fires for real deployment targets). **Verified red→green**: the unmatched-role test fails (`db-down` blocks the deploy) when the overload ignores roles, passes with the fix.
- [x] Existing transient-target / preview / planner / target-finder / convergence sweep: 153/153, no regression. `dotnet build` (Core + Api) 0 errors.