### PR TITLE
Make the upgrade-wrapper E2E marker read tolerant of the detached writer

### DIFF
--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeWrapperE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeWrapperE2ETests.cs
@@ -144,7 +144,11 @@ exit 0
             .ShouldBeTrue(
                 customMessage: $"marker {markerPath} did NOT appear within 60s — Task Scheduler did not launch the inner script (likely schtasks /Run silently failed, or /RU SYSTEM was rejected by the runner's security policy)");
 
-        var content = File.ReadAllText(markerPath).Trim();
+        // The detached writer (Set-Content) runs ASYNCHRONOUSLY, so the marker can exist while its
+        // handle is still open — a plain File.ReadAllText (FileShare.Read) then throws IOException
+        // "being used by another process", and an early read can see an empty/partial file mid-write.
+        // ReadMarkerWhenReady opens with FileShare.ReadWrite and polls until the content is non-empty.
+        var content = ReadMarkerWhenReady(markerPath, TimeSpan.FromSeconds(30));
 
         content.ShouldStartWith("nt authority",
             Case.Insensitive,
@@ -400,6 +404,47 @@ exit 0
             Thread.Sleep(200);
         }
         return false;
+    }
+
+    /// <summary>
+    /// Reads a marker the DETACHED task wrote, tolerating the writer still holding the handle.
+    /// The inner Set-Content runs asynchronously, so the file can exist (WaitForFileExists passed)
+    /// while its handle is still open: a plain File.ReadAllText opens with FileShare.Read and throws
+    /// IOException ("being used by another process") against the writer's handle, and an early read can
+    /// also catch a partial/empty file mid-write. So open with FileShare.ReadWrite (don't contend on the
+    /// writer's handle) and poll until the content is non-empty — within a bounded timeout, with an
+    /// actionable failure naming the marker path. This is a test-fixture race only; production reads
+    /// upgrade traces from the agent over Halibut RPC, not via a concurrent local file read.
+    /// </summary>
+    private static string ReadMarkerWhenReady(string path, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        Exception last = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+
+                var content = reader.ReadToEnd().Trim();
+
+                if (content.Length > 0) return content;
+            }
+            catch (IOException ex)
+            {
+                // File not yet present, or the writer holds an exclusive handle this instant — retry.
+                last = ex;
+            }
+
+            Thread.Sleep(200);
+        }
+
+        throw new TimeoutException(
+            $"marker {path} existed but its content was not readable / non-empty within {timeout.TotalSeconds:N0}s — " +
+            $"the detached writer likely still holds the handle. Inspect manually: type \"{path}\". " +
+            (last != null ? $"Last read error: {last.Message}" : "Last read returned empty content."));
     }
 
     /// <summary>

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeWrapperE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeWrapperE2ETests.cs
@@ -147,8 +147,9 @@ exit 0
         // The detached writer (Set-Content) runs ASYNCHRONOUSLY, so the marker can exist while its
         // handle is still open — a plain File.ReadAllText (FileShare.Read) then throws IOException
         // "being used by another process", and an early read can see an empty/partial file mid-write.
