### PR TITLE
Scope the in-flight reattach store to the dispatch unit, not the machine

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
@@ -463,6 +463,12 @@ public sealed partial class ExecuteStepsPhase
         // which is the contract that downstream execution strategies expect.
         request.Masker = BuildSensitiveMasker(effectiveVariables);
 
+        // Attach the stable, process-unique step/action ids — the renderer only carries
+        // display names, but the in-flight reattach slot must be keyed by ids so two
+        // identically-named steps dispatched in parallel to one machine stay distinct.
+        request.StepId = step.Id;
+        request.ActionId = prepared.Context.Action.Id;
+
         return request;
     }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Script/ScriptExecutionRequest.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Script/ScriptExecutionRequest.cs
@@ -38,6 +38,13 @@ public class ScriptExecutionRequest
     public string StepName { get; set; }
     public string ActionName { get; set; }
 
+    // Stable, process-unique ids of the step/action that produced this dispatch.
+    // Used to key the in-flight reattach slot (StepName/ActionName are display
+    // names with no uniqueness guarantee, so they cannot key concurrent
+    // same-machine dispatches). Set post-render in ExecuteStepsPhase.
+    public int StepId { get; set; }
+    public int ActionId { get; set; }
+
     /// <summary>
     /// Optional live-output sink. When set, an execution strategy that observes incremental output
     /// (the Halibut/Tentacle poll loop) invokes it with each new batch of lines as they arrive, so

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -224,6 +224,13 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         ScriptExecutionRequest request, IAsyncScriptService scriptClient, ServiceEndPoint endpoint,
         ScriptTicket scriptTicket, StartScriptCommand command, TimeSpan scriptTimeout, CancellationToken ct)
     {
+        // Scope the in-flight slot to the (machine, step, action) dispatch unit, NOT
+        // the machine alone: a parallel batch can dispatch two scripts to one machine
+        // at once (two StartWithPrevious steps sharing a target role), and a
+        // machine-only key would make the second dispatch re-attach to the first's
+        // ticket and skip its own script.
+        var slot = new DispatchSlot(request.Machine.Id, request.StepName, request.ActionName);
+
         var reattached = await TryReattachAsync(request, scriptClient, endpoint, scriptTimeout, ct).ConfigureAwait(false);
         if (reattached != null) return reattached;
 
@@ -238,7 +245,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         // script never actually started. The agent is idempotent for a known
         // ticket, so even a retried StartScript returns status, not a second run.
         if (_inFlightStore != null)
-            await _inFlightStore.RecordDispatchedAsync(request.ServerTaskId, request.Machine.Id, scriptTicket.TaskId, ct).ConfigureAwait(false);
+            await _inFlightStore.RecordDispatchedAsync(request.ServerTaskId, slot, scriptTicket.TaskId, ct).ConfigureAwait(false);
 
         var startResponse = await scriptClient.StartScriptAsync(command).ConfigureAwait(false);
 
@@ -252,7 +259,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         finally
         {
             if (_inFlightStore != null)
-                await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+                await _inFlightStore.ClearAsync(request.ServerTaskId, slot, ct).ConfigureAwait(false);
         }
     }
 
@@ -270,7 +277,12 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
     {
         if (_inFlightStore == null) return null;
 
-        var existingTicketId = await _inFlightStore.TryGetTicketAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+        // Same dispatch-unit scope as DispatchOrReattachAsync: only re-attach to a
+        // ticket recorded for THIS (machine, step, action), never to a sibling step
+        // concurrently dispatching to the same machine.
+        var slot = new DispatchSlot(request.Machine.Id, request.StepName, request.ActionName);
+
+        var existingTicketId = await _inFlightStore.TryGetTicketAsync(request.ServerTaskId, slot, ct).ConfigureAwait(false);
         if (string.IsNullOrEmpty(existingTicketId)) return null;
 
         var existingTicket = new ScriptTicket(existingTicketId);
@@ -284,13 +296,13 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         {
             Log.Information(ex, "[Deploy] Re-attach probe failed for agent {MachineName} (ticket {Ticket}); dispatching fresh.",
                 request.Machine.Name, existingTicketId);
-            await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+            await _inFlightStore.ClearAsync(request.ServerTaskId, slot, ct).ConfigureAwait(false);
             return null;
         }
 
         if (!AgentHasUsableScript(probe))
         {
-            await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+            await _inFlightStore.ClearAsync(request.ServerTaskId, slot, ct).ConfigureAwait(false);
             return null;
         }
 
@@ -303,7 +315,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         }
         finally
         {
-            await _inFlightStore.ClearAsync(request.ServerTaskId, request.Machine.Id, ct).ConfigureAwait(false);
+            await _inFlightStore.ClearAsync(request.ServerTaskId, slot, ct).ConfigureAwait(false);
         }
     }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -228,8 +228,9 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         // the machine alone: a parallel batch can dispatch two scripts to one machine
         // at once (two StartWithPrevious steps sharing a target role), and a
         // machine-only key would make the second dispatch re-attach to the first's
-        // ticket and skip its own script.
-        var slot = new DispatchSlot(request.Machine.Id, request.StepName, request.ActionName);
+        // ticket and skip its own script. Keyed by the stable, process-unique
+        // step/action ids — display names carry no uniqueness guarantee.
+        var slot = new DispatchSlot(request.Machine.Id, request.StepId, request.ActionId);
 
         var reattached = await TryReattachAsync(request, scriptClient, endpoint, scriptTimeout, ct).ConfigureAwait(false);
         if (reattached != null) return reattached;
@@ -280,7 +281,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         // Same dispatch-unit scope as DispatchOrReattachAsync: only re-attach to a
         // ticket recorded for THIS (machine, step, action), never to a sibling step
         // concurrently dispatching to the same machine.
-        var slot = new DispatchSlot(request.Machine.Id, request.StepName, request.ActionName);
+        var slot = new DispatchSlot(request.Machine.Id, request.StepId, request.ActionId);
 
         var existingTicketId = await _inFlightStore.TryGetTicketAsync(request.ServerTaskId, slot, ct).ConfigureAwait(false);
         if (string.IsNullOrEmpty(existingTicketId)) return null;

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
@@ -1,58 +1,85 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Squid.Core.Services.Deployments.Checkpoints;
 
 /// <summary>
 /// Pure read/modify helpers for the deployment checkpoint's in-flight-scripts
-/// map — the JSON shape <c>{ "&lt;machineId&gt;": "&lt;scriptTicket&gt;" }</c> stored on
+/// list — the JSON array of <c>{ "m": machineId, "s": stepName, "a": actionName,
+/// "t": scriptTicket }</c> entries stored on
 /// <see cref="Persistence.Entities.Deployments.DeploymentExecutionCheckpoint.InFlightScriptsJson"/>.
 ///
 /// <para>It records the ScriptTicket of a script dispatched to a Halibut agent
 /// but not yet observed to completion, so a resumed deployment can re-attach to
 /// a still-running script (probe the agent with the same ticket) instead of
-/// launching a duplicate. No I/O or locking here — the store layer owns
-/// persistence and the per-task write serialisation; this type is pure so the
-/// add/remove/lookup semantics are unit-testable in isolation.</para>
+/// launching a duplicate. The entry is keyed by the <see cref="DispatchSlot"/>
+/// (machine + step + action), NOT by the machine alone: a parallel batch can
+/// dispatch MORE THAN ONE script to the SAME machine at once (two
+/// <c>StartWithPrevious</c> steps sharing a target role), and a machine-only key
+/// would let the second dispatch re-attach to the first's ticket and skip its
+/// own script. Scoping to the dispatch unit keeps concurrent same-machine
+/// dispatches independent — live AND on resume (each re-attaches to its own
+/// ticket).</para>
+///
+/// <para>No I/O or locking here — the store layer owns persistence and the
+/// per-task write serialisation; this type is pure so the add/remove/lookup
+/// semantics are unit-testable in isolation.</para>
 /// </summary>
 public static class InFlightScriptMap
 {
-    /// <summary>Record (or overwrite) the in-flight ticket for a machine.</summary>
-    public static string Add(string json, int machineId, string scriptTicket)
+    private sealed record Entry(
+        [property: JsonPropertyName("m")] int MachineId,
+        [property: JsonPropertyName("s")] string StepName,
+        [property: JsonPropertyName("a")] string ActionName,
+        [property: JsonPropertyName("t")] string Ticket);
+
+    /// <summary>Record (or replace) the in-flight ticket for one dispatch slot.</summary>
+    public static string Add(string json, DispatchSlot slot, string scriptTicket)
     {
-        var map = Parse(json);
-        map[machineId.ToString()] = scriptTicket;
-        return Serialize(map);
+        var entries = Parse(json);
+
+        entries.RemoveAll(e => Matches(e, slot));
+        entries.Add(new Entry(slot.MachineId, slot.StepName, slot.ActionName, scriptTicket));
+
+        return Serialize(entries);
     }
 
-    /// <summary>Drop a machine's in-flight ticket once its script is observed
-    /// to completion. Removing an absent machine is a no-op.</summary>
-    public static string Remove(string json, int machineId)
+    /// <summary>Drop a dispatch slot's in-flight ticket once its script is
+    /// observed to completion. Removing an absent slot is a no-op.</summary>
+    public static string Remove(string json, DispatchSlot slot)
     {
-        var map = Parse(json);
-        map.Remove(machineId.ToString());
-        return Serialize(map);
+        var entries = Parse(json);
+
+        entries.RemoveAll(e => Matches(e, slot));
+
+        return Serialize(entries);
     }
 
-    /// <summary>The recorded in-flight ticket for a machine, or
+    /// <summary>The recorded in-flight ticket for a dispatch slot, or
     /// <see langword="null"/> if none.</summary>
-    public static string? TryGet(string json, int machineId)
-        => Parse(json).TryGetValue(machineId.ToString(), out var ticket) ? ticket : null;
+    public static string? TryGet(string json, DispatchSlot slot)
+        => Parse(json).FirstOrDefault(e => Matches(e, slot))?.Ticket;
 
-    private static Dictionary<string, string> Parse(string json)
+    private static bool Matches(Entry entry, DispatchSlot slot)
+        => entry.MachineId == slot.MachineId && entry.StepName == slot.StepName && entry.ActionName == slot.ActionName;
+
+    private static List<Entry> Parse(string json)
     {
         if (string.IsNullOrWhiteSpace(json)) return new();
 
         try
         {
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+            return JsonSerializer.Deserialize<List<Entry>>(json) ?? new();
         }
         catch (JsonException)
         {
-            // A malformed column (manual edit, partial write) must not crash the
-            // deploy — treat it as empty and let the executor re-dispatch fresh.
+            // A malformed column (manual edit, partial write) OR a row written in
+            // the legacy machine-keyed object shape by an older server must not
+            // crash the deploy — treat it as empty and let the executor
+            // re-dispatch fresh.
             return new();
         }
     }
 
-    private static string Serialize(Dictionary<string, string> map) => JsonSerializer.Serialize(map);
+    private static string Serialize(List<Entry> entries) => JsonSerializer.Serialize(entries);
 }

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
@@ -5,7 +5,7 @@ namespace Squid.Core.Services.Deployments.Checkpoints;
 
 /// <summary>
 /// Pure read/modify helpers for the deployment checkpoint's in-flight-scripts
