### PR TITLE
Enforce one in-flight deployment per concurrency tag (multi-pod)

### DIFF
--- a/src/Squid.Core/Persistence/DbUpFiles/20260614_add_unique_active_deployment_per_concurrency_tag.sql
+++ b/src/Squid.Core/Persistence/DbUpFiles/20260614_add_unique_active_deployment_per_concurrency_tag.sql
@@ -1,0 +1,45 @@
+-- Enforce the cross-process (multi-pod) concurrency-slot invariant at the database level:
+-- at most ONE ACTIVE task per ConcurrencyTag, where "active" = Executing, Paused, or
+-- Cancelling. Paused and Cancelling MUST count as occupying the slot: a transient-infra pause
+-- or a wall-clock timeout transitions Executing→Paused while DELIBERATELY leaving the in-flight
+-- agent script running (the pointer is preserved so a resume re-attaches). If the slot only
+-- counted Executing, a second same-environment deployment could start while the paused one's
+-- script is still live on the agent — the exact overlap this guard exists to prevent.
+--
+-- Before this, same-environment serialization relied on WaitForConcurrencySlotAsync, a
+-- non-atomic check-then-act poll that "proceeded anyway" on timeout. With multiple server pods
+-- (K8s Deployment, dynamic replicas) two pods could both observe a free slot and both run a
+-- deployment to the same environment. The runner's poll stays as a fast path, but THIS partial
+-- unique index is the load-bearing guarantee: the only way a second row enters the active set
+-- for a tag is a Pending/Paused→Executing transition, which then fails with 23505 → mapped to
+-- ConcurrencySlotOccupiedException and re-enqueued (never overlapped, never lost).
+--
+-- Pre-flight: a database that ran the pre-fix racy code MAY already hold >1 active row for one
+-- tag (e.g. an Executing one plus a Paused-with-running-script one). The unique index cannot
+-- build over duplicates, so keep the earliest-started active row and administratively FAIL the
+-- rest — these are anomalous overlaps that should never have coexisted; failing them (with a
+-- clear message) is the honest resolution and the operator can redeploy. Idempotent: a DB with
+-- no duplicates is untouched, and CREATE UNIQUE INDEX IF NOT EXISTS is re-runnable.
+--
+-- The index is built non-CONCURRENTLY (CONCURRENTLY is incompatible with DbUp's single
+-- transaction). It briefly takes a SHARE lock on server_task during the build, blocking writes
+-- on still-serving old pods during a rolling upgrade. server_task is retention-pruned (bounded)
+-- and the index is partial (only active rows), so the build is fast and the window is brief.
+UPDATE server_task
+SET state = 'Failed',
+    completed_time = now(),
+    last_modified_date = now(),
+    error_message = 'Auto-resolved on upgrade: multiple concurrent deployments shared one concurrency tag (pre-fix race). The earliest was kept active; this duplicate was failed. Redeploy if needed.'
+WHERE id IN (
+    SELECT id FROM (
+        SELECT id,
+               row_number() OVER (PARTITION BY concurrency_tag ORDER BY start_time NULLS LAST, id) AS rn
+        FROM server_task
+        WHERE concurrency_tag IS NOT NULL AND state IN ('Executing', 'Paused', 'Cancelling')
+    ) ranked
+    WHERE ranked.rn > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_server_task_active_per_tag
+    ON server_task (concurrency_tag)
+    WHERE concurrency_tag IS NOT NULL AND state IN ('Executing', 'Paused', 'Cancelling');

--- a/src/Squid.Core/Persistence/EntityConfigurations/ServerTaskConfiguration.cs
+++ b/src/Squid.Core/Persistence/EntityConfigurations/ServerTaskConfiguration.cs
@@ -4,6 +4,18 @@ namespace Squid.Core.Persistence.EntityConfigurations;
 
 public class ServerTaskConfiguration: IEntityTypeConfiguration<ServerTask>
 {
+    /// <summary>
+    /// Name of the UNIQUE partial index that enforces "at most one ACTIVE task per
+    /// ConcurrencyTag" at the database level — the cross-process (multi-pod) atomic slot
+    /// guarantee. "Active" = Executing, Paused, or Cancelling: a paused/cancelling deployment
+    /// still holds the slot because its in-flight agent script may be running (preserved for
+    /// resume). Created by <c>20260614_add_unique_active_deployment_per_concurrency_tag.sql</c>
+    /// and matched by name in the data provider to map the 23505 violation to
+    /// <see cref="Squid.Core.Services.Deployments.ServerTask.Exceptions.ConcurrencySlotOccupiedException"/>.
+    /// Renaming it requires updating the migration, this constant, and the pin test together.
+    /// </summary>
+    public const string OneActivePerTagIndexName = "ux_server_task_active_per_tag";
+
     public void Configure(EntityTypeBuilder<ServerTask> builder)
     {
         builder.ToTable("server_task");
@@ -18,5 +30,18 @@ public class ServerTaskConfiguration: IEntityTypeConfiguration<ServerTask>
         builder.HasIndex(p => new { p.ConcurrencyTag, p.State })
             .HasFilter("concurrency_tag IS NOT NULL")
             .HasDatabaseName("ix_server_task_concurrency_tag_state");
+
+        // Cross-process atomic slot: at most ONE ACTIVE task (Executing/Paused/Cancelling) per
+        // ConcurrencyTag. Paused/Cancelling count as occupying because their in-flight agent
+        // script may still be running. The only transition that adds a second row to the active
+        // set is Pending/Paused→Executing, which then violates this index and is mapped to
+        // ConcurrencySlotOccupiedException — so two deployments to the same environment cannot
+        // run concurrently regardless of how many pods race the (non-atomic) free-slot poll.
+        // NOTE: schema is created by the DbUp migration, not by EF; keep this filter byte-identical
+        // to that migration's WHERE clause.
+        builder.HasIndex(p => p.ConcurrencyTag)
+            .IsUnique()
+            .HasFilter("concurrency_tag IS NOT NULL AND state IN ('Executing', 'Paused', 'Cancelling')")
+            .HasDatabaseName(OneActivePerTagIndexName);
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentPipelineRunner.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentPipelineRunner.cs
@@ -3,14 +3,24 @@ using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Deployments.ServerTask.Exceptions;
+using Squid.Core.Services.Jobs;
 
 namespace Squid.Core.Services.DeploymentExecution.Pipeline;
 
-public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhase> phases, IDeploymentLifecycle lifecycle, IDeploymentCompletionHandler completion, ITaskCancellationRegistry registry, IServerTaskDataProvider serverTaskDataProvider) : IDeploymentTaskExecutor
+public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhase> phases, IDeploymentLifecycle lifecycle, IDeploymentCompletionHandler completion, ITaskCancellationRegistry registry, IServerTaskDataProvider serverTaskDataProvider, ISquidBackgroundJobClient backgroundJobClient) : IDeploymentTaskExecutor
 {
     private const int CompletionTimeoutSeconds = 30;
-    private static readonly TimeSpan DefaultConcurrencyMaxWait = TimeSpan.FromSeconds(300);
-    private static readonly TimeSpan DefaultConcurrencyPollInterval = TimeSpan.FromMilliseconds(3000);
+
+    /// <summary>
+    /// How long to defer a re-enqueued deployment that could not get its environment
+    /// concurrency slot. Cross-process serialization is now DB-enforced (the
+    /// <c>ux_server_task_active_per_tag</c> unique index), so a blocked deployment is not
+    /// run-anyway and is not held in-process — it stays Pending and is re-dispatched after this
+    /// delay (by any pod) until the slot frees. Sibling of the per-machine poll cadence; kept a
+    /// plain const matching the prior concurrency-poll settings (no env var).
+    /// </summary>
+    internal static readonly TimeSpan ConcurrencyRequeueDelay = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Operator escape hatch (Rule 8): maximum wall-clock minutes a single
@@ -44,8 +54,6 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
 
     internal TimeSpan DeploymentTimeout { get; init; } = ResolveDeploymentTimeout();
     internal bool TimeoutResumable { get; init; } = ResolveTimeoutResumable();
-    internal TimeSpan ConcurrencyMaxWait { get; init; } = DefaultConcurrencyMaxWait;
-    internal TimeSpan ConcurrencyPollInterval { get; init; } = DefaultConcurrencyPollInterval;
 
     public async Task ProcessAsync(int serverTaskId, CancellationToken ct)
     {
@@ -57,7 +65,19 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
 
         try
         {
-            await WaitForConcurrencySlotAsync(serverTaskId, linkedCts.Token).ConfigureAwait(false);
+            var slot = await EvaluateSlotAsync(serverTaskId, linkedCts.Token).ConfigureAwait(false);
+
+            if (slot == SlotDecision.AlreadyResolved)
+            {
+                Log.Information("[Deploy] Task {TaskId} is already in a terminal state; skipping re-dispatched run", serverTaskId);
+                return;
+            }
+
+            if (slot == SlotDecision.SlotBusy)
+            {
+                await RequeueForConcurrencySlotAsync(serverTaskId, linkedCts.Token).ConfigureAwait(false);
+                return;
+            }
 
             lifecycle.Initialize(ctx);
 
@@ -115,6 +135,17 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
         {
             await SafeCompleteAsync(ctx, () => completion.OnCancelledAsync(ctx, CancellationToken.None), new DeploymentCancelledEvent(new DeploymentEventContext()));
         }
+        catch (ConcurrencySlotOccupiedException ex)
+        {
+            // Lost the environment slot in the TOCTOU window between the free-slot check above
+            // and LoadTaskPhase's atomic →Executing claim — a peer pod's active task held it and
+            // the ux_server_task_active_per_tag unique index rejected this claim. Re-enqueue (the
+            // task stays Pending, or Paused if this was a resume) instead of failing: never
+            // overlapped, never lost. No completion record is written — the deployment has not
+            // started.
+            Log.Information("[Deploy] Task {TaskId} lost concurrency slot at claim (tag: {Tag}); re-enqueuing", serverTaskId, ex.ConcurrencyTag);
+            await RequeueForConcurrencySlotAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+        }
         catch (Exception ex) when (!timeoutCts.IsCancellationRequested && !registryCts.IsCancellationRequested && !ct.IsCancellationRequested
             && TargetCatchClassifier.IsTransientInfraFailure(ex))
         {
@@ -169,33 +200,43 @@ public sealed class DeploymentPipelineRunner(IEnumerable<IDeploymentPipelinePhas
         }
     }
 
-    private async Task WaitForConcurrencySlotAsync(int serverTaskId, CancellationToken ct)
+    private enum SlotDecision { Proceed, SlotBusy, AlreadyResolved }
+
+    // One read decides the cold-path outcome: (a) AlreadyResolved if the task is terminal —
+    // covers a re-dispatched job whose task was cancelled while it sat re-enqueued, so it
+    // short-circuits instead of trying an illegal Cancelled→Executing claim; (b) SlotBusy if
+    // another ACTIVE task (Executing/Paused/Cancelling) holds the same tag's slot; (c) Proceed
+    // otherwise. A false negative on (b) under a race is harmless — LoadTaskPhase's atomic claim
+    // (the unique index) still rejects an overlapping →Executing and re-enqueues. An untagged
+    // task is never slot-blocked.
+    private async Task<SlotDecision> EvaluateSlotAsync(int serverTaskId, CancellationToken ct)
     {
         var task = await serverTaskDataProvider.GetServerTaskByIdNoTrackingAsync(serverTaskId, ct).ConfigureAwait(false);
 
-        if (task == null || string.IsNullOrEmpty(task.ConcurrencyTag)) return;
+        if (task == null) return SlotDecision.Proceed;
 
-        var deadline = DateTime.UtcNow.Add(ConcurrencyMaxWait);
-        var logged = false;
+        if (TaskState.IsTerminal(task.State)) return SlotDecision.AlreadyResolved;
 
-        while (DateTime.UtcNow < deadline)
-        {
-            ct.ThrowIfCancellationRequested();
+        if (string.IsNullOrEmpty(task.ConcurrencyTag)) return SlotDecision.Proceed;
 
-            var hasBlocker = await serverTaskDataProvider.HasExecutingTaskWithTagAsync(task.ConcurrencyTag, serverTaskId, ct).ConfigureAwait(false);
+        return await serverTaskDataProvider.HasActiveTaskWithTagAsync(task.ConcurrencyTag, serverTaskId, ct).ConfigureAwait(false)
+            ? SlotDecision.SlotBusy
+            : SlotDecision.Proceed;
+    }
 
-            if (!hasBlocker) return;
+    // Re-dispatch the still-Pending (or Paused, on resume) task after a short delay so any pod
+    // can retry the slot once the occupant finishes. Replaces the legacy in-process "wait up to
+    // 300s then proceed anyway" poll: the worker is freed immediately and the deployment is never
+    // run while the slot is held. The new job id is persisted to task.JobId so a subsequent
+    // cancel targets THIS scheduled job rather than the already-finished original.
+    private async Task RequeueForConcurrencySlotAsync(int serverTaskId, CancellationToken ct)
+    {
+        Log.Information("[Deploy] Task {TaskId} waiting for concurrency slot; re-enqueuing in {Delay}s", serverTaskId, ConcurrencyRequeueDelay.TotalSeconds);
 
-            if (!logged)
-            {
-                Log.Information("[Deploy] Task {TaskId} waiting for concurrency slot (tag: {Tag})", serverTaskId, task.ConcurrencyTag);
-                logged = true;
-            }
+        var jobId = backgroundJobClient.Schedule<IDeploymentTaskExecutor>(executor => executor.ProcessAsync(serverTaskId, CancellationToken.None), ConcurrencyRequeueDelay);
 
-            await Task.Delay(ConcurrencyPollInterval, ct).ConfigureAwait(false);
-        }
-
-        Log.Warning("[Deploy] Task {TaskId} exceeded concurrency wait timeout ({Timeout}), proceeding anyway", serverTaskId, ConcurrencyMaxWait);
+        if (!string.IsNullOrEmpty(jobId))
+            await serverTaskDataProvider.SetJobIdAsync(serverTaskId, jobId, ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Squid.Core/Services/Deployments/ServerTask/Exceptions/ConcurrencySlotOccupiedException.cs
+++ b/src/Squid.Core/Services/Deployments/ServerTask/Exceptions/ConcurrencySlotOccupiedException.cs
@@ -1,0 +1,25 @@
+namespace Squid.Core.Services.Deployments.ServerTask.Exceptions;
+
+/// <summary>
+/// Thrown when a task cannot transition to <see cref="TaskState.Executing"/> because another
+/// task with the SAME <c>ConcurrencyTag</c> is already ACTIVE (Executing, Paused, or
+/// Cancelling) — the cross-process atomic slot guarantee. It is raised when the DB rejects the
+/// transition with a unique-constraint violation (23505) on <c>ux_server_task_active_per_tag</c>,
+/// i.e. a second pod won the slot in the TOCTOU window between the runner's free-slot check and
+/// the claim.
+///
+/// <para>Distinct from <see cref="ServerTaskStateTransitionException"/> (an illegal state
+/// transition): this is a CONTENTION signal, not an error. The deployment runner catches it
+/// and re-enqueues the task (it stays Pending, or Paused on a resume) to retry the slot later,
+/// rather than failing — so the loser is never lost and the two deployments never overlap.</para>
+/// </summary>
+public sealed class ConcurrencySlotOccupiedException : InvalidOperationException
+{
+    public string ConcurrencyTag { get; }
+
+    public ConcurrencySlotOccupiedException(string concurrencyTag)
+        : base($"Concurrency slot for tag '{concurrencyTag}' is already occupied by another active deployment")
+    {
+        ConcurrencyTag = concurrencyTag;
+    }
+}

--- a/src/Squid.Core/Services/Deployments/ServerTask/ServerTaskDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/ServerTask/ServerTaskDataProvider.cs
@@ -24,7 +24,9 @@ public interface IServerTaskDataProvider : IScopedDependency
 
     Task SetHasPendingInterruptionsAsync(int taskId, bool hasPending, CancellationToken cancellationToken = default);
 
-    Task<bool> HasExecutingTaskWithTagAsync(string tag, int excludeId, CancellationToken cancellationToken = default);
+    Task SetJobIdAsync(int taskId, string jobId, CancellationToken cancellationToken = default);
+
+    Task<bool> HasActiveTaskWithTagAsync(string tag, int excludeId, CancellationToken cancellationToken = default);
 
     Task<(int TotalCount, List<Persistence.Entities.Deployments.ServerTask> Items)> GetServerTasksByProjectAsync(int projectId, string state, int skip, int take, CancellationToken cancellationToken = default);
 }
@@ -114,10 +116,44 @@ public class ServerTaskDataProvider : IServerTaskDataProvider
         var now = DateTimeOffset.UtcNow;
         var dataVersion = Guid.NewGuid().ToByteArray();
 
-        var rowsAffected = await ExecuteStateUpdateAsync(taskId, expectedCurrentState, newState, now, dataVersion, cancellationToken).ConfigureAwait(false);
+        int rowsAffected;
+
+        try
+        {
+            rowsAffected = await ExecuteStateUpdateAsync(taskId, expectedCurrentState, newState, now, dataVersion, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsActiveSlotConflict(ex, newState))
+        {
+            throw new ConcurrencySlotOccupiedException(await ReadConcurrencyTagAsync(taskId, cancellationToken).ConfigureAwait(false));
+        }
 
         if (rowsAffected == 0)
             await ThrowTransitionErrorAsync(taskId, newState, cancellationToken).ConfigureAwait(false);
+    }
+
+    // A second pod's →Executing transition for a ConcurrencyTag that already has an active task
+    // violates the ux_server_task_active_per_tag unique partial index (Postgres 23505). Only
+    // →Executing adds a row to the active set, so scope the mapping to that newState and to that
+    // specific index (by name) — any other unique violation propagates unchanged.
+    private static bool IsActiveSlotConflict(Exception ex, string newState)
+        => string.Equals(newState, TaskState.Executing, StringComparison.OrdinalIgnoreCase)
+           && FindPostgresException(ex) is { SqlState: "23505" } pg
+           && string.Equals(pg.ConstraintName, Persistence.EntityConfigurations.ServerTaskConfiguration.OneActivePerTagIndexName, StringComparison.Ordinal);
+
+    private static Npgsql.PostgresException FindPostgresException(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException)
+            if (current is Npgsql.PostgresException pg) return pg;
+
+        return null;
+    }
+
+    private async Task<string> ReadConcurrencyTagAsync(int taskId, CancellationToken ct)
+    {
+        var task = await _repository.QueryNoTracking<Persistence.Entities.Deployments.ServerTask>(t => t.Id == taskId)
+            .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+
+        return task?.ConcurrencyTag ?? string.Empty;
     }
 
     private Task<int> ExecuteStateUpdateAsync(int taskId, string expectedCurrentState, string newState, DateTimeOffset now, byte[] dataVersion, CancellationToken ct)
@@ -180,10 +216,21 @@ public class ServerTaskDataProvider : IServerTaskDataProvider
             .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<bool> HasExecutingTaskWithTagAsync(string tag, int excludeId, CancellationToken cancellationToken = default)
+    public async Task<bool> HasActiveTaskWithTagAsync(string tag, int excludeId, CancellationToken cancellationToken = default)
     {
+        // "Active" mirrors the ux_server_task_active_per_tag index filter: a Paused/Cancelling
+        // task still holds the slot because its in-flight agent script may be running.
         return await _repository.AnyAsync<Persistence.Entities.Deployments.ServerTask>(
-            t => t.ConcurrencyTag == tag && t.Id != excludeId && t.State == TaskState.Executing,
+            t => t.ConcurrencyTag == tag && t.Id != excludeId
+                 && (t.State == TaskState.Executing || t.State == TaskState.Paused || t.State == TaskState.Cancelling),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SetJobIdAsync(int taskId, string jobId, CancellationToken cancellationToken = default)
+    {
+        await _repository.ExecuteUpdateAsync<Persistence.Entities.Deployments.ServerTask>(
+            t => t.Id == taskId,
+            s => s.SetProperty(t => t.JobId, jobId),
             cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/Squid.IntegrationTests/Services/Deployments/Concurrency/IntegrationConcurrencySlotClaim.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Concurrency/IntegrationConcurrencySlotClaim.cs
@@ -1,0 +1,211 @@
+using Microsoft.EntityFrameworkCore;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Deployments.ServerTask.Exceptions;
+using ServerTaskEntity = Squid.Core.Persistence.Entities.Deployments.ServerTask;
+
+namespace Squid.IntegrationTests.Services.Deployments.Concurrency;
+
+/// <summary>
+/// Real-Postgres coverage of the cross-process atomic concurrency-slot guarantee
+/// (<c>ux_server_task_active_per_tag</c>): at most ONE ACTIVE task (Executing, Paused, or
+/// Cancelling) per ConcurrencyTag. The runner's free-slot poll is only a fast path — THIS unique
+/// partial index is the load-bearing guard that makes two pods physically unable to both run a
+/// deployment to the same environment. A second Pending/Paused→Executing transition while the
+/// tag already has an active task is rejected (23505) and surfaced as
+/// <see cref="ConcurrencySlotOccupiedException"/>; a Paused/Cancelling holder still blocks;
+/// different tags and untagged tasks are unconstrained; the slot frees when the holder reaches a
+/// terminal state. The final test fires two claims concurrently from independent scopes and
+/// asserts exactly one wins — the genuine multi-pod race.
+/// </summary>
+public class IntegrationConcurrencySlotClaim : TestBase
+{
+    public IntegrationConcurrencySlotClaim()
+        : base("ConcurrencySlotClaim", "squid_it_concurrency_slot_claim")
+    {
+    }
+
+    [Fact]
+    public async Task SecondExecutingWithSameTag_IsRejectedAsSlotOccupied()
+    {
+        var (occupantId, claimantId) = await SeedOccupantAndClaimantAsync("deploy:env-1");
+
+        await Run<IServerTaskDataProvider>(async provider =>
+        {
+            var ex = await Should.ThrowAsync<ConcurrencySlotOccupiedException>(() =>
+                provider.TransitionStateAsync(claimantId, TaskState.Pending, TaskState.Executing)).ConfigureAwait(false);
+
+            ex.ConcurrencyTag.ShouldBe("deploy:env-1");
+        }).ConfigureAwait(false);
+
+        await AssertStateAsync(claimantId, TaskState.Pending, "the loser must stay Pending — the failed claim made no state change");
+        await AssertStateAsync(occupantId, TaskState.Executing, "the occupant keeps the slot");
+    }
+
+    [Theory]
+    [InlineData(TaskState.Paused)]
+    [InlineData(TaskState.Cancelling)]
+    public async Task ActiveButNotExecutingHolder_StillOccupiesSlot_SecondClaimRejected(string holderState)
+    {
+        // A Paused (transient-pause/timeout) or Cancelling holder still owns the slot because its
+        // in-flight agent script may be running — a same-tag deployment must NOT start over it.
+        var (occupantId, claimantId) = await SeedOccupantAndClaimantAsync("deploy:env-1", occupantState: holderState);
+
+        await Run<IServerTaskDataProvider>(async provider =>
+        {
+            await Should.ThrowAsync<ConcurrencySlotOccupiedException>(() =>
+                provider.TransitionStateAsync(claimantId, TaskState.Pending, TaskState.Executing)).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await AssertStateAsync(claimantId, TaskState.Pending, $"a {holderState} holder still occupies the slot, so the claimant stays Pending");
+        await AssertStateAsync(occupantId, holderState, "the active (non-Executing) holder is unchanged");
+    }
+
+    [Fact]
+    public async Task DifferentTags_BothExecuting_Allowed()
+    {
+        var (_, claimantId) = await SeedOccupantAndClaimantAsync("deploy:env-1", claimantTag: "deploy:env-2");
+
+        await Run<IServerTaskDataProvider>(provider =>
+            provider.TransitionStateAsync(claimantId, TaskState.Pending, TaskState.Executing)).ConfigureAwait(false);
+
+        await AssertStateAsync(claimantId, TaskState.Executing, "a different tag is a different slot — no conflict");
+    }
+
+    [Fact]
+    public async Task UntaggedTasks_MultipleExecuting_Allowed()
+    {
+        // The unique index is filtered to "concurrency_tag IS NOT NULL", so untagged tasks
+        // (no per-environment serialization) are never constrained.
+        var (_, claimantId) = await SeedOccupantAndClaimantAsync(occupantTag: null, claimantTag: null);
+
+        await Run<IServerTaskDataProvider>(provider =>
+            provider.TransitionStateAsync(claimantId, TaskState.Pending, TaskState.Executing)).ConfigureAwait(false);
+
+        await AssertStateAsync(claimantId, TaskState.Executing, "untagged tasks are not slot-constrained");
+    }
+
+    [Fact]
+    public async Task SlotFreesWhenHolderLeavesExecuting_ThenClaimSucceeds()
+    {
+        var (occupantId, claimantId) = await SeedOccupantAndClaimantAsync("deploy:env-1");
+
+        await Run<IServerTaskDataProvider>(provider =>
+            provider.TransitionStateAsync(occupantId, TaskState.Executing, TaskState.Success)).ConfigureAwait(false);
+
+        await Run<IServerTaskDataProvider>(provider =>
+            provider.TransitionStateAsync(claimantId, TaskState.Pending, TaskState.Executing)).ConfigureAwait(false);
+
+        await AssertStateAsync(claimantId, TaskState.Executing, "the slot frees once the holder leaves Executing (Success), so the next claim wins");
+    }
+
+    [Fact]
+    public async Task TwoConcurrentClaims_SameTag_ExactlyOneWins()
+    {
+        // The genuine multi-pod race: two Pending tasks, same tag, two independent scopes
+        // (DbContexts) firing the →Executing claim at once. The unique index serializes them at
+        // commit, so exactly one commits and the other gets 23505 → ConcurrencySlotOccupiedException.
+        var (aId, bId) = await SeedTwoPendingAsync("deploy:env-9");
+
+        var aOutcome = ClaimAsync(aId);
+        var bOutcome = ClaimAsync(bId);
+
+        var results = await Task.WhenAll(aOutcome, bOutcome).ConfigureAwait(false);
+
+        results.Count(won => won).ShouldBe(1, customMessage: "exactly one concurrent claim may win the slot");
+        results.Count(won => !won).ShouldBe(1, customMessage: "the other concurrent claim must be rejected as slot-occupied");
+
+        var executing = await CountExecutingAsync("deploy:env-9");
+        executing.ShouldBe(1, customMessage: "the database must hold exactly one Executing row for the tag");
+    }
+
+    private Task<bool> ClaimAsync(int taskId) => Run<IServerTaskDataProvider, bool>(async provider =>
+    {
+        try
+        {
+            await provider.TransitionStateAsync(taskId, TaskState.Pending, TaskState.Executing).ConfigureAwait(false);
+            return true;
+        }
+        catch (ConcurrencySlotOccupiedException)
+        {
+            return false;
+        }
+    });
+
+    private async Task<(int occupantId, int claimantId)> SeedOccupantAndClaimantAsync(string occupantTag, string claimantTag = null, string occupantState = TaskState.Executing)
+    {
+        var occupantId = 0;
+        var claimantId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var occupant = NewTask(occupantState, occupantTag);
+            var claimant = NewTask(TaskState.Pending, claimantTag ?? occupantTag);
+
+            await repository.InsertAsync(occupant).ConfigureAwait(false);
+            await repository.InsertAsync(claimant).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            occupantId = occupant.Id;
+            claimantId = claimant.Id;
+        }).ConfigureAwait(false);
+
+        return (occupantId, claimantId);
+    }
+
+    private async Task<(int aId, int bId)> SeedTwoPendingAsync(string tag)
+    {
+        var aId = 0;
+        var bId = 0;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var a = NewTask(TaskState.Pending, tag);
+            var b = NewTask(TaskState.Pending, tag);
+
+            await repository.InsertAsync(a).ConfigureAwait(false);
+            await repository.InsertAsync(b).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            aId = a.Id;
+            bId = b.Id;
+        }).ConfigureAwait(false);
+
+        return (aId, bId);
+    }
+
+    private Task AssertStateAsync(int taskId, string expected, string because) => Run<IRepository>(async repository =>
+    {
+        var task = await repository.QueryNoTracking<ServerTaskEntity>(t => t.Id == taskId).FirstOrDefaultAsync().ConfigureAwait(false);
+        task.State.ShouldBe(expected, customMessage: because);
+    });
+
+    private Task<int> CountExecutingAsync(string tag) => Run<IRepository, int>(repository =>
+        repository.QueryNoTracking<ServerTaskEntity>(t => t.ConcurrencyTag == tag && t.State == TaskState.Executing).CountAsync());
+
+    private static ServerTaskEntity NewTask(string state, string concurrencyTag) => new()
+    {
+        Name = "DeploymentTask",
+        Description = "concurrency-slot integration",
+        QueueTime = DateTimeOffset.UtcNow.AddMinutes(-1),
+        StartTime = string.Equals(state, TaskState.Executing, StringComparison.Ordinal) ? DateTimeOffset.UtcNow : null,
+        State = state,
+        HasWarningsOrErrors = false,
+        ServerNodeId = Guid.Empty,
+        ProjectId = 0,
+        EnvironmentId = 0,
+        DurationSeconds = 0,
+        BatchId = 0,
+        JSON = "{}",
+        DataVersion = Guid.NewGuid().ToByteArray(),
+        SpaceId = 1,
+        LastModifiedDate = DateTimeOffset.UtcNow,
+        ConcurrencyTag = concurrencyTag,
+        ErrorMessage = string.Empty,
+        BusinessProcessState = string.Empty,
+        ServerTaskType = string.Empty,
+        StateOrder = 0,
+        Weight = 0,
+        JobId = string.Empty
+    };
+}

--- a/tests/Squid.UnitTests/Services/Deployments/ConcurrencyTagTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/ConcurrencyTagTests.cs
@@ -1,26 +1,41 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Squid.Core.Persistence.EntityConfigurations;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline;
+using Squid.Core.Services.DeploymentExecution.Pipeline.Phases;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Deployments.ServerTask.Exceptions;
+using Squid.Core.Services.Jobs;
 using ServerTaskEntity = Squid.Core.Persistence.Entities.Deployments.ServerTask;
 
 namespace Squid.UnitTests.Services.Deployments;
 
+/// <summary>
+/// Pins the runner's environment concurrency-slot behaviour. The legacy in-process poll
+/// ("wait up to 300s, then proceed anyway") is replaced by a single read-only free-slot check:
+/// if the slot is free the deployment runs; if it is busy the still-Pending task is re-enqueued
+/// (no worker held, never run-anyway), and a TOCTOU claim race (LoadTaskPhase's atomic
+/// →Executing transition rejected by the unique index) surfaces as
+/// <see cref="ConcurrencySlotOccupiedException"/> and is likewise re-enqueued, never failed.
+/// The DB unique index is the hard cross-pod guarantee (covered by integration/E2E tiers).
+/// </summary>
 public class ConcurrencyTagTests
 {
     private readonly Mock<IDeploymentLifecycle> _lifecycle = new();
     private readonly Mock<IDeploymentCompletionHandler> _completion = new();
     private readonly TaskCancellationRegistry _registry = new();
     private readonly Mock<IServerTaskDataProvider> _taskDataProvider = new();
+    private readonly Mock<ISquidBackgroundJobClient> _backgroundJobClient = new();
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public async Task WaitForConcurrencySlot_NullOrEmptyTag_SkipsWait(string tag)
+    public async Task UntaggedTask_SkipsSlotCheck_AndRuns(string tag)
     {
         _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = tag });
@@ -29,12 +44,13 @@ public class ConcurrencyTagTests
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
-        _taskDataProvider.Verify(p => p.HasExecutingTaskWithTagAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _taskDataProvider.Verify(p => p.HasActiveTaskWithTagAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        VerifyNotRequeued();
         _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task WaitForConcurrencySlot_TaskNotFound_SkipsWait()
+    public async Task TaskNotFound_SkipsSlotCheck_AndRuns()
     {
         _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(99, It.IsAny<CancellationToken>()))
             .ReturnsAsync((ServerTaskEntity)null);
@@ -43,138 +59,114 @@ public class ConcurrencyTagTests
 
         await runner.ProcessAsync(99, CancellationToken.None);
 
-        _taskDataProvider.Verify(p => p.HasExecutingTaskWithTagAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _taskDataProvider.Verify(p => p.HasActiveTaskWithTagAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        VerifyNotRequeued();
         _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task WaitForConcurrencySlot_NoBlocker_Immediate()
+    public async Task SlotFree_RunsDeployment_NoRequeue()
     {
         _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5" });
-        _taskDataProvider.Setup(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
+        _taskDataProvider.Setup(p => p.HasActiveTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         var runner = CreateRunner();
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
-        _taskDataProvider.Verify(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()), Times.Once);
+        _taskDataProvider.Verify(p => p.HasActiveTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()), Times.Once);
+        VerifyNotRequeued();
         _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task WaitForConcurrencySlot_BlockerCompletes_Proceeds()
+    public async Task SlotBusy_RequeuesAndPersistsNewJobId_AndDoesNotRunOrComplete()
     {
-        var callCount = 0;
-
         _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5" });
-        _taskDataProvider.Setup(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                callCount++;
-                return callCount <= 2;
-            });
+        _taskDataProvider.Setup(p => p.HasActiveTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _backgroundJobClient.Setup(c => c.Schedule<IDeploymentTaskExecutor>(
+                It.IsAny<Expression<Func<IDeploymentTaskExecutor, Task>>>(), It.IsAny<TimeSpan>(), It.IsAny<string>()))
+            .Returns("requeue-job-123");
 
         var runner = CreateRunner();
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
-        callCount.ShouldBe(3);
-        _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        VerifyRequeuedOnce();
+        _taskDataProvider.Verify(p => p.SetJobIdAsync(1, "requeue-job-123", It.IsAny<CancellationToken>()), Times.Once);
+        _lifecycle.Verify(l => l.Initialize(It.IsAny<DeploymentTaskContext>()), Times.Never);
+        _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Never);
+        _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task WaitForConcurrencySlot_TimeoutExceeded_ProceedsAnyway()
+    public async Task AlreadyTerminal_ShortCircuits_NoRunNoRequeue()
     {
+        // A re-dispatched job whose task was Cancelled while it sat re-enqueued must short-circuit,
+        // not attempt an illegal Cancelled→Executing claim nor re-enqueue itself forever.
         _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5" });
-        _taskDataProvider.Setup(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5", State = TaskState.Cancelled });
 
-        var runner = CreateRunnerWithFastConcurrency();
+        var runner = CreateRunner();
 
-        var sw = Stopwatch.StartNew();
         await runner.ProcessAsync(1, CancellationToken.None);
-        sw.Stop();
 
-        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(5));
-        _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        _taskDataProvider.Verify(p => p.HasActiveTaskWithTagAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        VerifyNotRequeued();
+        _lifecycle.Verify(l => l.Initialize(It.IsAny<DeploymentTaskContext>()), Times.Never);
+        _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Never);
+        _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task WaitForConcurrencySlot_CancellationDuringWait_PropagatesCancellation()
+    public async Task SlotClaimRace_RequeuesInsteadOfFailing()
     {
+        // The free-slot check passes, but the claim (LoadTaskPhase's atomic →Executing) loses the
+        // race to a peer pod — the unique index throws ConcurrencySlotOccupiedException. The runner
+        // must re-enqueue (Pending, retried), NOT fail the task.
         _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5" });
-        _taskDataProvider.Setup(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+        _taskDataProvider.Setup(p => p.HasActiveTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
-        var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+        var claimRacePhase = new Mock<IDeploymentPipelinePhase>();
+        claimRacePhase.SetupGet(p => p.Order).Returns(100);
+        claimRacePhase.Setup(p => p.ExecuteAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConcurrencySlotOccupiedException("deploy:env-5"));
 
-        var runner = CreateRunnerWithFastConcurrency(concurrencyMaxWait: TimeSpan.FromSeconds(30));
+        var runner = CreateRunner(claimRacePhase.Object);
 
-        await runner.ProcessAsync(1, cts.Token);
+        await runner.ProcessAsync(1, CancellationToken.None);
 
-        _completion.Verify(c => c.OnCancelledAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        VerifyRequeuedOnce();
+        _completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Never);
         _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task WaitForConcurrencySlot_RegistryCancelDuringWait_PropagatesCancellation()
+    public void OneActivePerTagIndexName_IsPinned()
     {
-        _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5" });
-        _taskDataProvider.Setup(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                _registry.TryCancel(1);
-                return true;
-            });
-
-        var runner = CreateRunnerWithFastConcurrency(concurrencyMaxWait: TimeSpan.FromSeconds(30));
-
-        await runner.ProcessAsync(1, CancellationToken.None);
-
-        _completion.Verify(c => c.OnCancelledAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
-        _completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Never);
+        // SSOT for the unique partial index: the migration SQL hard-codes this literal and the
+        // data provider matches the 23505 ConstraintName against this const to map the violation
+        // to ConcurrencySlotOccupiedException. A rename must change all three together — pin it so
+        // the rename is a visible, deliberate decision rather than a silent mapping break.
+        ServerTaskConfiguration.OneActivePerTagIndexName.ShouldBe("ux_server_task_active_per_tag");
     }
 
-    [Fact]
-    public async Task WaitForConcurrencySlot_ConcurrencyWaitCountsTowardDeploymentTimeout()
-    {
-        _taskDataProvider.Setup(p => p.GetServerTaskByIdNoTrackingAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ServerTaskEntity { Id = 1, ConcurrencyTag = "deploy:env-5" });
-        _taskDataProvider.Setup(p => p.HasExecutingTaskWithTagAsync("deploy:env-5", 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+    private void VerifyRequeuedOnce() =>
+        _backgroundJobClient.Verify(c => c.Schedule<IDeploymentTaskExecutor>(
+            It.IsAny<Expression<Func<IDeploymentTaskExecutor, Task>>>(), It.IsAny<TimeSpan>(), It.IsAny<string>()), Times.Once);
 
-        var runner = new DeploymentPipelineRunner(Enumerable.Empty<IDeploymentPipelinePhase>(), _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
-        {
-            DeploymentTimeout = TimeSpan.FromMilliseconds(100),
-            ConcurrencyMaxWait = TimeSpan.FromSeconds(60),
-            ConcurrencyPollInterval = TimeSpan.FromMilliseconds(10)
-        };
-
-        var sw = Stopwatch.StartNew();
-        await runner.ProcessAsync(1, CancellationToken.None);
-        sw.Stop();
-
-        sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(5));
-    }
+    private void VerifyNotRequeued() =>
+        _backgroundJobClient.Verify(c => c.Schedule<IDeploymentTaskExecutor>(
+            It.IsAny<Expression<Func<IDeploymentTaskExecutor, Task>>>(), It.IsAny<TimeSpan>(), It.IsAny<string>()), Times.Never);
 
     private DeploymentPipelineRunner CreateRunner(params IDeploymentPipelinePhase[] phases)
     {
-        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object);
-    }
-
-    private DeploymentPipelineRunner CreateRunnerWithFastConcurrency(TimeSpan? concurrencyMaxWait = null, params IDeploymentPipelinePhase[] phases)
-    {
-        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
-        {
-            ConcurrencyMaxWait = concurrencyMaxWait ?? TimeSpan.FromMilliseconds(100),
-            ConcurrencyPollInterval = TimeSpan.FromMilliseconds(10)
-        };
+        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object, _backgroundJobClient.Object);
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerCancellationTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerCancellationTests.cs
@@ -5,6 +5,7 @@ using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Jobs;
 
 namespace Squid.UnitTests.Services.Deployments.Pipeline;
 
@@ -232,6 +233,6 @@ public class DeploymentPipelineRunnerCancellationTests
 
     private DeploymentPipelineRunner CreateRunner(params IDeploymentPipelinePhase[] phases)
     {
-        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object);
+        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
     }
 }

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTests.cs
@@ -6,6 +6,7 @@ using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Jobs;
 
 namespace Squid.UnitTests.Services.Deployments.Pipeline;
 
@@ -25,7 +26,7 @@ public class DeploymentPipelineRunnerTests
             .Returns(Task.CompletedTask);
 
         var registry = new TaskCancellationRegistry();
-        var runner = new DeploymentPipelineRunner(Enumerable.Empty<IDeploymentPipelinePhase>(), lifecycle.Object, completion.Object, registry, _taskDataProvider.Object);
+        var runner = new DeploymentPipelineRunner(Enumerable.Empty<IDeploymentPipelinePhase>(), lifecycle.Object, completion.Object, registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
@@ -41,7 +42,7 @@ public class DeploymentPipelineRunnerTests
             .Returns<DeploymentTaskContext, CancellationToken>(async (_, token) => await Task.Delay(TimeSpan.FromSeconds(60), token));
 
         var registry = new TaskCancellationRegistry();
-        var runner = new DeploymentPipelineRunner(Enumerable.Empty<IDeploymentPipelinePhase>(), lifecycle.Object, completion.Object, registry, _taskDataProvider.Object);
+        var runner = new DeploymentPipelineRunner(Enumerable.Empty<IDeploymentPipelinePhase>(), lifecycle.Object, completion.Object, registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
 
         var sw = Stopwatch.StartNew();
         await Should.ThrowAsync<OperationCanceledException>(() => runner.ProcessAsync(1, CancellationToken.None));
@@ -65,7 +66,7 @@ public class DeploymentPipelineRunnerTests
             .Returns(Task.CompletedTask);
 
         var registry = new TaskCancellationRegistry();
-        var runner = new DeploymentPipelineRunner(new[] { failurePhase.Object }, lifecycle.Object, completion.Object, registry, _taskDataProvider.Object);
+        var runner = new DeploymentPipelineRunner(new[] { failurePhase.Object }, lifecycle.Object, completion.Object, registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
 
         await runner.ProcessAsync(1, CancellationToken.None);
 
@@ -87,7 +88,7 @@ public class DeploymentPipelineRunnerTests
             .Returns(Task.CompletedTask);
 
         var registry = new TaskCancellationRegistry();
-        var runner = new DeploymentPipelineRunner(new[] { okPhase.Object }, lifecycle.Object, completion.Object, registry, _taskDataProvider.Object);
+        var runner = new DeploymentPipelineRunner(new[] { okPhase.Object }, lifecycle.Object, completion.Object, registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
 
         await runner.ProcessAsync(1, CancellationToken.None);
 

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTimeoutTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTimeoutTests.cs
@@ -5,6 +5,7 @@ using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Jobs;
 
 namespace Squid.UnitTests.Services.Deployments.Pipeline;
 
@@ -265,7 +266,7 @@ public class DeploymentPipelineRunnerTimeoutTests
 
     private DeploymentPipelineRunner CreateRunnerWithoutTimeoutOverride()
     {
-        return new DeploymentPipelineRunner(Array.Empty<IDeploymentPipelinePhase>(), _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object);
+        return new DeploymentPipelineRunner(Array.Empty<IDeploymentPipelinePhase>(), _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
     }
 
     private IDeploymentPipelinePhase CreateHangingPhase()
@@ -283,7 +284,7 @@ public class DeploymentPipelineRunnerTimeoutTests
 
     private DeploymentPipelineRunner CreateRunner(params IDeploymentPipelinePhase[] phases)
     {
-        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
+        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>())
         {
             DeploymentTimeout = TimeSpan.FromMilliseconds(50),
             TimeoutResumable = true
@@ -292,7 +293,7 @@ public class DeploymentPipelineRunnerTimeoutTests
 
     private DeploymentPipelineRunner CreateFailFastRunner(params IDeploymentPipelinePhase[] phases)
     {
-        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
+        return new DeploymentPipelineRunner(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>())
         {
             DeploymentTimeout = TimeSpan.FromMilliseconds(50),
             TimeoutResumable = false

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTransientPauseTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTransientPauseTests.cs
@@ -6,6 +6,7 @@ using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Jobs;
 
 namespace Squid.UnitTests.Services.Deployments.Pipeline;
 
@@ -132,7 +133,7 @@ public class DeploymentPipelineRunnerTransientPauseTests
 
     // Long timeout so the wall-clock timer never fires before the phase throws.
     private DeploymentPipelineRunner CreateRunner(params IDeploymentPipelinePhase[] phases)
-        => new(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object)
+        => new(phases, _lifecycle.Object, _completion.Object, _registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>())
         {
             DeploymentTimeout = TimeSpan.FromMinutes(5)
         };


### PR DESCRIPTION
## Summary

First of two PRs hardening multi-pod concurrency correctness (Squid runs as a horizontally-scaled K8s Deployment with a shared Redis-backed Hangfire queue, so any pod can run any task).

**Problem.** Per-environment deployment serialization relied on `WaitForConcurrencySlotAsync` — a non-atomic check-then-act poll that on timeout logged a warning and *proceeded anyway*, over a **non-unique** `(ConcurrencyTag, State)` index. Two pods could each observe a free slot and both run a deployment to the same environment. (Per-task exactly-once is already safe via the `Pending→Executing` CAS; this is the *cross-task, same-tag* hole.)

**Fix — DB-enforced atomic claim over the ACTIVE set {Executing, Paused, Cancelling}:**
- New unique partial index `ux_server_task_active_per_tag` = at most one **active** row per `ConcurrencyTag`. Paused/Cancelling count as occupying because a transient-pause or wall-clock timeout transitions `Executing→Paused` while **leaving the in-flight agent script running** (preserved for resume) — a same-env deployment must not start over it. Migration pre-flight keeps the earliest active row per tag and administratively fails any pre-existing duplicates so the index builds on a live DB.
- `TransitionStateAsync` maps the `23505` violation on the `→Executing` transition (the only transition that adds a row to the active set) to a typed `ConcurrencySlotOccupiedException`, scoped to the index **by name** via a shared const (`OneActivePerTagIndexName`) so migration ⇄ model ⇄ provider stay in lockstep.
- The runner replaces the 300s in-process poll with one read → three outcomes: **terminal** (re-dispatched after cancel) → short-circuit; **slot held** → re-enqueue the still-Pending task (worker freed, never run-anyway), persisting the new Hangfire job id to `task.JobId` so a later cancel targets the live job; otherwise **proceed**. A TOCTOU claim race surfaces as `ConcurrencySlotOccupiedException` and is likewise re-enqueued — never overlapped, never failed, never lost.

Not a Postgres advisory lock: the EF DbContext runs over pooled connections, so a session-scoped advisory lock is unsafe; the unique index is connection-pool-safe and self-heals (terminal writes release it). Index built non-`CONCURRENTLY` (incompatible with DbUp's transaction) — partial over a retention-bounded table, so the brief build-time SHARE lock is acceptable. Untagged tasks skip the slot logic and are unchanged. PR2 will add the per-machine deploy↔upgrade mutex (reusing the existing Redis lock).

Pre-merge adversarial review (18 agents) drove this revision: the original scoped the slot to `Executing` only (Paused-overlap gap) and discarded the re-enqueued job id (cancel-zombie); both are fixed here, with the Paused/Cancelling-holder case now covered by an integration test.

## Test plan

- [x] Unit (6025/6025): runner terminal-guard / busy→requeue + JobId-persist / claim-race→requeue-not-fail; index-name SSOT pin
- [x] Integration (real Postgres, 7/7): unique index rejects a second active-same-tag (real 23505 → `ConcurrencySlotOccupiedException`); a **Paused/Cancelling holder still blocks** a same-tag claim; allows different tags + untagged; frees on terminal; **two concurrent claims → exactly one winner + exactly one active row**
- [x] Solution build: 0 errors