### PR TITLE
Defer tentacle upgrade when a deployment script is in flight on the machine

### DIFF
--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptMap.cs
@@ -60,6 +60,12 @@ public static class InFlightScriptMap
     public static string? TryGet(string json, DispatchSlot slot)
         => Parse(json).FirstOrDefault(e => Matches(e, slot))?.Ticket;
 
+    /// <summary>True if ANY in-flight entry targets <paramref name="machineId"/> — i.e. a script
+    /// is dispatched to that machine's agent and not yet observed to completion. Used by the
+    /// tentacle upgrade to defer restarting an agent that has a deployment script in flight.</summary>
+    public static bool ContainsMachine(string json, int machineId)
+        => Parse(json).Any(e => e.MachineId == machineId);
+
     private static bool Matches(Entry entry, DispatchSlot slot)
         => entry.MachineId == slot.MachineId && entry.StepId == slot.StepId && entry.ActionId == slot.ActionId;
 

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
@@ -117,8 +117,15 @@ public sealed class InFlightScriptStore(IRepository repository) : IInFlightScrip
         // Only checkpoints that still carry in-flight entries can match — a successful deployment's
         // checkpoint is deleted, so the scanned set is just the active/paused deployments. No per-task
         // stripe: this is a stand-alone read on the caller's own (upgrade) scope, not the deploy worker's.
+        //
+        // Both IDLE shapes are excluded at the DB layer: "[]" (an array emptied after add-then-remove)
+        // AND "{}" (the value EnsureExistsAsync seeds + the column default) — a checkpoint that exists
+        // but has never dispatched, or is between batches, carries "{}". Filtering both keeps the scan
+        // tight to checkpoints that genuinely hold an in-flight entry. (ContainsMachine would return
+        // false for either idle shape anyway via its parse-fallback, so this is a narrowing, not a
+        // correctness fix.)
         var jsons = await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(
-                c => c.InFlightScriptsJson != null && c.InFlightScriptsJson != "[]")
+                c => c.InFlightScriptsJson != null && c.InFlightScriptsJson != "[]" && c.InFlightScriptsJson != "{}")
             .Select(c => c.InFlightScriptsJson)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
+++ b/src/Squid.Core/Services/Deployments/Checkpoints/InFlightScriptStore.cs
@@ -57,6 +57,15 @@ public interface IInFlightScriptStore : IScopedDependency
     Task ClearAsync(int serverTaskId, DispatchSlot slot, CancellationToken cancellationToken = default);
 
     Task<string?> TryGetTicketAsync(int serverTaskId, DispatchSlot slot, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Cross-task: is ANY deployment currently holding an in-flight script on <paramref name="machineId"/>?
+    /// Scans the (small, retention-bounded) set of checkpoints that still carry in-flight entries — a
+    /// checkpoint exists only for an active or paused deployment, and is deleted on success. The tentacle
+    /// upgrade consults this before restarting a machine's agent, so it never kills a running deployment
+    /// script. Read-only; no per-task lock needed (the caller owns its own scope).
+    /// </summary>
+    Task<bool> IsMachineBusyAsync(int machineId, CancellationToken cancellationToken = default);
 }
 
 public sealed class InFlightScriptStore(IRepository repository) : IInFlightScriptStore
@@ -101,6 +110,19 @@ public sealed class InFlightScriptStore(IRepository repository) : IInFlightScrip
         {
             gate.Release();
         }
+    }
+
+    public async Task<bool> IsMachineBusyAsync(int machineId, CancellationToken cancellationToken = default)
+    {
+        // Only checkpoints that still carry in-flight entries can match — a successful deployment's
+        // checkpoint is deleted, so the scanned set is just the active/paused deployments. No per-task
+        // stripe: this is a stand-alone read on the caller's own (upgrade) scope, not the deploy worker's.
+        var jsons = await repository.QueryNoTracking<DeploymentExecutionCheckpoint>(
+                c => c.InFlightScriptsJson != null && c.InFlightScriptsJson != "[]")
+            .Select(c => c.InFlightScriptsJson)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return jsons.Any(json => InFlightScriptMap.ContainsMachine(json, machineId));
     }
 
     private async Task MutateAsync(int serverTaskId, Func<string, string> mutate, CancellationToken cancellationToken)

--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Squid.Core.Services.Caching.Redis;
+using Squid.Core.Services.Deployments.Checkpoints;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.Jobs;
 using Squid.Core.Services.Machines.Exceptions;
@@ -96,8 +97,9 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
     private readonly IRedisSafeRunner _redisLock;
     private readonly ISquidBackgroundJobClient _backgroundJobClient;
     private readonly IUpgradeDispatchMetadataStore _dispatchMetadata;
