### PR TITLE
Encrypt Tentacle certificate password and subscription id at rest

### DIFF
--- a/src/Squid.Tentacle/Certificate/ProductionTentacleCertificateManager.cs
+++ b/src/Squid.Tentacle/Certificate/ProductionTentacleCertificateManager.cs
@@ -24,6 +24,12 @@ namespace Squid.Tentacle.Certificate;
 /// encryptor cannot be initialised (key derivation throws on an unusual host), this degrades to
 /// the legacy plaintext manager rather than preventing the Tentacle from starting — at-rest
 /// encryption is best-effort hardening, never a startup gate.</para>
+///
+/// <para>Threat boundary: the machine-key scheme defends secrets in artefacts that leave the
+/// host — backups, disk images, exported logs — where the machine-id is not present. It does NOT
+/// defend against an attacker with live read access to this host's filesystem, who can re-derive
+/// the key from the (world-readable) machine-id. That is the same trust model as the on-disk PFX
+/// itself, so it is the intended scope, not a gap.</para>
 /// </summary>
 public static class ProductionTentacleCertificateManager
 {
@@ -38,6 +44,10 @@ public static class ProductionTentacleCertificateManager
         }
         catch (Exception ex)
         {
+            // Defensive: MachineIdProvider.Read() never returns empty (it has a hostname
+            // fallback), so MachineIdKeyEncryptor's ctor does not throw under the current
+            // contract — this catch is belt-and-suspenders against a future provider/KDF
+            // change, ensuring at-rest encryption can never become a Tentacle startup gate.
             Log.Warning(ex, "Could not initialise the machine-key encryptor; Tentacle secrets (certificate password, subscription id) will be stored UNENCRYPTED at rest. Investigate machine-id availability on this host.");
             return null;
         }

--- a/src/Squid.Tentacle/Certificate/ProductionTentacleCertificateManager.cs
+++ b/src/Squid.Tentacle/Certificate/ProductionTentacleCertificateManager.cs
@@ -1,0 +1,45 @@
+using Serilog;
+using Squid.Tentacle.Security;
+
+namespace Squid.Tentacle.Certificate;
+
+/// <summary>
+/// Single construction site for the PRODUCTION Tentacle certificate manager. Wires the
+/// machine-key encryptor so the certificate password (which protects the PFX holding the
+/// agent's PRIVATE KEY) and the polling subscription id are encrypted at rest, instead of
+/// the plaintext the bare <see cref="TentacleCertificateManager(string)"/> constructor leaves.
+///
+/// <para>Every production caller — the runtime (<c>TentacleApp</c>) AND every CLI command
+/// (<c>register</c>, <c>show-thumbprint</c>, <c>show-config</c>, <c>check-services</c>,
+/// <c>new-certificate</c>) — MUST construct through here. The write path (<c>register</c> /
+/// <c>new-certificate</c>) and the read paths (<c>show-thumbprint</c>, the runtime load) have
+/// to AGREE on whether the cert password is encrypted: a writer that stores a random,
+/// encrypted password and a reader built without the encryptor would fall back to the legacy
+/// fixed password and fail to open the PFX. Routing all sites through one factory is what keeps
+/// them consistent.</para>
+///
+/// <para>Non-breaking: <see cref="TentacleCertificateManager"/> already migrates a legacy
+/// plaintext install on first encryptor-aware load (writes the existing password / subscription
+/// id back in encrypted form), so an upgrade needs no data migration. If the machine-key
+/// encryptor cannot be initialised (key derivation throws on an unusual host), this degrades to
+/// the legacy plaintext manager rather than preventing the Tentacle from starting — at-rest
+/// encryption is best-effort hardening, never a startup gate.</para>
+/// </summary>
+public static class ProductionTentacleCertificateManager
+{
+    public static ITentacleCertificateManager Create(string certsPath)
+        => new TentacleCertificateManager(certsPath, TryCreateMachineKeyEncryptor());
+
+    private static IMachineKeyEncryptor TryCreateMachineKeyEncryptor()
+    {
+        try
+        {
+            return new MachineIdKeyEncryptor();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Could not initialise the machine-key encryptor; Tentacle secrets (certificate password, subscription id) will be stored UNENCRYPTED at rest. Investigate machine-id availability on this host.");
+            return null;
+        }
+    }
+}

--- a/src/Squid.Tentacle/Certificate/TentacleCertificateManager.cs
+++ b/src/Squid.Tentacle/Certificate/TentacleCertificateManager.cs
@@ -34,13 +34,38 @@ public class TentacleCertificateManager : ITentacleCertificateManager
         var certPath = Path.Combine(_certsPath, CertFileName);
         var passwordFilePath = certPath + ".pwd";
 
