### PR TITLE
Wire disk self-heal into K8s-agent local-exec mode

### DIFF
--- a/src/Squid.Core/Halibut/Resilience/CircuitOpenException.cs
+++ b/src/Squid.Core/Halibut/Resilience/CircuitOpenException.cs
@@ -3,9 +3,12 @@ namespace Squid.Core.Halibut.Resilience;
 /// <summary>
 /// Thrown by <see cref="MachineCircuitBreaker"/> when the breaker is Open —
 /// indicates an attempt to reach a machine that has recently failed enough
-/// times to warrant fail-fast. Callers should treat this as transient
-/// (not a deployment error) and either abort the step or wait for the
-/// open duration to expire.
+/// times to warrant fail-fast. This is NOT a transient pause: the breaker only
+/// opens after the failure threshold (a SUSTAINED agent problem, not a one-off
+/// blip) and is raised BEFORE any script is dispatched, so there is no in-flight
+/// script to re-attach to. <see cref="TransientFailureClassifier"/> deliberately
+/// EXCLUDES it, so it fails the deployment for an operator to investigate rather
+/// than pause-looping on a dead agent.
 /// </summary>
 public sealed class CircuitOpenException : Exception
 {

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
@@ -102,10 +102,9 @@ public sealed class DeploymentCompletionHandler(
     /// pointer preserved, so a resume re-attaches to the still-running script
     /// instead of re-dispatching a duplicate. Like <see cref="OnTimedOutAsync"/> we
     /// deliberately do NOT delete the checkpoint and do NOT write a
-    /// <c>DeploymentCompletion</c> record (the deployment has not completed). The
-    /// historical fail-fast behaviour remains available via the
-    /// <c>SQUID_DEPLOYMENT_TRANSIENT_RESUMABLE</c> escape hatch, which routes
-    /// transient failures back through <see cref="OnFailureAsync"/>.
+    /// <c>DeploymentCompletion</c> record (the deployment has not completed). This is
+    /// unconditional — there is no opt-out, because failing fast on a transient blip
+    /// would discard already-completed progress and risk a duplicate run.
     /// </summary>
     public async Task OnTransientPauseAsync(DeploymentTaskContext ctx, Exception ex, CancellationToken ct)
     {

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentPipelineRunner.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentPipelineRunner.cs
@@ -119,7 +119,7 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
             && TargetCatchClassifier.IsTransientInfraFailure(ex))
         {
             // A transient infra failure (Halibut RPC drop after the library's
-            // retries, an unreachable agent, or an open breaker) pauses the
+            // retries, or an unreachable agent) pauses the
             // deployment instead of failing it: the in-flight script pointer is
             // preserved (the strategy clears it only on a definitive observation),
             // so a resume re-attaches to the still-running script rather than

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Execute.cs
@@ -401,7 +401,7 @@ public sealed partial class ExecuteStepsPhase
         catch (Exception ex) when (TransientFailureClassifier.IsTransient(ex))
         {
             // A transient infra failure (Halibut RPC drop after the library's
-            // retries, an unreachable agent, or an open breaker) must PROPAGATE so
+            // retries, or an unreachable agent) must PROPAGATE so
             // the runner pauses the deployment for resume — regardless of whether
             // the step is required. Recording it as a per-target/terminal failure
             // (the path below) would route to OnFailureAsync, which deletes the

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/TargetCatchClassifier.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/TargetCatchClassifier.cs
@@ -68,9 +68,9 @@ public static class TargetCatchClassifier
     /// Whether <paramref name="ex"/> is a transient infrastructure failure that
     /// should pause (resumable) rather than fail the deployment. Delegates to the
     /// single source of truth, <see cref="TransientFailureClassifier.IsTransient"/>
-    /// (which excludes the permanent Halibut protocol/invocation subtypes and
-    /// includes <c>CircuitOpenException</c>), kept here as the name the pipeline
-    /// callers already reference.
+    /// (which excludes the permanent Halibut protocol/invocation subtypes AND
+    /// <c>CircuitOpenException</c> — a sustained, fail-fast breaker-open state, not a
+    /// one-off blip), kept here as the name the pipeline callers already reference.
     /// </summary>
     public static bool IsTransientInfraFailure(System.Exception ex)
         => TransientFailureClassifier.IsTransient(ex);

--- a/src/Squid.Tentacle/Flavors/KubernetesAgent/KubernetesAgentFlavor.cs
+++ b/src/Squid.Tentacle/Flavors/KubernetesAgent/KubernetesAgentFlavor.cs
@@ -5,6 +5,7 @@ using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Health;
 using Squid.Tentacle.Kubernetes;
 using Squid.Tentacle.ScriptExecution;
+using Squid.Tentacle.SelfHeal;
 using Serilog;
 
 namespace Squid.Tentacle.Flavors.KubernetesAgent;
@@ -56,7 +57,15 @@ public sealed class KubernetesAgentFlavor : ITentacleFlavor
         if (!kubernetesSettings.UseScriptPods)
         {
             Log.Information("Using local script execution mode");
-            backend = new LocalScriptService();
+
+            var localBackend = new LocalScriptService();
+            backend = localBackend;
+
+            // Local-exec mode (the default K8s-agent mode) creates the identical
+            // {tempRoot}/squid-tentacle-{ticketId} workspaces the standalone Tentacle does, so a
+            // disk-full agent must auto-reclaim here too — schedule the same disk-pressure
+            // self-heal TentacleFlavor uses (the backend is its own live-script veto reporter).
+            backgroundTasks.Add(SelfHealBackgroundTask.ForLocalWorkspaces(localBackend));
         }
         else
         {

--- a/tests/Squid.IntegrationTests/Services/Certificates/IntegrationCertificateSecretsAtRest.cs
+++ b/tests/Squid.IntegrationTests/Services/Certificates/IntegrationCertificateSecretsAtRest.cs
@@ -98,7 +98,7 @@ public class IntegrationCertificateSecretsAtRest : TestBase
         {
             var raw = await repository.Query<Certificate>(c => c.Id == id).FirstOrDefaultAsync().ConfigureAwait(false);
             raw.Password.ShouldStartWith("SQUID_ENCRYPTED_V2:",
-                customMessage: "a read+decrypt then unrelated same-scope SaveChanges must NOT un-encrypt — reads must be AsNoTracking");
+                customMessage: "a read+decrypt then unrelated same-scope SaveChanges must NOT un-encrypt — the provider detaches the entity after decrypting so EF cannot flush the in-memory plaintext");
             raw.CertificateData.ShouldStartWith("SQUID_ENCRYPTED_V2:");
         }).ConfigureAwait(false);
     }

--- a/tests/Squid.IntegrationTests/Services/Deployments/Preview/IntegrationDeploymentPreviewRoleScoping.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Preview/IntegrationDeploymentPreviewRoleScoping.cs
@@ -1,0 +1,139 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Deployments;
+using Squid.Core.Services.Deployments.Snapshots;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Deployment;
+
+namespace Squid.IntegrationTests.Services.Deployments.Preview;
+
+/// <summary>
+/// Integration coverage for the deployment-PREVIEW role-scoping wiring
+/// (<c>DeploymentService.GetRequiredRolesAsync</c> feeding the role-scoped
+/// <c>TransientDeploymentTargetEvaluator.ApplyProjectPolicy</c> overload). The deployment
+/// pipeline half of this behaviour is regression-locked; the preview half shipped untested,
+/// the coverage hole the SOTA re-audit flagged.
+///
+/// <para>The guarded regression: an unavailable target whose role NO enabled step targets must
+/// not be evaluated by the project's Transient-Deployment-Targets policy — it is not a target
+/// for this release, so it must neither be reported as excluded nor block the deployment.
+/// Dropping the role-scoping silently reverts the preview to evaluating EVERY machine in the
+/// environment, and the discriminating test below goes red.</para>
+///
+/// <para>Real Postgres + real EF + the real <see cref="IDeploymentService"/> seam through the
+/// real planner/snapshot stack — no mocks on the path under test.</para>
+/// </summary>
+public class IntegrationDeploymentPreviewRoleScoping : TestBase
+{
+    public IntegrationDeploymentPreviewRoleScoping()
+        : base("DeploymentPreviewRoleScoping", "squid_it_preview_role_scoping")
+    {
+    }
+
+    [Fact]
+    public async Task Preview_StepTargetsOneRole_UnavailableTargetOfUnusedRole_IsNotEvaluatedByPolicy()
+    {
+        var seed = await SeedAsync(stepTargetRoles: "web").ConfigureAwait(false);
+
+        var result = await PreviewAsync(seed).ConfigureAwait(false);
+
+        var excludedIds = result.ExcludedTargets.Select(target => target.MachineId).ToList();
+
+        excludedIds.ShouldContain(seed.WebMachineId,
+            customMessage: "the role-matched unavailable target (role 'web', which the step targets) must be flagged by the default 'Fail deployment' policy");
+
+        excludedIds.ShouldNotContain(seed.DbMachineId,
+            customMessage: "an unavailable target whose role ('db') no enabled step targets must NOT be evaluated by the preview policy — preview must scope to the deployment's real step roles, not the whole environment");
+
+        result.BlockingReasons.Any(reason => reason.Contains(seed.DbMachineName)).ShouldBeFalse(
+            customMessage: "no blocking reason may name a target the deployment would never touch");
+    }
+
+    [Fact]
+    public async Task Preview_StepTargetsAllMachines_EveryUnavailableTargetIsEvaluated()
+    {
+        // Control: a step with NO target roles means "all machines" (CollectAllTargetRoles -> empty
+        // -> FilterByRoles applies no narrowing). Both unavailable targets are now real targets, so
+        // both must be evaluated by the policy. This proves the discriminator above genuinely flips
+        // on step roles rather than passing because the 'db' target was never loaded.
+        var seed = await SeedAsync(stepTargetRoles: null).ConfigureAwait(false);
+
+        var result = await PreviewAsync(seed).ConfigureAwait(false);
+
+        var excludedIds = result.ExcludedTargets.Select(target => target.MachineId).ToList();
+
+        excludedIds.ShouldContain(seed.WebMachineId);
+
+        excludedIds.ShouldContain(seed.DbMachineId,
+            customMessage: "with a step that targets all machines, the 'db' target is in scope and its unavailability must be evaluated");
+    }
+
+    private Task<DeploymentPreviewResult> PreviewAsync(SeedResult seed) =>
+        Run<IDeploymentService, DeploymentPreviewResult>(service =>
+            service.PreviewDeploymentAsync(new DeploymentRequestPayload { ReleaseId = seed.ReleaseId, EnvironmentId = seed.EnvironmentId }));
+
+    private async Task<SeedResult> SeedAsync(string stepTargetRoles)
+    {
+        var seed = new SeedResult();
+
+        await Run<IRepository, IUnitOfWork, IDeploymentSnapshotService>(async (repository, unitOfWork, snapshotService) =>
+        {
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            var step = await builder.CreateDeploymentStepAsync(process.Id, 1, "Deploy web").ConfigureAwait(false);
+            var action = await builder.CreateDeploymentActionAsync(step.Id, 1, "Run Script", SpecialVariables.ActionTypes.Script).ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(action.Id, (SpecialVariables.Action.ScriptBody, "echo hi")).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(stepTargetRoles))
+                await builder.CreateStepPropertiesAsync(step.Id, (SpecialVariables.Step.TargetRoles, stepTargetRoles)).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync().ConfigureAwait(false);
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id).ConfigureAwait(false);
+
+            var snapshot = await snapshotService.SnapshotProcessFromIdAsync(process.Id).ConfigureAwait(false);
+
+            release.ProjectDeploymentProcessSnapshotId = snapshot.Id;
+            await repository.UpdateAsync(release).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var web = await builder.CreateMachineAsync(environment.Id, "web-1", "web").ConfigureAwait(false);
+            var db = await builder.CreateMachineAsync(environment.Id, "db-1", "db").ConfigureAwait(false);
+            await MarkUnavailableAsync(repository, unitOfWork, web, db).ConfigureAwait(false);
+
+            seed.ReleaseId = release.Id;
+            seed.EnvironmentId = environment.Id;
+            seed.WebMachineId = web.Id;
+            seed.DbMachineId = db.Id;
+            seed.DbMachineName = db.Name;
+        }).ConfigureAwait(false);
+
+        return seed;
+    }
+
+    private static async Task MarkUnavailableAsync(IRepository repository, IUnitOfWork unitOfWork, params Machine[] machines)
+    {
+        foreach (var machine in machines)
+            machine.HealthStatus = MachineHealthStatus.Unavailable;
+
+        await repository.UpdateAllAsync(machines).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    private sealed class SeedResult
+    {
+        public int ReleaseId { get; set; }
+        public int EnvironmentId { get; set; }
+        public int WebMachineId { get; set; }
+        public int DbMachineId { get; set; }
+        public string DbMachineName { get; set; }
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Flavors/KubernetesAgent/KubernetesAgentFlavorRuntimeTests.cs
+++ b/tests/Squid.Tentacle.Tests/Flavors/KubernetesAgent/KubernetesAgentFlavorRuntimeTests.cs
@@ -3,6 +3,7 @@ using Squid.Tentacle.Abstractions;
 using Squid.Tentacle.Configuration;
 using Squid.Tentacle.Flavors.KubernetesAgent;
 using Squid.Tentacle.ScriptExecution;
+using Squid.Tentacle.SelfHeal;
 using Squid.Tentacle.Tests.Support;
 using Squid.Tentacle.Tests.Support.Scenarios;
 
@@ -22,7 +23,10 @@ public class KubernetesAgentFlavorRuntimeTests
         flavor.Id.ShouldBe("KubernetesAgent");
         runtime.Registrar.ShouldBeOfType<KubernetesAgentRegistrar>();
         runtime.ScriptBackend.ShouldBeOfType<LocalScriptService>();
-        runtime.BackgroundTasks.ShouldBeEmpty();
+        // Local-exec mode creates real {tempRoot}/squid-tentacle-* workspaces, so it must schedule
+        // the disk-pressure self-heal — same as the standalone Tentacle flavor.
+        runtime.BackgroundTasks.OfType<SelfHealBackgroundTask>().ShouldHaveSingleItem()
+            .Name.ShouldBe("SelfHeal");
         runtime.StartupHooks.ShouldNotBeEmpty();
         runtime.StartupHooks.Select(h => h.Name).ShouldContain("InitializationFlag");
     }

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTransientPauseTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTransientPauseTests.cs
@@ -12,10 +12,10 @@ namespace Squid.UnitTests.Services.Deployments.Pipeline;
 /// <summary>
 /// Pins how the runner classifies a TRANSIENT INFRASTRUCTURE failure (a Halibut
 /// RPC drop that outlived the library's own retries, or an unreachable agent):
-/// by default it pauses the deployment for resume (OnTransientPauseAsync —
+/// it unconditionally pauses the deployment for resume (OnTransientPauseAsync —
 /// Paused + checkpoint preserved) rather than failing it terminally, so the
-/// still-running script can be re-attached to. The historical fail-fast
-/// behaviour remains behind the SQUID_DEPLOYMENT_TRANSIENT_RESUMABLE escape hatch.
+/// still-running script can be re-attached to. There is no opt-out — failing fast
+/// on a transient blip would discard progress and risk a duplicate run.
 ///
 /// <para>Sibling to <c>DeploymentPipelineRunnerTimeoutTests</c>, which pins the
 /// analogous wall-clock-timeout classification. A genuine (non-transient)


### PR DESCRIPTION
## Summary

- **Wire disk self-heal into the KubernetesAgent local-exec path.** The `!UseScriptPods` branch (the default — `UseScriptPods` is false) builds a `LocalScriptService` that creates the same `{tempRoot}/squid-tentacle-{ticketId}` workspaces the standalone Tentacle does, but scheduled no background task — so a disk-full agent never auto-reclaimed. Now schedules `SelfHealBackgroundTask.ForLocalWorkspaces(backend)`, byte-identical to `TentacleFlavor.cs:50`. The flavor-runtime test flips from asserting `BackgroundTasks` empty to asserting the single `SelfHeal` task.
- **Cover the preview-path role-scoping** that shipped untested. A new integration test drives the real `IDeploymentService.PreviewDeploymentAsync` and proves an unavailable target whose role no enabled step targets is *not* evaluated by the project's Transient-Deployment-Targets policy (so it neither shows in `ExcludedTargets` nor blocks). A control case (a step that targets all machines) proves the discriminator genuinely flips on step roles, not on whether the target was loaded.
- **Correct a cluster of stale doc comments**: the removed `SQUID_DEPLOYMENT_TRANSIENT_RESUMABLE` escape hatch (transient pause is now unconditional — no opt-out); "open breaker" wrongly listed as a transient-pause cause in two pipeline catches and the `TargetCatchClassifier` XML doc (`CircuitOpenException` is *excluded* from the transient set — it fails fast); and a certificate at-rest `customMessage` that named `AsNoTracking` where the provider actually detaches.

No production behavior changes except the self-heal wiring (additive — a background task on the default K8s-agent mode). Everything else is a test addition or comment correction. No interface, signature, or schema changes.

## Test plan

- [x] Solution build: 0 errors
- [x] `KubernetesAgentFlavorRuntimeTests` (4/4) — self-heal now scheduled in local-exec mode
- [x] New `IntegrationDeploymentPreviewRoleScoping` (2/2) against real Postgres
- [x] **Red-green discrimination proof**: temporarily dropping the role-scoping (`ApplyProjectPolicy(selected, json)` over all machines) makes the primary test fail on the exact `db-not-excluded` assertion (`[1, 2]` vs `[1]`) while the all-machines control stays green; restored to confirm green
- [x] `DeploymentPipelineRunnerTransientPauseTests` (7/7) — comment-only touch, still green