+    private readonly IInFlightScriptStore _inFlightScriptStore;
 
-    public MachineUpgradeService(IMachineDataProvider machineDataProvider, IMachineRuntimeCapabilitiesCache runtimeCache, ITentacleVersionRegistry versionRegistry, IEnumerable<IMachineUpgradeStrategy> strategies, IRedisSafeRunner redisLock, ISquidBackgroundJobClient backgroundJobClient, IMachineRuntimeCapabilitiesPersistence runtimePersistence = null, IUpgradeDispatchMetadataStore dispatchMetadata = null)
+    public MachineUpgradeService(IMachineDataProvider machineDataProvider, IMachineRuntimeCapabilitiesCache runtimeCache, ITentacleVersionRegistry versionRegistry, IEnumerable<IMachineUpgradeStrategy> strategies, IRedisSafeRunner redisLock, ISquidBackgroundJobClient backgroundJobClient, IMachineRuntimeCapabilitiesPersistence runtimePersistence = null, IUpgradeDispatchMetadataStore dispatchMetadata = null, IInFlightScriptStore inFlightScriptStore = null)
     {
         _machineDataProvider = machineDataProvider;
         _runtimeCache = runtimeCache;
@@ -107,6 +109,7 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         _redisLock = redisLock;
         _backgroundJobClient = backgroundJobClient;
         _dispatchMetadata = dispatchMetadata;
+        _inFlightScriptStore = inFlightScriptStore;
     }
 
     public async Task<UpgradeMachineResponseData> UpgradeAsync(UpgradeMachineCommand command, CancellationToken ct)
@@ -547,6 +550,17 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
     /// </summary>
     private async Task<UpgradeMachineResponseData> RunStrategyWithMetadataAsync(Persistence.Entities.Deployments.Machine machine, IMachineUpgradeStrategy strategy, string targetVersion, string currentVersion, CancellationToken ct)
     {
+        // Defer (do NOT restart the agent) if a deployment currently has a script in flight on this
+        // machine — restarting now would kill the running deployment script. Checked here, inside the
+        // per-machine dispatch lock and immediately before dispatch, so the window between the check
+        // and the restart is as small as possible. The deployment side is unchanged; it records its
+        // in-flight scripts (record-before-RPC) which this read consults.
+        if (_inFlightScriptStore != null && await _inFlightScriptStore.IsMachineBusyAsync(machine.Id, ct).ConfigureAwait(false))
+            return BuildResponse(machine, currentVersion, targetVersion, MachineUpgradeStatus.Failed,
+                $"Machine '{machine.Name}' has an active deployment running a script on its agent. The upgrade " +
+                "was NOT dispatched — restarting the agent now would kill the in-flight deployment script. " +
+                "Retry the upgrade once the deployment completes.");
+
         if (_dispatchMetadata != null)
         {
             try

--- a/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
+++ b/src/Squid.Core/Services/Machines/Upgrade/MachineUpgradeService.cs
@@ -555,6 +555,10 @@ public sealed class MachineUpgradeService : IMachineUpgradeService
         // per-machine dispatch lock and immediately before dispatch, so the window between the check
         // and the restart is as small as possible. The deployment side is unchanged; it records its
         // in-flight scripts (record-before-RPC) which this read consults.
+        // Status is Failed (no new enum — matches the H4 contention convention), so the Detail text is
+        // the only signal distinguishing "deferred, deployment intact, retry later" from a genuine
+        // upgrade failure. The phrases below are a load-bearing contract pinned by
+        // UpgradeAsync_DeploymentScriptInFlightOnMachine_DefersWithoutDispatching — reword in lockstep.
         if (_inFlightScriptStore != null && await _inFlightScriptStore.IsMachineBusyAsync(machine.Id, ct).ConfigureAwait(false))
             return BuildResponse(machine, currentVersion, targetVersion, MachineUpgradeStatus.Failed,
                 $"Machine '{machine.Name}' has an active deployment running a script on its agent. The upgrade " +

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
@@ -209,6 +209,72 @@ public class InFlightScriptStoreTests : TestBase
                 customMessage: $"Concurrent read+write on one context lost machine {id}'s ticket.");
     }
 
+    // ── IsMachineBusyAsync — the cross-task signal the tentacle upgrade consults ──
+    //
+    // IsMachineBusyAsync scans EVERY checkpoint in the DB (it has no taskId), so these
+    // tests use high machine ids (9100+) that NO sibling test records, keeping the scan
+    // result deterministic regardless of leftover rows from other test methods.
+
+    [Fact]
+    public async Task IsMachineBusy_WithInFlightScriptForMachine_ReturnsTrue()
+    {
+        const int taskId = 700020;
+        const int machineId = 9101;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(machineId), "ticket-a")).ConfigureAwait(false);
+
+        (await IsBusyAsync(machineId).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A deployment with an in-flight script on the machine MUST report it busy so the upgrade defers rather than restarting the agent mid-script.");
+        (await IsBusyAsync(9199).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "An unrelated machine MUST NOT be reported busy.");
+    }
+
+    [Fact]
+    public async Task IsMachineBusy_AfterScriptCleared_ReturnsFalse()
+    {
+        // Once the deployment's script completes the slot is cleared → the JSON
+        // collapses to "[]" (which the scan predicate excludes) → the machine is
+        // free and the upgrade may proceed.
+        const int taskId = 700021;
+        const int machineId = 9102;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(taskId, Slot(machineId), "ticket-a")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.ClearAsync(taskId, Slot(machineId))).ConfigureAwait(false);
+
+        (await IsBusyAsync(machineId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "A machine whose only in-flight script was cleared MUST report free.");
+    }
+
+    [Fact]
+    public async Task IsMachineBusy_ScansAcrossTasks_NotJustOne()
+    {
+        // The upgrade does NOT know which deployment task holds the machine — it has
+        // no taskId, so it must scan every active/paused checkpoint. Two separate
+        // tasks each holding a different machine must both report busy from one scan.
+        const int machineA = 9103;
+        const int machineB = 9105;
+        await EnsureRowAsync(700022).ConfigureAwait(false);
+        await EnsureRowAsync(700023).ConfigureAwait(false);
+
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(700022, Slot(machineA, stepId: 30, actionId: 300), "ticket-x")).ConfigureAwait(false);
+        await Run<IInFlightScriptStore>(s => s.RecordDispatchedAsync(700023, Slot(machineB, stepId: 40, actionId: 400), "ticket-y")).ConfigureAwait(false);
+
+        (await IsBusyAsync(machineA).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "A script in flight under one task MUST block an upgrade of its machine even though the upgrade never references that task.");
+        (await IsBusyAsync(machineB).ConfigureAwait(false)).ShouldBeTrue(
+            customMessage: "The scan MUST span all tasks — a second task's in-flight machine is equally blocked.");
+    }
+
+    [Fact]
+    public async Task IsMachineBusy_NoCheckpointForMachine_ReturnsFalse()
+        // A machine no deployment has ever touched in this DB → not busy → upgrade proceeds.
+        => (await IsBusyAsync(9104).ConfigureAwait(false)).ShouldBeFalse();
+
+    private Task<bool> IsBusyAsync(int machineId)
+        => Run<IInFlightScriptStore, bool>(s => s.IsMachineBusyAsync(machineId));
+
     private Task EnsureRowAsync(int taskId)
         => Run<IDeploymentCheckpointService>(svc => svc.EnsureExistsAsync(taskId, deploymentId: 1));
 