-/// list — the JSON array of <c>{ "m": machineId, "s": stepName, "a": actionName,
+/// list — the JSON array of <c>{ "m": machineId, "s": stepId, "a": actionId,
 /// "t": scriptTicket }</c> entries stored on
 /// <see cref="Persistence.Entities.Deployments.DeploymentExecutionCheckpoint.InFlightScriptsJson"/>.
 ///
@@ -29,8 +29,8 @@ public static class InFlightScriptMap
 {
     private sealed record Entry(
         [property: JsonPropertyName("m")] int MachineId,
-        [property: JsonPropertyName("s")] string StepName,
-        [property: JsonPropertyName("a")] string ActionName,
+        [property: JsonPropertyName("s")] int StepId,
+        [property: JsonPropertyName("a")] int ActionId,
         [property: JsonPropertyName("t")] string Ticket);
 
     /// <summary>Record (or replace) the in-flight ticket for one dispatch slot.</summary>
@@ -39,7 +39,7 @@ public static class InFlightScriptMap
         var entries = Parse(json);
 
         entries.RemoveAll(e => Matches(e, slot));
-        entries.Add(new Entry(slot.MachineId, slot.StepName, slot.ActionName, scriptTicket));
+        entries.Add(new Entry(slot.MachineId, slot.StepId, slot.ActionId, scriptTicket));
 
         return Serialize(entries);
     }
@@ -61,7 +61,7 @@ public static class InFlightScriptMap
         => Parse(json).FirstOrDefault(e => Matches(e, slot))?.Ticket;
 
     private static bool Matches(Entry entry, DispatchSlot slot)
-        => entry.MachineId == slot.MachineId && entry.StepName == slot.StepName && entry.ActionName == slot.ActionName;
+        => entry.MachineId == slot.MachineId && entry.StepId == slot.StepId && entry.ActionId == slot.ActionId;
 
     private static List<Entry> Parse(string json)
     {

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
@@ -5,16 +5,23 @@ namespace Squid.Core.Services.Deployments.Checkpoints;
 
 /// <summary>
 /// Identifies a single in-flight script dispatch within a deployment task: the
-/// target <paramref name="MachineId"/> plus the <paramref name="StepName"/> /
-/// <paramref name="ActionName"/> that produced it. A parallel batch can dispatch
+/// target <paramref name="MachineId"/> plus the <paramref name="StepId"/> /
+/// <paramref name="ActionId"/> that produced it. A parallel batch can dispatch
 /// MORE THAN ONE script to the SAME machine at once (two <c>StartWithPrevious</c>
 /// steps that share a target role), so the machine id alone is too coarse a key —
 /// the second dispatch would re-attach to the first's recorded ticket and skip
 /// its own script. Scoping the in-flight slot to the (machine, step, action)
 /// dispatch unit keeps concurrent dispatches to one machine independent, and lets
 /// a resumed run re-attach to EACH of them.
+///
+/// <para>The step/action are identified by their stable, process-unique <b>ids</b>,
+/// NOT their display names — step and action names carry no uniqueness constraint
+/// (the schema only enforces unique step_order / action_order), so two distinct
+/// identically-named steps targeting one machine would otherwise collapse to the
+/// same slot and re-open the very collision this prevents. The ids come from the
+/// frozen process snapshot, so they are identical on a resumed run.</para>
 /// </summary>
-public readonly record struct DispatchSlot(int MachineId, string StepName, string ActionName);
+public readonly record struct DispatchSlot(int MachineId, int StepId, int ActionId);
 
 /// <summary>
 /// Durable record of scripts dispatched to a Halibut agent but not yet observed

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
@@ -4,12 +4,26 @@ using Squid.Core.Persistence.Entities.Deployments;
 namespace Squid.Core.Services.Deployments.Checkpoints;
 
 /// <summary>
+/// Identifies a single in-flight script dispatch within a deployment task: the
+/// target <paramref name="MachineId"/> plus the <paramref name="StepName"/> /
+/// <paramref name="ActionName"/> that produced it. A parallel batch can dispatch
+/// MORE THAN ONE script to the SAME machine at once (two <c>StartWithPrevious</c>
+/// steps that share a target role), so the machine id alone is too coarse a key —
+/// the second dispatch would re-attach to the first's recorded ticket and skip
+/// its own script. Scoping the in-flight slot to the (machine, step, action)
+/// dispatch unit keeps concurrent dispatches to one machine independent, and lets
+/// a resumed run re-attach to EACH of them.
+/// </summary>
+public readonly record struct DispatchSlot(int MachineId, string StepName, string ActionName);
+
+/// <summary>
 /// Durable record of scripts dispatched to a Halibut agent but not yet observed
 /// to completion, persisted on the deployment checkpoint's
 /// <see cref="DeploymentExecutionCheckpoint.InFlightScriptsJson"/> column so a
 /// deployment resumed after a server crash can re-attach to a still-running
 /// script (probe the agent with the same ScriptTicket) instead of launching a
-/// duplicate.
+/// duplicate. Keyed by <see cref="DispatchSlot"/> so two concurrent dispatches to
+/// one machine (a parallel batch) never collide.
 ///
 /// <para><b>Concurrency</b>: a parallel batch dispatches to several targets at
 /// once, each recording its ticket AND probing for a re-attach ticket — all on
@@ -31,11 +45,11 @@ namespace Squid.Core.Services.Deployments.Checkpoints;
 /// </summary>
 public interface IInFlightScriptStore : IScopedDependency
 {
-    Task RecordDispatchedAsync(int serverTaskId, int machineId, string scriptTicket, CancellationToken cancellationToken = default);
+    Task RecordDispatchedAsync(int serverTaskId, DispatchSlot slot, string scriptTicket, CancellationToken cancellationToken = default);
 
-    Task ClearAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default);
+    Task ClearAsync(int serverTaskId, DispatchSlot slot, CancellationToken cancellationToken = default);
 
-    Task<string?> TryGetTicketAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default);
+    Task<string?> TryGetTicketAsync(int serverTaskId, DispatchSlot slot, CancellationToken cancellationToken = default);
 }
 
 public sealed class InFlightScriptStore(IRepository repository) : IInFlightScriptStore
@@ -51,13 +65,13 @@ public sealed class InFlightScriptStore(IRepository repository) : IInFlightScrip
 
     private static SemaphoreSlim LockFor(int serverTaskId) => Stripes[(uint)serverTaskId % LockStripeCount];
 
-    public Task RecordDispatchedAsync(int serverTaskId, int machineId, string scriptTicket, CancellationToken cancellationToken = default)
-        => MutateAsync(serverTaskId, current => InFlightScriptMap.Add(current, machineId, scriptTicket), cancellationToken);
+    public Task RecordDispatchedAsync(int serverTaskId, DispatchSlot slot, string scriptTicket, CancellationToken cancellationToken = default)
+        => MutateAsync(serverTaskId, current => InFlightScriptMap.Add(current, slot, scriptTicket), cancellationToken);
 
-    public Task ClearAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default)
-        => MutateAsync(serverTaskId, current => InFlightScriptMap.Remove(current, machineId), cancellationToken);
+    public Task ClearAsync(int serverTaskId, DispatchSlot slot, CancellationToken cancellationToken = default)
+        => MutateAsync(serverTaskId, current => InFlightScriptMap.Remove(current, slot), cancellationToken);
 
-    public async Task<string?> TryGetTicketAsync(int serverTaskId, int machineId, CancellationToken cancellationToken = default)
+    public async Task<string?> TryGetTicketAsync(int serverTaskId, DispatchSlot slot, CancellationToken cancellationToken = default)
     {
         // The read MUST take the same per-task stripe as the writes. A parallel
         // batch dispatches to several targets at once on one Hangfire worker, and
@@ -74,7 +88,7 @@ public sealed class InFlightScriptStore(IRepository repository) : IInFlightScrip
             var row = await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(c => c.ServerTaskId == serverTaskId)
                 .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
-            return row == null ? null : InFlightScriptMap.TryGet(row.InFlightScriptsJson ?? "{}", machineId);
+            return row == null ? null : InFlightScriptMap.TryGet(row.InFlightScriptsJson ?? "[]", slot);
         }
         finally
         {
@@ -99,7 +113,7 @@ public sealed class InFlightScriptStore(IRepository repository) : IInFlightScrip
                 return;
             }
 
