### PR TITLE
Encrypt Certificate.Password + CertificateData at rest

### DIFF
--- a/src/Squid.Core/Persistence/Db/EfRepository.cs
+++ b/src/Squid.Core/Persistence/Db/EfRepository.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Squid.Core.Persistence.Entities;
@@ -76,6 +77,13 @@ public class EfRepository : IRepository
         _dbContext.RemoveRange(entities);
         _dbContext.ShouldSaveChanges = true;
         return Task.CompletedTask;
+    }
+
+    public void Detach<TEntity>(TEntity entity) where TEntity : class, IEntity
+    {
+        if (entity == null) return;
+
+        _dbContext.Entry(entity).State = EntityState.Detached;
     }
 
     public Task<int> CountAsync<TEntity>(Expression<Func<TEntity, bool>> predicate,

--- a/src/Squid.Core/Persistence/Db/IRepository.cs
+++ b/src/Squid.Core/Persistence/Db/IRepository.cs
@@ -28,6 +28,14 @@ public interface IRepository
 
     Task DeleteAllAsync<TEntity>(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)  where TEntity : class, IEntity;
 
+    /// <summary>
+    /// Stop tracking the entity. Used when a tracking read mutates an entity in memory in a way
+    /// that must NOT be persisted (e.g. decrypting a column on read) — detaching guarantees a
+    /// later shared-scope SaveChanges cannot flush the in-memory mutation, and frees the identity
+    /// map so a subsequent Update/Remove of the same key does not conflict. No-op for null.
+    /// </summary>
+    void Detach<TEntity>(TEntity entity) where TEntity : class, IEntity;
+
     Task<int> CountAsync<TEntity>(Expression<Func<TEntity, bool>> predicate,
         CancellationToken cancellationToken = default) where TEntity : class, IEntity;
 

--- a/src/Squid.Core/Services/Deployments/Certificates/CertificateDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/Certificates/CertificateDataProvider.cs
@@ -1,4 +1,6 @@
+using Microsoft.EntityFrameworkCore;
 using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Security;
 
 namespace Squid.Core.Services.Deployments.Certificates;
 
@@ -17,10 +19,35 @@ public interface ICertificateDataProvider : IScopedDependency
     Task<Persistence.Entities.Deployments.Certificate> GetCertificateByIdAsync(int certificateId, CancellationToken cancellationToken = default);
 }
 