--- a/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Checkpoints/InFlightScriptStoreTests.cs
@@ -272,6 +272,44 @@ public class InFlightScriptStoreTests : TestBase
         // A machine no deployment has ever touched in this DB → not busy → upgrade proceeds.
         => (await IsBusyAsync(9104).ConfigureAwait(false)).ShouldBeFalse();
 
+    [Fact]
+    public async Task IsMachineBusy_CheckpointSeededButNeverDispatched_ReturnsFalse()
+    {
+        // A checkpoint that EXISTS but has not (yet) dispatched any script carries the idle
+        // seed value "{}" (EnsureExistsAsync). It must report NOT busy — and the scan predicate
+        // now excludes BOTH idle shapes ("[]" and "{}") at the DB layer, so such rows are never
+        // even materialized into the busy-check.
+        const int taskId = 700024;
+        const int machineId = 9106;
+        await EnsureRowAsync(taskId).ConfigureAwait(false);
+
+        (await IsBusyAsync(machineId).ConfigureAwait(false)).ShouldBeFalse(
+            customMessage: "A seeded-but-never-dispatched checkpoint ('{}') must not report any machine busy.");
+    }
+
+    [Fact]
+    public async Task DependencyInjection_ResolvesRealInFlightScriptStore_SoTheUpgradeDeferGuardStaysWired()
+    {
+        // The tentacle upgrade's defer-guard (MachineUpgradeService.RunStrategyWithMetadataAsync)
+        // depends on IInFlightScriptStore being injected by Autofac. That ctor param is OPTIONAL
+        // (= null) so the guard silently no-ops if the dependency ever stops being registered — and
+        // the all-mock unit suite cannot catch that (it always passes the mock explicitly). Pin the
+        // production wiring against the REAL SquidModule: it must resolve IInFlightScriptStore to the
+        // real store, otherwise every upgrade would dispatch and could kill an in-flight deploy script.
+        //
+        // This pins the REGISTRATION, not a full UpgradeAsync drive-through: the guard sits inside the
+        // per-machine Redis lock, and RedisSafeRunner eagerly connects on activation, which the
+        // integration DI config can't satisfy (RedisSafeRunner is never DI-resolved in these tests —
+        // see UpgradeDispatchLockReconcilerIntegrationTests, which connects to Redis directly). The
+        // guard's own defer/proceed logic is unit-covered.
+        await Run<IInFlightScriptStore>(store =>
+        {
+            store.ShouldNotBeNull();
+            store.ShouldBeOfType<InFlightScriptStore>();
+            return Task.CompletedTask;
+        }).ConfigureAwait(false);
+    }
+
     private Task<bool> IsBusyAsync(int machineId)
         => Run<IInFlightScriptStore, bool>(s => s.IsMachineBusyAsync(machineId));
 