-            var updated = mutate(row.InFlightScriptsJson ?? "{}");
+            var updated = mutate(row.InFlightScriptsJson ?? "[]");
 
             await repository.ExecuteUpdateAsync<DeploymentExecutionCheckpoint>(
                 c => c.ServerTaskId == serverTaskId,

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/StepBatcherParallelE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/StepBatcherParallelE2ETests.cs
@@ -88,9 +88,9 @@ public class StepBatcherParallelE2ETests
     {
         _fixture.LogSink.Clear();
 
-        // Each step echoes "STEPTIME <id> START|END <epoch>" around its sleep, plus a
-        // unique completion marker, so we can both prove BOTH ran and reconstruct each
-        // step's agent-side execution interval.
+        // Each step emits "STEPTIME_<id>_START_<epoch>" / "STEPTIME_<id>_END_<epoch>"
+        // around its sleep, plus a unique completion marker, so we can both prove BOTH
+        // ran and reconstruct each step's agent-side execution interval.
         var step1Marker = $"parallel-step1-{Guid.NewGuid().ToString("N")[..12]}";
         var step2Marker = $"parallel-step2-{Guid.NewGuid().ToString("N")[..12]}";
 
@@ -129,12 +129,16 @@ public class StepBatcherParallelE2ETests
     }
 
     // Builds a bash body that timestamps its own execution interval (agent clock)
-    // around the sleep, then echoes the completion marker. The $(date +%s.%N) runs on
-    // the agent, not in C# — interpolation only fills {id}, {marker}, {SleepSecondsPerStep}.
+    // around the sleep, then echoes the completion marker. The marker text is baked
+    // INTO the `date` format string ("date +STEPTIME_step1_START_%s.%N") so the line is
+    // emitted with NO shell quotes and NO command substitution — a form that survives
+    // the JSON action-property round-trip verbatim (double-quote + $(...) bodies got
+    // mangled in transit and failed to parse on the agent). `date` expands %s.%N on the
+    // agent; C# interpolation only fills {id}, {marker}, {SleepSecondsPerStep}.
     private static string TimedScript(string id, string marker) =>
-        $"echo \"STEPTIME {id} START $(date +%s.%N)\"; " +
+        $"date +STEPTIME_{id}_START_%s.%N; " +
         $"sleep {SleepSecondsPerStep}; " +
-        $"echo \"STEPTIME {id} END $(date +%s.%N)\"; " +
+        $"date +STEPTIME_{id}_END_%s.%N; " +
         $"echo '{marker}'";
 
     // Reconstructs a step's [Start, End] epoch interval from the captured agent log
@@ -142,7 +146,7 @@ public class StepBatcherParallelE2ETests
     private (double Start, double End) ParseStepInterval(string id)
     {
         double? start = null, end = null;
-        var pattern = new Regex($@"STEPTIME {Regex.Escape(id)} (START|END) ([0-9]+(?:\.[0-9]+)?)");
+        var pattern = new Regex($@"STEPTIME_{Regex.Escape(id)}_(START|END)_([0-9]+(?:\.[0-9]+)?)");
 
         foreach (var message in _fixture.LogSink.Messages)
         {

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/StepBatcherParallelE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/StepBatcherParallelE2ETests.cs
@@ -1,5 +1,6 @@
-using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
@@ -34,23 +35,26 @@ namespace Squid.E2ETests.Deployments.Kubernetes.Pipeline;
 /// overlap a slow database migration step with a slow CDN warmup step would
 /// silently see total deploy time double.</para>
 ///
-/// <para><b>Method</b>: two steps both running <c>sleep 2</c> on the same agent.
+/// <para><b>Method</b>: two steps both running <c>sleep 3</c> on the same agent.
 /// Step 1 with default StartTrigger; Step 2 with <c>StartWithPrevious</c> so the
-/// batcher groups them. With true parallelism total wall-clock should be ~2s; a
-/// sequential regression would push it to ~4s. We assert &lt; 3.5s — a generous
-/// CI margin that still catches a 2× slowdown.</para>
+/// batcher groups them. Each step echoes an epoch timestamp (<c>date +%s.%N</c>)
+/// immediately BEFORE and AFTER its sleep, so we know each step's execution
+/// interval on the agent's own clock. Parallelism is proven by the two intervals
+/// OVERLAPPING — if the orchestrator ran the batch sequentially, step 2 would only
+/// start after step 1 finished and the intervals could not overlap.</para>
+///
+/// <para><b>Why interval overlap, not total wall-clock</b>: an earlier version
+/// stop-watched the whole <c>ProcessAsync</c> and asserted &lt; 3.5s. That
+/// conflated "did the two steps overlap" with "how much Halibut-handshake /
+/// 1s-polling / DB / Kind overhead the pipeline incurred" — on a loaded CI runner
+/// the overhead alone could exceed the ceiling on a genuinely parallel run, making
+/// the test flaky. Comparing the agent-side execution intervals measures ONLY the
+/// overlap and is immune to pipeline/CI overhead.</para>
 ///
 /// <para><b>Tier</b>: 🟢 High-fidelity. Real Postgres + real Kind cluster + real
 /// Halibut polling + real <c>TentacleStub.ScriptRunner</c> bash execution. The
-/// only synthesised element is the precise sleep duration, which is a property
-/// of the test script's body, not a production seam.</para>
-///
-/// <para><b>Why 2s and not 1.5s</b>: shorter durations narrow the parallel-vs-
-/// sequential ratio. 1s sleep × 2 parallel = ~1s; sequential = ~2s; ratio 2×.
-/// 2s × 2 parallel = ~2s; sequential = ~4s; ratio 2×. The absolute margin matters
-/// more for CI noise: 1s and 1.5s thresholds can be missed by container scheduling
-/// jitter on a busy CI host. 2s leaves 1.5s of headroom for jitter on the parallel
-/// path while still flagging a sequential regression.</para>
+/// only synthesised element is the precise sleep duration, a property of the test
+/// script's body, not a production seam.</para>
 /// </summary>
 [Collection("KindCluster")]
 [Trait("Category", "E2E")]
@@ -59,9 +63,14 @@ public class StepBatcherParallelE2ETests
 {
     private const string Step1Name = "ParallelStep1";
     private const string Step2Name = "ParallelStep2";
-    private const int SleepSecondsPerStep = 2;
-    private const double SequentialBaselineSeconds = SleepSecondsPerStep * 2;
-    private const double ParallelCeilingSeconds = 3.5;  // < sequential baseline by ≥ 500ms
+    private const int SleepSecondsPerStep = 3;
+
+    // Minimum overlap (seconds) between the two steps' agent-side execution
+    // intervals that proves parallel dispatch. With sleep=3s the parallel overlap is
+    // ~2-3s (dispatch stagger ≤ the 1s polling interval); a sequential run yields a
+    // NEGATIVE overlap (step 2 starts after step 1 ends). 1.0s cleanly separates the
+    // two with ~2s of headroom for CI scheduling jitter on the agent.
+    private const double MinOverlapSeconds = 1.0;
 
     private readonly KindClusterFixture _cluster;
     private readonly KubernetesAgentE2EFixture<StepBatcherParallelE2ETests> _fixture;
@@ -75,57 +84,80 @@ public class StepBatcherParallelE2ETests
     }
 
     [Fact]
-    public async Task TwoStepsStartWithPrevious_ExecuteInParallel_TotalWallClockProvesOverlap()
+    public async Task TwoStepsStartWithPrevious_ExecuteInParallel_IntervalsOverlap()
     {
         _fixture.LogSink.Clear();
 
-        // Both steps emit a unique marker AFTER the sleep so we can prove BOTH ran.
+        // Each step echoes "STEPTIME <id> START|END <epoch>" around its sleep, plus a
+        // unique completion marker, so we can both prove BOTH ran and reconstruct each
+        // step's agent-side execution interval.
         var step1Marker = $"parallel-step1-{Guid.NewGuid().ToString("N")[..12]}";
         var step2Marker = $"parallel-step2-{Guid.NewGuid().ToString("N")[..12]}";
 
-        var step1Script = $"sleep {SleepSecondsPerStep}; echo '{step1Marker}'";
-        var step2Script = $"sleep {SleepSecondsPerStep}; echo '{step2Marker}'";
+        var serverTaskId = await SeedTwoStepDeploymentWithParallelTriggerAsync(
+            TimedScript("step1", step1Marker), TimedScript("step2", step2Marker)).ConfigureAwait(false);
 
-        var serverTaskId = await SeedTwoStepDeploymentWithParallelTriggerAsync(step1Script, step2Script).ConfigureAwait(false);
-
-        // ──── Stopwatch around the full pipeline dispatch ────────────────────────
-        //
-        // The whole ProcessAsync includes seeding overhead + Halibut handshake +
-        // both script executions + post-execution merge. The sleep dominates so
-        // measurement noise from the other phases is negligible compared to a 2×
-        // regression. We start the stopwatch immediately before ProcessAsync and
-        // stop AFTER it completes — same convention as the Halibut breaker test.
-        var stopwatch = Stopwatch.StartNew();
         await ExecutePipelineAsync(serverTaskId).ConfigureAwait(false);
-        stopwatch.Stop();
 
         // ──── INVARIANT 1: Task ended Success ─────────────────────────────────────
         await AssertTaskStateAsync(serverTaskId, TaskState.Success).ConfigureAwait(false);
 
         // ──── INVARIANT 2: Both steps actually executed ───────────────────────────
-        // Without this assertion, a regression that SKIPPED step 2 would pass the
-        // wall-clock check (one step at ~2s is under the ceiling).
         _fixture.LogSink.ContainsMessage(step1Marker).ShouldBeTrue(
             customMessage: $"Step 1 marker '{step1Marker}' missing — step 1 didn't actually run.");
         _fixture.LogSink.ContainsMessage(step2Marker).ShouldBeTrue(
             customMessage: $"Step 2 marker '{step2Marker}' missing — step 2 didn't actually run.");
 
-        // ──── INVARIANT 3: Wall-clock under the parallel ceiling ──────────────────
-        // The headline assertion. Sequential execution would be ~4s; parallel ~2s.
-        // Anything between ~2.5s and 3.5s is the marginal zone where CI jitter
-        // could push a true-parallel run, but a sequential regression would be
-        // well past 3.5s.
-        stopwatch.Elapsed.TotalSeconds.ShouldBeLessThan(ParallelCeilingSeconds,
+        // ──── INVARIANT 3: The two execution intervals OVERLAP ────────────────────
+        // The headline assertion, measured on the agent's clock so it is immune to
+        // pipeline/CI overhead. overlap = min(end) - max(start). Parallel dispatch ⇒
+        // the intervals overlap (positive, ~2-3s); a sequential regression ⇒ step 2
+        // starts after step 1 ends ⇒ overlap is negative.
+        var s1 = ParseStepInterval("step1");
+        var s2 = ParseStepInterval("step2");
+
+        var overlapSeconds = Math.Min(s1.End, s2.End) - Math.Max(s1.Start, s2.Start);
+
+        overlapSeconds.ShouldBeGreaterThan(MinOverlapSeconds,
             customMessage:
-                $"Pipeline took {stopwatch.Elapsed.TotalSeconds:F1}s — expected < {ParallelCeilingSeconds:F1}s with " +
-                $"StartWithPrevious parallel batching of 2 steps each sleeping {SleepSecondsPerStep}s.\n\n" +
-                $"Sequential baseline would be {SequentialBaselineSeconds:F1}s + overhead. A measurement at or above " +
-                $"{SequentialBaselineSeconds:F1}s indicates the regression: the orchestrator is running steps " +
-                $"sequentially within the batch.\n\n" +
-                "Diagnose:\n" +
-                "  - 6_ExecuteStepsPhase.cs:90-93 should branch on batch.Count == 1 vs Task.WhenAll(...)\n" +
-                $"  - StepBatcher.BatchSteps must group steps with StartTrigger='StartWithPrevious' into one batch\n" +
-                "  - Check the activity log for two simultaneous 'Starting direct script on agent' lines");
+                $"The two StartWithPrevious-batched steps did not overlap on the agent (overlap {overlapSeconds:F2}s, " +
+                $"expected > {MinOverlapSeconds:F1}s with each sleeping {SleepSecondsPerStep}s).\n" +
+                $"  step1 [{s1.Start:F3} .. {s1.End:F3}]  step2 [{s2.Start:F3} .. {s2.End:F3}]\n\n" +
+                "A non-positive overlap means the orchestrator ran the batch SEQUENTIALLY. Diagnose:\n" +
+                "  - 6_ExecuteStepsPhase.cs branch on batch.Count == 1 vs Task.WhenAll(...)\n" +
+                "  - StepBatcher.BatchSteps must group steps with StartTrigger='StartWithPrevious' into one batch");
+    }
+
+    // Builds a bash body that timestamps its own execution interval (agent clock)
+    // around the sleep, then echoes the completion marker. The $(date +%s.%N) runs on
+    // the agent, not in C# — interpolation only fills {id}, {marker}, {SleepSecondsPerStep}.
+    private static string TimedScript(string id, string marker) =>
+        $"echo \"STEPTIME {id} START $(date +%s.%N)\"; " +
+        $"sleep {SleepSecondsPerStep}; " +
+        $"echo \"STEPTIME {id} END $(date +%s.%N)\"; " +
+        $"echo '{marker}'";
+
+    // Reconstructs a step's [Start, End] epoch interval from the captured agent log
+    // lines. CapturingLogSink.Messages is an unordered bag, so we match by content.
+    private (double Start, double End) ParseStepInterval(string id)
+    {
+        double? start = null, end = null;
+        var pattern = new Regex($@"STEPTIME {Regex.Escape(id)} (START|END) ([0-9]+(?:\.[0-9]+)?)");
+
+        foreach (var message in _fixture.LogSink.Messages)
+        {
+            var match = pattern.Match(message);
+            if (!match.Success) continue;
+
+            var epoch = double.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+
+            if (match.Groups[1].Value == "START") start = epoch; else end = epoch;
+        }
+
+        start.ShouldNotBeNull($"No START timestamp captured for {id} — its script body didn't run to completion.");
+        end.ShouldNotBeNull($"No END timestamp captured for {id} — its script body didn't run to completion.");
+
+        return (start.Value, end.Value);
     }
 
     /// <summary>

--- a/tests/Squid.E2ETests/Deployments/Tentacle/HalibutCircuitBreakerE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/HalibutCircuitBreakerE2ETests.cs
@@ -110,18 +110,26 @@ public class HalibutCircuitBreakerE2ETests
         //
         // The breaker's ThrowIfOpen at HalibutMachineExecutionStrategy.cs:66 must
         // fire BEFORE any CreateClient call, so dispatch should complete in
-        // milliseconds. We allow 5 seconds as a generous CI ceiling — anything
-        // approaching the 30-min script timeout means the breaker bypass regressed.
+        // milliseconds. The REAL proof that the breaker blocked dispatch is
+        // INVARIANT 3 below (the stub never ran the script) — that's non-temporal
+        // and never flakes. This wall-clock check is only a coarse anti-hang guard:
+        // the failure mode it catches is the breaker bypass regressing into a full
+        // 30-min script timeout, so we use a deliberately generous ceiling (20s,
+        // ~90x the real regression threshold) that the DB-bound prepare phases can
+        // never breach on even a heavily loaded CI runner.
+        const double AntiHangCeilingSeconds = 20;
+
         var stopwatch = Stopwatch.StartNew();
         await ExecutePipelineAsync(serverTaskId).ConfigureAwait(false);
         stopwatch.Stop();
 
-        // ──── INVARIANT 1: Dispatch fails fast ───────────────────────────────────
-        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(5),
+        // ──── INVARIANT 1: Dispatch did not hang on the 30-min script timeout ─────
+        stopwatch.Elapsed.TotalSeconds.ShouldBeLessThan(AntiHangCeilingSeconds,
             customMessage:
-                $"Pipeline took {stopwatch.Elapsed.TotalSeconds:F1}s — expected < 5s with breaker Open. " +
-                "Either ThrowIfOpen ran AFTER CreateClient (regressed wiring), or the breaker isn't " +
-                $"being checked at all. Machine={_fixture.TentacleMachineId}, " +
+                $"Pipeline took {stopwatch.Elapsed.TotalSeconds:F1}s — expected « {AntiHangCeilingSeconds:F0}s with breaker Open. " +
+                "Either ThrowIfOpen ran AFTER CreateClient (regressed wiring) and the dispatch hit the " +
+                "full script timeout, or the breaker isn't being checked at all. " +
+                $"Machine={_fixture.TentacleMachineId}, " +
                 $"ScriptTimeoutMinutes={(int)_fixture.LifetimeScope.Resolve<Core.Settings.Halibut.HalibutSetting>().Polling.ScriptTimeoutMinutes}.");
 
         // ──── INVARIANT 2: Task ended in Failed state ────────────────────────────

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
@@ -180,6 +180,69 @@ public class HalibutResumeReattachTests : TestBase
                           "and the resumed run re-dispatches a duplicate (the exact double-run this ordering prevents).");
     }
 
+    [Fact]
+    public async Task ConcurrentDispatch_SameMachineDifferentSteps_EachRunsItsOwnScript_NoCrossReattach()
+    {
+        // The parallel-batch regression: two StartWithPrevious steps sharing a target
+        // role both dispatch to ONE machine at once. The in-flight slot is scoped to
+        // (machine, step, action), so step B must NOT re-attach to step A's recorded
+        // ticket — it must run its OWN script. The machine-only key this replaced made
+        // step B re-attach and silently skip its work (StartScript count 1, not 2).
+        const int taskId = 810006, machineId = 16;
+
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        // Gate: park the FIRST StartScript inside the agent — AFTER its in-flight
+        // ticket is recorded (record-before-RPC) — until step B has fully run its own
+        // dispatch. This deterministically forces the exact window the bug lived in.
+        var firstParked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var agent = new RecordingScriptService(
+            getStatusScript: new[] { (ProcessState.Complete, 0) },
+            completeResult: (ProcessState.Complete, 0));
+
+        agent.OnStartScript = async _ =>
+        {
+            // StartScriptCalls is incremented before this hook runs, so the first
+            // dispatch sees == 1 and parks; the second proceeds immediately.
+            if (agent.StartScriptCalls == 1)
+            {
+                firstParked.TrySetResult();
+                await releaseFirst.Task.ConfigureAwait(false);
+            }
+        };
+
+        await Run<IEnumerable<IExecutionStrategy>>(
+            async strategies =>
+            {
+                var strategy = strategies.OfType<HalibutMachineExecutionStrategy>().Single();
+
+                var stepA = strategy.ExecuteScriptAsync(BuildRequest(taskId, machineId, "StepA", "ActionA"), CancellationToken.None);
+
+                await firstParked.Task.ConfigureAwait(false);   // step A parked in StartScript, slot A recorded
+
+                // Step B dispatches WHILE step A is still in-flight on the same machine.
+                var stepBResult = await strategy.ExecuteScriptAsync(BuildRequest(taskId, machineId, "StepB", "ActionB"), CancellationToken.None).ConfigureAwait(false);
+
+                releaseFirst.TrySetResult();
+                var stepAResult = await stepA.ConfigureAwait(false);
+
+                stepAResult.Success.ShouldBeTrue();
+                stepBResult.Success.ShouldBeTrue();
+            },
+            extraRegistration: b => b.RegisterInstance(new FixedHalibutClientFactory(agent)).As<IHalibutClientFactory>()).ConfigureAwait(false);
+
+        agent.StartScriptCalls.ShouldBe(2,
+            customMessage: "Two parallel steps on ONE machine must EACH dispatch their own script. A count of 1 means step B " +
+                          "re-attached to step A's in-flight ticket (the machine-only key bug) and silently skipped its own work.");
+        agent.StartedTickets.Distinct().Count().ShouldBe(2,
+            customMessage: "Each parallel step must run under its OWN ScriptTicket.");
+
+        (await GetTicketAsync(taskId, machineId).ConfigureAwait(false)).ShouldBeNull(
+            customMessage: "Both dispatch slots must be cleared once observed to completion.");
+    }
+
     // ── Drive the real strategy with a fake agent (per-scope IHalibutClientFactory override) ──
 
     private async Task<ScriptExecutionResult> ExecuteWithAgentAsync(int taskId, int machineId, RecordingScriptService agent)
@@ -197,15 +260,15 @@ public class HalibutResumeReattachTests : TestBase
         return result;
     }
 