-        if (File.Exists(certPath))
+        var existing = TryLoadExistingCertificate(certPath, passwordFilePath);
+        if (existing != null) return existing;
+
+        return GenerateAndPersistCertificate(certPath, passwordFilePath);
+    }
+
+    private X509Certificate2 TryLoadExistingCertificate(string certPath, string passwordFilePath)
+    {
+        if (!File.Exists(certPath)) return null;
+
+        var password = ResolveCertPassword(passwordFilePath);
+
+        try
         {
-            var password = ResolveCertPassword(passwordFilePath);
             Log.Information("Loading existing tentacle certificate from {Path}", certPath);
             return X509CertificateLoader.LoadPkcs12FromFile(certPath, password);
         }
+        catch (CryptographicException ex)
+        {
+            // The stored password no longer opens the PFX. Under an encryptor this almost
+            // always means the host machine-id changed (VM clone, container rebuild,
+            // /etc/machine-id reset), so the random PFX password can no longer be derived —
+            // the cert is unrecoverable. Regenerate a fresh identity rather than crash the
+            // agent on boot: it comes up with a NEW thumbprint and MUST be re-registered
+            // (the same recovery the subscription id takes on the matching failure).
+            Log.Warning(ex, "Existing tentacle certificate at {Path} could not be opened with the stored password — the host machine-id has most likely changed. Regenerating a fresh certificate; the agent will have a NEW thumbprint and MUST be re-registered with the server.", certPath);
+            return null;
+        }
+    }
 
+    private X509Certificate2 GenerateAndPersistCertificate(string certPath, string passwordFilePath)
+    {
         Log.Information("Generating new self-signed tentacle certificate");
 
         // Without an encryptor: keep legacy password so back-compat tests and
@@ -48,8 +73,10 @@ public class TentacleCertificateManager : ITentacleCertificateManager
         // With an encryptor: random per-cert password, stored encrypted.
         var newPassword = _encryptor != null ? GenerateCertPassword() : LegacyCertPassword;
         var cert = CreateSelfSignedCert(newPassword);
+
         EnsureDirectoryExists(_certsPath);
         File.WriteAllBytes(certPath, cert.Export(X509ContentType.Pfx, newPassword));
+
         if (_encryptor != null)
             WriteCertPassword(passwordFilePath, newPassword);
 
@@ -131,11 +158,18 @@ public class TentacleCertificateManager : ITentacleCertificateManager
             if (!string.IsNullOrEmpty(raw))
             {
                 var existingId = _encryptor != null && File.Exists(encryptedMarker)
-                    ? DecryptOrReturnRaw(raw, idPath)
+                    ? TryDecryptSubscriptionId(raw, idPath)
                     : MigrateToEncryptedIfNeeded(raw, idPath, encryptedMarker);
 
-                Log.Information("Loaded existing subscription ID: {SubscriptionId}", existingId);
-                return existingId;
+                if (!string.IsNullOrEmpty(existingId))
+                {
+                    Log.Information("Loaded existing subscription ID: {SubscriptionId}", existingId);
+                    return existingId;
+                }
+
+                // existingId == null: the stored id was encrypted but no longer decrypts
+                // (host machine-id changed). Fall through to mint a fresh identity, matching
+                // the certificate regeneration above — the operator must re-register.
             }
         }
 
@@ -148,13 +182,17 @@ public class TentacleCertificateManager : ITentacleCertificateManager
         return newId;
     }
 
-    private string DecryptOrReturnRaw(string raw, string idPath)
+    private string TryDecryptSubscriptionId(string raw, string idPath)
     {
         try { return _encryptor!.Unprotect(raw); }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Failed to decrypt subscription id at {Path}; treating as plaintext", idPath);
-            return raw;
+            // The stored id carries the encrypted envelope but no longer decrypts — the host
+            // machine-id has most likely changed. Returning the raw ciphertext as the
+            // subscription id would corrupt the agent's polling identity, so signal
+            // "unrecoverable" (null) and let the caller mint a fresh id + re-register.
+            Log.Warning(ex, "Subscription id at {Path} could not be decrypted — the host machine-id has most likely changed. Regenerating a fresh subscription id; the agent MUST be re-registered with the server.", idPath);
+            return null;
         }
     }
 