--- a/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Checkpoints/InFlightScriptMapTests.cs
@@ -101,6 +101,50 @@ public class InFlightScriptMapTests
     public void TryGet_AbsentSlot_ReturnsNull()
         => InFlightScriptMap.TryGet("[]", Slot(7)).ShouldBeNull();
 
+    // ── ContainsMachine — the machine-coarse predicate the upgrade consults ──
+
+    [Fact]
+    public void ContainsMachine_MatchesAnyEntryForThatMachine_IgnoringStepAndAction()
+    {
+        // The upgrade asks the machine-level question "is ANY script in flight on
+        // this agent?" — it must match regardless of which step/action dispatched it.
+        var json = InFlightScriptMap.Add("[]", Slot(7, stepId: 10, actionId: 100), "ticket-a");
+
+        InFlightScriptMap.ContainsMachine(json, 7).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ContainsMachine_OtherMachineOnly_ReturnsFalse()
+    {
+        // A deployment in flight on machine 9 must NOT block an upgrade of machine 7.
+        var json = InFlightScriptMap.Add("[]", Slot(9), "ticket-b");
+
+        InFlightScriptMap.ContainsMachine(json, 7).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ContainsMachine_MatchesWhenAnySiblingSlotTargetsMachine()
+    {
+        var json = InFlightScriptMap.Add("[]", Slot(7, stepId: 10, actionId: 100), "ticket-a");
+        json = InFlightScriptMap.Add(json, Slot(9), "ticket-b");
+
+        InFlightScriptMap.ContainsMachine(json, 7).ShouldBeTrue();
+        InFlightScriptMap.ContainsMachine(json, 9).ShouldBeTrue();
+        InFlightScriptMap.ContainsMachine(json, 5).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("[]")]
+    [InlineData("not json at all")]
+    [InlineData("{\"11\":\"legacy-machine-keyed-ticket\"}")]
+    public void ContainsMachine_EmptyMalformedOrLegacyJson_ReturnsFalse(string json)
+        // A blank/corrupt/legacy column must never falsely block an upgrade — fall
+        // back to "no script in flight" (let the upgrade proceed), matching the
+        // re-dispatch-fresh behaviour the resume path relies on.
+        => InFlightScriptMap.ContainsMachine(json, 7).ShouldBeFalse();
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/Machines/Upgrade/MachineUpgradeServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Caching.Redis;
+using Squid.Core.Services.Deployments.Checkpoints;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.Jobs;
 using Squid.Core.Services.Machines;
@@ -1633,6 +1634,52 @@ public sealed class MachineUpgradeServiceTests
             Times.Never,
             "GetUpgradeInfo is a read — must never actually dispatch the upgrade");
     }