-    private static ScriptExecutionRequest BuildRequest(int taskId, int machineId) => new()
+    private static ScriptExecutionRequest BuildRequest(int taskId, int machineId, string stepName = "Step1", string actionName = "Action1") => new()
     {
         ExecutionMode = ExecutionMode.DirectScript,
         ScriptBody = "echo resume-reattach",
         Syntax = ScriptSyntax.Bash,
         Variables = new List<VariableDto>(),
         ServerTaskId = taskId,
-        StepName = "Step1",
-        ActionName = "Action1",
+        StepName = stepName,
+        ActionName = actionName,
         Machine = new Machine
         {
             Id = machineId,
@@ -221,14 +284,18 @@ public class HalibutResumeReattachTests : TestBase
 
     // ── Helpers (mirror InFlightScriptStoreTests) ──
 
+    // The default slot matches BuildRequest's Step1/Action1 so a ticket recorded
+    // here is the one the strategy's reattach probe looks up.
+    private static DispatchSlot DefaultSlot(int machineId) => new(machineId, "Step1", "Action1");
+
     private Task EnsureRowAsync(int taskId)
         => Run<IDeploymentCheckpointService>(svc => svc.EnsureExistsAsync(taskId, deploymentId: 1));
 
     private Task RecordTicketAsync(int taskId, int machineId, string ticket)
-        => Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, machineId, ticket));
+        => Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, DefaultSlot(machineId), ticket));
 
     private Task<string> GetTicketAsync(int taskId, int machineId)