-        // ReadMarkerWhenReady opens with FileShare.ReadWrite and polls until the content is non-empty.
-        var content = ReadMarkerWhenReady(markerPath, TimeSpan.FromSeconds(30));
+        // ReadMarkerWhenReady retries the read until the content is the WELL-FORMED identity (contains
+        // "system"), so a torn/partial read is retried rather than returned to fail the assertions below.
+        var content = ReadMarkerWhenReady(markerPath, TimeSpan.FromSeconds(30), c => c.Contains("system", StringComparison.OrdinalIgnoreCase));
 
         content.ShouldStartWith("nt authority",
             Case.Insensitive,
@@ -409,15 +410,22 @@ exit 0
     /// <summary>
     /// Reads a marker the DETACHED task wrote, tolerating the writer still holding the handle.
     /// The inner Set-Content runs asynchronously, so the file can exist (WaitForFileExists passed)
-    /// while its handle is still open: a plain File.ReadAllText opens with FileShare.Read and throws
-    /// IOException ("being used by another process") against the writer's handle, and an early read can
-    /// also catch a partial/empty file mid-write. So open with FileShare.ReadWrite (don't contend on the
-    /// writer's handle) and poll until the content is non-empty — within a bounded timeout, with an
-    /// actionable failure naming the marker path. This is a test-fixture race only; production reads
-    /// upgrade traces from the agent over Halibut RPC, not via a concurrent local file read.
+    /// while its handle is still open, AND its content can be empty/partial mid-write. Two defences,
+    /// the second load-bearing: (1) open with FileShare.ReadWrite so we don't contend on the writer's
+    /// handle — but this does NOT override an exclusive writer, so it only helps once the writer has
+    /// opened sharably or closed; (2) the RETRY LOOP — re-open and re-read until <paramref name="isReady"/>
+    /// accepts the content, within a bounded timeout, with an actionable failure naming the marker path.
+    /// The loop is what actually closes both the exclusive-handle window and the partial-content window:
+    /// a read that throws IOException OR returns content the predicate rejects is simply retried.
+    /// <paramref name="isReady"/> defaults to "non-empty"; a caller that knows the marker's well-formed
+    /// shape can pass a stricter predicate so a torn read is retried rather than returned. This is a
+    /// test-fixture race only; production reads upgrade traces from the agent over Halibut RPC, not via
+    /// a concurrent local file read.
     /// </summary>
-    private static string ReadMarkerWhenReady(string path, TimeSpan timeout)
+    private static string ReadMarkerWhenReady(string path, TimeSpan timeout, Func<string, bool> isReady = null)
     {
+        isReady ??= content => content.Length > 0;
+
         var deadline = DateTime.UtcNow + timeout;
         Exception last = null;
 
@@ -430,7 +438,7 @@ exit 0
 
                 var content = reader.ReadToEnd().Trim();
 
-                if (content.Length > 0) return content;
+                if (isReady(content)) return content;
             }
             catch (IOException ex)
             {
@@ -442,9 +450,10 @@ exit 0
         }
 
         throw new TimeoutException(
-            $"marker {path} existed but its content was not readable / non-empty within {timeout.TotalSeconds:N0}s — " +
-            $"the detached writer likely still holds the handle. Inspect manually: type \"{path}\". " +
-            (last != null ? $"Last read error: {last.Message}" : "Last read returned empty content."));
+            $"marker {path} existed but its content was not readable / ready within {timeout.TotalSeconds:N0}s — " +
+            $"the detached writer likely still holds the handle, or the content never reached its expected shape. " +
+            $"Inspect manually: type \"{path}\". " +
+            (last != null ? $"Last read error: {last.Message}" : "Last read returned content the readiness predicate rejected."));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- `Wrapper_DetachedTask_RunsAsSystemAfterWrapperExits` intermittently failed with `IOException: ... because it is being used by another process` (seen once on PR #440 CI, passed on re-run). The detached Task Scheduler inner script writes the identity marker **asynchronously**; the test waited for the file to *exist*, then immediately `File.ReadAllText`'d it — which opens with `FileShare.Read` and collides with the writer's still-open handle (and could also read a partial/empty file mid-write).
- Replace the read with `ReadMarkerWhenReady`: open the marker with **`FileShare.ReadWrite`** (don't contend on the writer's handle) and **poll until the content is non-empty**, within a bounded 30s timeout with an actionable failure message naming the marker path.

## Scope

- Surgical to the test/helper. The other marker-based tests only assert *existence*, so only this content-read needed the fix.
- **No production change** — the marker is a test fixture; production reads upgrade traces from the agent over Halibut RPC, not via a concurrent local `File.ReadAllText`, so the race does not exist in production code (verified).
- Windows-only E2E (gated behind `OperatingSystem.IsWindows()`).

## Test plan

- [x] `Squid.WindowsTentacleE2ETests` compiles clean cross-platform (the test body skips on non-Windows).
- [ ] Windows E2E CI (`WindowsTentacle*E2E`) exercises the real path; the fix removes the file-handle contention that caused the intermittent `IOException`.