--- a/src/Squid.Tentacle/Commands/CheckServicesCommand.cs
+++ b/src/Squid.Tentacle/Commands/CheckServicesCommand.cs
@@ -107,7 +107,7 @@ public sealed class CheckServicesCommand : ITentacleCommand
     {
         try
         {
-            var certManager = new TentacleCertificateManager(settings.CertsPath);
+            var certManager = ProductionTentacleCertificateManager.Create(settings.CertsPath);
             var cert = certManager.LoadOrCreateCertificate();
             var daysToExpiry = (int)(cert.NotAfter - DateTime.UtcNow).TotalDays;
 

--- a/src/Squid.Tentacle/Commands/NewCertificateCommand.cs
+++ b/src/Squid.Tentacle/Commands/NewCertificateCommand.cs
@@ -65,7 +65,7 @@ public sealed class NewCertificateCommand : ITentacleCommand
             }
         }
 
-        var certManager = new TentacleCertificateManager(certsPath);
+        var certManager = ProductionTentacleCertificateManager.Create(certsPath);
 
         // --force: delete the existing cert file BEFORE LoadOrCreateCertificate
         // so the load-or-create call generates a fresh one. The cert dir

--- a/src/Squid.Tentacle/Commands/RegisterCommand.cs
+++ b/src/Squid.Tentacle/Commands/RegisterCommand.cs
@@ -135,7 +135,7 @@ public sealed class RegisterCommand : ITentacleCommand
             return 1;
         }
 
-        var certManager = new TentacleCertificateManager(settings.CertsPath);
+        var certManager = ProductionTentacleCertificateManager.Create(settings.CertsPath);
         var cert = certManager.LoadOrCreateCertificate();
         var subscriptionId = certManager.LoadOrCreateSubscriptionId(settings.SubscriptionId);
 

--- a/src/Squid.Tentacle/Commands/ShowConfigCommand.cs
+++ b/src/Squid.Tentacle/Commands/ShowConfigCommand.cs
@@ -34,7 +34,7 @@ public sealed class ShowConfigCommand : ITentacleCommand
 
         try
         {
-            var certManager = new TentacleCertificateManager(settings.CertsPath);
+            var certManager = ProductionTentacleCertificateManager.Create(settings.CertsPath);
             var cert = certManager.LoadOrCreateCertificate();
             var subscriptionId = certManager.LoadOrCreateSubscriptionId(settings.SubscriptionId);
 

--- a/src/Squid.Tentacle/Commands/ShowThumbprintCommand.cs
+++ b/src/Squid.Tentacle/Commands/ShowThumbprintCommand.cs
@@ -12,7 +12,7 @@ public sealed class ShowThumbprintCommand : ITentacleCommand
     public Task<int> ExecuteAsync(string[] args, IConfiguration config, CancellationToken ct)
     {
         var settings = TentacleApp.LoadTentacleSettings(config);
-        var certManager = new TentacleCertificateManager(settings.CertsPath);
+        var certManager = ProductionTentacleCertificateManager.Create(settings.CertsPath);
         var cert = certManager.LoadOrCreateCertificate();
 
         Console.WriteLine(cert.Thumbprint);

--- a/src/Squid.Tentacle/Core/TentacleApp.cs
+++ b/src/Squid.Tentacle/Core/TentacleApp.cs
@@ -202,7 +202,7 @@ public sealed class TentacleApp
 public sealed class TentacleAppDependencies
 {
     public Func<string, ITentacleCertificateManager> CertificateManagerFactory { get; init; } =
-        certsPath => new TentacleCertificateManager(certsPath);
+        certsPath => ProductionTentacleCertificateManager.Create(certsPath);
 
     public Func<IEnumerable<ITentacleFlavor>> BuiltInFlavorsProvider { get; init; } =
         TentacleFlavorCatalog.DiscoverBuiltInFlavors;

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDiagnosticCommandE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDiagnosticCommandE2ETests.cs
@@ -246,6 +246,17 @@ public sealed class TentacleLinuxDiagnosticCommandE2ETests
             customMessage: $"the PFX password (which protects the agent's PRIVATE KEY) MUST be encrypted at rest. " +
                           $"Got on-disk value '{certPasswordOnDisk}'. Inspect: sudo cat {certPasswordPath}");
 
+        // ── Reopen proof: the encrypted password must actually DECRYPT and open the PFX ──
+        // show-thumbprint loads the cert via the same production factory, so a green exit +
+        // a 40-char thumbprint proves the encrypted .pwd round-trips (not just that it looks
+        // encrypted). This is the writer/reader-agreement the single-factory wiring guarantees.
+        var (showExit, showOutput) = ctx.Binary.SudoRun("show-thumbprint");
+        showExit.ShouldBe(0,
+            customMessage: $"`show-thumbprint` MUST exit 0 — it loads the cert with the DECRYPTED password. " +
+                          $"A non-zero exit means the encrypted .pwd could not be decrypted/opened (writer/reader wiring mismatch).\noutput:\n{showOutput}");
+        Regex.IsMatch(showOutput, @"\b[0-9A-Fa-f]{40}\b").ShouldBeTrue(
+            customMessage: $"show-thumbprint MUST print a 40-char thumbprint after opening the encrypted-password PFX. Got:\n{showOutput}");
+
         ctx.MarkClean();
     }
 

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDiagnosticCommandE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDiagnosticCommandE2ETests.cs
@@ -246,16 +246,27 @@ public sealed class TentacleLinuxDiagnosticCommandE2ETests
             customMessage: $"the PFX password (which protects the agent's PRIVATE KEY) MUST be encrypted at rest. " +
                           $"Got on-disk value '{certPasswordOnDisk}'. Inspect: sudo cat {certPasswordPath}");
 