-        => Run<IInFlightScriptStore, string>(s => s.TryGetTicketAsync(taskId, machineId));
+        => Run<IInFlightScriptStore, string>(s => s.TryGetTicketAsync(taskId, DefaultSlot(machineId)));
 
     // ── Recording fake agent (the Halibut RPC counterpart) ──
 

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/HalibutResumeReattachTests.cs
@@ -181,13 +181,19 @@ public class HalibutResumeReattachTests : TestBase
     }
 
     [Fact]
-    public async Task ConcurrentDispatch_SameMachineDifferentSteps_EachRunsItsOwnScript_NoCrossReattach()
+    public async Task ConcurrentDispatch_SameMachineIdenticallyNamedSteps_EachRunsItsOwnScript_NoCrossReattach()
     {
         // The parallel-batch regression: two StartWithPrevious steps sharing a target
         // role both dispatch to ONE machine at once. The in-flight slot is scoped to
-        // (machine, step, action), so step B must NOT re-attach to step A's recorded
-        // ticket — it must run its OWN script. The machine-only key this replaced made
-        // step B re-attach and silently skip its work (StartScript count 1, not 2).
+        // (machine, stepId, actionId), so step B must NOT re-attach to step A's
+        // recorded ticket — it must run its OWN script. The machine-only key this
+        // replaced made step B re-attach and silently skip its work (StartScript count
+        // 1, not 2).
+        //
+        // The two steps deliberately share IDENTICAL display names ("deploy"/"deploy")
+        // and differ ONLY by their stable ids — proving the slot keys on the ids, not
+        // the names (step/action names have no uniqueness constraint, so a name-keyed
+        // slot would re-collapse these two dispatches into one).
         const int taskId = 810006, machineId = 16;
 
         await EnsureRowAsync(taskId).ConfigureAwait(false);
@@ -218,12 +224,15 @@ public class HalibutResumeReattachTests : TestBase
             {
                 var strategy = strategies.OfType<HalibutMachineExecutionStrategy>().Single();
 
-                var stepA = strategy.ExecuteScriptAsync(BuildRequest(taskId, machineId, "StepA", "ActionA"), CancellationToken.None);
+                var stepA = strategy.ExecuteScriptAsync(
+                    BuildRequest(taskId, machineId, stepId: 1, actionId: 101, stepName: "deploy", actionName: "deploy"), CancellationToken.None);
 
                 await firstParked.Task.ConfigureAwait(false);   // step A parked in StartScript, slot A recorded
 
-                // Step B dispatches WHILE step A is still in-flight on the same machine.
-                var stepBResult = await strategy.ExecuteScriptAsync(BuildRequest(taskId, machineId, "StepB", "ActionB"), CancellationToken.None).ConfigureAwait(false);
+                // Step B dispatches WHILE step A is still in-flight on the same machine —
+                // same names, different ids.
+                var stepBResult = await strategy.ExecuteScriptAsync(
+                    BuildRequest(taskId, machineId, stepId: 2, actionId: 102, stepName: "deploy", actionName: "deploy"), CancellationToken.None).ConfigureAwait(false);
 
                 releaseFirst.TrySetResult();
                 var stepAResult = await stepA.ConfigureAwait(false);
@@ -260,7 +269,7 @@ public class HalibutResumeReattachTests : TestBase
         return result;
     }
 
-    private static ScriptExecutionRequest BuildRequest(int taskId, int machineId, string stepName = "Step1", string actionName = "Action1") => new()
+    private static ScriptExecutionRequest BuildRequest(int taskId, int machineId, int stepId = 1, int actionId = 1, string stepName = "Step", string actionName = "Action") => new()
     {
         ExecutionMode = ExecutionMode.DirectScript,
         ScriptBody = "echo resume-reattach",
@@ -269,6 +278,8 @@ public class HalibutResumeReattachTests : TestBase
         ServerTaskId = taskId,
         StepName = stepName,
         ActionName = actionName,
+        StepId = stepId,
+        ActionId = actionId,
         Machine = new Machine
         {
             Id = machineId,
@@ -284,9 +295,9 @@ public class HalibutResumeReattachTests : TestBase
 
     // ── Helpers (mirror InFlightScriptStoreTests) ──
 
-    // The default slot matches BuildRequest's Step1/Action1 so a ticket recorded
-    // here is the one the strategy's reattach probe looks up.
-    private static DispatchSlot DefaultSlot(int machineId) => new(machineId, "Step1", "Action1");
+    // The default slot matches BuildRequest's default StepId/ActionId (1,1) so a
+    // ticket recorded here is the one the strategy's reattach probe looks up.
+    private static DispatchSlot DefaultSlot(int machineId) => new(machineId, 1, 1);
 
     private Task EnsureRowAsync(int taskId)
         => Run<IDeploymentCheckpointService>(svc => svc.EnsureExistsAsync(taskId, deploymentId: 1));

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
@@ -19,8 +19,8 @@ public class InFlightScriptStoreTests : TestBase
     {
     }
 
-    private static DispatchSlot Slot(int machineId, string step = "Step1", string action = "Action1")
-        => new(machineId, step, action);
+    private static DispatchSlot Slot(int machineId, int stepId = 1, int actionId = 1)
+        => new(machineId, stepId, actionId);
 
     [Fact]
     public async Task EnsureExists_ThenRecordAndClear_RoundTrips()
@@ -55,27 +55,28 @@ public class InFlightScriptStoreTests : TestBase
     public async Task Record_SameMachineDifferentDispatches_AreIndependent()
     {
         // The headline fix: two parallel StartWithPrevious steps targeting ONE machine
-        // each record their own slot. The probe for step B must NOT find step A's
-        // ticket (the machine-only key this replaced would have — making step B
-        // re-attach to step A and silently skip its own script).
+        // each record their own slot, keyed by the stable action id. The probe for
+        // action 200 must NOT find action 100's ticket (the machine-only key this
+        // replaced would have — making the second dispatch re-attach to the first and
+        // silently skip its own script).
         const int taskId = 700008;
         await EnsureRowAsync(taskId).ConfigureAwait(false);
 
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, "StepA", "ActionA"), "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, stepId: 10, actionId: 100), "ticket-a")).ConfigureAwait(false);
 
-        (await GetTicketAsync(taskId, Slot(11, "StepB", "ActionB")).ConfigureAwait(false)).ShouldBeNull(
-            customMessage: "Step B's reattach probe must not match Step A's slot on the same machine — that cross-reattach is the bug this fixes.");
+        (await GetTicketAsync(taskId, Slot(11, stepId: 20, actionId: 200)).ConfigureAwait(false)).ShouldBeNull(
+            customMessage: "Action 200's reattach probe must not match action 100's slot on the same machine — that cross-reattach is the bug this fixes.");
 
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, "StepB", "ActionB"), "ticket-b")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, stepId: 20, actionId: 200), "ticket-b")).ConfigureAwait(false);
 
-        (await GetTicketAsync(taskId, Slot(11, "StepA", "ActionA")).ConfigureAwait(false)).ShouldBe("ticket-a");
-        (await GetTicketAsync(taskId, Slot(11, "StepB", "ActionB")).ConfigureAwait(false)).ShouldBe("ticket-b");
+        (await GetTicketAsync(taskId, Slot(11, stepId: 10, actionId: 100)).ConfigureAwait(false)).ShouldBe("ticket-a");
+        (await GetTicketAsync(taskId, Slot(11, stepId: 20, actionId: 200)).ConfigureAwait(false)).ShouldBe("ticket-b");
 
         // Clearing one slot leaves the sibling slot on the same machine intact.
-        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, Slot(11, "StepA", "ActionA"))).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, Slot(11, stepId: 10, actionId: 100))).ConfigureAwait(false);
 
-        (await GetTicketAsync(taskId, Slot(11, "StepA", "ActionA")).ConfigureAwait(false)).ShouldBeNull();
-        (await GetTicketAsync(taskId, Slot(11, "StepB", "ActionB")).ConfigureAwait(false)).ShouldBe("ticket-b",
+        (await GetTicketAsync(taskId, Slot(11, stepId: 10, actionId: 100)).ConfigureAwait(false)).ShouldBeNull();
+        (await GetTicketAsync(taskId, Slot(11, stepId: 20, actionId: 200)).ConfigureAwait(false)).ShouldBe("ticket-b",
             customMessage: "Clearing one dispatch slot MUST NOT drop a sibling slot on the same machine.");
     }
 
