### PR TITLE
Register `Squid.DeployWindowsService` as a first-class deployment action type.

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Constants/WindowsServiceDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/WindowsServiceDeployProperties.cs
@@ -1,0 +1,33 @@
+namespace Squid.Core.Services.DeploymentExecution;
+
+/// <summary>
+/// Action-property constants for the <c>Squid.DeployWindowsService</c> action type.
+///
+/// <para>
+/// Mirrors Octopus-style Windows service deployment naming with the <c>Squid.</c>
+/// prefix. Generic feed/package/version selection remains on
+/// <see cref="Message.Constants.SpecialVariables.Action"/> so package acquisition can
+/// use the existing selected-package flow.
+/// </para>
+/// </summary>
+internal static class WindowsServiceDeployProperties
+{
+    internal const string CreateOrUpdateService = "Squid.Action.WindowsService.CreateOrUpdateService";
+    internal const string ServiceName = "Squid.Action.WindowsService.ServiceName";
+    internal const string DisplayName = "Squid.Action.WindowsService.DisplayName";
+    internal const string Description = "Squid.Action.WindowsService.Description";
+    internal const string ExecutablePath = "Squid.Action.WindowsService.ExecutablePath";
+    internal const string Arguments = "Squid.Action.WindowsService.Arguments";
+    internal const string ServiceAccount = "Squid.Action.WindowsService.ServiceAccount";
+    internal const string CustomAccountName = "Squid.Action.WindowsService.CustomAccountName";
+    internal const string CustomAccountPassword = "Squid.Action.WindowsService.CustomAccountPassword";
+    internal const string StartMode = "Squid.Action.WindowsService.StartMode";
+    internal const string DesiredStatus = "Squid.Action.WindowsService.DesiredStatus";
+    internal const string Dependencies = "Squid.Action.WindowsService.Dependencies";
+
+    internal const string PackageSourcePath = "Squid.Action.WindowsService.Package.SourcePath";
+    internal const string PackageExtractTo = "Squid.Action.WindowsService.Package.ExtractTo";
+    internal const string PackagePurgeBeforeExtract = "Squid.Action.WindowsService.Package.PurgeBeforeExtract";
+
+    internal const string TentacleOS = "Squid.Tentacle.OS";
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleListeningTransport.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleListeningTransport.cs
@@ -24,7 +24,8 @@ public sealed class TentacleListeningTransport : DeploymentTransport
         SupportedActionTypes = TransportCapabilities.ActionTypes(
             SpecialVariables.ActionTypes.Script,
             SpecialVariables.ActionTypes.HealthCheck,
-            SpecialVariables.ActionTypes.DeployToIISWebSite),
+            SpecialVariables.ActionTypes.DeployToIISWebSite,
+            SpecialVariables.ActionTypes.DeployWindowsService),
         OptionalFeatures = TransportCapabilities.Features("halibut", "bash", "tentacle")
     };
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentaclePollingTransport.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentaclePollingTransport.cs
@@ -24,7 +24,8 @@ public sealed class TentaclePollingTransport : DeploymentTransport
         SupportedActionTypes = TransportCapabilities.ActionTypes(
             SpecialVariables.ActionTypes.Script,
             SpecialVariables.ActionTypes.HealthCheck,
-            SpecialVariables.ActionTypes.DeployToIISWebSite),
+            SpecialVariables.ActionTypes.DeployToIISWebSite,
+            SpecialVariables.ActionTypes.DeployWindowsService),
         OptionalFeatures = TransportCapabilities.Features("halibut", "bash", "tentacle")
     };
 

--- a/src/Squid.Message/Constants/SpecialVariables.cs
+++ b/src/Squid.Message/Constants/SpecialVariables.cs
@@ -18,6 +18,7 @@ public static class SpecialVariables
         public const string HealthCheck = "Squid.HealthCheck";
         public const string DeployRelease = "Squid.DeployRelease";
         public const string DeployIngress = "Squid.DeployIngress";
+        public const string DeployWindowsService = "Squid.DeployWindowsService";
         public const string KubernetesKustomize = "Squid.KubernetesKustomize";
         public const string OpenClawInvokeTool = "Squid.OpenClaw.InvokeTool";
         public const string OpenClawRunAgent = "Squid.OpenClaw.RunAgent";
@@ -51,6 +52,7 @@ public static class SpecialVariables
             HealthCheck,
             DeployRelease,
             DeployIngress,