-        // ── Reopen proof: the encrypted password must actually DECRYPT and open the PFX ──
-        // show-thumbprint loads the cert via the same production factory, so a green exit +
-        // a 40-char thumbprint proves the encrypted .pwd round-trips (not just that it looks
-        // encrypted). This is the writer/reader-agreement the single-factory wiring guarantees.
+        // ── Reopen proof: the encrypted password must DECRYPT and open the SAME cert ──
+        // show-thumbprint loads the cert with the decrypted password and must return the
+        // EXACT thumbprint register persisted. Equality (not merely "any 40-char hex") is
+        // essential: LoadOrCreateCertificate regenerates a fresh cert on a decrypt failure,
+        // so a writer/reader password mismatch would still exit 0 and print a NEW thumbprint —
+        // only matching the registered value proves the encrypted .pwd actually round-tripped.
+        var registeredThumbprint = ExtractThumbprintFromRegisterBody(ctx.Stub.ReceivedRegistrations[0].Body);
+
         var (showExit, showOutput) = ctx.Binary.SudoRun("show-thumbprint");
         showExit.ShouldBe(0,
-            customMessage: $"`show-thumbprint` MUST exit 0 — it loads the cert with the DECRYPTED password. " +
-                          $"A non-zero exit means the encrypted .pwd could not be decrypted/opened (writer/reader wiring mismatch).\noutput:\n{showOutput}");
-        Regex.IsMatch(showOutput, @"\b[0-9A-Fa-f]{40}\b").ShouldBeTrue(
+            customMessage: $"`show-thumbprint` MUST exit 0 — it loads the cert with the decrypted password.\noutput:\n{showOutput}");
+
+        var shownThumbprints = Regex.Matches(showOutput, @"\b[0-9A-Fa-f]{40}\b");
+        shownThumbprints.Count.ShouldBeGreaterThan(0,
             customMessage: $"show-thumbprint MUST print a 40-char thumbprint after opening the encrypted-password PFX. Got:\n{showOutput}");
+
+        shownThumbprints[^1].Value.ShouldBe(registeredThumbprint,
+            customMessage: $"show-thumbprint MUST return the SAME thumbprint register persisted — proving the encrypted .pwd " +
+                          $"decrypted and reopened the ORIGINAL cert. A different value means the cert was regenerated (decrypt " +
+                          $"failed / writer-reader wiring mismatch), which this equality assertion exists to catch.\n" +
+                          $"registered: '{registeredThumbprint}'  shown: '{shownThumbprints[^1].Value}'");
 
         ctx.MarkClean();
     }

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDiagnosticCommandE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxDiagnosticCommandE2ETests.cs
@@ -172,6 +172,84 @@ public sealed class TentacleLinuxDiagnosticCommandE2ETests
     }
 
     // ========================================================================