@@ -156,7 +157,7 @@ public class InFlightScriptStoreTests : TestBase
     }
 
     [Fact]
-    public async Task ConcurrentRecord_SameMachineDistinctSteps_AllPersist()
+    public async Task ConcurrentRecord_SameMachineDistinctActions_AllPersist()
     {
         // The production parallel-batch shape: several steps in ONE batch each
         // dispatch to the SAME machine concurrently. Every (machine, step, action)
@@ -165,14 +166,14 @@ public class InFlightScriptStoreTests : TestBase
         const int taskId = 700009;
         await EnsureRowAsync(taskId).ConfigureAwait(false);
 
-        var steps = Enumerable.Range(1, 25).ToList();
+        var actions = Enumerable.Range(1, 25).ToList();
 
-        await Task.WhenAll(steps.Select(i =>
-            Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, $"Step{i}", $"Action{i}"), $"ticket-{i}")))).ConfigureAwait(false);
+        await Task.WhenAll(actions.Select(i =>
+            Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, stepId: i, actionId: 100 + i), $"ticket-{i}")))).ConfigureAwait(false);
 
-        foreach (var i in steps)
-            (await GetTicketAsync(taskId, Slot(11, $"Step{i}", $"Action{i}")).ConfigureAwait(false)).ShouldBe($"ticket-{i}",
-                customMessage: $"Concurrent same-machine dispatch lost step {i}'s slot — the per-task RMW lock or the slot key is not isolating sibling dispatches.");
+        foreach (var i in actions)
+            (await GetTicketAsync(taskId, Slot(11, stepId: i, actionId: 100 + i)).ConfigureAwait(false)).ShouldBe($"ticket-{i}",
+                customMessage: $"Concurrent same-machine dispatch lost action {100 + i}'s slot — the per-task RMW lock or the slot key is not isolating sibling dispatches.");
     }
 
     [Fact]

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
@@ -7,10 +7,11 @@ namespace Squid.IntegrationTests.Services.Deployments.Checkpoints;
 
 /// <summary>
 /// Resume-by-ticket — integration tests for <see cref="InFlightScriptStore"/>
-/// against a real Postgres checkpoint row. Covers record/clear/lookup, the
-/// clobber-fix (a batch-boundary save must NOT wipe in-flight tickets), the
-/// ensure-row helper, the no-row fail-safe, and concurrent record under the
-/// per-task lock.
+/// against a real Postgres checkpoint row. Covers record/clear/lookup keyed by
+/// <see cref="DispatchSlot"/>, the dispatch-scoped independence (two parallel
+/// steps on ONE machine must not collide), the clobber-fix (a batch-boundary save
+/// must NOT wipe in-flight tickets), the ensure-row helper, the no-row fail-safe,
+/// and concurrent record under the per-task lock.
 /// </summary>
 public class InFlightScriptStoreTests : TestBase
 {
@@ -18,17 +19,20 @@ public class InFlightScriptStoreTests : TestBase
     {
     }
 
+    private static DispatchSlot Slot(int machineId, string step = "Step1", string action = "Action1")
+        => new(machineId, step, action);
+
     [Fact]
     public async Task EnsureExists_ThenRecordAndClear_RoundTrips()
     {
         const int taskId = 700001;
         await EnsureRowAsync(taskId).ConfigureAwait(false);
 
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, machineId: 11, scriptTicket: "ticket-a")).ConfigureAwait(false);
-        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBe("ticket-a");
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11), "ticket-a")).ConfigureAwait(false);
+        (await GetTicketAsync(taskId, Slot(11)).ConfigureAwait(false)).ShouldBe("ticket-a");
 
-        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, machineId: 11)).ConfigureAwait(false);
-        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBeNull();
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, Slot(11))).ConfigureAwait(false);
+        (await GetTicketAsync(taskId, Slot(11)).ConfigureAwait(false)).ShouldBeNull();
     }
 
     [Fact]
@@ -37,14 +41,42 @@ public class InFlightScriptStoreTests : TestBase
         const int taskId = 700002;
         await EnsureRowAsync(taskId).ConfigureAwait(false);
 
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 22, "ticket-b")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11), "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(22), "ticket-b")).ConfigureAwait(false);
 
-        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, 11)).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, Slot(11))).ConfigureAwait(false);
 
-        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBeNull();
-        (await GetTicketAsync(taskId, 22).ConfigureAwait(false)).ShouldBe("ticket-b",
+        (await GetTicketAsync(taskId, Slot(11)).ConfigureAwait(false)).ShouldBeNull();
+        (await GetTicketAsync(taskId, Slot(22)).ConfigureAwait(false)).ShouldBe("ticket-b",
             customMessage: "Clearing one machine MUST NOT drop another machine's in-flight ticket.");
+    }
+
+    [Fact]
+    public async Task Record_SameMachineDifferentDispatches_AreIndependent()
+    {
+        // The headline fix: two parallel StartWithPrevious steps targeting ONE machine
+        // each record their own slot. The probe for step B must NOT find step A's
+        // ticket (the machine-only key this replaced would have — making step B
+        // re-attach to step A and silently skip its own script).
+        const int taskId = 700008;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, "StepA", "ActionA"), "ticket-a")).ConfigureAwait(false);
+
+        (await GetTicketAsync(taskId, Slot(11, "StepB", "ActionB")).ConfigureAwait(false)).ShouldBeNull(
+            customMessage: "Step B's reattach probe must not match Step A's slot on the same machine — that cross-reattach is the bug this fixes.");
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, "StepB", "ActionB"), "ticket-b")).ConfigureAwait(false);
+
+        (await GetTicketAsync(taskId, Slot(11, "StepA", "ActionA")).ConfigureAwait(false)).ShouldBe("ticket-a");
+        (await GetTicketAsync(taskId, Slot(11, "StepB", "ActionB")).ConfigureAwait(false)).ShouldBe("ticket-b");
+
+        // Clearing one slot leaves the sibling slot on the same machine intact.
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, Slot(11, "StepA", "ActionA"))).ConfigureAwait(false);
+
+        (await GetTicketAsync(taskId, Slot(11, "StepA", "ActionA")).ConfigureAwait(false)).ShouldBeNull();
+        (await GetTicketAsync(taskId, Slot(11, "StepB", "ActionB")).ConfigureAwait(false)).ShouldBe("ticket-b",
+            customMessage: "Clearing one dispatch slot MUST NOT drop a sibling slot on the same machine.");
     }
 
     [Fact]
@@ -56,7 +88,7 @@ public class InFlightScriptStoreTests : TestBase
         const int taskId = 700003;
         await EnsureRowAsync(taskId).ConfigureAwait(false);
 
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11), "ticket-a")).ConfigureAwait(false);
 
         // Simulate a batch-boundary checkpoint save (note its InFlightScriptsJson="{}").
         await Run<IDeploymentCheckpointService>(svc => svc.SaveAsync(new DeploymentExecutionCheckpoint
@@ -70,7 +102,7 @@ public class InFlightScriptStoreTests : TestBase
             InFlightScriptsJson = "{}"
         })).ConfigureAwait(false);
 
-        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBe("ticket-a",
+        (await GetTicketAsync(taskId, Slot(11)).ConfigureAwait(false)).ShouldBe("ticket-a",
             customMessage: "A batch-boundary save MUST preserve in-flight tickets — InFlightScriptsJson is owned by the store.");
 
         // And the batch save still updated its own column.
@@ -83,13 +115,13 @@ public class InFlightScriptStoreTests : TestBase
     {
         const int taskId = 700004;
         await EnsureRowAsync(taskId).ConfigureAwait(false);
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11), "ticket-a")).ConfigureAwait(false);
 
         // A second EnsureExists (e.g. a resume re-entering the phase) must be a
         // no-op — never reset the row or wipe the recorded ticket.
         await EnsureRowAsync(taskId).ConfigureAwait(false);
 
-        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBe("ticket-a");
+        (await GetTicketAsync(taskId, Slot(11)).ConfigureAwait(false)).ShouldBe("ticket-a");
     }
 
     [Fact]
@@ -99,10 +131,10 @@ public class InFlightScriptStoreTests : TestBase
         // re-dispatches). Must not throw or create a row.
         const int taskId = 700005;
 
-        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, 11, "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11), "ticket-a")).ConfigureAwait(false);
 
         (await LoadAsync(taskId).ConfigureAwait(false)).ShouldBeNull();
-        (await GetTicketAsync(taskId, 11).ConfigureAwait(false)).ShouldBeNull();
+        (await GetTicketAsync(taskId, Slot(11)).ConfigureAwait(false)).ShouldBeNull();
     }
 
     [Fact]
@@ -116,11 +148,31 @@ public class InFlightScriptStoreTests : TestBase
         var machineIds = Enumerable.Range(1, 25).ToList();
 
         await Task.WhenAll(machineIds.Select(id =>
-            Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, id, $"ticket-{id}")))).ConfigureAwait(false);
+            Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(id), $"ticket-{id}")))).ConfigureAwait(false);
 
         foreach (var id in machineIds)
-            (await GetTicketAsync(taskId, id).ConfigureAwait(false)).ShouldBe($"ticket-{id}",
+            (await GetTicketAsync(taskId, Slot(id)).ConfigureAwait(false)).ShouldBe($"ticket-{id}",
                 customMessage: $"Concurrent record lost machine {id}'s ticket — the per-task RMW lock is not serialising writes.");
+    }
+
+    [Fact]
+    public async Task ConcurrentRecord_SameMachineDistinctSteps_AllPersist()
+    {
+        // The production parallel-batch shape: several steps in ONE batch each
+        // dispatch to the SAME machine concurrently. Every (machine, step, action)
+        // slot must survive the contended read-modify-write — none lost, none
+        // overwritten by a sibling.
+        const int taskId = 700009;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        var steps = Enumerable.Range(1, 25).ToList();
+
+        await Task.WhenAll(steps.Select(i =>
+            Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(11, $"Step{i}", $"Action{i}"), $"ticket-{i}")))).ConfigureAwait(false);
+
+        foreach (var i in steps)
+            (await GetTicketAsync(taskId, Slot(11, $"Step{i}", $"Action{i}")).ConfigureAwait(false)).ShouldBe($"ticket-{i}",
+                customMessage: $"Concurrent same-machine dispatch lost step {i}'s slot — the per-task RMW lock or the slot key is not isolating sibling dispatches.");
     }
 
     [Fact]