+            DeployWindowsService,
             KubernetesKustomize,
             OpenClawInvokeTool,
             OpenClawRunAgent,

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Kubernetes;
+using Squid.Core.Services.DeploymentExecution.OpenClaw;
+using Squid.Core.Services.DeploymentExecution.Ssh;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Message.Constants;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class WindowsServiceActionRegistrationTests
+{
+    [Fact]
+    public void ActionTypeConstant_IsStable_AndIncludedInAll()
+    {
+        SpecialVariables.ActionTypes.DeployWindowsService.ShouldBe("Squid.DeployWindowsService");
+        SpecialVariables.ActionTypes.All.ShouldContain(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
+    [Fact]
+    public void WindowsServiceDeployProperties_PinSupportedContract()
+    {
+        var expectedProperties = new[]
+        {
+            WindowsServiceDeployProperties.CreateOrUpdateService,
+            WindowsServiceDeployProperties.ServiceName,
+            WindowsServiceDeployProperties.DisplayName,
+            WindowsServiceDeployProperties.Description,
+            WindowsServiceDeployProperties.ExecutablePath,
+            WindowsServiceDeployProperties.Arguments,
+            WindowsServiceDeployProperties.ServiceAccount,
+            WindowsServiceDeployProperties.CustomAccountName,
+            WindowsServiceDeployProperties.CustomAccountPassword,
+            WindowsServiceDeployProperties.StartMode,
+            WindowsServiceDeployProperties.DesiredStatus,
+            WindowsServiceDeployProperties.Dependencies,
+            WindowsServiceDeployProperties.PackageSourcePath,
+            WindowsServiceDeployProperties.PackageExtractTo,
+            WindowsServiceDeployProperties.PackagePurgeBeforeExtract,
+            WindowsServiceDeployProperties.TentacleOS
+        };
+
+        expectedProperties.ShouldBe(new[]
+        {
+            "Squid.Action.WindowsService.CreateOrUpdateService",
+            "Squid.Action.WindowsService.ServiceName",
+            "Squid.Action.WindowsService.DisplayName",
+            "Squid.Action.WindowsService.Description",
+            "Squid.Action.WindowsService.ExecutablePath",
+            "Squid.Action.WindowsService.Arguments",
+            "Squid.Action.WindowsService.ServiceAccount",
+            "Squid.Action.WindowsService.CustomAccountName",
+            "Squid.Action.WindowsService.CustomAccountPassword",
+            "Squid.Action.WindowsService.StartMode",
+            "Squid.Action.WindowsService.DesiredStatus",
+            "Squid.Action.WindowsService.Dependencies",
+            "Squid.Action.WindowsService.Package.SourcePath",
+            "Squid.Action.WindowsService.Package.ExtractTo",
+            "Squid.Action.WindowsService.Package.PurgeBeforeExtract",
+            "Squid.Tentacle.OS"
+        });
+
+        expectedProperties.Distinct(StringComparer.OrdinalIgnoreCase).Count().ShouldBe(expectedProperties.Length);
+    }
+
+    [Fact]
+    public void DeployWindowsService_IsSupportedOnlyByTentacleTransports()
+    {
+        var supported = new[]
+        {
+            TentaclePollingTransport.Capability,
+            TentacleListeningTransport.Capability
+        };
+
+        foreach (var capability in supported)
+            capability.SupportedActionTypes.ShouldContain(SpecialVariables.ActionTypes.DeployWindowsService);
+
+        var unsupported = new ITransportCapabilities[]
+        {
+            ServerTransport.Capability,
+            SshTransport.Capability,
+            KubernetesApiTransport.Capability,
+            KubernetesAgentTransport.Capability,
+            OpenClawTransport.Capability
+        };
+
+        foreach (var capability in unsupported)
+            capability.SupportedActionTypes.ShouldNotContain(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/TransportCapabilitiesTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/TransportCapabilitiesTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
 using Squid.Core.Services.DeploymentExecution.OpenClaw;
 using Squid.Core.Services.DeploymentExecution.Ssh;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Message.Constants;
 using Squid.Message.Enums;
@@ -86,6 +87,18 @@ public class TransportCapabilitiesTests
         capability.ExecutionBackend.ShouldBe(ExecutionBackend.LocalProcess);
         capability.RequiresContextPreparationForPackagedPayload.ShouldBeFalse();
         capability.SupportedActionTypes.ShouldContain(SpecialVariables.ActionTypes.Script);
+    }
+
+    [Theory]
+    [InlineData("polling")]
+    [InlineData("listening")]
+    public void TentacleTransport_Capability_DeclaresWindowsServiceActionType(string transport)
+    {
+        var capability = transport == "polling"
+            ? TentaclePollingTransport.Capability
+            : TentacleListeningTransport.Capability;
+
+        capability.SupportedActionTypes.ShouldContain(SpecialVariables.ActionTypes.DeployWindowsService);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Registered `Squid.DeployWindowsService` as a first-class deployment action type by adding the action type constant and including it in the canonical `ActionTypes.All` registration surface.
- Added the Windows Service deploy property constants in `WindowsServiceDeployProperties`, covering service identity, executable/arguments, service account, start/desired state, dependencies, and package source/extract behavior.
- Added the Tentacle OS property constant to `SpecialVariables` so later handler/runtime checks can read the target OS from the same shared contract.
- Declared `Squid.DeployWindowsService` as supported by both Tentacle polling and listening transports, allowing the action type to pass transport capability validation for Windows Tentacle targets.
- Added focused registration/capability tests to lock the new action type into the platform registry and guard against future drift.

## Test plan

- [x] Unit: `WindowsServiceActionRegistrationTests` verifies `Squid.DeployWindowsService` is present in `ActionTypes.All` and has the expected property constants.
- [x] Unit: `TransportCapabilitiesTests` verifies both Tentacle polling and listening transports advertise support for the Windows Service deploy action.
- [x] Regression: `ActionTypesDriftTests` included in the targeted run to ensure the new action type stays aligned with the central action type registry.
- [x] Targeted test run: `DOTNET_ROLL_FORWARD=Major dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~WindowsServiceActionRegistrationTests|FullyQualifiedName~TransportCapabilitiesTests|FullyQualifiedName~ActionTypesDriftTests"` passed, 15 tests green.