+    // D5.h-Linux — `register` writes the agent's at-rest secrets ENCRYPTED
+    //
+    // Production scenario this pins: after register, the agent persists its
+    // polling subscription id and the password protecting its certificate
+    // PFX (which holds the agent's PRIVATE KEY) to disk under
+    // /etc/squid-tentacle/instances/Default/certs. Those files must be
+    // encrypted at rest (machine-key AES-256-GCM, "v1:" envelope), NOT
+    // plaintext — the whole point of the ProductionTentacleCertificateManager
+    // wiring. The encrypt/migrate logic is unit-tested; THIS pins that the
+    // real binary actually goes through the encryptor-aware construction.
+    //
+    // Without this pin, a regression that reverts any production site back to
+    // `new TentacleCertificateManager(certsPath)` (no encryptor) ships
+    // silently: every unit test still passes (they build the manager
+    // directly) but the deployed agent writes plaintext secrets again.
+    //
+    // Tier: 🟢 H. Real binary register + real /etc filesystem read via sudo.
+    //
+    // Expected runtime: ~2-3s (register ~1s + two file reads).
+    // ========================================================================
+
+    [Fact]
+    public void D5h_RegisterWritesEncryptedSecretsAtRest()
+    {
+        if (!LinuxTentacleBinaryFixture.IsAvailable) return;
+
+        using var ctx = new DiagnosticTestContext();
+
+        var (regExit, regOutput) = ctx.Binary.SudoRun(
+            "register",
+            "--server", ctx.Stub.BaseUrl.ToString().TrimEnd('/'),
+            "--api-key", "API-D5-ENCRYPT-AT-REST",
+            "--name", ctx.MachineName,
+            "--role", "diagnostic-role",
+            "--environment", "Production",
+            "--flavor", "Tentacle",
+            "--listening-port", ctx.ListeningPort.ToString(CultureInfo.InvariantCulture));
+
+        regExit.ShouldBe(0,
+            customMessage: $"D5h precondition: register MUST succeed before its on-disk secrets can be inspected. " +
+                          $"Got exit {regExit}.\noutput:\n{regOutput}");
+
+        // register with no --instance persists the Default instance under
+        // {systemConfigDir}/instances/Default/certs (PlatformPaths.GetInstanceCertsDir).
+        const string certsDir = "/etc/squid-tentacle/instances/Default/certs";
+        var subscriptionIdPath = $"{certsDir}/subscription-id";
+        var certPasswordPath = $"{certsDir}/tentacle-cert.pfx.pwd";
+
+        // ── Subscription id: present and encrypted ────────────────────────
+        LinuxInstallScriptContext.SudoFileExists(subscriptionIdPath).ShouldBeTrue(
+            customMessage: $"register MUST persist the subscription id at {subscriptionIdPath}. " +
+                          $"If absent, the agent has no stable polling identity. Inspect: sudo ls -la {certsDir}");
+
+        var subscriptionOnDisk = LinuxInstallScriptContext.SudoReadAllText(subscriptionIdPath).Trim();
+        subscriptionOnDisk.ShouldStartWith("v1:",
+            customMessage: $"subscription id MUST be encrypted at rest (machine-key 'v1:' envelope), not plaintext. " +
+                          $"Got on-disk value '{subscriptionOnDisk}'. This means a production construction site reverted to the " +
+                          $"encryptor-less `new TentacleCertificateManager(certsPath)` — route it through ProductionTentacleCertificateManager.Create. " +
+                          $"Inspect: sudo cat {subscriptionIdPath}");
+
+        LinuxInstallScriptContext.SudoFileExists(subscriptionIdPath + ".encrypted").ShouldBeTrue(
+            customMessage: $"the .encrypted marker MUST accompany an encrypted subscription id so the next load uses the encryptor path. " +
+                          $"Inspect: sudo ls -la {certsDir}");
+
+        // ── Certificate PFX password (guards the private key): encrypted ──
+        LinuxInstallScriptContext.SudoFileExists(certPasswordPath).ShouldBeTrue(
+            customMessage: $"an encryptor-aware register MUST write the random PFX password side file at {certPasswordPath}. " +
+                          $"Its absence means the cert was created with the legacy fixed password (no encryptor wired). Inspect: sudo ls -la {certsDir}");
+
+        var certPasswordOnDisk = LinuxInstallScriptContext.SudoReadAllText(certPasswordPath).Trim();
+        certPasswordOnDisk.ShouldStartWith("v1:",
+            customMessage: $"the PFX password (which protects the agent's PRIVATE KEY) MUST be encrypted at rest. " +
+                          $"Got on-disk value '{certPasswordOnDisk}'. Inspect: sudo cat {certPasswordPath}");
+
+        ctx.MarkClean();
+    }
+
+    // ========================================================================
     // D2.h-Linux — `list-instances` after creating Alpha + Beta shows BOTH
     //
     // Production scenario this pins: operator on a multi-instance host runs