@@ -143,8 +195,8 @@ public class InFlightScriptStoreTests : TestBase
 
             foreach (var id in Enumerable.Range(1, 24))
             {
-                ops.Add(store.RecordDispatchedAsync(taskId, id, $"ticket-{id}"));
-                ops.Add(store.TryGetTicketAsync(taskId, id));
+                ops.Add(store.RecordDispatchedAsync(taskId, Slot(id), $"ticket-{id}"));
+                ops.Add(store.TryGetTicketAsync(taskId, Slot(id)));
             }
 
             await Task.WhenAll(ops).ConfigureAwait(false);
@@ -152,15 +204,15 @@ public class InFlightScriptStoreTests : TestBase
 
         // Serialised RMW also means no write was lost in the contention.
         foreach (var id in Enumerable.Range(1, 24))
-            (await GetTicketAsync(taskId, id).ConfigureAwait(false)).ShouldBe($"ticket-{id}",
+            (await GetTicketAsync(taskId, Slot(id)).ConfigureAwait(false)).ShouldBe($"ticket-{id}",
                 customMessage: $"Concurrent read+write on one context lost machine {id}'s ticket.");
     }
 
     private Task EnsureRowAsync(int taskId)
         => Run<IDeploymentCheckpointService>(svc => svc.EnsureExistsAsync(taskId, deploymentId: 1));
 
-    private Task<string> GetTicketAsync(int taskId, int machineId)
-        => Run<IInFlightScriptStore, string>(s => s.TryGetTicketAsync(taskId, machineId));
+    private Task<string> GetTicketAsync(int taskId, DispatchSlot slot)
+        => Run<IInFlightScriptStore, string>(s => s.TryGetTicketAsync(taskId, slot));
 
     private Task<DeploymentExecutionCheckpoint> LoadAsync(int taskId)
         => Run<IDeploymentCheckpointService, DeploymentExecutionCheckpoint>(svc => svc.LoadAsync(taskId));

--- a/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
@@ -4,77 +4,113 @@ namespace Squid.UnitTests.Services.Deployments.Checkpoints;
 
 /// <summary>
 /// Unit tests for <see cref="InFlightScriptMap"/> — the pure add/remove/lookup