-public class CertificateDataProvider(IUnitOfWork unitOfWork, IRepository repository) : ICertificateDataProvider
+/// <summary>
+/// Owns at-rest protection of a certificate's private-key material —
+/// <see cref="Persistence.Entities.Deployments.Certificate.Password"/> (the PFX password) and
+/// <see cref="Persistence.Entities.Deployments.Certificate.CertificateData"/> (the PFX/PEM blob),
+/// both previously persisted in cleartext (so the PFX password protection was moot). This is the
+/// single seam every certificate read and write funnels through (deploy-pipeline client-cert auth
+/// via <c>EndpointContextBuilder</c>, the cert-variable expander, the certificate service), so
+/// encrypting here covers every consumer transparently — same pattern as
+/// <c>DeploymentAccountDataProvider</c> / <c>ExternalFeedDataProvider</c> / <c>VariableDataProvider</c>.
+///
+/// <para>Read-both / non-breaking: <see cref="IVariableEncryptionService.EncryptAsync"/> always
+/// emits the <c>SQUID_ENCRYPTED_V2:</c> envelope; <c>DecryptAsync</c> returns any value lacking
+/// that prefix verbatim, so pre-existing plaintext rows still load and upgrade lazily on next save.
+/// Reads load tracked (identity-map reuse) then <c>Detach</c> each entity before the in-place
+/// decrypt: detaching guarantees a later shared-scope SaveChanges cannot flush the plaintext back,
+/// and — unlike a second AsNoTracking instance — frees the identity map so a same-scope
+/// create-then-update/delete (as the CRUD tests exercise) does not hit a duplicate-tracking
+/// conflict.</para>
+/// </summary>
+public class CertificateDataProvider(IUnitOfWork unitOfWork, IRepository repository, IVariableEncryptionService encryption) : ICertificateDataProvider
 {
+    // The V2 envelope derives its key from a random per-payload salt, so the legacy KDF-scope
+    // argument (a V1-only deterministic-salt input) is irrelevant for certificates (write V2 only).
+    private const int SecretKdfScope = 0;
+
     public async Task AddCertificateAsync(Persistence.Entities.Deployments.Certificate certificate, bool forceSave = true, CancellationToken cancellationToken = default)
     {
+        EncryptSecrets(certificate);
+
         await repository.InsertAsync(certificate, cancellationToken).ConfigureAwait(false);
 
         if (forceSave) await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -28,6 +55,8 @@ public class CertificateDataProvider(IUnitOfWork unitOfWork, IRepository reposit
 
     public async Task UpdateCertificateAsync(Persistence.Entities.Deployments.Certificate certificate, bool forceSave = true, CancellationToken cancellationToken = default)
     {
+        EncryptSecrets(certificate);
+
         await repository.UpdateAsync(certificate, cancellationToken).ConfigureAwait(false);
 
         if (forceSave) await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -52,18 +81,64 @@ public class CertificateDataProvider(IUnitOfWork unitOfWork, IRepository reposit
         if (pageIndex.HasValue && pageSize.HasValue)
             query = query.Skip((pageIndex.Value - 1) * pageSize.Value).Take(pageSize.Value);
 
-        return (count, await query.ToListAsync(cancellationToken).ConfigureAwait(false));
+        var certificates = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return (count, await DecryptSecretsAsync(certificates).ConfigureAwait(false));
     }
 
     public async Task<List<Persistence.Entities.Deployments.Certificate>> GetCertificatesByIdsAsync(List<int> ids, CancellationToken cancellationToken)
     {
-        return await repository.Query<Persistence.Entities.Deployments.Certificate>()
-            .Where(f => ids.Contains(f.Id))
+        var certificates = await repository.Query<Persistence.Entities.Deployments.Certificate>()
+            .Where(c => ids.Contains(c.Id))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return await DecryptSecretsAsync(certificates).ConfigureAwait(false);
     }
 
     public async Task<Persistence.Entities.Deployments.Certificate> GetCertificateByIdAsync(int certificateId, CancellationToken cancellationToken = default)
     {
-        return await repository.GetByIdAsync<Persistence.Entities.Deployments.Certificate>(certificateId, cancellationToken).ConfigureAwait(false);
+        var certificate = await repository.GetByIdAsync<Persistence.Entities.Deployments.Certificate>(certificateId, cancellationToken).ConfigureAwait(false);
+
+        return await DecryptSecretsAsync(certificate).ConfigureAwait(false);
+    }
+
+    // Encrypt the password + the cert blob; each guarded by IsValidEncryptedValue so a re-save
+    // (or an already-encrypted value) never double-wraps.
+    private void EncryptSecrets(Persistence.Entities.Deployments.Certificate certificate)
+    {
+        if (certificate == null) return;
+
+        certificate.Password = Protect(certificate.Password);
+        certificate.CertificateData = Protect(certificate.CertificateData);
+    }
+
+    private string Protect(string value)
+    {
+        if (string.IsNullOrEmpty(value) || encryption.IsValidEncryptedValue(value)) return value;
+
+        return encryption.EncryptAsync(value, SecretKdfScope);
+    }
+
+    private async Task<Persistence.Entities.Deployments.Certificate> DecryptSecretsAsync(Persistence.Entities.Deployments.Certificate certificate)
+    {
+        if (certificate == null) return certificate;
+
+        // Detach BEFORE the in-place decrypt so the plaintext is never flushed and the identity
+        // map is freed (no duplicate-tracking conflict on a same-scope update/delete).
+        repository.Detach(certificate);
+
+        // Read-both: a plaintext (unprefixed) value is returned verbatim by DecryptAsync.
+        certificate.Password = await encryption.DecryptAsync(certificate.Password, SecretKdfScope).ConfigureAwait(false);
+        certificate.CertificateData = await encryption.DecryptAsync(certificate.CertificateData, SecretKdfScope).ConfigureAwait(false);
+
+        return certificate;
+    }
+
+    private async Task<List<Persistence.Entities.Deployments.Certificate>> DecryptSecretsAsync(List<Persistence.Entities.Deployments.Certificate> certificates)
+    {
+        foreach (var certificate in certificates)
+            await DecryptSecretsAsync(certificate).ConfigureAwait(false);
+
+        return certificates;
     }
 }

--- a/tests/Squid.IntegrationTests/Services/Certificates/IntegrationCertificateSecretsAtRest.cs
+++ b/tests/Squid.IntegrationTests/Services/Certificates/IntegrationCertificateSecretsAtRest.cs
@@ -1,0 +1,163 @@
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Certificates;
+using Squid.Message.Enums;
+
+namespace Squid.IntegrationTests.Services.Certificates;
+
+/// <summary>
+/// End-to-end (real Postgres + real EF + real <see cref="Squid.Core.Services.Security.IVariableEncryptionService"/>
+/// with the test MasterKey) coverage of at-rest encryption for a certificate's private-key
+/// material — <see cref="Certificate.Password"/> (the PFX password) AND
+/// <see cref="Certificate.CertificateData"/> (the PFX/PEM blob) — through the real
+/// <see cref="ICertificateDataProvider"/> seam: both raw columns carry the
+/// <c>SQUID_ENCRYPTED_V2:</c> envelope and never the cleartext secret; reads decrypt both
+/// transparently; pre-existing PLAINTEXT rows still read back (read-both / zero-migration); a
+/// read+decrypt then unrelated same-scope SaveChanges does NOT flush plaintext back; and an
+/// update that touches only metadata re-encrypts the preserved secrets.
+/// </summary>
+public class IntegrationCertificateSecretsAtRest : TestBase
+{
+    private const string Password = "pfx-pass-3b7e-VALUE";
+    private const string CertData = "BASE64-CERT-BLOB-with-private-key-9f21-VALUE";
+
+    public IntegrationCertificateSecretsAtRest()
+        : base("CertificateSecretsAtRest", "squid_it_cert_secrets_atrest")
+    {
+    }
+
+    [Fact]
+    public async Task Create_StoresPasswordAndDataEncrypted_AndReadsBackDecrypted()
+    {
+        var id = await Run<ICertificateDataProvider, int>(async provider =>
+        {
+            var cert = NewCertificate(Password, CertData);
+            await provider.AddCertificateAsync(cert).ConfigureAwait(false);
+            return cert.Id;
+        }).ConfigureAwait(false);
+
+        await Run<IRepository>(async repository =>
+        {
+            var raw = await repository.Query<Certificate>(c => c.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
+
+            raw.ShouldNotBeNull();
+            raw.Password.ShouldStartWith("SQUID_ENCRYPTED_V2:", customMessage: "the PFX password must be a V2 envelope at rest");
+            raw.CertificateData.ShouldStartWith("SQUID_ENCRYPTED_V2:", customMessage: "the cert blob (private-key material) must be a V2 envelope at rest");
+            raw.Password.ShouldNotContain(Password);
+            raw.CertificateData.ShouldNotContain(CertData);
+        }).ConfigureAwait(false);
+
+        await Run<ICertificateDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetCertificateByIdAsync(id).ConfigureAwait(false);
+            loaded.Password.ShouldBe(Password);
+            loaded.CertificateData.ShouldBe(CertData);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task LegacyPlaintextRow_ReadsBack_NonBreaking()
+    {
+        var id = 0;
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var cert = NewCertificate(Password, CertData);   // inserted raw = legacy plaintext
+            await repository.InsertAsync(cert).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+            id = cert.Id;
+        }).ConfigureAwait(false);
+
+        await Run<ICertificateDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetCertificateByIdAsync(id).ConfigureAwait(false);
+            loaded.Password.ShouldBe(Password, customMessage: "read-both: legacy plaintext password reads back verbatim");
+            loaded.CertificateData.ShouldBe(CertData, customMessage: "read-both: legacy plaintext cert blob reads back verbatim");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task ReadThenUnrelatedSaveInSameScope_DoesNotFlushPlaintextBack()
+    {
+        var id = await Run<ICertificateDataProvider, int>(async provider =>
+        {
+            var cert = NewCertificate(Password, CertData);
+            await provider.AddCertificateAsync(cert).ConfigureAwait(false);
+            return cert.Id;
+        }).ConfigureAwait(false);
+
+        await Run<ICertificateDataProvider, IUnitOfWork>(async (provider, unitOfWork) =>
+        {
+            var loaded = await provider.GetCertificateByIdAsync(id).ConfigureAwait(false);
+            loaded.Password.ShouldBe(Password);
+
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);   // would flush plaintext if reads tracked
+        }).ConfigureAwait(false);
+
+        await Run<IRepository>(async repository =>
+        {
+            var raw = await repository.Query<Certificate>(c => c.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
+            raw.Password.ShouldStartWith("SQUID_ENCRYPTED_V2:",
+                customMessage: "a read+decrypt then unrelated same-scope SaveChanges must NOT un-encrypt — reads must be AsNoTracking");
+            raw.CertificateData.ShouldStartWith("SQUID_ENCRYPTED_V2:");
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task MetadataUpdate_PreservesAndReEncryptsSecrets()
+    {
+        var id = await Run<ICertificateDataProvider, int>(async provider =>
+        {
+            var cert = NewCertificate(Password, CertData);
+            await provider.AddCertificateAsync(cert).ConfigureAwait(false);
+            return cert.Id;
+        }).ConfigureAwait(false);
+
+        // Mirror CertificateService.UpdateCertificateAsync: load (decrypted), change metadata only,
+        // save (re-encrypts the preserved secrets).
+        await Run<ICertificateDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetCertificateByIdAsync(id).ConfigureAwait(false);
+            loaded.Name = "renamed";
+            await provider.UpdateCertificateAsync(loaded).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await Run<IRepository>(async repository =>
+        {
+            var raw = await repository.Query<Certificate>(c => c.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
+            raw.Name.ShouldBe("renamed");
+            raw.Password.ShouldStartWith("SQUID_ENCRYPTED_V2:");
+            raw.CertificateData.ShouldStartWith("SQUID_ENCRYPTED_V2:");
+        }).ConfigureAwait(false);
+
+        await Run<ICertificateDataProvider>(async provider =>
+        {
+            var loaded = await provider.GetCertificateByIdAsync(id).ConfigureAwait(false);
+            loaded.Password.ShouldBe(Password, customMessage: "the preserved password must still decrypt after a metadata update");
+            loaded.CertificateData.ShouldBe(CertData);
+        }).ConfigureAwait(false);
+    }
+
+    private static Certificate NewCertificate(string password, string certData) => new()
+    {
+        SpaceId = 1,
+        Name = $"at-rest-cert-{Guid.NewGuid():N}"[..24],
+        Notes = string.Empty,
+        CertificateData = certData,
+        Password = password,
+        CertificateDataFormat = CertificateDataFormat.Pkcs12,
+        HasPrivateKey = true,
+        Thumbprint = Guid.NewGuid().ToString("N").ToUpperInvariant(),
+        SubjectDistinguishedName = "CN=at-rest-test",
+        SubjectCommonName = "at-rest-test",
+        IssuerDistinguishedName = "CN=at-rest-test",
+        IssuerCommonName = "at-rest-test",
+        SerialNumber = "00",
+        SignatureAlgorithmName = "sha256RSA",
+        SubjectAlternativeNames = string.Empty,
+        SelfSigned = true,
+        Version = 3,
+        NotBefore = DateTimeOffset.UtcNow,
+        NotAfter = DateTimeOffset.UtcNow.AddYears(1)
+    };
+}


### PR DESCRIPTION
## Summary

- Encrypt a certificate's private-key material at rest — both `Certificate.Password` (the PFX password) AND `Certificate.CertificateData` (the PFX/PEM blob), previously cleartext (so the PFX password protection was moot) — in `CertificateDataProvider`, the single seam every certificate read/write funnels through (deploy-pipeline client-cert auth via `EndpointContextBuilder`, the cert-variable expander, the certificate service). Reuses the `IVariableEncryptionService` V2 envelope. Same proven pattern as `DeploymentAccount.Credentials` ([#437](https://github.com/SolarifyDev/Squid/pull/437)) and `ExternalFeed.Password` ([#438](https://github.com/SolarifyDev/Squid/pull/438)). Makes the long-stale `Certificate.cs` "encrypted at rest" comment finally true.
- **Non-breaking / zero migration**: read-both via the `SQUID_ENCRYPTED_V2:` prefix (unprefixed plaintext returned verbatim → pre-existing rows still load, upgrade lazily). Idempotent encrypt-on-write. **No service-layer change** — `CertificateDto` exposes only `PasswordHasValue`/`HasPrivateKey`.
- **Reads detach-then-decrypt** (new `IRepository.Detach`) rather than `QueryNoTracking`. Detaching gives the same flush-safety as #437/#438 (the in-place decrypt is never flushed back as plaintext by a later shared-scope `SaveChanges`) **and** frees the identity map, so the existing single-scope create-then-update/delete CRUD tests don't hit a duplicate-tracking conflict. (`QueryNoTracking` is production-safe for account/feed since each mediator request is a fresh scope; the certificate CRUD tests run multiple ops in one scope, which detach handles cleanly.)
- Reuses the existing `Security:VariableEncryption:MasterKey` — no new key, no hardcoded default (P5 key-lifecycle hardening tracked separately).

## Test plan

- [x] Integration (real Postgres, `IntegrationCertificateSecretsAtRest`, 4): both columns carry `SQUID_ENCRYPTED_V2:` at rest and not the cleartext secret; decrypt-on-read; read-both on a legacy plaintext row; same-scope read+decrypt+`SaveChanges` keeps both columns encrypted (flush regression); a metadata-only update preserves + re-encrypts the secrets.
- [x] Regression: all 34 existing `IntegrationCertificateCrud` integration tests + 99 Certificate unit tests stay green (the detach approach keeps the single-scope CRUD flows working). At-rest integration across Account + Feed + Certificate (12) green — the additive `IRepository.Detach` doesn't affect the `QueryNoTracking` slices.
- [x] Crypto-envelope contract (round-trip / read-both / tamper) is unit-covered by the shared `IVariableEncryptionService` tests; this persistence-layer change is covered at the integration tier (Rule 9).
- [ ] CI: existing K8s Pipeline E2E (client-certificate auth) exercises certificate consumption via the same decrypting provider seam.