+
+    // ── P3: upgrade defers to an active deployment script on the same machine ──
+
+    [Fact]
+    public async Task UpgradeAsync_DeploymentScriptInFlightOnMachine_DefersWithoutDispatching()
+    {
+        // A deployment currently has a script in flight on this agent. Restarting the
+        // agent to upgrade it would kill that script, so the upgrade must NOT dispatch.
+        ArrangeMachine(id: 70, style: nameof(CommunicationStyle.TentaclePolling));
+        _runtimeCache.Store(70, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.0");
+
+        var inFlight = new Mock<IInFlightScriptStore>();
+        inFlight.Setup(s => s.IsMachineBusyAsync(70, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var resp = await NewServiceWithInFlight(inFlight.Object).UpgradeAsync(new UpgradeMachineCommand { MachineId = 70 }, CancellationToken.None);
+
+        resp.Status.ShouldBe(MachineUpgradeStatus.Failed);
+        resp.Detail.ShouldContain("active deployment",
+            customMessage: "the operator must be told WHY the upgrade was withheld — a deployment is running a script on the agent.");
+        resp.Detail.ShouldContain("NOT dispatched",
+            customMessage: "the message must make clear nothing was restarted, so the operator knows the deployment is intact.");
+        _linuxStrategy.Verify(s => s.UpgradeAsync(It.IsAny<Machine>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never,
+            failMessage: "the upgrade MUST NOT restart an agent that has a deployment script in flight — doing so kills the running deployment.");
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_NoDeploymentScriptInFlight_ProceedsToDispatch()
+    {
+        // Contrast: no deployment in flight on this machine → the upgrade dispatches normally.
+        ArrangeMachine(id: 71, style: nameof(CommunicationStyle.TentaclePolling));
+        _runtimeCache.Store(71, new Dictionary<string, string> { ["os"] = "Linux" }, agentVersion: "1.3.0");
+        _linuxStrategy
+            .Setup(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MachineUpgradeOutcome { Status = MachineUpgradeStatus.Upgraded, Detail = "done", AgentVersionMayHaveChanged = true });
+
+        var inFlight = new Mock<IInFlightScriptStore>();
+        inFlight.Setup(s => s.IsMachineBusyAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var resp = await NewServiceWithInFlight(inFlight.Object).UpgradeAsync(new UpgradeMachineCommand { MachineId = 71 }, CancellationToken.None);
+
+        resp.Status.ShouldBe(MachineUpgradeStatus.Upgraded);
+        _linuxStrategy.Verify(s => s.UpgradeAsync(It.IsAny<Machine>(), "1.4.0", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private MachineUpgradeService NewServiceWithInFlight(IInFlightScriptStore inFlight) =>
+        new(_machineDataProvider.Object, _runtimeCache, _versionRegistry.Object, new[] { _linuxStrategy.Object, _k8sStrategy.Object }, _redisLock.Object, _backgroundJobClient.Object, inFlightScriptStore: inFlight);
 
     private void ArrangeMachine(int id, string style)
     {


### PR DESCRIPTION
## Summary

- A tentacle upgrade restarts the agent process. If a deployment currently has a script in flight on that agent (recorded before the `StartScript` RPC, per the in-flight checkpoint), the restart kills the running script. The upgrade now consults the deployment checkpoint's in-flight state and **defers** (returns `Failed` with a retry-later detail) when the machine is busy, instead of dispatching.
- **Asymmetric by design**: only the upgrade — rare, operator-triggered, already holding the per-machine upgrade lock — checks for an active deployment. The deployment path is **unchanged**: no new lock, no self-contention on parallel same-machine `StartWithPrevious` steps, no new dependency on the deploy hot path. (The earlier machine-exclusive-mutex approach was abandoned precisely because a symmetric lock over-serialized coexisting deploys.)
- New `IInFlightScriptStore.IsMachineBusyAsync(machineId)` scans only checkpoints that still carry in-flight entries — a checkpoint exists only for an active/paused deployment and is deleted on success — so the scan set stays small. Backed by a pure `InFlightScriptMap.ContainsMachine` helper.

### Placement & residual window

The check sits inside the **existing** per-machine upgrade Redis lock, immediately before dispatch and before the H4 metadata write — so a deferred upgrade leaves no metadata stragglers, and the cheap up-to-date / downgrade short-circuits still run first (a no-op upgrade never scans). The TOCTOU window between "machine is free" and "agent restarts" is minimal and accepted: a deploy that *starts* a script in that sub-second window is itself resilient — a killed in-flight script is classified transient and pauses/re-attaches on resume (#434), rather than failing the deployment.

`Failed` (not a new enum value) matches the established H4 contention convention for "couldn't dispatch right now, retry later" — non-breaking.

## Test plan

- [x] Unit — `InFlightScriptMap.ContainsMachine`: matches any slot for the machine regardless of step/action; other-machine-only → false; empty/malformed/legacy JSON → false (never falsely blocks).
- [x] Unit — `MachineUpgradeService`: defers without dispatching when the store reports busy (asserts the strategy is **never** invoked + the operator-facing detail); proceeds to dispatch when free.
- [x] Integration (real Postgres) — `InFlightScriptStore.IsMachineBusyAsync`: in-flight script → busy (unrelated machine not); cleared slot → free; scan spans tasks (two tasks' in-flight machines both reported); untouched machine → free.
- [x] Full unit suite green (6035) + `InFlightScriptStore` integration suite green (13).