-/// over the checkpoint's in-flight-scripts JSON. Pins round-trip correctness +
+/// over the checkpoint's in-flight-scripts JSON, keyed by <see cref="DispatchSlot"/>
+/// (machine + step + action). Pins round-trip correctness, the dispatch-scoped
+/// independence that keeps two parallel steps on ONE machine from colliding, and
 /// the defensive empty/malformed handling the resume path relies on.
 /// </summary>
 public class InFlightScriptMapTests
 {
+    private static DispatchSlot Slot(int machineId, string step = "Step1", string action = "Action1")
+        => new(machineId, step, action);
+
     [Fact]
     public void Add_OnEmpty_CreatesSingleEntry()
     {
-        var json = InFlightScriptMap.Add("{}", machineId: 7, scriptTicket: "ticket-a");
+        var json = InFlightScriptMap.Add("[]", Slot(7), "ticket-a");
 
-        InFlightScriptMap.TryGet(json, 7).ShouldBe("ticket-a");
+        InFlightScriptMap.TryGet(json, Slot(7)).ShouldBe("ticket-a");
     }
 
     [Fact]
     public void Add_MultipleMachines_KeepsBoth()
     {
-        var json = InFlightScriptMap.Add("{}", 7, "ticket-a");
-        json = InFlightScriptMap.Add(json, 9, "ticket-b");
+        var json = InFlightScriptMap.Add("[]", Slot(7), "ticket-a");
+        json = InFlightScriptMap.Add(json, Slot(9), "ticket-b");
 
-        InFlightScriptMap.TryGet(json, 7).ShouldBe("ticket-a");
-        InFlightScriptMap.TryGet(json, 9).ShouldBe("ticket-b");
+        InFlightScriptMap.TryGet(json, Slot(7)).ShouldBe("ticket-a");
+        InFlightScriptMap.TryGet(json, Slot(9)).ShouldBe("ticket-b");
     }
 
     [Fact]
-    public void Add_SameMachineTwice_OverwritesWithLatestTicket()
+    public void Add_SameSlotTwice_OverwritesWithLatestTicket()
     {
-        // A fresh dispatch (new Guid ticket) for the same machine replaces the
+        // A fresh dispatch (new Guid ticket) for the same dispatch slot replaces the
         // prior in-flight ticket — the latest dispatch is the one to re-attach to.
-        var json = InFlightScriptMap.Add("{}", 7, "ticket-old");
-        json = InFlightScriptMap.Add(json, 7, "ticket-new");
+        var json = InFlightScriptMap.Add("[]", Slot(7), "ticket-old");
+        json = InFlightScriptMap.Add(json, Slot(7), "ticket-new");
 
-        InFlightScriptMap.TryGet(json, 7).ShouldBe("ticket-new");
+        InFlightScriptMap.TryGet(json, Slot(7)).ShouldBe("ticket-new");
     }
 
     [Fact]
-    public void Remove_DropsOnlyThatMachine()
+    public void Add_SameMachineDifferentSteps_AreIndependent()
     {
-        var json = InFlightScriptMap.Add("{}", 7, "ticket-a");
-        json = InFlightScriptMap.Add(json, 9, "ticket-b");
+        // The headline guarantee: two StartWithPrevious steps dispatched in parallel
+        // to the SAME machine each get their OWN in-flight slot. The machine-only key
+        // this replaced would have made the second dispatch overwrite (and re-attach
+        // to) the first's ticket — silently skipping the second step's script.
+        var json = InFlightScriptMap.Add("[]", Slot(7, "StepA", "ActionA"), "ticket-a");
+        json = InFlightScriptMap.Add(json, Slot(7, "StepB", "ActionB"), "ticket-b");
 
-        json = InFlightScriptMap.Remove(json, 7);
-
-        InFlightScriptMap.TryGet(json, 7).ShouldBeNull();
-        InFlightScriptMap.TryGet(json, 9).ShouldBe("ticket-b");
+        InFlightScriptMap.TryGet(json, Slot(7, "StepA", "ActionA")).ShouldBe("ticket-a");
+        InFlightScriptMap.TryGet(json, Slot(7, "StepB", "ActionB")).ShouldBe("ticket-b",
+            customMessage: "A second dispatch to the same machine (different step/action) MUST get its own slot, not collide with the first.");
     }
 
     [Fact]
-    public void Remove_AbsentMachine_IsNoOp()
+    public void TryGet_SameMachineDifferentAction_DoesNotMatchSiblingSlot()
     {
-        var json = InFlightScriptMap.Add("{}", 7, "ticket-a");
+        // The reattach probe for StepB MUST NOT find StepA's ticket just because they
+        // target the same machine — that is exactly the cross-reattach this fixes.
+        var json = InFlightScriptMap.Add("[]", Slot(7, "StepA", "ActionA"), "ticket-a");
 
-        var after = InFlightScriptMap.Remove(json, 999);
-
-        InFlightScriptMap.TryGet(after, 7).ShouldBe("ticket-a");
+        InFlightScriptMap.TryGet(json, Slot(7, "StepB", "ActionB")).ShouldBeNull(
+            customMessage: "StepB's reattach probe must not match StepA's slot on the same machine.");
     }
 
     [Fact]
-    public void TryGet_AbsentMachine_ReturnsNull()
-        => InFlightScriptMap.TryGet("{}", 7).ShouldBeNull();
+    public void Remove_DropsOnlyThatSlot()
+    {
+        var json = InFlightScriptMap.Add("[]", Slot(7, "StepA", "ActionA"), "ticket-a");
+        json = InFlightScriptMap.Add(json, Slot(7, "StepB", "ActionB"), "ticket-b");
+        json = InFlightScriptMap.Add(json, Slot(9), "ticket-c");
+
+        json = InFlightScriptMap.Remove(json, Slot(7, "StepA", "ActionA"));
+
+        InFlightScriptMap.TryGet(json, Slot(7, "StepA", "ActionA")).ShouldBeNull();
+        InFlightScriptMap.TryGet(json, Slot(7, "StepB", "ActionB")).ShouldBe("ticket-b",
+            customMessage: "Clearing one slot MUST NOT drop a sibling slot on the same machine.");
+        InFlightScriptMap.TryGet(json, Slot(9)).ShouldBe("ticket-c");
+    }
+
+    [Fact]
+    public void Remove_AbsentSlot_IsNoOp()
+    {
+        var json = InFlightScriptMap.Add("[]", Slot(7), "ticket-a");
+
+        var after = InFlightScriptMap.Remove(json, Slot(999));
+
+        InFlightScriptMap.TryGet(after, Slot(7)).ShouldBe("ticket-a");
+    }
+
+    [Fact]
+    public void TryGet_AbsentSlot_ReturnsNull()
+        => InFlightScriptMap.TryGet("[]", Slot(7)).ShouldBeNull();
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("not json at all")]
-    [InlineData("{ broken")]
-    public void EmptyOrMalformedJson_TreatedAsEmpty(string json)
+    [InlineData("[ broken")]
+    [InlineData("{\"11\":\"legacy-machine-keyed-ticket\"}")]
+    public void EmptyMalformedOrLegacyJson_TreatedAsEmpty(string json)
     {
-        // The resume path must never crash on a blank/corrupt column — it falls
+        // The resume path must never crash on a blank/corrupt column — nor on a row
+        // written in the OLD machine-keyed object shape by an older server. All fall
         // back to "no in-flight script", i.e. re-dispatch fresh.
-        InFlightScriptMap.TryGet(json, 7).ShouldBeNull();
-        InFlightScriptMap.Add(json, 7, "ticket-a").ShouldContain("ticket-a");
+        InFlightScriptMap.TryGet(json, Slot(7)).ShouldBeNull();
+        InFlightScriptMap.Add(json, Slot(7), "ticket-a").ShouldContain("ticket-a");
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
@@ -5,14 +5,15 @@ namespace Squid.UnitTests.Services.Deployments.Checkpoints;
 /// <summary>
 /// Unit tests for <see cref="InFlightScriptMap"/> — the pure add/remove/lookup
 /// over the checkpoint's in-flight-scripts JSON, keyed by <see cref="DispatchSlot"/>
-/// (machine + step + action). Pins round-trip correctness, the dispatch-scoped
-/// independence that keeps two parallel steps on ONE machine from colliding, and
-/// the defensive empty/malformed handling the resume path relies on.
+/// (machine + stable step-id + stable action-id). Pins round-trip correctness, the
+/// dispatch-scoped independence that keeps two parallel steps on ONE machine from
+/// colliding, and the defensive empty/malformed/legacy handling the resume path
+/// relies on.
 /// </summary>
 public class InFlightScriptMapTests
 {
-    private static DispatchSlot Slot(int machineId, string step = "Step1", string action = "Action1")
-        => new(machineId, step, action);
+    private static DispatchSlot Slot(int machineId, int stepId = 1, int actionId = 1)
+        => new(machineId, stepId, actionId);
 
     [Fact]
     public void Add_OnEmpty_CreatesSingleEntry()
@@ -44,42 +45,44 @@ public class InFlightScriptMapTests
     }
 
     [Fact]
-    public void Add_SameMachineDifferentSteps_AreIndependent()
+    public void Add_SameMachineDifferentActions_AreIndependent()
     {
         // The headline guarantee: two StartWithPrevious steps dispatched in parallel
-        // to the SAME machine each get their OWN in-flight slot. The machine-only key
-        // this replaced would have made the second dispatch overwrite (and re-attach
-        // to) the first's ticket — silently skipping the second step's script.
-        var json = InFlightScriptMap.Add("[]", Slot(7, "StepA", "ActionA"), "ticket-a");
-        json = InFlightScriptMap.Add(json, Slot(7, "StepB", "ActionB"), "ticket-b");
+        // to the SAME machine each get their OWN in-flight slot, keyed by the stable
+        // action id. The machine-only key this replaced would have made the second
+        // dispatch overwrite (and re-attach to) the first's ticket — silently
+        // skipping the second step's script.
+        var json = InFlightScriptMap.Add("[]", Slot(7, stepId: 10, actionId: 100), "ticket-a");
+        json = InFlightScriptMap.Add(json, Slot(7, stepId: 20, actionId: 200), "ticket-b");
 
-        InFlightScriptMap.TryGet(json, Slot(7, "StepA", "ActionA")).ShouldBe("ticket-a");
-        InFlightScriptMap.TryGet(json, Slot(7, "StepB", "ActionB")).ShouldBe("ticket-b",
-            customMessage: "A second dispatch to the same machine (different step/action) MUST get its own slot, not collide with the first.");
+        InFlightScriptMap.TryGet(json, Slot(7, stepId: 10, actionId: 100)).ShouldBe("ticket-a");
+        InFlightScriptMap.TryGet(json, Slot(7, stepId: 20, actionId: 200)).ShouldBe("ticket-b",
+            customMessage: "A second dispatch to the same machine (different action id) MUST get its own slot, not collide with the first.");
     }
 
     [Fact]
-    public void TryGet_SameMachineDifferentAction_DoesNotMatchSiblingSlot()
+    public void TryGet_SameMachineDifferentActionId_DoesNotMatchSiblingSlot()
     {
-        // The reattach probe for StepB MUST NOT find StepA's ticket just because they
-        // target the same machine — that is exactly the cross-reattach this fixes.
-        var json = InFlightScriptMap.Add("[]", Slot(7, "StepA", "ActionA"), "ticket-a");
+        // The reattach probe for action 200 MUST NOT find action 100's ticket just
+        // because they target the same machine — that is exactly the cross-reattach
+        // this fixes. Display names are irrelevant; only the id matters.
+        var json = InFlightScriptMap.Add("[]", Slot(7, stepId: 10, actionId: 100), "ticket-a");
 
-        InFlightScriptMap.TryGet(json, Slot(7, "StepB", "ActionB")).ShouldBeNull(
-            customMessage: "StepB's reattach probe must not match StepA's slot on the same machine.");
+        InFlightScriptMap.TryGet(json, Slot(7, stepId: 20, actionId: 200)).ShouldBeNull(
+            customMessage: "Action 200's reattach probe must not match action 100's slot on the same machine.");
     }
 
     [Fact]
     public void Remove_DropsOnlyThatSlot()
     {
-        var json = InFlightScriptMap.Add("[]", Slot(7, "StepA", "ActionA"), "ticket-a");
-        json = InFlightScriptMap.Add(json, Slot(7, "StepB", "ActionB"), "ticket-b");
+        var json = InFlightScriptMap.Add("[]", Slot(7, stepId: 10, actionId: 100), "ticket-a");
+        json = InFlightScriptMap.Add(json, Slot(7, stepId: 20, actionId: 200), "ticket-b");
         json = InFlightScriptMap.Add(json, Slot(9), "ticket-c");
 
-        json = InFlightScriptMap.Remove(json, Slot(7, "StepA", "ActionA"));
+        json = InFlightScriptMap.Remove(json, Slot(7, stepId: 10, actionId: 100));
 
-        InFlightScriptMap.TryGet(json, Slot(7, "StepA", "ActionA")).ShouldBeNull();
-        InFlightScriptMap.TryGet(json, Slot(7, "StepB", "ActionB")).ShouldBe("ticket-b",
+        InFlightScriptMap.TryGet(json, Slot(7, stepId: 10, actionId: 100)).ShouldBeNull();
+        InFlightScriptMap.TryGet(json, Slot(7, stepId: 20, actionId: 200)).ShouldBe("ticket-b",
             customMessage: "Clearing one slot MUST NOT drop a sibling slot on the same machine.");
         InFlightScriptMap.TryGet(json, Slot(9)).ShouldBe("ticket-c");
     }
@@ -105,11 +108,13 @@ public class InFlightScriptMapTests
     [InlineData("not json at all")]
     [InlineData("[ broken")]
     [InlineData("{\"11\":\"legacy-machine-keyed-ticket\"}")]
+    [InlineData("[{\"m\":7,\"s\":\"StepA\",\"a\":\"ActionA\",\"t\":\"legacy-name-keyed\"}]")]
     public void EmptyMalformedOrLegacyJson_TreatedAsEmpty(string json)
     {
         // The resume path must never crash on a blank/corrupt column — nor on a row
-        // written in the OLD machine-keyed object shape by an older server. All fall
-        // back to "no in-flight script", i.e. re-dispatch fresh.
+        // written in an older shape (the machine-keyed object, or the interim
+        // name-keyed list whose s/a are strings not ints). All fall back to "no
+        // in-flight script", i.e. re-dispatch fresh.
         InFlightScriptMap.TryGet(json, Slot(7)).ShouldBeNull();
         InFlightScriptMap.Add(json, Slot(7), "ticket-a").ShouldContain("ticket-a");
     }


### PR DESCRIPTION
## Summary

- A parallel `StartWithPrevious` batch dispatches its steps concurrently (`Task.WhenAll`). When two steps share a target machine, both call `DispatchOrReattachAsync` for the same `(task, machine)` at once. The in-flight reattach store ([`InFlightScriptStore`](src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs)) was keyed by `(serverTaskId, machineId)` only, so the second dispatch's reattach probe found the first's just-recorded ticket and "skipped duplicate dispatch" — silently running the first step's script instead of its own, with the losing observer returning exit `-1` and failing the deployment. Record-before-RPC (#431) widened the window by persisting the ticket before `StartScript`.
- Fix: key the in-flight slot by the **dispatch unit** via a new `DispatchSlot(MachineId, StepId, ActionId)`. It keys on the **stable, process-unique step/action ids** — NOT display names, which carry no uniqueness constraint (the schema enforces unique `step_order`/`action_order` only, so two identically-named steps would otherwise re-collapse to one slot). The ids come from the frozen process snapshot, so they are identical across a crash→resume; threaded onto `ScriptExecutionRequest` and attached post-render at the single dispatch site (alongside the existing masker attach).
- Concurrent dispatches to one machine now stay independent — live and on resume each re-attaches only to its OWN ticket. The checkpoint JSON moves from a machine-keyed object to a `{m,s,a,t}` list; older/interim shapes deserialise to empty (the documented re-dispatch fail-safe), so it is **non-breaking**.
- This is the real bug behind the flaky `StepBatcherParallelE2ETests` (two `StartWithPrevious` steps on one agent): with the slot fix both steps run their own script, the deployment succeeds, and the agent-side execution intervals overlap deterministically. The E2E also now proves overlap from agent-clock timestamps emitted via a `date` format string (immune to the JSON action-property round-trip) instead of a flaky total-wall-clock ceiling.

## Test plan

- [x] Unit (5986/5986): `InFlightScriptMapTests` — same-machine/different-action-id independence, sibling-slot non-match, legacy machine-keyed + interim name-keyed shapes tolerated as empty
- [x] Integration (real Postgres): `InFlightScriptStoreTests` dispatch-scoped independence + concurrent same-machine record; `HalibutResumeReattachTests.ConcurrentDispatch_SameMachineIdenticallyNamedSteps_…` — deterministic two-concurrent-dispatch regression with TWO identically-named steps differing only by id (a gate parks step A's RPC until step B has dispatched), proving no cross-reattach, `StartScriptCalls == 2`
- [x] E2E (K8s Pipeline): `StepBatcherParallelE2ETests` two `StartWithPrevious` steps on one agent → Success + overlapping intervals
- [x] Full unit suite green; non-breaking (transient checkpoint column, fail-safe handles old shapes)
- [x] Adversarial multi-agent review (concurrency / resume / non-breaking / completeness) — the name-vs-id finding drove the id-keying