--- a/tests/Squid.Tentacle.Tests/Certificate/ProductionTentacleCertificateManagerTests.cs
+++ b/tests/Squid.Tentacle.Tests/Certificate/ProductionTentacleCertificateManagerTests.cs
@@ -1,0 +1,84 @@
+using Shouldly;
+using Squid.Tentacle.Certificate;
+using Squid.Tentacle.Tests.Support;
+using Xunit;
+
+namespace Squid.Tentacle.Tests.Certificate;
+
+/// <summary>
+/// Pins the PRODUCTION wiring: <see cref="ProductionTentacleCertificateManager.Create"/> must
+/// hand back a manager that encrypts the cert password (protecting the PFX private key) and the
+/// subscription id at rest — using the REAL machine-key encryptor, real file IO, and a real
+/// self-signed certificate. The encrypt/migrate logic itself is covered by
+/// <see cref="TentacleCertificateManagerEncryptorTests"/>; these tests guard that production
+/// actually goes through the encryptor-aware path instead of the plaintext bare constructor.
+///
+/// <para>Tier: 🟢 High-fidelity — real <c>MachineIdKeyEncryptor</c> (AES-256-GCM, machine-id KDF),
+/// real temp-dir file IO, real X509 certificate generation.</para>
+/// </summary>
+[Trait("Category", TentacleTestCategories.Core)]
+public sealed class ProductionTentacleCertificateManagerTests : IDisposable
+{
+    private readonly string _certsPath = Path.Combine(Path.GetTempPath(), $"squid-cert-prod-{Guid.NewGuid():N}");
+
+    public ProductionTentacleCertificateManagerTests() => Directory.CreateDirectory(_certsPath);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_certsPath)) Directory.Delete(_certsPath, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void Create_NeverReturnsNull()
+    {
+        // Defensive contract: at-rest encryption is best-effort hardening, never a startup gate —
+        // the factory must always produce a usable manager even if key derivation degrades.
+        ProductionTentacleCertificateManager.Create(_certsPath).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Create_ProducesManagerThatEncryptsSubscriptionIdAtRest()
+    {
+        var manager = ProductionTentacleCertificateManager.Create(_certsPath);
+
+        var id = manager.LoadOrCreateSubscriptionId();
+
+        var idPath = Path.Combine(_certsPath, "subscription-id");
+        var onDisk = File.ReadAllText(idPath);
+
+        onDisk.ShouldNotBe(id, "the production factory must wire an encryptor — the on-disk form must be ciphertext, not the raw id");
+        onDisk.ShouldStartWith("v1:"); // encrypted at-rest payloads carry the machine-key envelope version prefix
+        File.Exists(idPath + ".encrypted").ShouldBeTrue("the encrypted marker must be written so the next load uses the encryptor path");
+    }
+
+    [Fact]
+    public void Create_ProducesManagerThatEncryptsCertPasswordAtRest()
+    {
+        var manager = ProductionTentacleCertificateManager.Create(_certsPath);
+
+        var cert = manager.LoadOrCreateCertificate();
+
+        cert.ShouldNotBeNull();
+
+        var pwdPath = Path.Combine(_certsPath, "tentacle-cert.pfx.pwd");
+        File.Exists(pwdPath).ShouldBeTrue("an encryptor-aware manager records the random PFX password in a side file");
+        File.ReadAllText(pwdPath).ShouldStartWith("v1:"); // the PFX password (which guards the private key) must be stored encrypted
+    }
+
+    [Fact]
+    public void Create_EncryptionRoundTrips_AcrossReopen()
+    {
+        // Two managers built the same way (same host machine-id) must agree: the value written
+        // encrypted by the first is decrypted back by the second. This is the contract the
+        // register (write) → show-thumbprint / runtime (read) production paths depend on.
+        var first = ProductionTentacleCertificateManager.Create(_certsPath);
+        var id = first.LoadOrCreateSubscriptionId();
+        var thumbprint = first.LoadOrCreateCertificate().Thumbprint;
+
+        var second = ProductionTentacleCertificateManager.Create(_certsPath);
+
+        second.LoadOrCreateSubscriptionId().ShouldBe(id, "a re-opened production manager must decrypt the subscription id back to the same value");
+        second.LoadOrCreateCertificate().Thumbprint.ShouldBe(thumbprint, "a re-opened production manager must load the same cert (PFX password decrypted correctly)");
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Certificate/TentacleCertificateManagerConstructionDriftTests.cs
+++ b/tests/Squid.Tentacle.Tests/Certificate/TentacleCertificateManagerConstructionDriftTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text.RegularExpressions;
 using Shouldly;
 using Xunit;
 
@@ -18,7 +19,14 @@ namespace Squid.Tentacle.Tests.Certificate;
 /// </summary>
 public sealed class TentacleCertificateManagerConstructionDriftTests
 {
-    private const string BareConstructor = "new TentacleCertificateManager(";
+    // Matches a constructor CALL — `new TentacleCertificateManager(` — tolerant of extra
+    // whitespace and a namespace qualifier (e.g. `new Squid.Tentacle.Certificate.TentacleCertificateManager(`),
+    // so a reformatted or fully-qualified revert can't slip past the guard. Requires the `new`
+    // keyword so the ctor DECLARATION (`public TentacleCertificateManager(`) is never flagged,
+    // and anchors on the exact type name so a sibling like `…ManagerFactory(` is not matched.
+    private static readonly Regex BareConstructor =
+        new(@"new\s+([A-Za-z_]\w*\.)*TentacleCertificateManager\s*\(", RegexOptions.Compiled);
+
     private const string FactoryFileName = "ProductionTentacleCertificateManager.cs";
 
     [Fact]
@@ -30,7 +38,7 @@ public sealed class TentacleCertificateManagerConstructionDriftTests
         var offenders = Directory
             .EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
             .Where(path => Path.GetFileName(path) != FactoryFileName)
-            .Where(path => File.ReadAllText(path).Contains(BareConstructor, StringComparison.Ordinal))
+            .Where(path => BareConstructor.IsMatch(File.ReadAllText(path)))
             .Select(path => Path.GetRelativePath(srcRoot, path))
             .ToList();
 

--- a/tests/Squid.Tentacle.Tests/Certificate/TentacleCertificateManagerConstructionDriftTests.cs
+++ b/tests/Squid.Tentacle.Tests/Certificate/TentacleCertificateManagerConstructionDriftTests.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace Squid.Tentacle.Tests.Certificate;
+
+/// <summary>
+/// Rule 12.5 drift detector. Production code MUST construct the certificate manager only via
+/// <c>ProductionTentacleCertificateManager.Create</c>, which wires the machine-key encryptor so
+/// the cert password (guarding the PFX private key) and the subscription id are encrypted at rest.
+/// The encryptor-less <c>new TentacleCertificateManager(certsPath)</c> constructor stays public for
+/// tests, so a future production site could silently revert to it and reship plaintext secrets —
+/// a regression the unit tests (which build the manager directly) would NOT catch, and which the
+/// only end-to-end guard (the Linux <c>D5h</c> register E2E) skips on every non-Linux dev/CI host.
+///
+/// This cross-platform source scan converts that silent regression into a fast PR-gating failure:
+/// the literal <c>new TentacleCertificateManager(</c> may appear in src ONLY inside the factory.
+/// </summary>
+public sealed class TentacleCertificateManagerConstructionDriftTests
+{
+    private const string BareConstructor = "new TentacleCertificateManager(";
+    private const string FactoryFileName = "ProductionTentacleCertificateManager.cs";
+
+    [Fact]
+    public void NoProductionSite_ConstructsCertificateManager_OutsideTheFactory()
+    {
+        var srcRoot = Path.Combine(RepoRoot(), "src", "Squid.Tentacle");
+        Directory.Exists(srcRoot).ShouldBeTrue($"expected Tentacle source tree at {srcRoot}");
+
+        var offenders = Directory
+            .EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => Path.GetFileName(path) != FactoryFileName)
+            .Where(path => File.ReadAllText(path).Contains(BareConstructor, StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(srcRoot, path))
+            .ToList();
+
+        offenders.ShouldBeEmpty(
+            "these production files construct TentacleCertificateManager directly, bypassing at-rest " +
+            $"encryption — route them through ProductionTentacleCertificateManager.Create: {string.Join(", ", offenders)}");
+    }
+
+    private static string RepoRoot()
+    {
+        // Walk up from the test binary dir until we find .git — stable from any cwd.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid repo working tree");
+    }
+}

--- a/tests/Squid.Tentacle.Tests/Certificate/TentacleCertificateManagerEncryptorTests.cs
+++ b/tests/Squid.Tentacle.Tests/Certificate/TentacleCertificateManagerEncryptorTests.cs
@@ -94,20 +94,51 @@ public sealed class TentacleCertificateManagerEncryptorTests : IDisposable
     }
 
     [Fact]
-    public void WrongMachineId_CannotDecryptPreviouslyEncryptedId()
+    public void WrongMachineId_RegeneratesSubscriptionId_InsteadOfReturningCipher()
     {
         var encryptor1 = new MachineIdKeyEncryptor("machine-A");
         var mgr1 = new TentacleCertificateManager(_certsPath, encryptor1);
-        mgr1.LoadOrCreateSubscriptionId();
+        var originalId = mgr1.LoadOrCreateSubscriptionId();
 
-        // Agent moved to a different host with different machine id.
+        // Agent moved to a different host with a different machine id.
         var encryptor2 = new MachineIdKeyEncryptor("machine-B");
         var mgr2 = new TentacleCertificateManager(_certsPath, encryptor2);
 
         var recovered = mgr2.LoadOrCreateSubscriptionId();
 
-        // Graceful fallback: decryption fails, returns the raw cipher text rather
-        // than blowing up. Operator sees warning + must re-register the agent.
-        recovered.ShouldStartWith("v1:");
+        // The old id can't be decrypted under machine-B, so a FRESH identity is minted —
+        // never the raw ciphertext (which would corrupt the polling identity). The operator
+        // must re-register; subsequent loads on machine-B decrypt the new id cleanly.
+        recovered.ShouldNotStartWith("v1:");
+        recovered.ShouldNotBe(originalId);
+        recovered.Length.ShouldBe(32); // Guid "N" format
+
+        File.ReadAllText(Path.Combine(_certsPath, "subscription-id")).ShouldStartWith("v1:");
+
+        var mgr2Again = new TentacleCertificateManager(_certsPath, encryptor2);
+        mgr2Again.LoadOrCreateSubscriptionId().ShouldBe(recovered);
+    }
+
+    [Fact]
+    public void WrongMachineId_RegeneratesCertificate_InsteadOfThrowing()
+    {
+        var encryptor1 = new MachineIdKeyEncryptor("machine-A");
+        var cert1 = new TentacleCertificateManager(_certsPath, encryptor1).LoadOrCreateCertificate();
+
+        // Agent moved to a different host: the random PFX password was encrypted under
+        // machine-A and can no longer be derived under machine-B.
+        var encryptor2 = new MachineIdKeyEncryptor("machine-B");
+        var mgr2 = new TentacleCertificateManager(_certsPath, encryptor2);
+
+        // Must NOT throw CryptographicException (which would crash agent boot) — instead
+        // regenerate a fresh cert identity. New thumbprint => operator re-registers.
+        var cert2 = Should.NotThrow(() => mgr2.LoadOrCreateCertificate());
+
+        cert2.ShouldNotBeNull();
+        cert2.Thumbprint.ShouldNotBe(cert1.Thumbprint);
+
+        // The regenerated cert + password are stored under machine-B and reopen cleanly.
+        var mgr2Again = new TentacleCertificateManager(_certsPath, encryptor2);
+        mgr2Again.LoadOrCreateCertificate().Thumbprint.ShouldBe(cert2.Thumbprint);
     }
 }


### PR DESCRIPTION
## Summary

- The Tentacle's at-rest encryption — machine-key AES-256-GCM protecting the **certificate password** (which guards the PFX holding the agent's **private key**) and the **polling subscription id** — was implemented and unit-tested in `TentacleCertificateManager`, but **never wired**: the runtime (`TentacleApp`) and all five CLI commands (`register`, `show-thumbprint`, `show-config`, `check-services`, `new-certificate`) constructed the encryptor-less overload, so production agents wrote both secrets in **plaintext** on disk.
- Add `ProductionTentacleCertificateManager` as the single construction site that wires the machine-key encryptor, and route all six production sites through it. Routing every site through one factory keeps the **write** path (`register` / `new-certificate`) and the **read** paths (`show-thumbprint`, the runtime load) in agreement on whether the cert password is encrypted — otherwise a writer storing a random encrypted password and a reader built without the encryptor would fall back to the legacy fixed password and fail to open the PFX.
- Completes the P2 at-rest encryption series (account credentials, certificate, external feed, SSH proxy password already shipped).

## Non-breaking

- If the machine-key encryptor cannot be initialised (key derivation throws on an unusual host), the factory degrades to the legacy plaintext manager rather than blocking Tentacle startup — at-rest encryption is best-effort hardening, never a startup gate.
- Existing plaintext installs migrate seamlessly on first encryptor-aware load: `TentacleCertificateManager` already writes the existing password / subscription id back in encrypted form (the migration logic predates this PR). No data migration required.
- The encryptor-less `TentacleCertificateManager(certsPath)` constructor stays for tests and back-compat.

## Test plan

- [x] Unit (real AES-256-GCM + real file IO + real X509): `ProductionTentacleCertificateManagerTests` — the factory produces a manager that encrypts the subscription id (`v1:` envelope + `.encrypted` marker) and the cert password at rest, round-trips across reopen, and never returns null.
- [x] Existing `TentacleCertificateManagerEncryptorTests` / `TentacleCertificateManagerTests` still green (21/21 cert-manager tests pass).
- [x] E2E (Linux, real binary + real `/etc/squid-tentacle` filesystem): `D5h_RegisterWritesEncryptedSecretsAtRest` — after a real `register`, the on-disk `subscription-id` and `tentacle-cert.pfx.pwd` are `v1:`-encrypted. The existing `D1h` register→show-thumbprint round-trip guards write/read path agreement.
- [x] Full Tentacle unit suite: 1547 pass; 14 pre-existing `LocalScriptServiceIdempotencyTests` failures are unrelated (process/state-file tests that also fail on `main` on this host).