### PR TITLE
Encrypt DeploymentAccount.Credentials at rest

### DIFF
--- a/src/Squid.Core/Services/Deployments/Account/DeploymentAccountDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/Account/DeploymentAccountDataProvider.cs
@@ -1,5 +1,7 @@
+using Microsoft.EntityFrameworkCore;
 using Squid.Core.Persistence.Db;
 using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Security;
 
 namespace Squid.Core.Services.Deployments.Account;
 
@@ -14,15 +16,41 @@ public interface IDeploymentAccountDataProvider : IScopedDependency
     Task<(int count, List<DeploymentAccount>)> GetAccountPagingAsync(int? spaceId = null, int? pageIndex = null, int? pageSize = null, CancellationToken cancellationToken = default);
 }
 
-public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork unitOfWork) : IDeploymentAccountDataProvider
+/// <summary>
+/// Owns at-rest protection of <see cref="DeploymentAccount.Credentials"/> — the most
+/// sensitive secret store in the system (every account type's token / password / cloud
+/// secret / SSH private key). This is the single seam every account read and write
+/// funnels through, so encrypting here covers the deploy pipeline, the OpenClaw paths,
+/// and the account service transparently — mirroring how <c>VariableDataProvider</c>
+/// protects the <c>Variable</c> table.
+///
+/// <para>Read-both / non-breaking: <see cref="IVariableEncryptionService.EncryptAsync"/>
+/// always emits the <c>SQUID_ENCRYPTED_V2:</c> envelope; <c>DecryptAsync</c> returns any
+/// value lacking that prefix verbatim, so pre-existing plaintext rows still load and
+/// upgrade naturally on the next save. Reads use the repository's AsNoTracking query so
+/// decrypting the in-memory entity can never be flushed back to the DB as plaintext.</para>
+/// </summary>
+public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork unitOfWork, IVariableEncryptionService encryption) : IDeploymentAccountDataProvider
 {
+    // The V2 envelope derives its key from a random per-payload salt, so the legacy
+    // KDF-scope argument (a V1-only deterministic-salt input) is irrelevant for accounts,
+    // which only ever write V2. Pass a constant.
+    private const int CredentialsKdfScope = 0;
+
     public async Task<DeploymentAccount> GetAccountByIdAsync(int accountId, CancellationToken cancellationToken = default)
     {
-        return await repository.GetByIdAsync<DeploymentAccount>(accountId, cancellationToken).ConfigureAwait(false);
+        // AsNoTracking (via Query) so the decrypt below mutates a detached entity — a
+        // tracked entity would risk a later in-scope SaveChanges flushing plaintext back.
+        var account = await repository.Query<DeploymentAccount>(a => a.Id == accountId)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        return await DecryptCredentialsAsync(account).ConfigureAwait(false);
     }
 
     public async Task<DeploymentAccount> AddAccountAsync(DeploymentAccount account, bool forceSave = true, CancellationToken cancellationToken = default)
     {
+        EncryptCredentials(account);
+
         await repository.InsertAsync(account, cancellationToken).ConfigureAwait(false);
 
         if (forceSave) await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -32,6 +60,8 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
 
     public async Task UpdateAccountAsync(DeploymentAccount account, bool forceSave = true, CancellationToken cancellationToken = default)
     {
+        EncryptCredentials(account);
+
         await repository.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
 
         if (forceSave) await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -46,16 +76,20 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
 
     public async Task<List<DeploymentAccount>> GetAccountsByIdsAsync(List<int> ids, CancellationToken cancellationToken = default)
     {
-        return await repository.Query<DeploymentAccount>()
+        var accounts = await repository.Query<DeploymentAccount>()
             .Where(a => ids.Contains(a.Id))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return await DecryptCredentialsAsync(accounts).ConfigureAwait(false);
     }
 
     public async Task<List<DeploymentAccount>> GetAccountsBySpaceIdAsync(int spaceId, CancellationToken cancellationToken = default)
     {
-        return await repository.Query<DeploymentAccount>()
+        var accounts = await repository.Query<DeploymentAccount>()
             .Where(a => a.SpaceId == spaceId)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return await DecryptCredentialsAsync(accounts).ConfigureAwait(false);
     }
 
     public async Task<(int count, List<DeploymentAccount>)> GetAccountPagingAsync(int? spaceId = null, int? pageIndex = null, int? pageSize = null, CancellationToken cancellationToken = default)
@@ -70,7 +104,36 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
         if (pageIndex.HasValue && pageSize.HasValue)
             query = query.Skip((pageIndex.Value - 1) * pageSize.Value).Take(pageSize.Value);
 
-        return (count, await query.ToListAsync(cancellationToken).ConfigureAwait(false));
+        var accounts = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return (count, await DecryptCredentialsAsync(accounts).ConfigureAwait(false));
+    }
+
+    // Encrypt only if not already an envelope — idempotent, so a re-save (or a value that
+    // somehow arrives pre-encrypted) never double-wraps.
+    private void EncryptCredentials(DeploymentAccount account)
+    {
+        if (account == null || string.IsNullOrEmpty(account.Credentials)) return;
+        if (encryption.IsValidEncryptedValue(account.Credentials)) return;
+
+        account.Credentials = encryption.EncryptAsync(account.Credentials, CredentialsKdfScope);
+    }
+
+    private async Task<DeploymentAccount> DecryptCredentialsAsync(DeploymentAccount account)
+    {
+        if (account == null || string.IsNullOrEmpty(account.Credentials)) return account;
+
+        // Read-both: a plaintext (unprefixed) value is returned verbatim by DecryptAsync.
+        account.Credentials = await encryption.DecryptAsync(account.Credentials, CredentialsKdfScope).ConfigureAwait(false);
+
+        return account;
+    }
+
+    private async Task<List<DeploymentAccount>> DecryptCredentialsAsync(List<DeploymentAccount> accounts)
+    {
+        foreach (var account in accounts)
+            await DecryptCredentialsAsync(account).ConfigureAwait(false);
+
+        return accounts;
     }
 }
-

--- a/src/Squid.Core/Services/Deployments/Account/DeploymentAccountDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/Account/DeploymentAccountDataProvider.cs
@@ -39,9 +39,10 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
 
     public async Task<DeploymentAccount> GetAccountByIdAsync(int accountId, CancellationToken cancellationToken = default)
     {
-        // AsNoTracking (via Query) so the decrypt below mutates a detached entity — a
-        // tracked entity would risk a later in-scope SaveChanges flushing plaintext back.
-        var account = await repository.Query<DeploymentAccount>(a => a.Id == accountId)
+        // QueryNoTracking so the decrypt below mutates a DETACHED entity — a tracked entity
+        // would be detected as Modified and a later in-scope SaveChanges (the deploy pipeline
+        // shares one DbContext across phases) would flush the plaintext back to the column.
+        var account = await repository.QueryNoTracking<DeploymentAccount>(a => a.Id == accountId)
             .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
         return await DecryptCredentialsAsync(account).ConfigureAwait(false);
@@ -76,7 +77,7 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
 
     public async Task<List<DeploymentAccount>> GetAccountsByIdsAsync(List<int> ids, CancellationToken cancellationToken = default)
     {
-        var accounts = await repository.Query<DeploymentAccount>()
+        var accounts = await repository.QueryNoTracking<DeploymentAccount>()
             .Where(a => ids.Contains(a.Id))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -85,7 +86,7 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
 
     public async Task<List<DeploymentAccount>> GetAccountsBySpaceIdAsync(int spaceId, CancellationToken cancellationToken = default)
     {
-        var accounts = await repository.Query<DeploymentAccount>()
+        var accounts = await repository.QueryNoTracking<DeploymentAccount>()
             .Where(a => a.SpaceId == spaceId)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -94,7 +95,7 @@ public class DeploymentAccountDataProvider(IRepository repository, IUnitOfWork u
 
     public async Task<(int count, List<DeploymentAccount>)> GetAccountPagingAsync(int? spaceId = null, int? pageIndex = null, int? pageSize = null, CancellationToken cancellationToken = default)
     {
-        var query = repository.Query<DeploymentAccount>();
+        var query = repository.QueryNoTracking<DeploymentAccount>();
 
         if (spaceId.HasValue)
             query = query.Where(a => a.SpaceId == spaceId.Value);

--- a/src/Squid.Core/Services/Deployments/Account/DeploymentAccountService.cs
+++ b/src/Squid.Core/Services/Deployments/Account/DeploymentAccountService.cs
@@ -34,9 +34,11 @@ public class DeploymentAccountService(IDeploymentAccountDataProvider dataProvide
 
         await dataProvider.AddAccountAsync(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
 
+        // entity.Credentials is encrypted-at-rest by the provider on write, so build the
+        // response summary from the plaintext credentials we already deserialized.
         return new CreateDeploymentAccountResponseData
         {
-            DeploymentAccount = MapToDto(entity)
+            DeploymentAccount = MapToDto(entity, credentials)
         };
     }
 
@@ -61,11 +63,16 @@ public class DeploymentAccountService(IDeploymentAccountDataProvider dataProvide
             ? DeploymentAccountCredentialsConverter.Serialize(incoming)
             : entity.Credentials;
 
+        // Capture the plaintext credentials for the response BEFORE the provider encrypts
+        // entity.Credentials on write (the loaded entity arrives decrypted; a null incoming
+        // means we keep — and re-report — the existing credentials).
+        var summaryCredentials = DeploymentAccountCredentialsConverter.Deserialize(entity.AccountType, entity.Credentials);
+
         await dataProvider.UpdateAccountAsync(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return new UpdateDeploymentAccountResponseData
         {
-            DeploymentAccount = MapToDto(entity)
+            DeploymentAccount = MapToDto(entity, summaryCredentials)
         };
     }
 
@@ -91,15 +98,16 @@ public class DeploymentAccountService(IDeploymentAccountDataProvider dataProvide
             Data = new GetDeploymentAccountsResponseData
             {
                 Count = count,
-                DeploymentAccounts = data.Select(MapToDto).ToList()
+                // Provider returns decrypted entities, so entity.Credentials is plaintext here.
+                DeploymentAccounts = data
+                    .Select(e => MapToDto(e, DeploymentAccountCredentialsConverter.Deserialize(e.AccountType, e.Credentials)))
+                    .ToList()
             }
         };
     }
 
-    private static DeploymentAccountDto MapToDto(DeploymentAccount entity)
+    private static DeploymentAccountDto MapToDto(DeploymentAccount entity, object creds)
     {
-        var creds = DeploymentAccountCredentialsConverter.Deserialize(entity.AccountType, entity.Credentials);
-
         return new DeploymentAccountDto
         {
             Id = entity.Id,

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/DeploymentHistoryE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/DeploymentHistoryE2ETests.cs
@@ -1,4 +1,5 @@
 using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.Account;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Script;
@@ -96,9 +97,9 @@ public class DeploymentHistoryE2ETests : IClassFixture<DeploymentPipelineFixture
     {
         var serverTaskId = 0;
 
-        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        await _fixture.Run<IRepository, IUnitOfWork, IDeploymentAccountDataProvider>(async (repository, unitOfWork, accountDataProvider) =>
         {
-            var seeder = new K8sTestDataSeeder(repository, unitOfWork);
+            var seeder = new K8sTestDataSeeder(repository, unitOfWork, accountDataProvider);
             await seeder.SeedAsync(createFeedSecrets: false).ConfigureAwait(false);
             serverTaskId = seeder.ServerTaskId;
         }).ConfigureAwait(false);

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesContainersDeployE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesContainersDeployE2ETests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.Account;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.Deployments.DeploymentCompletions;
 using Squid.Core.Services.Deployments.ServerTask;
@@ -276,9 +277,9 @@ public class KubernetesContainersDeployE2ETests
 
         var serverTaskId = 0;
 
-        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        await _fixture.Run<IRepository, IUnitOfWork, IDeploymentAccountDataProvider>(async (repository, unitOfWork, accountDataProvider) =>
         {
-            var seeder = new K8sTestDataSeeder(repository, unitOfWork);
+            var seeder = new K8sTestDataSeeder(repository, unitOfWork, accountDataProvider);
             await seeder.SeedAsync(createFeedSecrets, replicas, testNs, communicationStyle).ConfigureAwait(false);
             serverTaskId = seeder.ServerTaskId;
         }).ConfigureAwait(false);

--- a/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesCredentialTypeE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Kubernetes/Pipeline/KubernetesCredentialTypeE2ETests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.Account;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.Deployments.Certificates;
@@ -98,9 +99,9 @@ public class KubernetesCredentialTypeE2ETests
     {
         var serverTaskId = 0;
 
-        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        await _fixture.Run<IRepository, IUnitOfWork, IDeploymentAccountDataProvider>(async (repository, unitOfWork, accountDataProvider) =>
         {
-            var seeder = new K8sTestDataSeeder(repository, unitOfWork);
+            var seeder = new K8sTestDataSeeder(repository, unitOfWork, accountDataProvider);
 
             await seeder.SeedAsync(
                 createFeedSecrets: false,
@@ -122,9 +123,9 @@ public class KubernetesCredentialTypeE2ETests
         var accountId = 0;
         var certName = $"E2E Cluster CA {Guid.NewGuid().ToString("N")[..6]}";
 
-        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        await _fixture.Run<IRepository, IUnitOfWork, IDeploymentAccountDataProvider>(async (repository, unitOfWork, accountDataProvider) =>
         {
-            var seeder = new K8sTestDataSeeder(repository, unitOfWork);
+            var seeder = new K8sTestDataSeeder(repository, unitOfWork, accountDataProvider);
 
             await seeder.SeedAsync(
                 createFeedSecrets: false,

--- a/tests/Squid.E2ETests/Helpers/K8sTestDataSeeder.cs
+++ b/tests/Squid.E2ETests/Helpers/K8sTestDataSeeder.cs
@@ -16,16 +16,18 @@ public class K8sTestDataSeeder
 {
     private readonly IRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IDeploymentAccountDataProvider _accountDataProvider;
     private readonly TestDataBuilder _builder;
 
     public int ServerTaskId { get; private set; }
     public int AccountId { get; private set; }
     public int MachineId { get; private set; }
 
-    public K8sTestDataSeeder(IRepository repository, IUnitOfWork unitOfWork)
+    public K8sTestDataSeeder(IRepository repository, IUnitOfWork unitOfWork, IDeploymentAccountDataProvider accountDataProvider)
     {
         _repository = repository;
         _unitOfWork = unitOfWork;
+        _accountDataProvider = accountDataProvider;
         _builder = new TestDataBuilder(repository, unitOfWork);
     }
 
@@ -256,8 +258,9 @@ public class K8sTestDataSeeder
             Credentials = DeploymentAccountCredentialsConverter.Serialize(creds)
         };
 
-        await _repository.InsertAsync(account, ct).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(ct).ConfigureAwait(false);
+        // Route through the encrypting provider so E2E exercises the at-rest-encrypted
+        // credential path (write encrypted → pipeline reads + decrypts), matching production.
+        await _accountDataProvider.AddAccountAsync(account, cancellationToken: ct).ConfigureAwait(false);
 
         return account.Id;
     }

--- a/tests/Squid.E2ETests/Infrastructure/E2EFixtureBase.cs
+++ b/tests/Squid.E2ETests/Infrastructure/E2EFixtureBase.cs
@@ -103,6 +103,12 @@ public class E2EFixtureBase<TTestClass> : IAsyncLifetime
         await action(scope.Resolve<T1>(), scope.Resolve<T2>()).ConfigureAwait(false);
     }
 
+    public async Task Run<T1, T2, T3>(Func<T1, T2, T3, Task> action)
+    {
+        await using var scope = LifetimeScope.BeginLifetimeScope();
+        await action(scope.Resolve<T1>(), scope.Resolve<T2>(), scope.Resolve<T3>()).ConfigureAwait(false);
+    }
+
     public async Task<TR> Run<T, TR>(Func<T, Task<TR>> action)
     {
         await using var scope = LifetimeScope.BeginLifetimeScope();

--- a/tests/Squid.IntegrationTests/Services/Account/IntegrationAccountCredentialsAtRest.cs
+++ b/tests/Squid.IntegrationTests/Services/Account/IntegrationAccountCredentialsAtRest.cs
@@ -1,0 +1,140 @@
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Account;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Account;
+
+namespace Squid.IntegrationTests.Services.Account;
+
+/// <summary>
+/// End-to-end (real Postgres + real EF + real <see cref="Squid.Core.Services.Security.IVariableEncryptionService"/>
+/// with the test MasterKey) coverage of at-rest encryption for
+/// <see cref="DeploymentAccount.Credentials"/> through the real
+/// <see cref="IDeploymentAccountDataProvider"/> seam:
+/// <list type="bullet">
+///   <item>a written account's RAW DB column carries the <c>SQUID_ENCRYPTED_V2:</c>
+///         envelope and never the cleartext secret;</item>
+///   <item>reading it back through the provider decrypts transparently;</item>
+///   <item>a pre-existing PLAINTEXT row (hand-inserted, bypassing the provider) still
+///         reads back verbatim — the read-both / zero-migration guarantee;</item>
+///   <item>an update re-encrypts.</item>
+/// </list>
+/// </summary>
+public class IntegrationAccountCredentialsAtRest : TestBase
+{
+    private const string Secret = "top-secret-token-9c3f-VALUE";
+
+    public IntegrationAccountCredentialsAtRest()
+        : base("AccountCredentialsAtRest", "squid_it_account_creds_atrest")
+    {
+    }
+
+    [Fact]
+    public async Task Create_StoresCredentialsEncrypted_AndReadsBackDecrypted()
+    {
+        var plaintextJson = DeploymentAccountCredentialsConverter.Serialize(new TokenCredentials { Token = Secret });
+
+        var id = await Run<IDeploymentAccountDataProvider, int>(async provider =>
+        {
+            var account = await provider.AddAccountAsync(NewAccount(plaintextJson)).ConfigureAwait(false);
+            return account.Id;
+        }).ConfigureAwait(false);
+
+        // Raw column read via the repository directly (NOT the provider → no decrypt).
+        await Run<IRepository>(async repository =>
+        {
+            var raw = await repository.Query<DeploymentAccount>(a => a.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
+
+            raw.ShouldNotBeNull();
+            raw.Credentials.ShouldStartWith("SQUID_ENCRYPTED_V2:",
+                customMessage: "the persisted credentials column must be a V2 envelope, never cleartext");
+            raw.Credentials.ShouldNotContain(Secret,
+                customMessage: "the secret must not survive verbatim in the DB column");
+        }).ConfigureAwait(false);
+
+        // Through the provider → decrypted transparently.
+        await Run<IDeploymentAccountDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetAccountByIdAsync(id).ConfigureAwait(false);
+
+            loaded.ShouldNotBeNull();
+            loaded.Credentials.ShouldBe(plaintextJson, customMessage: "the provider must decrypt on read");
+
+            var creds = DeploymentAccountCredentialsConverter.Deserialize(AccountType.Token, loaded.Credentials) as TokenCredentials;
+            creds.ShouldNotBeNull();
+            creds.Token.ShouldBe(Secret);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task LegacyPlaintextRow_ReadsBack_NonBreaking()
+    {
+        // Hand-insert a row with PLAINTEXT credentials (bypassing the encrypting provider)
+        // to simulate data written before this feature shipped.
+        var plaintextJson = DeploymentAccountCredentialsConverter.Serialize(new TokenCredentials { Token = Secret });
+
+        var id = 0;
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var account = NewAccount(plaintextJson);
+            await repository.InsertAsync(account).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+            id = account.Id;
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentAccountDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetAccountByIdAsync(id).ConfigureAwait(false);
+
+            loaded.ShouldNotBeNull();
+            loaded.Credentials.ShouldBe(plaintextJson,
+                customMessage: "read-both: a pre-existing plaintext row must read back verbatim with no error");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task Update_ReEncryptsCredentials()
+    {
+        const string newSecret = "rotated-secret-7b21-VALUE";
+        var originalJson = DeploymentAccountCredentialsConverter.Serialize(new TokenCredentials { Token = Secret });
+        var rotatedJson = DeploymentAccountCredentialsConverter.Serialize(new TokenCredentials { Token = newSecret });
+
+        var id = await Run<IDeploymentAccountDataProvider, int>(async provider =>
+        {
+            var account = await provider.AddAccountAsync(NewAccount(originalJson)).ConfigureAwait(false);
+            return account.Id;
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentAccountDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetAccountByIdAsync(id).ConfigureAwait(false);   // decrypted
+            loaded.Credentials = rotatedJson;                                            // plaintext rotation
+            await provider.UpdateAccountAsync(loaded).ConfigureAwait(false);             // re-encrypts
+        }).ConfigureAwait(false);
+
+        await Run<IRepository>(async repository =>
+        {
+            var raw = await repository.Query<DeploymentAccount>(a => a.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
+
+            raw.Credentials.ShouldStartWith("SQUID_ENCRYPTED_V2:");
+            raw.Credentials.ShouldNotContain(newSecret);
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentAccountDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetAccountByIdAsync(id).ConfigureAwait(false);
+            loaded.Credentials.ShouldBe(rotatedJson, customMessage: "the rotated secret must decrypt back after update");
+        }).ConfigureAwait(false);
+    }
+
+    private static DeploymentAccount NewAccount(string credentialsJson) => new()
+    {
+        SpaceId = 1,
+        Name = $"at-rest-{Guid.NewGuid():N}"[..20],
+        Slug = $"account-{Guid.NewGuid():N}",
+        AccountType = AccountType.Token,
+        Credentials = credentialsJson,
+        EnvironmentIds = null
+    };
+}

--- a/tests/Squid.IntegrationTests/Services/Account/IntegrationAccountCredentialsAtRest.cs
+++ b/tests/Squid.IntegrationTests/Services/Account/IntegrationAccountCredentialsAtRest.cs
@@ -94,6 +94,38 @@ public class IntegrationAccountCredentialsAtRest : TestBase
     }
 
     [Fact]
+    public async Task ReadThenUnrelatedSaveInSameScope_DoesNotFlushPlaintextBack()
+    {
+        // Reproduces the production scope shape: the deploy pipeline loads + decrypts the
+        // account in one phase, then a LATER phase calls SaveChanges on the SAME scoped
+        // DbContext. If the read TRACKED the entity, the in-place decrypt would be detected
+        // as a modification and flushed back as plaintext — silently un-encrypting the most
+        // sensitive column in the system on the first deployment. The read must not track.
+        var plaintextJson = DeploymentAccountCredentialsConverter.Serialize(new TokenCredentials { Token = Secret });
+
+        var id = await Run<IDeploymentAccountDataProvider, int>(async provider =>
+            (await provider.AddAccountAsync(NewAccount(plaintextJson)).ConfigureAwait(false)).Id).ConfigureAwait(false);
+
+        // One shared scope/DbContext: load+decrypt the account, then an unrelated SaveChanges.
+        await Run<IDeploymentAccountDataProvider, IUnitOfWork>(async (provider, unitOfWork) =>
+        {
+            var loaded = await provider.GetAccountByIdAsync(id).ConfigureAwait(false);
+            loaded.Credentials.ShouldBe(plaintextJson, customMessage: "decrypted in memory");
+
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);   // DetectChanges flushes the whole tracker
+        }).ConfigureAwait(false);
+
+        // Fresh scope: the persisted column must STILL be the encrypted envelope.
+        await Run<IRepository>(async repository =>
+        {
+            var raw = await repository.Query<DeploymentAccount>(a => a.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
+
+            raw.Credentials.ShouldStartWith("SQUID_ENCRYPTED_V2:",
+                customMessage: "a read+decrypt followed by an unrelated SaveChanges in the same scope must NOT flush plaintext back — reads must be AsNoTracking");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
     public async Task Update_ReEncryptsCredentials()
     {
         const string newSecret = "rotated-secret-7b21-VALUE";

--- a/tests/Squid.UnitTests/Services/Deployments/Account/DeploymentAccountCredentialsEncryptionTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Account/DeploymentAccountCredentialsEncryptionTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+using Squid.Core.Services.Deployments.Account;
+using Squid.Core.Services.Security;
+using Squid.Core.Settings.Security;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Account;
+using Xunit;
+
+namespace Squid.UnitTests.Services.Deployments.Account;
+
+/// <summary>
+/// Pins the crypto contract that <see cref="DeploymentAccountDataProvider"/> relies on to
+/// protect <see cref="Squid.Core.Persistence.Entities.Deployments.DeploymentAccount.Credentials"/>
+/// at rest: every account type's serialized credentials JSON round-trips through the
+/// <c>SQUID_ENCRYPTED_V2:</c> envelope with the secret intact, a pre-existing PLAINTEXT
+/// value passes straight through on read (the read-both / non-breaking guarantee), and a
+/// tampered ciphertext is rejected by the GCM tag.
+///
+/// <para>The provider wraps the WHOLE serialized blob, so this exercises the realistic
+/// payloads — large GCP JSON keys, multi-line SSH private keys, cloud secrets.</para>
+/// </summary>
+public sealed class DeploymentAccountCredentialsEncryptionTests
+{
+    [Theory]
+    [MemberData(nameof(EveryAccountTypeWithSecrets))]
+    public async Task SerializedCredentials_RoundTripThroughEnvelope_SecretIntact(AccountType accountType, object credentials)
+    {
+        var encryption = MakeEncryptionService();
+        var plaintextJson = DeploymentAccountCredentialsConverter.Serialize(credentials);
+
+        var stored = encryption.EncryptAsync(plaintextJson, variableSetId: 0);
+
+        stored.ShouldStartWith("SQUID_ENCRYPTED_V2:", customMessage: "the at-rest column value must be a V2 envelope, never cleartext");
+        encryption.IsValidEncryptedValue(stored).ShouldBeTrue();
+        stored.ShouldNotContain("super-secret", customMessage: "no secret material may survive verbatim in the envelope");
+
+        var roundTripped = await encryption.DecryptAsync(stored, variableSetId: 0).ConfigureAwait(false);
+
+        roundTripped.ShouldBe(plaintextJson);
+        // And the decrypted JSON still deserializes back to credentials with the secret present.
+        DeploymentAccountCredentialsConverter.Serialize(
+            DeploymentAccountCredentialsConverter.Deserialize(accountType, roundTripped)).ShouldBe(plaintextJson);
+    }
+
+    [Fact]
+    public async Task LegacyPlaintextValue_ReadsBackVerbatim_NonBreaking()
+    {
+        // A row written before this feature has no envelope prefix. The read path must
+        // return it untouched so existing accounts keep working with zero migration.
+        var encryption = MakeEncryptionService();
+        var legacyPlaintext = DeploymentAccountCredentialsConverter.Serialize(new TokenCredentials { Token = "super-secret-token" });
+
+        encryption.IsValidEncryptedValue(legacyPlaintext).ShouldBeFalse(
+            customMessage: "plaintext JSON must NOT be mistaken for an envelope (it has no SQUID_ENCRYPTED prefix)");
+
+        (await encryption.DecryptAsync(legacyPlaintext, variableSetId: 0).ConfigureAwait(false))
+            .ShouldBe(legacyPlaintext, customMessage: "read-both: an unprefixed value is returned verbatim");
+    }
+
+    [Fact]
+    public async Task AlreadyEncryptedValue_IsDetected_SoTheProviderNeverDoubleWraps()
+    {
+        // The provider's encrypt-on-write is guarded by IsValidEncryptedValue so a re-save
+        // never wraps an envelope inside another envelope.
+        var encryption = MakeEncryptionService();
+        var once = encryption.EncryptAsync("{\"token\":\"super-secret\"}", variableSetId: 0);
+
+        encryption.IsValidEncryptedValue(once).ShouldBeTrue();
+
+        // Decrypting the once-encrypted value yields the original (not a second envelope).
+        (await encryption.DecryptAsync(once, variableSetId: 0).ConfigureAwait(false))
+            .ShouldBe("{\"token\":\"super-secret\"}");
+    }
+
+    [Fact]
+    public async Task TamperedCiphertext_IsRejected()
+    {
+        var encryption = MakeEncryptionService();
+        var stored = encryption.EncryptAsync("{\"secretKey\":\"super-secret\"}", variableSetId: 0);
+
+        // Flip a byte in the base64 body — GCM tag authentication must reject it.
+        var body = stored["SQUID_ENCRYPTED_V2:".Length..].ToCharArray();
+        body[^2] = body[^2] == 'A' ? 'B' : 'A';
+        var tampered = "SQUID_ENCRYPTED_V2:" + new string(body);
+
+        await Should.ThrowAsync<Exception>(() => encryption.DecryptAsync(tampered, variableSetId: 0));
+    }
+
+    public static IEnumerable<object[]> EveryAccountTypeWithSecrets() => new List<object[]>
+    {
+        new object[] { AccountType.Token, new TokenCredentials { Token = "super-secret-token" } },
+        new object[] { AccountType.UsernamePassword, new UsernamePasswordCredentials { Username = "svc", Password = "super-secret-pw" } },
+        new object[] { AccountType.ClientCertificate, new ClientCertificateCredentials { ClientCertificateData = "cert", ClientCertificateKeyData = "super-secret-key" } },
+        new object[] { AccountType.AmazonWebServicesAccount, new AwsCredentials { AccessKey = "AKIA", SecretKey = "super-secret-aws" } },
+        new object[] { AccountType.AmazonWebServicesRoleAccount, new AwsRoleCredentials { AccessKey = "AKIA", SecretKey = "super-secret-aws", RoleArn = "arn:aws:iam::1:role/x" } },
+        new object[] { AccountType.SshKeyPair, new SshKeyPairCredentials { Username = "deploy", PrivateKeyFile = "-----BEGIN KEY-----\nsuper-secret-line\n-----END KEY-----", PrivateKeyPassphrase = "super-secret-pass" } },
+        new object[] { AccountType.AzureServicePrincipal, new AzureServicePrincipalCredentials { SubscriptionNumber = "sub", ClientId = "cid", TenantId = "tid", Key = "super-secret-sp" } },
+        new object[] { AccountType.AzureOidc, new AzureOidcCredentials { SubscriptionNumber = "sub", ClientId = "cid", TenantId = "tid", Jwt = "super-secret-jwt" } },
+        new object[] { AccountType.GoogleCloudAccount, new GcpCredentials { JsonKey = "{\"type\":\"service_account\",\"private_key\":\"super-secret-gcp\"}" } },
+        new object[] { AccountType.AmazonWebServicesOidcAccount, new AwsOidcCredentials { RoleArn = "arn:aws:iam::1:role/x", WebIdentityToken = "super-secret-token" } },
+        new object[] { AccountType.OpenClawGateway, new OpenClawGatewayCredentials { GatewayToken = "super-secret-gw", HooksToken = "super-secret-hooks" } },
+    };
+
+    private static IVariableEncryptionService MakeEncryptionService()
+    {
+        var key = new byte[32];
+        for (var i = 0; i < key.Length; i++) key[i] = (byte)(0x40 + i);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Security:VariableEncryption:MasterKey"] = Convert.ToBase64String(key)
+            })
+            .Build();
+
+        return new VariableEncryptionService(new SecuritySetting(configuration));
+    }
+}


### PR DESCRIPTION
## Summary

- Encrypt the `DeploymentAccount.Credentials` column at rest — the system's most sensitive secret store (every account type's token / password / cloud secret / SSH private key), previously persisted as plaintext JSON.
- Do it at the single seam every account read and write funnels through, `DeploymentAccountDataProvider` (deploy pipeline, OpenClaw paths, and account service all load via it), reusing the existing `IVariableEncryptionService` V2 envelope — mirroring how `VariableDataProvider` protects the `Variable` table.
- **Non-breaking / zero migration**: read-both via the `SQUID_ENCRYPTED_V2:` prefix — a value lacking it is returned verbatim, so pre-existing plaintext rows keep working and upgrade lazily on next save. No schema change, no backfill. Encrypt-on-write is idempotent (`IsValidEncryptedValue` guard) so a re-save never double-wraps.
- Reads use the repository's AsNoTracking query so decrypting the in-memory entity can never be flushed back as plaintext; `GetAccountByIdAsync` is switched from tracking `FindAsync` to an AsNoTracking query for the same reason. `MapToDto` builds the response summary from the plaintext credentials the service already holds (the entity carries ciphertext after a write).

**Operational prerequisite:** reuses the already-configured `Security:VariableEncryption:MasterKey` — no new key source, no hardcoded default. With an unset MasterKey the envelope is cosmetic (key derived from empty input); real protection requires an operator-set key + `SQUID_MASTER_KEY_ENFORCEMENT=strict`. Key-lifecycle hardening (forcing a non-empty key in strict mode, platform-rooted derivation) is tracked separately under the SOTA-audit P5.

## Test plan

- [x] Unit (`DeploymentAccountCredentialsEncryptionTests`, 14): every account type's serialized credentials round-trips through the V2 envelope with the secret intact + never verbatim; legacy plaintext reads back verbatim (read-both); already-encrypted detection (no double-wrap); tampered ciphertext rejected by the GCM tag.
- [x] Integration (real Postgres, `IntegrationAccountCredentialsAtRest`, 3): a written account's RAW DB column carries the `SQUID_ENCRYPTED_V2:` prefix and never the cleartext secret; reads back decrypted through the provider; a hand-inserted plaintext row reads back verbatim (read-both); update re-encrypts.
- [x] Regression: 165 account-related unit tests + 19 integration tests green (incl. `DeploymentAccountServiceTests`, `EndpointContextBuilderTests`, `PrepareTargetsPhaseTests`, OpenClaw) — the MapToDto refactor + provider change are non-breaking.
- [ ] CI: the existing K8s Pipeline E2E exercises account-credential consumption end-to-end through the same `GetAccountByIdAsync` decrypt seam.