### PR TITLE
Add deploy a windows service

### DIFF
--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -131,10 +131,13 @@ jobs:
         shell: pwsh
         run: |
           $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E" }
+          $resultsDir = Join-Path $env:RUNNER_TEMP "windows-e2e-results"
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `
-            --logger "console;verbosity=normal"
+            --logger "console;verbosity=normal" `
+            --logger "trx;LogFileName=windows-e2e.trx" `
+            --results-directory $resultsDir
 
       - name: Capture IIS metabase state on failure
         if: failure()
@@ -147,3 +150,11 @@ jobs:
           Get-WebAppPool | Format-Table -Property Name, State | Out-String
           Write-Host "=== Bindings ==="
           Get-WebBinding | Format-Table -Property protocol, bindingInformation, sslFlags | Out-String
+
+      - name: Upload Windows E2E test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-e2e-test-results
+          path: ${{ runner.temp }}/windows-e2e-results
+          if-no-files-found: warn

--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -31,7 +31,7 @@ on:
       upgrade_test_filter:
         description: "xUnit --filter for the Squid.WindowsTentacleE2ETests step (defaults to wrapper + service categories)"
         required: false
-        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E"
+        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E"
 
 permissions:
   contents: read
@@ -130,7 +130,7 @@ jobs:
       - name: Run Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E" }
+          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E" }
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `

--- a/.github/workflows/tentacle-windows-smoke-e2e.yml
+++ b/.github/workflows/tentacle-windows-smoke-e2e.yml
@@ -123,10 +123,13 @@ jobs:
         shell: pwsh
         run: |
           $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E" }
+          $resultsDir = Join-Path $env:RUNNER_TEMP "windows-lifecycle-smoke-results"
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `
-            --logger "console;verbosity=normal"
+            --logger "console;verbosity=normal" `
+            --logger "trx;LogFileName=windows-lifecycle-smoke.trx" `
+            --results-directory $resultsDir
 
       - name: Capture leaked test services on failure
         if: failure()
@@ -136,6 +139,14 @@ jobs:
           Get-Service -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match 'squid' -or $_.Name -match 'SquidUpgradeE2E' } |
             Format-Table -Property Name, Status, StartType | Out-String
+
+      - name: Upload Windows smoke test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-lifecycle-smoke-test-results
+          path: ${{ runner.temp }}/windows-lifecycle-smoke-results
+          if-no-files-found: warn
 
   gate:
     name: Windows Lifecycle Smoke (PR gate)

--- a/.github/workflows/tentacle-windows-smoke-e2e.yml
+++ b/.github/workflows/tentacle-windows-smoke-e2e.yml
@@ -13,7 +13,7 @@ name: Tentacle Windows Smoke E2E
 # Three-job "sentinel" layout so this can be a REQUIRED status check WITHOUT
 # blocking PRs that don't touch Tentacle code:
 #   1. detect  (ubuntu, ~20s)  -- did the PR change Tentacle-relevant paths?
-#   2. tests   (windows-latest) -- runs ONLY when detect says relevant; the 54
+#   2. tests   (windows-latest) -- runs ONLY when detect says relevant; the 56
 #                                  real-OS lifecycle tests. Skipped (0 Windows
 #                                  minutes) on unrelated PRs.
 #   3. gate    (ubuntu, ~5s, ALWAYS runs) -- carries the required check. Green
@@ -30,6 +30,8 @@ name: Tentacle Windows Smoke E2E
 # the nightly suite: IISDeployE2E (66 tests; needs a ~1m IIS feature install +
 # XDT engine), the real-binary publish path, and deploy/register/capabilities/
 # diagnostic (cross-platform logic already exercised by unit + Linux E2E).
+# Includes Squid.DeployWindowsService's real-host payload tests because they
+# are the same SCM-backed service availability surface as the lifecycle tests.
 # Skipping IIS lets the tests job skip the slow IIS+XDT setup.
 
 on:
@@ -39,7 +41,7 @@ on:
       test_filter:
         description: "xUnit --filter override for the smoke subset"
         required: false
-        default: "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E"
+        default: "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E"
 
 permissions:
   contents: read
@@ -74,9 +76,10 @@ jobs:
           echo "Changed files:"; printf '%s\n' "$files"
 
           # Same path set the gate cares about (Tentacle source, the Windows
-          # upgrade script, the server-side upgrade strategy, the Windows E2E
-          # project, and this workflow itself).
-          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
+          # upgrade script, the Windows service deploy payload/handler, the
+          # server-side upgrade strategy, the Windows E2E project, and this
+          # workflow itself).
+          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "-> relevant=true (Tentacle paths changed)"
           else
@@ -119,7 +122,7 @@ jobs:
       - name: Run Windows lifecycle smoke subset
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E" }
+          $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E" }
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `
             --filter $filter `

--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -232,28 +232,15 @@ function Resolve-PackageRoot {
             return (Resolve-Path -LiteralPath $extractTo).Path
         }
 
-        if ([string]::IsNullOrWhiteSpace($extractTo)) {
-            $extractTo = Join-Path $sourceItem.DirectoryName ([System.IO.Path]::GetFileNameWithoutExtension($sourceItem.Name))
-        }
-
-        if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
-            Invoke-WithRetry -Description "Removing existing package extract directory '$extractTo'" -ScriptBlock {
-                Remove-Item -LiteralPath $extractTo -Recurse -Force
-            }
-        }
-
-        New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
-        Invoke-WithRetry -Description "Expanding package '$($sourceItem.FullName)' to '$extractTo'" -ScriptBlock {
-            Expand-Archive -LiteralPath $sourceItem.FullName -DestinationPath $extractTo -Force
-        }
-        return (Resolve-Path -LiteralPath $extractTo).Path
+        throw "Windows service package source '$($sourceItem.FullName)' is a file. Deploy Windows Service expects package acquisition to provide an extracted package directory; do not pass a raw .nupkg/.zip archive to the action script."
     }
 
     if (-not [string]::IsNullOrWhiteSpace($extractTo) -and (Test-Path -LiteralPath $extractTo)) {
         return (Resolve-Path -LiteralPath $extractTo).Path
     }
 
-    return (Get-Location).Path
+    $workingDirectory = (Get-Location).Path
+    throw "No Windows service package source was available for this action. Squid expected either Squid.Action.WindowsService.Package.SourcePath, a package-references.json entry, a package-references directory, or an existing Squid.Action.WindowsService.Package.ExtractTo path. Working directory: '$workingDirectory'. Verify the release selected package is bound to this action name and that the Acquire Packages step completed."
 }
 
 function Resolve-ExecutablePath {

--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -28,6 +28,30 @@ function Invoke-Sc {
     }
 }
 
+function Invoke-WithRetry {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$ScriptBlock,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [int]$Attempts = 10,
+        [int]$DelayMilliseconds = 500
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            & $ScriptBlock
+            return
+        }
+        catch {
+            if ($attempt -eq $Attempts) {
+                throw
+            }
+
+            Write-Host "$Description failed on attempt $attempt/$Attempts; retrying in $DelayMilliseconds ms. $($_.Exception.Message)"
+            Start-Sleep -Milliseconds $DelayMilliseconds
+        }
+    }
+}
+
 function Wait-ServiceStatus {
     param(
         [Parameter(Mandatory = $true)][string]$Name,
@@ -44,6 +68,63 @@ function Wait-ServiceStatus {
     }
 }
 
+function Wait-ServiceExists {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [int]$TimeoutSeconds = 30
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $service = Get-Service -Name $Name -ErrorAction SilentlyContinue
+        if ($null -ne $service) {
+            return
+        }
+
+        Start-Sleep -Milliseconds 200
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    throw "Service '$Name' was not visible to Get-Service within $TimeoutSeconds seconds after SCM create."
+}
+
+function Get-ServiceProcessId {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $escapedName = $Name.Replace("'", "''")
+    $service = Get-CimInstance -ClassName Win32_Service -Filter "Name='$escapedName'" -ErrorAction SilentlyContinue
+    if ($null -eq $service) {
+        return 0
+    }
+
+    return [int]$service.ProcessId
+}
+
+function Wait-ServiceProcessExit {
+    param(
+        [Parameter(Mandatory = $true)][int]$ProcessId,
+        [int]$TimeoutSeconds = 30
+    )
+
+    if ($ProcessId -le 0) {
+        return
+    }
+
+    try {
+        $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+        if ($null -eq $process) {
+            return
+        }
+
+        Wait-Process -Id $ProcessId -Timeout $TimeoutSeconds -ErrorAction Stop
+    }
+    catch {
+        $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+        if ($null -ne $process) {
+            throw "Service process '$ProcessId' did not exit within $TimeoutSeconds seconds after service stop."
+        }
+    }
+}
+
 function Stop-ServiceIfRunning {
     param([Parameter(Mandatory = $true)][string]$Name)
 
@@ -52,10 +133,13 @@ function Stop-ServiceIfRunning {
         return
     }
 
+    $processId = Get-ServiceProcessId -Name $Name
+
     if ($service.Status -ne [System.ServiceProcess.ServiceControllerStatus]::Stopped) {
         Write-Host "Stopping Windows service '$Name' before reconfiguration."
         Stop-Service -Name $Name -Force -ErrorAction Stop
         Wait-ServiceStatus -Name $Name -Status ([System.ServiceProcess.ServiceControllerStatus]::Stopped)
+        Wait-ServiceProcessExit -ProcessId $processId
     }
 }
 
@@ -136,11 +220,15 @@ function Resolve-PackageRoot {
             }
 
             if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
-                Remove-Item -LiteralPath $extractTo -Recurse -Force
+                Invoke-WithRetry -Description "Removing existing package extract directory '$extractTo'" -ScriptBlock {
+                    Remove-Item -LiteralPath $extractTo -Recurse -Force
+                }
             }
 
             New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
-            Copy-Item -Path (Join-Path $sourceItem.FullName '*') -Destination $extractTo -Recurse -Force
+            Invoke-WithRetry -Description "Copying package content from '$($sourceItem.FullName)' to '$extractTo'" -ScriptBlock {
+                Copy-Item -Path (Join-Path $sourceItem.FullName '*') -Destination $extractTo -Recurse -Force
+            }
             return (Resolve-Path -LiteralPath $extractTo).Path
         }
 
@@ -149,11 +237,15 @@ function Resolve-PackageRoot {
         }
 
         if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
-            Remove-Item -LiteralPath $extractTo -Recurse -Force
+            Invoke-WithRetry -Description "Removing existing package extract directory '$extractTo'" -ScriptBlock {
+                Remove-Item -LiteralPath $extractTo -Recurse -Force
+            }
         }
 
         New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
-        Expand-Archive -LiteralPath $sourceItem.FullName -DestinationPath $extractTo -Force
+        Invoke-WithRetry -Description "Expanding package '$($sourceItem.FullName)' to '$extractTo'" -ScriptBlock {
+            Expand-Archive -LiteralPath $sourceItem.FullName -DestinationPath $extractTo -Force
+        }
         return (Resolve-Path -LiteralPath $extractTo).Path
     }
 
@@ -256,6 +348,7 @@ $accountArgs = Get-ServiceAccountArgs
 if ($null -eq $existingService) {
     Write-Host "Creating Windows service '$serviceName'."
     Invoke-Sc create $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
+    Wait-ServiceExists -Name $serviceName
 } else {
     Write-Host "Reconfiguring Windows service '$serviceName'."
     Invoke-Sc config $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs

--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -82,10 +82,50 @@ function Split-Dependencies {
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
 }
 
+function Resolve-AcquiredPackageSourcePath {
+    $manifestPath = Join-Path (Get-Location) 'package-references.json'
+
+    if (Test-Path -LiteralPath $manifestPath) {
+        try {
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            $entry = @($manifest) | Select-Object -First 1
+
+            if ($null -ne $entry -and -not [string]::IsNullOrWhiteSpace([string]$entry.PackagePath)) {
+                $candidate = [string]$entry.PackagePath
+
+                if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+                    $candidate = Join-Path (Get-Location) $candidate
+                }
+
+                if (Test-Path -LiteralPath $candidate) {
+                    return (Resolve-Path -LiteralPath $candidate).Path
+                }
+            }
+        }
+        catch {
+            Write-Host "Unable to read package-references.json; falling back to package-references directory. $($_.Exception.Message)"
+        }
+    }
+
+    $packageReferencesDir = Join-Path (Get-Location) 'package-references'
+    if (Test-Path -LiteralPath $packageReferencesDir) {
+        $candidate = Get-ChildItem -LiteralPath $packageReferencesDir | Sort-Object Name | Select-Object -First 1
+        if ($null -ne $candidate) {
+            return $candidate.FullName
+        }
+    }
+
+    return ''
+}
+
 function Resolve-PackageRoot {
     $sourcePath = Get-SquidParameter 'Squid.Action.WindowsService.Package.SourcePath'
     $extractTo = Get-SquidParameter 'Squid.Action.WindowsService.Package.ExtractTo'
     $purgeBeforeExtract = Test-True (Get-SquidParameter 'Squid.Action.WindowsService.Package.PurgeBeforeExtract' 'False')
+
+    if ([string]::IsNullOrWhiteSpace($sourcePath)) {
+        $sourcePath = Resolve-AcquiredPackageSourcePath
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($sourcePath) -and (Test-Path -LiteralPath $sourcePath)) {
         $sourceItem = Get-Item -LiteralPath $sourcePath

--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -1,0 +1,241 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-SquidParameter {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ''
+    )
+
+    if ($SquidParameters.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($SquidParameters[$Name])) {
+        return [string]$SquidParameters[$Name]
+    }
+
+    return $Default
+}
+
+function Test-True {
+    param([string]$Value)
+    return [string]::Equals($Value, 'true', [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Invoke-Sc {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+    & sc.exe @Arguments | Write-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "sc.exe $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Wait-ServiceStatus {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][System.ServiceProcess.ServiceControllerStatus]$Status,
+        [int]$TimeoutSeconds = 60
+    )
+
+    $service = Get-Service -Name $Name -ErrorAction Stop
+    $service.WaitForStatus($Status, [TimeSpan]::FromSeconds($TimeoutSeconds))
+    $service.Refresh()
+
+    if ($service.Status -ne $Status) {
+        throw "Service '$Name' did not reach state '$Status' within $TimeoutSeconds seconds. Current state: '$($service.Status)'."
+    }
+}
+
+function Stop-ServiceIfRunning {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $service = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $service) {
+        return
+    }
+
+    if ($service.Status -ne [System.ServiceProcess.ServiceControllerStatus]::Stopped) {
+        Write-Host "Stopping Windows service '$Name' before reconfiguration."
+        Stop-Service -Name $Name -Force -ErrorAction Stop
+        Wait-ServiceStatus -Name $Name -Status ([System.ServiceProcess.ServiceControllerStatus]::Stopped)
+    }
+}
+
+function Convert-StartModeForSc {
+    param([string]$StartMode)
+
+    switch ($StartMode.ToLowerInvariant()) {
+        'automatic' { return 'auto' }
+        'manual' { return 'demand' }
+        'disabled' { return 'disabled' }
+        default { throw "Unsupported Windows service start mode '$StartMode'. Expected Automatic, Manual, or Disabled." }
+    }
+}
+
+function Split-Dependencies {
+    param([string]$Dependencies)
+
+    if ([string]::IsNullOrWhiteSpace($Dependencies)) {
+        return @()
+    }
+
+    return $Dependencies -split "[,;`r`n]+" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Resolve-PackageRoot {
+    $sourcePath = Get-SquidParameter 'Squid.Action.WindowsService.Package.SourcePath'
+    $extractTo = Get-SquidParameter 'Squid.Action.WindowsService.Package.ExtractTo'
+    $purgeBeforeExtract = Test-True (Get-SquidParameter 'Squid.Action.WindowsService.Package.PurgeBeforeExtract' 'False')
+
+    if (-not [string]::IsNullOrWhiteSpace($sourcePath) -and (Test-Path -LiteralPath $sourcePath)) {
+        $sourceItem = Get-Item -LiteralPath $sourcePath
+
+        if ($sourceItem.PSIsContainer) {
+            if ([string]::IsNullOrWhiteSpace($extractTo)) {
+                return $sourceItem.FullName
+            }
+
+            if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
+                Remove-Item -LiteralPath $extractTo -Recurse -Force
+            }
+
+            New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
+            Copy-Item -Path (Join-Path $sourceItem.FullName '*') -Destination $extractTo -Recurse -Force
+            return (Resolve-Path -LiteralPath $extractTo).Path
+        }
+
+        if ([string]::IsNullOrWhiteSpace($extractTo)) {
+            $extractTo = Join-Path $sourceItem.DirectoryName ([System.IO.Path]::GetFileNameWithoutExtension($sourceItem.Name))
+        }
+
+        if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
+            Remove-Item -LiteralPath $extractTo -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
+        Expand-Archive -LiteralPath $sourceItem.FullName -DestinationPath $extractTo -Force
+        return (Resolve-Path -LiteralPath $extractTo).Path
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($extractTo) -and (Test-Path -LiteralPath $extractTo)) {
+        return (Resolve-Path -LiteralPath $extractTo).Path
+    }
+
+    return (Get-Location).Path
+}
+
+function Resolve-ExecutablePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$PackageRoot,
+        [Parameter(Mandatory = $true)][string]$ExecutablePath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($ExecutablePath)) {
+        return $ExecutablePath
+    }
+
+    return Join-Path $PackageRoot $ExecutablePath
+}
+
+function Build-BinaryPathName {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExecutablePath,
+        [string]$Arguments
+    )
+
+    $binary = '"' + $ExecutablePath + '"'
+    if (-not [string]::IsNullOrWhiteSpace($Arguments)) {
+        $binary += ' ' + $Arguments
+    }
+
+    return $binary
+}
+
+function Get-ServiceAccountArgs {
+    $serviceAccount = Get-SquidParameter 'Squid.Action.WindowsService.ServiceAccount' 'LocalSystem'
+    $customAccountName = Get-SquidParameter 'Squid.Action.WindowsService.CustomAccountName'
+    $customAccountPassword = Get-SquidParameter 'Squid.Action.WindowsService.CustomAccountPassword'
+
+    switch ($serviceAccount.ToLowerInvariant()) {
+        'localsystem' { return @('obj=', 'LocalSystem') }
+        'networkservice' { return @('obj=', 'NT AUTHORITY\NetworkService') }
+        'localservice' { return @('obj=', 'NT AUTHORITY\LocalService') }
+        'specificuser' {
+            if ([string]::IsNullOrWhiteSpace($customAccountName)) {
+                throw "Windows service account 'SpecificUser' requires Squid.Action.WindowsService.CustomAccountName."
+            }
+
+            if ([string]::IsNullOrWhiteSpace($customAccountPassword)) {
+                throw "Windows service account 'SpecificUser' requires Squid.Action.WindowsService.CustomAccountPassword."
+            }
+
+            return @('obj=', $customAccountName, 'password=', $customAccountPassword)
+        }
+        default { throw "Unsupported Windows service account '$serviceAccount'. Expected LocalSystem, NetworkService, LocalService, or SpecificUser." }
+    }
+}
+
+$createOrUpdate = Get-SquidParameter 'Squid.Action.WindowsService.CreateOrUpdateService' 'True'
+if (-not (Test-True $createOrUpdate)) {
+    Write-Host "Windows service create/update is disabled for this action."
+    return
+}
+
+$serviceName = Get-SquidParameter 'Squid.Action.WindowsService.ServiceName'
+if ([string]::IsNullOrWhiteSpace($serviceName)) {
+    throw "Squid.Action.WindowsService.ServiceName is required."
+}
+
+$displayName = Get-SquidParameter 'Squid.Action.WindowsService.DisplayName' $serviceName
+$description = Get-SquidParameter 'Squid.Action.WindowsService.Description'
+$relativeExecutablePath = Get-SquidParameter 'Squid.Action.WindowsService.ExecutablePath'
+if ([string]::IsNullOrWhiteSpace($relativeExecutablePath)) {
+    throw "Squid.Action.WindowsService.ExecutablePath is required."
+}
+
+$arguments = Get-SquidParameter 'Squid.Action.WindowsService.Arguments'
+$startMode = Get-SquidParameter 'Squid.Action.WindowsService.StartMode' 'Automatic'
+$desiredStatus = Get-SquidParameter 'Squid.Action.WindowsService.DesiredStatus' 'Started'
+$dependencies = Split-Dependencies (Get-SquidParameter 'Squid.Action.WindowsService.Dependencies')
+
+$packageRoot = Resolve-PackageRoot
+$executablePath = Resolve-ExecutablePath -PackageRoot $packageRoot -ExecutablePath $relativeExecutablePath
+if (-not (Test-Path -LiteralPath $executablePath)) {
+    throw "Windows service executable '$executablePath' was not found. Package root: '$packageRoot'."
+}
+
+$binaryPathName = Build-BinaryPathName -ExecutablePath $executablePath -Arguments $arguments
+$scStartMode = Convert-StartModeForSc $startMode
+$accountArgs = Get-ServiceAccountArgs
+$existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+
+if ($null -eq $existingService) {
+    Write-Host "Creating Windows service '$serviceName'."
+    Invoke-Sc create $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
+} else {
+    Stop-ServiceIfRunning -Name $serviceName
+    Write-Host "Reconfiguring Windows service '$serviceName'."
+    Invoke-Sc config $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
+}
+
+if (-not [string]::IsNullOrWhiteSpace($description)) {
+    Invoke-Sc description $serviceName $description
+}
+
+if ($dependencies.Count -gt 0) {
+    Invoke-Sc config $serviceName depend= ($dependencies -join '/')
+}
+
+switch ($desiredStatus.ToLowerInvariant()) {
+    'started' {
+        Write-Host "Starting Windows service '$serviceName'."
+        Start-Service -Name $serviceName -ErrorAction Stop
+        Wait-ServiceStatus -Name $serviceName -Status ([System.ServiceProcess.ServiceControllerStatus]::Running)
+    }
+    'stopped' {
+        Stop-ServiceIfRunning -Name $serviceName
+    }
+    default {
+        throw "Unsupported Windows service desired status '$desiredStatus'. Expected Started or Stopped."
+    }
+}

--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -237,6 +237,11 @@ $arguments = Get-SquidParameter 'Squid.Action.WindowsService.Arguments'
 $startMode = Get-SquidParameter 'Squid.Action.WindowsService.StartMode' 'Automatic'
 $desiredStatus = Get-SquidParameter 'Squid.Action.WindowsService.DesiredStatus' 'Started'
 $dependencies = Split-Dependencies (Get-SquidParameter 'Squid.Action.WindowsService.Dependencies')
+$existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+
+if ($null -ne $existingService) {
+    Stop-ServiceIfRunning -Name $serviceName
+}
 
 $packageRoot = Resolve-PackageRoot
 $executablePath = Resolve-ExecutablePath -PackageRoot $packageRoot -ExecutablePath $relativeExecutablePath
@@ -247,13 +252,11 @@ if (-not (Test-Path -LiteralPath $executablePath)) {
 $binaryPathName = Build-BinaryPathName -ExecutablePath $executablePath -Arguments $arguments
 $scStartMode = Convert-StartModeForSc $startMode
 $accountArgs = Get-ServiceAccountArgs
-$existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 
 if ($null -eq $existingService) {
     Write-Host "Creating Windows service '$serviceName'."
     Invoke-Sc create $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
 } else {
-    Stop-ServiceIfRunning -Name $serviceName
     Write-Host "Reconfiguring Windows service '$serviceName'."
     Invoke-Sc config $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
 }

--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -328,7 +328,7 @@ if ([string]::IsNullOrWhiteSpace($relativeExecutablePath)) {
 $arguments = Get-SquidParameter 'Squid.Action.WindowsService.Arguments'
 $startMode = Get-SquidParameter 'Squid.Action.WindowsService.StartMode' 'Automatic'
 $desiredStatus = Get-SquidParameter 'Squid.Action.WindowsService.DesiredStatus' 'Started'
-$dependencies = Split-Dependencies (Get-SquidParameter 'Squid.Action.WindowsService.Dependencies')
+$dependencies = @(Split-Dependencies (Get-SquidParameter 'Squid.Action.WindowsService.Dependencies'))
 $existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 
 if ($null -ne $existingService) {

--- a/src/Squid.Core/Services/DeploymentExecution/Constants/WindowsServiceDeployProperties.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Constants/WindowsServiceDeployProperties.cs
@@ -1,0 +1,33 @@
+namespace Squid.Core.Services.DeploymentExecution;
+
+/// <summary>
+/// Action-property constants for the <c>Squid.DeployWindowsService</c> action type.
+///
+/// <para>
+/// Mirrors Octopus-style Windows service deployment naming with the <c>Squid.</c>
+/// prefix. Generic feed/package/version selection remains on
+/// <see cref="Message.Constants.SpecialVariables.Action"/> so package acquisition can
+/// use the existing selected-package flow.
+/// </para>
+/// </summary>
+internal static class WindowsServiceDeployProperties
+{
+    internal const string CreateOrUpdateService = "Squid.Action.WindowsService.CreateOrUpdateService";
+    internal const string ServiceName = "Squid.Action.WindowsService.ServiceName";
+    internal const string DisplayName = "Squid.Action.WindowsService.DisplayName";
+    internal const string Description = "Squid.Action.WindowsService.Description";
+    internal const string ExecutablePath = "Squid.Action.WindowsService.ExecutablePath";
+    internal const string Arguments = "Squid.Action.WindowsService.Arguments";
+    internal const string ServiceAccount = "Squid.Action.WindowsService.ServiceAccount";
+    internal const string CustomAccountName = "Squid.Action.WindowsService.CustomAccountName";
+    internal const string CustomAccountPassword = "Squid.Action.WindowsService.CustomAccountPassword";
+    internal const string StartMode = "Squid.Action.WindowsService.StartMode";
+    internal const string DesiredStatus = "Squid.Action.WindowsService.DesiredStatus";
+    internal const string Dependencies = "Squid.Action.WindowsService.Dependencies";
+
+    internal const string PackageSourcePath = "Squid.Action.WindowsService.Package.SourcePath";
+    internal const string PackageExtractTo = "Squid.Action.WindowsService.Package.ExtractTo";
+    internal const string PackagePurgeBeforeExtract = "Squid.Action.WindowsService.Package.PurgeBeforeExtract";
+
+    internal const string TentacleOS = "Squid.Tentacle.OS";
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Handlers/ActionHandlerRegistry.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Handlers/ActionHandlerRegistry.cs
@@ -1,3 +1,4 @@
+using Squid.Message.Constants;
 using Squid.Message.Models.Deployments.Process;
 
 namespace Squid.Core.Services.DeploymentExecution.Handlers;
@@ -33,6 +34,17 @@ public class ActionHandlerRegistry : IActionHandlerRegistry
     {
         var handler = Resolve(action);
 
-        return handler?.ExecutionScope ?? ExecutionScope.StepLevel;
+        if (handler != null)
+            return handler.ExecutionScope;
+
+        // Package acquisition is an internally injected synthetic step. It has no
+        // IActionHandler because ExecuteStepsPhase handles it directly.
+        if (string.Equals(action?.ActionType, SpecialVariables.ActionTypes.TentaclePackage, StringComparison.OrdinalIgnoreCase))
+            return ExecutionScope.StepLevel;
+
+        // An unregistered action must not be silently reclassified as server-only.
+        // Target-level is conservative: the pipeline will expose the missing handler
+        // as a configuration error instead of reporting a successful no-op deploy.
+        return ExecutionScope.TargetLevel;
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
@@ -1,5 +1,6 @@
 using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.VariableSubstitution;
@@ -51,11 +52,20 @@ public sealed partial class ExecuteStepsPhase
 
             if (handler == null)
             {
-                Log.Warning("[Deploy] No handler found for action {ActionType}, skipping", action.ActionType);
+                var message =
+                    $"No action handler is registered for action '{action.Name}' (type '{action.ActionType}') " +
+                    $"in step '{step.Name}'. Update the action type or deploy a Squid build that includes its handler.";
 
-                await lifecycle.EmitAsync(new ActionNoHandlerEvent(new DeploymentEventContext { StepDisplayOrder = stepDisplayOrder, ActionType = action.ActionType }), ct).ConfigureAwait(false);
+                Log.Error("[Deploy] {Message}", message);
 
-                continue;
+                await lifecycle.EmitAsync(new ActionNoHandlerEvent(new DeploymentEventContext
+                {
+                    StepDisplayOrder = stepDisplayOrder,
+                    ActionType = action.ActionType,
+                    Message = message
+                }), ct).ConfigureAwait(false);
+
+                throw new DeploymentValidationException(message);
             }
 
             await lifecycle.EmitAsync(new ActionRunningEvent(new DeploymentEventContext { StepDisplayOrder = stepDisplayOrder, ActionName = action.Name, MachineName = tc.Machine.Name }), ct).ConfigureAwait(false);
@@ -92,7 +102,18 @@ public sealed partial class ExecuteStepsPhase
         if (string.IsNullOrEmpty(actionName) || _ctx.SelectedPackages.Count == 0)
             return new List<PackageAcquisitionResult>();
 
-        return _ctx.SelectedPackages
+        var selectedActionNames = _ctx.SelectedPackages
+            .Select(p => p.ActionName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Log.Information(
+            "[Deploy] BuildPackageReferences called for action '{ActionName}'. Selected package action names: {SelectedActionNames}",
+            actionName,
+            selectedActionNames);
+
+        var resolved = _ctx.SelectedPackages
             .Where(p => string.Equals(p.ActionName, actionName, StringComparison.OrdinalIgnoreCase))
             .Select(p => p.PackageReferenceName)
             .Where(packageReferenceName => !string.IsNullOrWhiteSpace(packageReferenceName))
@@ -100,6 +121,16 @@ public sealed partial class ExecuteStepsPhase
             .Select(FindAcquiredPackage)
             .Where(package => package != null)
             .ToList();
+
+        if (resolved.Count == 0)
+        {
+            Log.Warning(
+                "[Deploy] No package references resolved for action '{ActionName}'. Selected package action names were: {SelectedActionNames}",
+                actionName,
+                selectedActionNames);
+        }
+
+        return resolved;
     }
 
     private PackageAcquisitionResult? FindAcquiredPackage(string packageReferenceName)

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
@@ -92,15 +92,24 @@ public sealed partial class ExecuteStepsPhase
         if (string.IsNullOrEmpty(actionName) || _ctx.SelectedPackages.Count == 0)
             return new List<PackageAcquisitionResult>();
 
-        var names = _ctx.SelectedPackages
+        return _ctx.SelectedPackages
             .Where(p => string.Equals(p.ActionName, actionName, StringComparison.OrdinalIgnoreCase))
             .Select(p => p.PackageReferenceName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .Where(packageReferenceName => !string.IsNullOrWhiteSpace(packageReferenceName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(FindAcquiredPackage)
+            .Where(package => package != null)
+            .ToList();
+    }
+
+    private PackageAcquisitionResult? FindAcquiredPackage(string packageReferenceName)
+    {
+        if (_ctx.AcquiredPackages.TryGetValue(packageReferenceName, out var package))
+            return package;
 
         return _ctx.AcquiredPackages
-            .Where(kv => names.Contains(kv.Key))
-            .Select(kv => kv.Value)
-            .ToList();
+            .FirstOrDefault(kv => string.Equals(kv.Key, packageReferenceName, StringComparison.OrdinalIgnoreCase))
+            .Value;
     }
 
     private static SensitiveValueMasker BuildSensitiveMasker(List<VariableDto> variables)

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
@@ -24,12 +24,14 @@ public class WindowsServiceDeployActionHandler : IActionHandler
 
         EnsureWindowsTentacleTarget(ctx);
 
+        var scriptBody = WindowsServiceDeployScriptBuilder.Build(ctx.Action, ctx.Variables, ctx.SelectedPackages);
+
         var intent = new RunScriptIntent
         {
             Name = "deploy-windows-service",
             StepName = ctx.Step?.Name ?? string.Empty,
             ActionName = ctx.Action?.Name ?? string.Empty,
-            ScriptBody = BuildScriptBuilderPendingBody(),
+            ScriptBody = scriptBody,
             Syntax = ScriptSyntax.PowerShell,
             InjectRuntimeBundle = false
         };
@@ -57,10 +59,6 @@ public class WindowsServiceDeployActionHandler : IActionHandler
             $"To deploy a Windows service, configure a Windows Tentacle (Polling or Listening) and assign it the role this step targets. " +
             $"If you believe the target IS Windows, run a health check against it so the runtime-capabilities cache refreshes.");
     }
-
-    private static string BuildScriptBuilderPendingBody() =>
-        "throw 'Squid.DeployWindowsService script generation is not implemented yet. " +
-        "Complete WindowsServiceDeployScriptBuilder and the embedded PowerShell resource before executing this action.'";
 
     internal static bool LooksLikeWindowsOsString(string osValue)
         => WindowsOsStringHelper.IsWindows(osValue);

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
@@ -13,6 +13,8 @@ public class WindowsServiceDeployActionHandler : IActionHandler
 {
     public string ActionType => SpecialVariables.ActionTypes.DeployWindowsService;
 
+    public ExecutionScope ExecutionScope => ExecutionScope.TargetLevel;
+
     public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
         CapabilityRequirements.Empty
             .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
@@ -1,0 +1,67 @@
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Execution;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+/// <summary>
+/// Handles the <c>Squid.DeployWindowsService</c> action for Windows Tentacle targets.
+/// </summary>
+public class WindowsServiceDeployActionHandler : IActionHandler
+{
+    public string ActionType => SpecialVariables.ActionTypes.DeployWindowsService;
+
+    public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
+        CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+
+    Task<ExecutionIntent> IActionHandler.DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        EnsureWindowsTentacleTarget(ctx);
+
+        var intent = new RunScriptIntent
+        {
+            Name = "deploy-windows-service",
+            StepName = ctx.Step?.Name ?? string.Empty,
+            ActionName = ctx.Action?.Name ?? string.Empty,
+            ScriptBody = BuildScriptBuilderPendingBody(),
+            Syntax = ScriptSyntax.PowerShell,
+            InjectRuntimeBundle = false
+        };
+
+        return Task.FromResult<ExecutionIntent>(intent);
+    }
+
+    private static void EnsureWindowsTentacleTarget(ActionExecutionContext ctx)
+    {
+        var osVariable = ctx.Variables?
+            .FirstOrDefault(v => string.Equals(v.Name, WindowsServiceDeployProperties.TentacleOS, StringComparison.OrdinalIgnoreCase));
+
+        if (osVariable == null || string.IsNullOrEmpty(osVariable.Value))
+            return;
+
+        if (WindowsOsStringHelper.IsWindows(osVariable.Value))
+            return;
+
+        var stepName = ctx.Step?.Name ?? "(unknown)";
+        var actionName = ctx.Action?.Name ?? "(unknown)";
+
+        throw new InvalidOperationException(
+            $"Action '{actionName}' (type '{SpecialVariables.ActionTypes.DeployWindowsService}') in step '{stepName}' " +
+            $"requires a Windows Tentacle target. The configured target reports '{WindowsServiceDeployProperties.TentacleOS}'='{osVariable.Value}'. " +
+            $"To deploy a Windows service, configure a Windows Tentacle (Polling or Listening) and assign it the role this step targets. " +
+            $"If you believe the target IS Windows, run a health check against it so the runtime-capabilities cache refreshes.");
+    }
+
+    private static string BuildScriptBuilderPendingBody() =>
+        "throw 'Squid.DeployWindowsService script generation is not implemented yet. " +
+        "Complete WindowsServiceDeployScriptBuilder and the embedded PowerShell resource before executing this action.'";
+
+    internal static bool LooksLikeWindowsOsString(string osValue)
+        => WindowsOsStringHelper.IsWindows(osValue);
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployScriptBuilder.cs
@@ -1,0 +1,180 @@
+using System.Reflection;
+using System.Text;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Release;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+internal static class WindowsServiceDeployScriptBuilder
+{
+    private const string EmbeddedScriptName = "Squid.Core.Resources.Deploy.WindowsService.DeployWindowsService.ps1";
+
+    internal static readonly IReadOnlyList<string> RecognisedProperties = new[]
+    {
+        WindowsServiceDeployProperties.CreateOrUpdateService,
+        WindowsServiceDeployProperties.ServiceName,
+        WindowsServiceDeployProperties.DisplayName,
+        WindowsServiceDeployProperties.Description,
+        WindowsServiceDeployProperties.ExecutablePath,
+        WindowsServiceDeployProperties.Arguments,
+        WindowsServiceDeployProperties.ServiceAccount,
+        WindowsServiceDeployProperties.CustomAccountName,
+        WindowsServiceDeployProperties.CustomAccountPassword,
+        WindowsServiceDeployProperties.StartMode,
+        WindowsServiceDeployProperties.DesiredStatus,
+        WindowsServiceDeployProperties.Dependencies,
+        WindowsServiceDeployProperties.PackageSourcePath,
+        WindowsServiceDeployProperties.PackageExtractTo,
+        WindowsServiceDeployProperties.PackagePurgeBeforeExtract
+    };
+
+    private static readonly HashSet<string> MultilineProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        WindowsServiceDeployProperties.Description,
+        WindowsServiceDeployProperties.Dependencies
+    };
+
+    internal static string Build(DeploymentActionDto action)
+        => Build(action, Array.Empty<VariableDto>(), Array.Empty<SelectedPackageDto>());
+
+    internal static string Build(
+        DeploymentActionDto action,
+        IReadOnlyList<VariableDto>? variables,
+        IReadOnlyList<SelectedPackageDto>? selectedPackages)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var preamble = BuildPreamble(action, variables ?? Array.Empty<VariableDto>(), selectedPackages ?? Array.Empty<SelectedPackageDto>());
+        var body = LoadEmbeddedScriptBody();
+
+        return preamble + body;
+    }
+
+    private static string BuildPreamble(
+        DeploymentActionDto action,
+        IReadOnlyList<VariableDto> variables,
+        IReadOnlyList<SelectedPackageDto> selectedPackages)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("# BEGIN GENERATED PREAMBLE (Squid WindowsServiceDeployScriptBuilder)");
+        sb.AppendLine("$SquidParameters = @{}");
+
+        foreach (var propertyName in RecognisedProperties)
+        {
+            var rawValue = ReadProperty(action, propertyName);
+
+            if (MultilineProperties.Contains(propertyName))
+                EmitMultilineAssignment(sb, propertyName, rawValue);
+            else
+                EmitDataAssignment(sb, propertyName, rawValue);
+        }
+
+        EmitSquidVariablesHashtable(sb, variables);
+        EmitSelectedPackages(sb, action, selectedPackages);
+
+        sb.AppendLine("# END GENERATED PREAMBLE");
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static void EmitDataAssignment(StringBuilder sb, string propertyName, string rawValue)
+    {
+        sb.Append("$SquidParameters['");
+        sb.Append(propertyName);
+        sb.Append("'] = '");
+        sb.Append(EscapeForPowerShellSingleQuote(rawValue));
+        sb.AppendLine("'");
+    }
+
+    private static void EmitMultilineAssignment(StringBuilder sb, string propertyName, string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            EmitDataAssignment(sb, propertyName, string.Empty);
+            return;
+        }
+
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(rawValue));
+        sb.Append("$SquidParameters['");
+        sb.Append(propertyName);
+        sb.Append("'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('");
+        sb.Append(base64);
+        sb.AppendLine("'))");
+    }
+
+    private static void EmitSquidVariablesHashtable(StringBuilder sb, IReadOnlyList<VariableDto> variables)
+    {
+        sb.AppendLine("$SquidVariables = @{}");
+
+        foreach (var variable in variables)
+        {
+            if (string.IsNullOrEmpty(variable?.Name)) continue;
+
+            sb.Append("$SquidVariables['");
+            sb.Append(EscapeForPowerShellSingleQuote(variable.Name));
+            sb.Append("'] = '");
+            sb.Append(EscapeForPowerShellSingleQuote(variable.Value ?? string.Empty));
+            sb.AppendLine("'");
+        }
+    }
+
+    private static void EmitSelectedPackages(StringBuilder sb, DeploymentActionDto action, IReadOnlyList<SelectedPackageDto> selectedPackages)
+    {
+        sb.AppendLine("$SquidSelectedPackages = @()");
+
+        foreach (var package in selectedPackages)
+        {
+            if (package == null) continue;
+
+            sb.Append("$SquidSelectedPackages += @{ ActionName = '");
+            sb.Append(EscapeForPowerShellSingleQuote(package.ActionName ?? string.Empty));
+            sb.Append("'; PackageReferenceName = '");
+            sb.Append(EscapeForPowerShellSingleQuote(package.PackageReferenceName ?? string.Empty));
+            sb.Append("'; Version = '");
+            sb.Append(EscapeForPowerShellSingleQuote(package.Version ?? string.Empty));
+            sb.AppendLine("' }");
+        }
+
+        sb.AppendLine("$SquidSelectedPackage = $null");
+        sb.Append("foreach ($package in $SquidSelectedPackages) { if ($package['ActionName'] -ieq '");
+        sb.Append(EscapeForPowerShellSingleQuote(action.Name ?? string.Empty));
+        sb.AppendLine("') { $SquidSelectedPackage = $package; break } }");
+    }
+
+    private static string ReadProperty(DeploymentActionDto action, string propertyName)
+    {
+        var prop = action.Properties?
+            .FirstOrDefault(p => string.Equals(p.PropertyName, propertyName, StringComparison.OrdinalIgnoreCase));
+
+        return prop?.PropertyValue ?? string.Empty;
+    }
+
+    internal static string EscapeForPowerShellSingleQuote(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var collapsed = value
+            .Replace("\r\n", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal);
+
+        return collapsed.Replace("'", "''", StringComparison.Ordinal);
+    }
+
+    private static string LoadEmbeddedScriptBody()
+    {
+        var assembly = typeof(WindowsServiceDeployScriptBuilder).Assembly;
+
+        using var stream = assembly.GetManifestResourceStream(EmbeddedScriptName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{EmbeddedScriptName}' not found in assembly '{assembly.GetName().Name}'. " +
+                $"Verify Squid.Core.csproj has '<EmbeddedResource Include=\"Resources\\Deploy\\WindowsService\\*.ps1\" />' " +
+                $"and the .ps1 file exists at src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -2,6 +2,7 @@ using Halibut;
 using Halibut.Diagnostics;
 using Squid.Core.Halibut.Resilience;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
+using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Script.Files;
 using Squid.Core.Services.DeploymentExecution.Transport;
@@ -185,7 +186,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         var (variableBytes, sensitiveBytes, password) =
             ScriptExecutionHelper.CreateVariableFileContents(request.Variables);
 
-        var scriptFiles = BuildDirectScriptFiles(request.DeploymentFiles, variableBytes, sensitiveBytes, password);
+        var scriptFiles = BuildDirectScriptFiles(request.DeploymentFiles, request.PackageReferences, variableBytes, sensitiveBytes, password);
         var scriptTimeout = request.Timeout ?? _defaultScriptTimeout;
         // See ExecuteCalamariViaHalibutAsync above for the ticket-vs-mutex-name
         // rationale: ticket is Guid-per-attempt; IsolationMutexName (arg 5) is the
@@ -361,6 +362,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
 
     private static ScriptFile[] BuildDirectScriptFiles(
         DeploymentFileCollection deploymentFiles,
+        IReadOnlyList<PackageAcquisitionResult> packageReferences,
         byte[] variableBytes,
         byte[] sensitiveBytes,
         string password)
@@ -368,6 +370,8 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         var files = deploymentFiles
             .Select(file => new ScriptFile(file.RelativePath, DataStream.FromBytes(file.Content), null))
             .ToList();
+
+        files.AddRange(PackageReferenceScriptFileBridge.BuildScriptFiles(packageReferences));
 
         files.Add(new ScriptFile("variables.json", DataStream.FromBytes(variableBytes), null));
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.IO.Compression;
 using Halibut;
 using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Message.Contracts.Tentacle;
@@ -18,7 +19,8 @@ internal static class PackageReferenceScriptFileBridge
 
         var files = new List<ScriptFile>();
         var manifest = new List<PackageReferenceManifestEntry>();
-        var usedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var usedPackageRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var usedFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var packageReference in packageReferences)
         {
@@ -30,14 +32,14 @@ internal static class PackageReferenceScriptFileBridge
             if (!File.Exists(packageReference.LocalPath))
                 throw new FileNotFoundException($"Acquired package '{packageReference.PackageId}' was not found at '{packageReference.LocalPath}'.", packageReference.LocalPath);
 
-            var packagePath = BuildPackageRelativePath(packageReference, usedPaths);
-            var packageBytes = File.ReadAllBytes(packageReference.LocalPath);
+            var packageRootPath = BuildPackageRelativePath(packageReference, usedPackageRoots);
+            var packageFiles = BuildExtractedPackageFiles(packageReference.LocalPath, packageRootPath, usedFilePaths);
 
-            files.Add(new ScriptFile(packagePath, DataStream.FromBytes(packageBytes), null));
+            files.AddRange(packageFiles);
             manifest.Add(new PackageReferenceManifestEntry(
                 packageReference.PackageId,
                 packageReference.Version,
-                packagePath,
+                packageRootPath,
                 packageReference.SizeBytes,
                 packageReference.Hash));
         }
@@ -57,8 +59,7 @@ internal static class PackageReferenceScriptFileBridge
 
         var packageId = SafePathSegment(packageReference.PackageId, "package");
         var version = SafePathSegment(packageReference.Version, "version");
-        var extension = SafeExtension(packageReference.LocalPath);
-        var baseName = $"{packageId}.{version}{extension}";
+        var baseName = $"{packageId}.{version}";
         var relativePath = Path.Combine(PackageReferencesDirectory, baseName).Replace('\\', '/');
 
         if (usedPaths == null)
@@ -70,12 +71,71 @@ internal static class PackageReferenceScriptFileBridge
         var suffix = 2;
         while (true)
         {
-            var candidate = Path.Combine(PackageReferencesDirectory, $"{packageId}.{version}.{suffix}{extension}").Replace('\\', '/');
+            var candidate = Path.Combine(PackageReferencesDirectory, $"{packageId}.{version}.{suffix}").Replace('\\', '/');
             if (usedPaths.Add(candidate))
                 return candidate;
 
             suffix++;
         }
+    }
+
+    private static List<ScriptFile> BuildExtractedPackageFiles(string localPath, string packageRootPath, ISet<string> usedFilePaths)
+    {
+        try
+        {
+            using var archive = ZipFile.OpenRead(localPath);
+            var files = new List<ScriptFile>();
+
+            foreach (var entry in archive.Entries)
+            {
+                if (string.IsNullOrEmpty(entry.Name))
+                    continue;
+
+                var entryPath = NormalizeArchiveEntryPath(entry.FullName);
+                if (string.IsNullOrEmpty(entryPath))
+                    continue;
+
+                var relativePath = $"{packageRootPath}/{entryPath}";
+                if (!usedFilePaths.Add(relativePath))
+                    throw new InvalidOperationException($"Package archive '{localPath}' contains duplicate entry '{entry.FullName}'.");
+
+                using var stream = entry.Open();
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+                files.Add(new ScriptFile(relativePath, DataStream.FromBytes(buffer.ToArray()), null));
+            }
+
+            if (files.Count == 0)
+                throw new InvalidOperationException($"Package archive '{localPath}' does not contain any files.");
+
+            return files;
+        }
+        catch (InvalidDataException ex)
+        {
+            throw new InvalidOperationException($"Package archive '{localPath}' could not be read as a zip/nupkg archive.", ex);
+        }
+    }
+
+    private static string NormalizeArchiveEntryPath(string entryPath)
+    {
+        var candidate = entryPath.Replace('\\', '/');
+        if (candidate.StartsWith("/", StringComparison.Ordinal) || candidate.Contains(":", StringComparison.Ordinal))
+            throw new InvalidOperationException($"Package archive contains unsafe entry path '{entryPath}'.");
+
+        var normalized = candidate.Trim('/');
+        if (string.IsNullOrEmpty(normalized))
+            return string.Empty;
+
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Any(segment =>
+                segment == "." ||
+                segment == ".." ||
+                Path.IsPathRooted(segment)))
+        {
+            throw new InvalidOperationException($"Package archive contains unsafe entry path '{entryPath}'.");
+        }
+
+        return string.Join('/', segments);
     }
 
     private static string SafePathSegment(string? value, string fallback)
@@ -89,21 +149,6 @@ internal static class PackageReferenceScriptFileBridge
         var sanitized = new string(chars).Trim('.', '_', '-');
 
         return string.IsNullOrEmpty(sanitized) ? fallback : sanitized;
-    }
-
-    private static string SafeExtension(string localPath)
-    {
-        var extension = Path.GetExtension(localPath);
-
-        if (string.IsNullOrWhiteSpace(extension))
-            return ".package";
-
-        var chars = extension
-            .Select(c => char.IsAsciiLetterOrDigit(c) || c == '.' ? c : '_')
-            .ToArray();
-        var sanitized = new string(chars);
-
-        return sanitized == "." ? ".package" : sanitized;
     }
 
     private sealed record PackageReferenceManifestEntry(

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using System.Text.Json;
+using Halibut;
+using Squid.Core.Services.DeploymentExecution.Packages;
+using Squid.Message.Contracts.Tentacle;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle;
+
+internal static class PackageReferenceScriptFileBridge
+{
+    internal const string ManifestFileName = "package-references.json";
+    internal const string PackageReferencesDirectory = "package-references";
+
+    internal static IReadOnlyList<ScriptFile> BuildScriptFiles(IReadOnlyList<PackageAcquisitionResult>? packageReferences)
+    {
+        if (packageReferences == null || packageReferences.Count == 0)
+            return Array.Empty<ScriptFile>();
+
+        var files = new List<ScriptFile>();
+        var manifest = new List<PackageReferenceManifestEntry>();
+        var usedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var packageReference in packageReferences)
+        {
+            if (packageReference == null) continue;
+
+            if (string.IsNullOrWhiteSpace(packageReference.LocalPath))
+                throw new InvalidOperationException($"Package '{packageReference.PackageId}' has no acquired local path.");
+
+            if (!File.Exists(packageReference.LocalPath))
+                throw new FileNotFoundException($"Acquired package '{packageReference.PackageId}' was not found at '{packageReference.LocalPath}'.", packageReference.LocalPath);
+
+            var packagePath = BuildPackageRelativePath(packageReference, usedPaths);
+            var packageBytes = File.ReadAllBytes(packageReference.LocalPath);
+
+            files.Add(new ScriptFile(packagePath, DataStream.FromBytes(packageBytes), null));
+            manifest.Add(new PackageReferenceManifestEntry(
+                packageReference.PackageId,
+                packageReference.Version,
+                packagePath,
+                packageReference.SizeBytes,
+                packageReference.Hash));
+        }
+
+        if (manifest.Count == 0)
+            return Array.Empty<ScriptFile>();
+
+        var manifestBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifest));
+        files.Insert(0, new ScriptFile(ManifestFileName, DataStream.FromBytes(manifestBytes), null));
+
+        return files;
+    }
+
+    internal static string BuildPackageRelativePath(PackageAcquisitionResult packageReference, ISet<string>? usedPaths = null)
+    {
+        ArgumentNullException.ThrowIfNull(packageReference);
+
+        var packageId = SafePathSegment(packageReference.PackageId, "package");
+        var version = SafePathSegment(packageReference.Version, "version");
+        var extension = SafeExtension(packageReference.LocalPath);
+        var baseName = $"{packageId}.{version}{extension}";
+        var relativePath = Path.Combine(PackageReferencesDirectory, baseName).Replace('\\', '/');
+
+        if (usedPaths == null)
+            return relativePath;
+
+        if (usedPaths.Add(relativePath))
+            return relativePath;
+
+        var suffix = 2;
+        while (true)
+        {
+            var candidate = Path.Combine(PackageReferencesDirectory, $"{packageId}.{version}.{suffix}{extension}").Replace('\\', '/');
+            if (usedPaths.Add(candidate))
+                return candidate;
+
+            suffix++;
+        }
+    }
+
+    private static string SafePathSegment(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        var chars = value
+            .Select(c => char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_' ? c : '_')
+            .ToArray();
+        var sanitized = new string(chars).Trim('.', '_', '-');
+
+        return string.IsNullOrEmpty(sanitized) ? fallback : sanitized;
+    }
+
+    private static string SafeExtension(string localPath)
+    {
+        var extension = Path.GetExtension(localPath);
+
+        if (string.IsNullOrWhiteSpace(extension))
+            return ".package";
+
+        var chars = extension
+            .Select(c => char.IsAsciiLetterOrDigit(c) || c == '.' ? c : '_')
+            .ToArray();
+        var sanitized = new string(chars);
+
+        return sanitized == "." ? ".package" : sanitized;
+    }
+
+    private sealed record PackageReferenceManifestEntry(
+        string PackageId,
+        string Version,
+        string PackagePath,
+        long SizeBytes,
+        string Hash);
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleListeningTransport.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentacleListeningTransport.cs
@@ -24,7 +24,8 @@ public sealed class TentacleListeningTransport : DeploymentTransport
         SupportedActionTypes = TransportCapabilities.ActionTypes(
             SpecialVariables.ActionTypes.Script,
             SpecialVariables.ActionTypes.HealthCheck,
-            SpecialVariables.ActionTypes.DeployToIISWebSite),
+            SpecialVariables.ActionTypes.DeployToIISWebSite,
+            SpecialVariables.ActionTypes.DeployWindowsService),
         OptionalFeatures = TransportCapabilities.Features("halibut", "bash", "tentacle")
     };
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentaclePollingTransport.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/TentaclePollingTransport.cs
@@ -24,7 +24,8 @@ public sealed class TentaclePollingTransport : DeploymentTransport
         SupportedActionTypes = TransportCapabilities.ActionTypes(
             SpecialVariables.ActionTypes.Script,
             SpecialVariables.ActionTypes.HealthCheck,
-            SpecialVariables.ActionTypes.DeployToIISWebSite),
+            SpecialVariables.ActionTypes.DeployToIISWebSite,
+            SpecialVariables.ActionTypes.DeployWindowsService),
         OptionalFeatures = TransportCapabilities.Features("halibut", "bash", "tentacle")
     };
 

--- a/src/Squid.Core/Services/Deployments/Process/Action/DeploymentActionPropertyDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/Process/Action/DeploymentActionPropertyDataProvider.cs
@@ -31,7 +31,11 @@ public class DeploymentActionPropertyDataProvider : IDeploymentActionPropertyDat
 
     public async Task AddDeploymentActionPropertiesAsync(List<DeploymentActionProperty> properties, CancellationToken cancellationToken = default)
     {
-        await _repository.InsertAllAsync(properties, cancellationToken).ConfigureAwait(false);
+        var normalized = NormalizeProperties(properties);
+
+        if (normalized.Count == 0) return;
+
+        await _repository.InsertAllAsync(normalized, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -73,5 +77,49 @@ public class DeploymentActionPropertyDataProvider : IDeploymentActionPropertyDat
         return await _repository.Query<DeploymentActionProperty>()
             .Where(p => actionIds.Contains(p.ActionId))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static List<DeploymentActionProperty> NormalizeProperties(List<DeploymentActionProperty> properties)
+    {
+        if (properties == null || properties.Count == 0) return new List<DeploymentActionProperty>();
+
+        var normalized = new List<DeploymentActionProperty>();
+        var indexesByKey = new Dictionary<ActionPropertyKey, int>(ActionPropertyKeyComparer.Instance);
+
+        foreach (var property in properties)
+        {
+            if (property == null) continue;
+
+            var key = new ActionPropertyKey(property.ActionId, property.PropertyName);
+
+            if (indexesByKey.TryGetValue(key, out var index))
+            {
+                normalized[index].PropertyValue = property.PropertyValue;
+                continue;
+            }
+
+            indexesByKey[key] = normalized.Count;
+            normalized.Add(property);
+        }
+
+        return normalized;
+    }
+
+    private readonly record struct ActionPropertyKey(int ActionId, string PropertyName);
+
+    private sealed class ActionPropertyKeyComparer : IEqualityComparer<ActionPropertyKey>
+    {
+        public static readonly ActionPropertyKeyComparer Instance = new();
+
+        public bool Equals(ActionPropertyKey x, ActionPropertyKey y)
+        {
+            return x.ActionId == y.ActionId
+                   && string.Equals(x.PropertyName, y.PropertyName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(ActionPropertyKey obj)
+        {
+            return HashCode.Combine(obj.ActionId, StringComparer.OrdinalIgnoreCase.GetHashCode(obj.PropertyName ?? string.Empty));
+        }
     }
 }

--- a/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
+++ b/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
@@ -283,6 +283,9 @@ public partial class ReleaseService : IReleaseService
         DeploymentProcessSnapshotDto deploymentProcessSnapshot,
         List<CreateReleaseSelectedPackageDto> selectedPackages)
     {
+        if (deploymentProcessSnapshot?.Data?.StepSnapshots == null)
+            return;
+
         var windowsServiceActions = deploymentProcessSnapshot.Data.StepSnapshots
             .SelectMany(step => step.ActionSnapshots.Select(action => new
             {

--- a/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
+++ b/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
@@ -8,8 +8,10 @@ using Squid.Core.Services.Deployments.Project;
 using Squid.Core.Services.Deployments.Releases.Exceptions;
 using Squid.Core.Services.Deployments.Snapshots;
 using Squid.Message.Commands.Deployments.Release;
+using Squid.Message.Constants;
 using Squid.Message.Events.Deployments.Release;
 using Squid.Message.Models.Deployments.Release;
+using Squid.Message.Models.Deployments.Snapshots;
 using Squid.Message.Requests.Deployments.Release;
 
 namespace Squid.Core.Services.Deployments.Release;
@@ -125,6 +127,8 @@ public partial class ReleaseService : IReleaseService
         release.ProjectDeploymentProcessSnapshotId = deploymentProcessSnapshot.Id;
         
         await _releaseDataProvider.CreateReleaseAsync(release, forceSave: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        LogSelectedPackageActionNameComparison(release.Id, deploymentProcessSnapshot, command.SelectedPackages);
 
         await PersistSelectedPackagesAsync(release.Id, command.SelectedPackages, cancellationToken).ConfigureAwait(false);
 
@@ -255,9 +259,56 @@ public partial class ReleaseService : IReleaseService
                 FeedId = sp.FeedId,
                 PackageReferenceName = sp.PackageReferenceName ?? string.Empty,
                 Version = sp.Version ?? string.Empty
-            });
+            })
+            .ToList();
+
+        if (entities.Count == 0) return;
+
+        Log.Information(
+            "[Release] Persisting selected packages for release {ReleaseId}: {SelectedPackages}",
+            releaseId,
+            entities.Select(p => new
+            {
+                p.ActionName,
+                p.PackageReferenceName,
+                p.Version,
+                p.FeedId
+            }).ToList());
 
         await _releaseSelectedPackageDataProvider.InsertAllAsync(entities, ct).ConfigureAwait(false);
+    }
+
+    private static void LogSelectedPackageActionNameComparison(
+        int releaseId,
+        DeploymentProcessSnapshotDto deploymentProcessSnapshot,
+        List<CreateReleaseSelectedPackageDto> selectedPackages)
+    {
+        var windowsServiceActions = deploymentProcessSnapshot.Data.StepSnapshots
+            .SelectMany(step => step.ActionSnapshots.Select(action => new
+            {
+                StepName = step.Name,
+                action.Name,
+                action.ActionType
+            }))
+            .Where(action => string.Equals(
+                action.ActionType,
+                SpecialVariables.ActionTypes.DeployWindowsService,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (windowsServiceActions.Count == 0) return;
+
+        var selectedPackageActionNames = (selectedPackages ?? new List<CreateReleaseSelectedPackageDto>())
+            .Select(package => package.ActionName)
+            .Where(actionName => !string.IsNullOrWhiteSpace(actionName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Log.Information(
+            "[Release] Windows Service action/package action-name comparison for release {ReleaseId}: SnapshotActions={SnapshotActions}; SelectedPackageActionNames={SelectedPackageActionNames}",
+            releaseId,
+            windowsServiceActions,
+            selectedPackageActionNames);
     }
 
     private async Task ValidateChannelVersionRulesAsync(int channelId, List<CreateReleaseSelectedPackageDto> selectedPackages, CancellationToken ct)

--- a/src/Squid.Core/Squid.Core.csproj
+++ b/src/Squid.Core/Squid.Core.csproj
@@ -58,6 +58,7 @@
     <EmbeddedResource Include="Services\DeploymentExecution\Runtime\Bundles\Resources\*" />
     <EmbeddedResource Include="Resources\Upgrade\*" />
     <EmbeddedResource Include="Resources\Deploy\IIS\*.ps1" />
+    <EmbeddedResource Include="Resources\Deploy\WindowsService\*.ps1" />
   </ItemGroup>
 
   <ItemGroup Label="DbUp">

--- a/src/Squid.Message/Constants/SpecialVariables.cs
+++ b/src/Squid.Message/Constants/SpecialVariables.cs
@@ -18,6 +18,7 @@ public static class SpecialVariables
         public const string HealthCheck = "Squid.HealthCheck";
         public const string DeployRelease = "Squid.DeployRelease";
         public const string DeployIngress = "Squid.DeployIngress";
+        public const string DeployWindowsService = "Squid.DeployWindowsService";
         public const string KubernetesKustomize = "Squid.KubernetesKustomize";
         public const string OpenClawInvokeTool = "Squid.OpenClaw.InvokeTool";
         public const string OpenClawRunAgent = "Squid.OpenClaw.RunAgent";
@@ -51,6 +52,7 @@ public static class SpecialVariables
             HealthCheck,
             DeployRelease,
             DeployIngress,
+            DeployWindowsService,
             KubernetesKustomize,
             OpenClawInvokeTool,
             OpenClawRunAgent,

--- a/tests/Squid.E2ETests/Deployments/Tentacle/WindowsServiceDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/WindowsServiceDeployPipelineE2ETests.cs
@@ -4,6 +4,7 @@ using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Filtering;
 using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.Deployments.ServerTask;
 using Squid.E2ETests.Deployments;
 using Squid.E2ETests.Infrastructure;
@@ -153,6 +154,46 @@ public class WindowsServiceDeployPipelineE2ETests
 
         captured.Masker.ShouldNotBeNull("Sensitive service-account password must be carried in the script request masker.");
         captured.Masker.Mask($"password={servicePassword}").ShouldBe($"password={SensitiveValueMasker.MaskToken}");
+    }
+
+    [Fact]
+    public async Task FullPipeline_DeployWindowsServiceOnNonWindowsTentacle_IsSkippedBeforeExecution()
+    {
+        ExecutionCapture.Clear();
+
+        var seed = await SeedWindowsServiceDeploymentAsync(
+            "TentaclePolling",
+            variables: null,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.WindowsService.CreateOrUpdateService"] = "True",
+                ["Squid.Action.WindowsService.ServiceName"] = "LinuxSkippedWorker",
+                ["Squid.Action.WindowsService.ExecutablePath"] = "Order.Worker.exe",
+                ["Squid.Action.WindowsService.StartMode"] = "Automatic",
+                ["Squid.Action.WindowsService.DesiredStatus"] = "Started"
+            });
+
+        await _fixture.Run<IMachineRuntimeCapabilitiesCache>(capabilities =>
+        {
+            capabilities.Store(seed.MachineId, new Dictionary<string, string>
+            {
+                ["os"] = AgentOperatingSystems.Linux,
+                ["installedShells"] = "powershell,pwsh,cmd",
+                ["defaultShell"] = "powershell"
+            }, agentVersion: "9.0.0");
+
+            return Task.CompletedTask;
+        });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(seed.ServerTaskId, CancellationToken.None);
+        });
+
+        await AssertTaskStateAsync(seed.ServerTaskId, TaskState.Success);
+
+        ExecutionCapture.CapturedRequests.ShouldBeEmpty(
+            customMessage: "A Deploy Windows Service action planned for a non-Windows Tentacle target must be capability-filtered before script rendering or execution.");
     }
 
     private async Task<SeededDeployment> SeedWindowsServiceDeploymentAsync(

--- a/tests/Squid.E2ETests/Deployments/Tentacle/WindowsServiceDeployPipelineE2ETests.cs
+++ b/tests/Squid.E2ETests/Deployments/Tentacle/WindowsServiceDeployPipelineE2ETests.cs
@@ -1,0 +1,317 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.E2ETests.Deployments;
+using Squid.E2ETests.Infrastructure;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Shouldly;
+using Xunit;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.E2ETests.Deployments.Tentacle;
+
+/// <summary>
+/// Contract E2E coverage for Squid.DeployWindowsService. The deployment pipeline
+/// fixture keeps the real handler, renderer, variable expansion, lifecycle, and
+/// Tentacle transport-capability flow while swapping final host execution for a
+/// capturing strategy.
+/// </summary>
+[Trait("Category", "E2E")]
+[Trait("Tier", "Contract")]
+public class WindowsServiceDeployPipelineE2ETests
+    : IClassFixture<DeploymentPipelineFixture<WindowsServiceDeployPipelineE2ETests>>
+{
+    private const string ActionName = "Deploy Worker";
+    private const string StepName = "Deploy Windows Service";
+    private const string TargetRole = "windows-service";
+
+    private readonly DeploymentPipelineFixture<WindowsServiceDeployPipelineE2ETests> _fixture;
+
+    public WindowsServiceDeployPipelineE2ETests(
+        DeploymentPipelineFixture<WindowsServiceDeployPipelineE2ETests> fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private CapturingExecutionStrategy ExecutionCapture => _fixture.ExecutionCapture;
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_DeployWindowsService_CapturesPowerShellRequestForBothTentacleStyles(string communicationStyle)
+    {
+        ExecutionCapture.Clear();
+
+        var seed = await SeedWindowsServiceDeploymentAsync(
+            communicationStyle,
+            variables: null,
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.WindowsService.CreateOrUpdateService"] = "True",
+                ["Squid.Action.WindowsService.ServiceName"] = "OrderWorker",
+                ["Squid.Action.WindowsService.DisplayName"] = "Order Worker",
+                ["Squid.Action.WindowsService.Description"] = "Processes queued orders",
+                ["Squid.Action.WindowsService.ExecutablePath"] = "Order.Worker.exe",
+                ["Squid.Action.WindowsService.Arguments"] = "--port 9000 --mode prod",
+                ["Squid.Action.WindowsService.ServiceAccount"] = "LocalSystem",
+                ["Squid.Action.WindowsService.StartMode"] = "Automatic",
+                ["Squid.Action.WindowsService.DesiredStatus"] = "Started",
+                ["Squid.Action.WindowsService.Dependencies"] = "EventLog",
+                ["Squid.Action.WindowsService.Package.ExtractTo"] = $@"C:\Squid\Services\OrderWorker-{Guid.NewGuid():N}",
+                ["Squid.Action.WindowsService.Package.PurgeBeforeExtract"] = "True"
+            });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(seed.ServerTaskId, CancellationToken.None);
+        });
+
+        await AssertTaskStateAsync(seed.ServerTaskId, TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.ShouldHaveSingleItem();
+
+        captured.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+        captured.StepName.ShouldBe(StepName);
+        captured.ActionName.ShouldBe(ActionName);
+        captured.StepId.ShouldBe(seed.StepId);
+        captured.ActionId.ShouldBe(seed.ActionId);
+        captured.Machine.Id.ShouldBe(seed.MachineId);
+        captured.Machine.Name.ShouldStartWith($"E2E Windows Service {communicationStyle} Target");
+        captured.PackageReferences.ShouldBeEmpty();
+
+        captured.ScriptBody.ShouldContain("# BEGIN GENERATED PREAMBLE (Squid WindowsServiceDeployScriptBuilder)");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'OrderWorker'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ExecutablePath'] = 'Order.Worker.exe'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.Arguments'] = '--port 9000 --mode prod'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.StartMode'] = 'Automatic'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.DesiredStatus'] = 'Started'");
+        captured.ScriptBody.ShouldContain("$SquidSelectedPackages = @()");
+
+        captured.ScriptBody.ShouldContain("function Resolve-PackageRoot");
+        captured.ScriptBody.ShouldContain("function Resolve-AcquiredPackageSourcePath");
+        captured.ScriptBody.ShouldContain("function Build-BinaryPathName");
+        captured.ScriptBody.ShouldContain("Invoke-Sc create");
+        captured.ScriptBody.ShouldContain("Invoke-Sc config");
+        captured.ScriptBody.ShouldContain("Start-Service");
+        captured.ScriptBody.ShouldContain("Stop-ServiceIfRunning");
+        captured.ScriptBody.ShouldContain("package-references.json");
+    }
+
+    [Theory]
+    [InlineData("TentaclePolling")]
+    [InlineData("TentacleListening")]
+    public async Task FullPipeline_DeployWindowsService_ResolvesVariablesAndMasksSensitivePassword(string communicationStyle)
+    {
+        ExecutionCapture.Clear();
+
+        const string serviceName = "VariableWorker";
+        const string servicePassword = "Super'Secret!";
+
+        var seed = await SeedWindowsServiceDeploymentAsync(
+            communicationStyle,
+            variables: new[]
+            {
+                ("WindowsServiceName", serviceName, false),
+                ("WindowsServicePort", "9443", false),
+                ("WindowsServicePassword", servicePassword, true)
+            },
+            properties: new Dictionary<string, string>
+            {
+                ["Squid.Action.WindowsService.CreateOrUpdateService"] = "True",
+                ["Squid.Action.WindowsService.ServiceName"] = "#{WindowsServiceName}",
+                ["Squid.Action.WindowsService.ExecutablePath"] = "Order.Worker.exe",
+                ["Squid.Action.WindowsService.Arguments"] = "--port #{WindowsServicePort}",
+                ["Squid.Action.WindowsService.ServiceAccount"] = "SpecificUser",
+                ["Squid.Action.WindowsService.CustomAccountName"] = @"DOMAIN\worker",
+                ["Squid.Action.WindowsService.CustomAccountPassword"] = "#{WindowsServicePassword}",
+                ["Squid.Action.WindowsService.StartMode"] = "Manual",
+                ["Squid.Action.WindowsService.DesiredStatus"] = "Stopped"
+            });
+
+        await _fixture.Run<IDeploymentTaskExecutor>(async executor =>
+        {
+            await executor.ProcessAsync(seed.ServerTaskId, CancellationToken.None);
+        });
+
+        await AssertTaskStateAsync(seed.ServerTaskId, TaskState.Success);
+
+        var captured = ExecutionCapture.CapturedRequests.ShouldHaveSingleItem();
+
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'VariableWorker'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.Arguments'] = '--port 9443'");
+        captured.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.CustomAccountPassword'] = 'Super''Secret!'");
+        captured.ScriptBody.ShouldNotContain("#{WindowsServiceName}");
+        captured.ScriptBody.ShouldNotContain("#{WindowsServicePort}");
+        captured.ScriptBody.ShouldNotContain("#{WindowsServicePassword}");
+
+        captured.Masker.ShouldNotBeNull("Sensitive service-account password must be carried in the script request masker.");
+        captured.Masker.Mask($"password={servicePassword}").ShouldBe($"password={SensitiveValueMasker.MaskToken}");
+    }
+
+    private async Task<SeededDeployment> SeedWindowsServiceDeploymentAsync(
+        string communicationStyle,
+        Dictionary<string, string> properties,
+        (string Name, string Value, bool IsSensitive)[] variables)
+    {
+        SeededDeployment result = null;
+
+        await _fixture.Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var suffix = Guid.NewGuid().ToString("N")[..8];
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            if (variables != null)
+            {
+                foreach (var variable in variables)
+                    await builder.CreateVariableAsync(variableSet.Id, variable.Name, variable.Value, isSensitive: variable.IsSensitive).ConfigureAwait(false);
+            }
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            var step = await builder.CreateDeploymentStepAsync(process.Id, 1, StepName).ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step.Id, (SpecialVariables.Step.TargetRoles, TargetRole)).ConfigureAwait(false);
+
+            var action = await builder.CreateDeploymentActionAsync(
+                step.Id,
+                1,
+                ActionName,
+                actionType: SpecialVariables.ActionTypes.DeployWindowsService).ConfigureAwait(false);
+
+            await builder.CreateActionMachineRolesAsync(action.Id, TargetRole).ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(action.Id, properties.Select(p => (p.Key, p.Value)).ToArray()).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync($"E2E Windows Service {communicationStyle} Env {suffix}").ConfigureAwait(false);
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            var endpointJson = BuildTentacleEndpointJson(communicationStyle, suffix);
+            var machine = new Machine
+            {
+                Name = $"E2E Windows Service {communicationStyle} Target {suffix}",
+                IsDisabled = false,
+                Roles = DeploymentTargetFinder.SerializeRoles(new[] { TargetRole }),
+                EnvironmentIds = DeploymentTargetFinder.SerializeIds(new[] { environment.Id }),
+                Endpoint = endpointJson,
+                SpaceId = 1,
+                Slug = $"e2e-windows-service-{communicationStyle.ToLowerInvariant()}-{suffix}"
+            };
+
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var deployment = await CreateDeploymentAsync(repository, unitOfWork, project, channel, environment, release, suffix).ConfigureAwait(false);
+            var serverTask = await CreateServerTaskAsync(repository, unitOfWork, project, environment, suffix).ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            result = new SeededDeployment(serverTask.Id, machine.Id, step.Id, action.Id);
+        }).ConfigureAwait(false);
+
+        return result!;
+    }
+
+    private static string BuildTentacleEndpointJson(string communicationStyle, string suffix)
+    {
+        return communicationStyle == "TentaclePolling"
+            ? JsonSerializer.Serialize(new
+            {
+                CommunicationStyle = "TentaclePolling",
+                SubscriptionId = $"windows-service-e2e-sub-{suffix}",
+                Thumbprint = $"WINDOWS-SERVICE-E2E-POLLING-{suffix}"
+            })
+            : JsonSerializer.Serialize(new
+            {
+                CommunicationStyle = "TentacleListening",
+                Uri = $"https://localhost:10933/{suffix}",
+                Thumbprint = $"WINDOWS-SERVICE-E2E-LISTENING-{suffix}"
+            });
+    }
+
+    private static async Task<Deployment> CreateDeploymentAsync(
+        IRepository repository,
+        IUnitOfWork unitOfWork,
+        Project project,
+        Channel channel,
+        Environment environment,
+        Release release,
+        string suffix)
+    {
+        var deployment = new Deployment
+        {
+            Name = $"E2E Windows Service Deployment {suffix}",
+            SpaceId = 1,
+            ChannelId = channel.Id,
+            ProjectId = project.Id,
+            ReleaseId = release.Id,
+            EnvironmentId = environment.Id,
+            DeployedBy = 1,
+            CreatedDate = DateTimeOffset.UtcNow,
+            Json = string.Empty
+        };
+
+        await repository.InsertAsync(deployment).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+        return deployment;
+    }
+
+    private static async Task<ServerTask> CreateServerTaskAsync(
+        IRepository repository,
+        IUnitOfWork unitOfWork,
+        Project project,
+        Environment environment,
+        string suffix)
+    {
+        var serverTask = new ServerTask
+        {
+            Name = $"E2E Windows Service Task {suffix}",
+            Description = "E2E Windows service deploy contract",
+            QueueTime = DateTimeOffset.UtcNow,
+            State = TaskState.Pending,
+            ServerTaskType = "Deploy",
+            ProjectId = project.Id,
+            EnvironmentId = environment.Id,
+            SpaceId = 1,
+            LastModifiedDate = DateTimeOffset.UtcNow,
+            BusinessProcessState = "Queued",
+            StateOrder = 1,
+            Weight = 1,
+            BatchId = 0,
+            JSON = string.Empty,
+            HasWarningsOrErrors = false,
+            ServerNodeId = Guid.NewGuid(),
+            DurationSeconds = 0,
+            DataVersion = Array.Empty<byte>()
+        };
+
+        await repository.InsertAsync(serverTask).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+        return serverTask;
+    }
+
+    private async Task AssertTaskStateAsync(int serverTaskId, string expectedState)
+    {
+        await _fixture.Run<IServerTaskDataProvider>(async taskDataProvider =>
+        {
+            var task = await taskDataProvider.GetServerTaskByIdAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+
+            task.ShouldNotBeNull();
+            task.State.ShouldBe(expectedState, $"Expected task {serverTaskId} state '{expectedState}' but was '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+
+    private sealed record SeededDeployment(int ServerTaskId, int MachineId, int StepId, int ActionId);
+}

--- a/tests/Squid.IntegrationTests/Deployments/Pipeline/IntegrationWindowsServiceCapabilityFiltering.cs
+++ b/tests/Squid.IntegrationTests/Deployments/Pipeline/IntegrationWindowsServiceCapabilityFiltering.cs
@@ -1,0 +1,268 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.IntegrationTests.Deployments.Pipeline;
+
+public class IntegrationWindowsServiceCapabilityFiltering : DeploymentFixtureBase
+{
+    [Fact]
+    public async Task ProcessAsync_WindowsServiceOnNonWindowsTarget_EmitsCapabilityFilteredEventAndDoesNotExecute()
+    {
+        var capture = new CapturingExecutionStrategy();
+        var events = new CapturingLifecycleHandler();
+        var capabilities = new InMemoryMachineRuntimeCapabilitiesCache();
+        var seed = await SeedWindowsServiceDeploymentAsync().ConfigureAwait(false);
+
+        capabilities.Store(seed.MachineId, new Dictionary<string, string>
+        {
+            ["os"] = AgentOperatingSystems.Linux,
+            ["installedShells"] = "powershell,pwsh,cmd",
+            ["defaultShell"] = "powershell"
+        }, agentVersion: "9.0.0");
+
+        await Run<IDeploymentTaskExecutor>(
+            executor => executor.ProcessAsync(seed.ServerTaskId, CancellationToken.None),
+            builder => RegisterExecutionOverrides(builder, capture, events, capabilities)).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(seed.ServerTaskId, TaskState.Success).ConfigureAwait(false);
+
+        capture.Calls.ShouldBe(0,
+            customMessage: "Capability-filtered Windows service dispatches must be skipped before rendering/execution.");
+
+        var filtered = events.Events.OfType<ActionCapabilityFilteredEvent>().ShouldHaveSingleItem();
+        filtered.Context.ActionName.ShouldBe("Deploy Worker");
+        filtered.Context.ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+        filtered.Context.MachineName.ShouldBe("Linux Tentacle Target");
+        filtered.Context.CommunicationStyle.ShouldBe(CommunicationStyle.TentaclePolling);
+        filtered.Context.Message.ShouldContain(CapabilityKeys.OsSlot);
+
+        events.Events.OfType<ActionRunningEvent>().ShouldBeEmpty();
+        events.Events.OfType<ActionExecutingEvent>().ShouldBeEmpty();
+
+        var completed = events.Events.OfType<StepCompletedEvent>()
+            .Where(e => e.Context.StepName == "Deploy Windows Service")
+            .ShouldHaveSingleItem();
+        completed.Context.Failed.ShouldBeFalse();
+    }
+
+    private static void RegisterExecutionOverrides(
+        ContainerBuilder builder,
+        CapturingExecutionStrategy capture,
+        CapturingLifecycleHandler events,
+        IMachineRuntimeCapabilitiesCache capabilities)
+    {
+        builder.RegisterInstance(capabilities)
+            .As<IMachineRuntimeCapabilitiesCache>()
+            .SingleInstance();
+
+        builder.RegisterInstance(events)
+            .As<IDeploymentLifecycleHandler>()
+            .SingleInstance();
+
+        builder.Register(ctx => new CapturingTentacleTransportRegistry(capabilities, capture))
+            .As<ITransportRegistry>()
+            .InstancePerLifetimeScope();
+    }
+
+    private async Task<SeededDeployment> SeedWindowsServiceDeploymentAsync()
+    {
+        SeededDeployment? result = null;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var suffix = Guid.NewGuid().ToString("N")[..8];
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            var step = await builder.CreateDeploymentStepAsync(process.Id, 1, "Deploy Windows Service").ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step.Id, (SpecialVariables.Step.TargetRoles, "windows-service")).ConfigureAwait(false);
+
+            var action = await builder.CreateDeploymentActionAsync(
+                step.Id,
+                1,
+                "Deploy Worker",
+                actionType: SpecialVariables.ActionTypes.DeployWindowsService).ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(action.Id, "windows-service").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(action.Id,
+                ("Squid.Action.WindowsService.CreateOrUpdateService", "True"),
+                ("Squid.Action.WindowsService.ServiceName", "OrderWorker"),
+                ("Squid.Action.WindowsService.ExecutablePath", "Order.Worker.exe"),
+                ("Squid.Action.WindowsService.StartMode", "Automatic"),
+                ("Squid.Action.WindowsService.DesiredStatus", "Started")).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync($"Windows Service Filter Env {suffix}").ConfigureAwait(false);
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            var endpointJson = JsonSerializer.Serialize(new
+            {
+                CommunicationStyle = "TentaclePolling",
+                SubscriptionId = $"linux-service-sub-{suffix}",
+                Thumbprint = $"LINUX-SERVICE-THUMBPRINT-{suffix}"
+            });
+
+            var machine = new Machine
+            {
+                Name = "Linux Tentacle Target",
+                IsDisabled = false,
+                Roles = DeploymentTargetFinder.SerializeRoles(new[] { "windows-service" }),
+                EnvironmentIds = DeploymentTargetFinder.SerializeIds(new[] { environment.Id }),
+                Endpoint = endpointJson,
+                SpaceId = 1,
+                Slug = $"linux-service-target-{suffix}"
+            };
+
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var deployment = new Deployment
+            {
+                Name = $"Windows Service Filter Deployment {suffix}",
+                SpaceId = 1,
+                ChannelId = channel.Id,
+                ProjectId = project.Id,
+                ReleaseId = release.Id,
+                EnvironmentId = environment.Id,
+                DeployedBy = 1,
+                CreatedDate = DateTimeOffset.UtcNow,
+                Json = string.Empty
+            };
+
+            await repository.InsertAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var serverTask = new ServerTask
+            {
+                Name = $"Windows Service Filter Task {suffix}",
+                Description = "Integration Windows service capability filter",
+                QueueTime = DateTimeOffset.UtcNow,
+                State = TaskState.Pending,
+                ServerTaskType = "Deploy",
+                ProjectId = project.Id,
+                EnvironmentId = environment.Id,
+                SpaceId = 1,
+                LastModifiedDate = DateTimeOffset.UtcNow,
+                BusinessProcessState = "Queued",
+                StateOrder = 1,
+                Weight = 1,
+                BatchId = 0,
+                JSON = string.Empty,
+                HasWarningsOrErrors = false,
+                ServerNodeId = Guid.NewGuid(),
+                DurationSeconds = 0,
+                DataVersion = Array.Empty<byte>()
+            };
+
+            await repository.InsertAsync(serverTask).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            result = new SeededDeployment(serverTask.Id, machine.Id);
+        }).ConfigureAwait(false);
+
+        return result!;
+    }
+
+    private async Task AssertTaskStateAsync(int serverTaskId, string expectedState)
+    {
+        await Run<IServerTaskDataProvider>(async taskDataProvider =>
+        {
+            var task = await taskDataProvider.GetServerTaskByIdAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+
+            task.ShouldNotBeNull();
+            task.State.ShouldBe(expectedState, $"Expected task {serverTaskId} state '{expectedState}' but was '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+
+    private sealed record SeededDeployment(int ServerTaskId, int MachineId);
+
+    private sealed class CapturingLifecycleHandler : IDeploymentLifecycleHandler
+    {
+        public int Order => int.MaxValue;
+        public List<DeploymentLifecycleEvent> Events { get; } = new();
+
+        public void Initialize(DeploymentTaskContext ctx) { }
+
+        public Task HandleAsync(DeploymentLifecycleEvent @event, CancellationToken ct)
+        {
+            Events.Add(@event);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingExecutionStrategy : IExecutionStrategy
+    {
+        public int Calls { get; private set; }
+
+        public Task<ScriptExecutionResult> ExecuteScriptAsync(ScriptExecutionRequest request, CancellationToken ct)
+        {
+            Calls++;
+
+            return Task.FromResult(new ScriptExecutionResult
+            {
+                Success = true,
+                ExitCode = 0,
+                LogLines = new List<string>()
+            });
+        }
+    }
+
+    private sealed class CapturingTentacleTransportRegistry : ITransportRegistry
+    {
+        private readonly Dictionary<CommunicationStyle, IDeploymentTransport> _transports;
+
+        public CapturingTentacleTransportRegistry(IMachineRuntimeCapabilitiesCache capabilities, IExecutionStrategy strategy)
+        {
+            _transports = new Dictionary<CommunicationStyle, IDeploymentTransport>
+            {
+                [CommunicationStyle.TentaclePolling] = new CapturingTentacleTransport(
+                    CommunicationStyle.TentaclePolling,
+                    new TentacleEndpointVariableContributor(capabilities),
+                    strategy,
+                    TentaclePollingTransport.Capability),
+                [CommunicationStyle.TentacleListening] = new CapturingTentacleTransport(
+                    CommunicationStyle.TentacleListening,
+                    new TentacleEndpointVariableContributor(capabilities),
+                    strategy,
+                    TentacleListeningTransport.Capability)
+            };
+        }
+
+        public IDeploymentTransport Resolve(CommunicationStyle style)
+            => _transports.TryGetValue(style, out var transport) ? transport : null;
+    }
+
+    private sealed class CapturingTentacleTransport : DeploymentTransport
+    {
+        public CapturingTentacleTransport(
+            CommunicationStyle communicationStyle,
+            IEndpointVariableContributor variables,
+            IExecutionStrategy strategy,
+            ITransportCapabilities capabilities)
+            : base(communicationStyle, variables, strategy, capabilities)
+        {
+        }
+    }
+}

--- a/tests/Squid.IntegrationTests/Deployments/Pipeline/IntegrationWindowsServiceDeploymentComposition.cs
+++ b/tests/Squid.IntegrationTests/Deployments/Pipeline/IntegrationWindowsServiceDeploymentComposition.cs
@@ -1,0 +1,368 @@
+using System.Text.Json;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Lifecycle;
+using Squid.Core.Services.DeploymentExecution.Packages;
+using Squid.Core.Services.DeploymentExecution.Script;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.IntegrationTests.Helpers;
+using Squid.Message.Constants;
+using Squid.Message.Enums;
+using Squid.Message.Models.Deployments.Execution;
+using Environment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.IntegrationTests.Deployments.Pipeline;
+
+public class IntegrationWindowsServiceDeploymentComposition : DeploymentFixtureBase
+{
+    [Fact]
+    public async Task ProcessAsync_WindowsServiceAction_ComposesRenderedTentacleRequest()
+    {
+        var capture = new CapturingExecutionStrategy();
+        var packageAcquisition = new CapturingPackageAcquisitionService(new PackageAcquisitionResult(
+            "/tmp/squid-packages/Order.Worker.2.3.4.nupkg",
+            "Order.Worker",
+            "2.3.4",
+            4096,
+            "ABCDEF0123456789"));
+        var capabilities = new InMemoryMachineRuntimeCapabilitiesCache();
+        var seed = await SeedWindowsServiceDeploymentAsync().ConfigureAwait(false);
+
+        capabilities.Store(seed.MachineId, new Dictionary<string, string>
+        {
+            ["os"] = AgentOperatingSystems.Windows,
+            ["installedShells"] = "powershell,pwsh,cmd",
+            ["defaultShell"] = "powershell"
+        }, agentVersion: "9.0.0");
+
+        await Run<IDeploymentTaskExecutor>(
+            executor => executor.ProcessAsync(seed.ServerTaskId, CancellationToken.None),
+            builder => RegisterExecutionOverrides(builder, capture, packageAcquisition, capabilities)).ConfigureAwait(false);
+
+        await AssertTaskStateAsync(seed.ServerTaskId, TaskState.Success).ConfigureAwait(false);
+
+        packageAcquisition.Calls.Count.ShouldBe(1,
+            customMessage: "The selected package must inject and execute the synthetic Acquire Packages step before the Windows service step.");
+        packageAcquisition.Calls[0].FeedId.ShouldBe(seed.FeedId);
+        packageAcquisition.Calls[0].PackageId.ShouldBe("Order.Worker");
+        packageAcquisition.Calls[0].Version.ShouldBe("2.3.4");
+        packageAcquisition.Calls[0].DeploymentId.ShouldBe(seed.DeploymentId);
+
+        var request = capture.CapturedRequests.ShouldHaveSingleItem();
+
+        request.StepName.ShouldBe("Deploy Windows Service");
+        request.ActionName.ShouldBe("Deploy Worker");
+        request.StepId.ShouldBe(seed.StepId);
+        request.ActionId.ShouldBe(seed.ActionId);
+        request.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+        request.Machine.Id.ShouldBe(seed.MachineId);
+        request.PackageReferences.ShouldHaveSingleItem().ShouldBe(packageAcquisition.Result);
+
+        request.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'OrderWorker'");
+        request.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.Arguments'] = '--port 9000 --mode prod'");
+        request.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.CustomAccountPassword'] = 'Super''Secret!'");
+        request.ScriptBody.ShouldContain("PackageReferenceName = 'Order.Worker'");
+        request.ScriptBody.ShouldContain("Version = '2.3.4'");
+        request.ScriptBody.ShouldContain("function Resolve-PackageRoot");
+        request.ScriptBody.ShouldNotContain("#{WindowsServiceName}");
+        request.ScriptBody.ShouldNotContain("#{WindowsServicePort}");
+        request.ScriptBody.ShouldNotContain("#{WindowsServicePassword}");
+
+        request.Masker.ShouldNotBeNull("Sensitive service-account password must be carried in the script request masker.");
+        request.Masker.Mask($"password={seed.ServicePassword}").ShouldBe($"password={SensitiveValueMasker.MaskToken}");
+    }
+
+    private void RegisterExecutionOverrides(
+        ContainerBuilder builder,
+        CapturingExecutionStrategy capture,
+        CapturingPackageAcquisitionService packageAcquisition,
+        IMachineRuntimeCapabilitiesCache capabilities)
+    {
+        builder.RegisterInstance(capabilities)
+            .As<IMachineRuntimeCapabilitiesCache>()
+            .SingleInstance();
+
+        builder.RegisterInstance(packageAcquisition)
+            .As<IPackageAcquisitionService>()
+            .SingleInstance();
+
+        builder.Register(ctx => new CapturingTentacleTransportRegistry(capabilities, capture))
+            .As<ITransportRegistry>()
+            .InstancePerLifetimeScope();
+    }
+
+    private async Task<SeededDeployment> SeedWindowsServiceDeploymentAsync()
+    {
+        SeededDeployment? result = null;
+        const string servicePassword = "Super'Secret!";
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var suffix = Guid.NewGuid().ToString("N")[..8];
+            var builder = new TestDataBuilder(repository, unitOfWork);
+
+            var variableSet = await builder.CreateVariableSetAsync().ConfigureAwait(false);
+            var project = await builder.CreateProjectAsync(variableSet.Id).ConfigureAwait(false);
+            await builder.UpdateVariableSetOwnerAsync(variableSet, project.Id).ConfigureAwait(false);
+            await builder.CreateVariableAsync(variableSet.Id, "WindowsServiceName", "OrderWorker").ConfigureAwait(false);
+            await builder.CreateVariableAsync(variableSet.Id, "WindowsServicePort", "9000").ConfigureAwait(false);
+            await builder.CreateVariableAsync(variableSet.Id, "WindowsServicePassword", servicePassword, isSensitive: true).ConfigureAwait(false);
+
+            var process = await builder.CreateDeploymentProcessAsync().ConfigureAwait(false);
+            await builder.UpdateProjectProcessIdAsync(project, process.Id).ConfigureAwait(false);
+
+            var step = await builder.CreateDeploymentStepAsync(process.Id, 1, "Deploy Windows Service").ConfigureAwait(false);
+            await builder.CreateStepPropertiesAsync(step.Id, (SpecialVariables.Step.TargetRoles, "windows-service")).ConfigureAwait(false);
+
+            var action = await builder.CreateDeploymentActionAsync(
+                step.Id,
+                1,
+                "Deploy Worker",
+                actionType: SpecialVariables.ActionTypes.DeployWindowsService).ConfigureAwait(false);
+            await builder.CreateActionMachineRolesAsync(action.Id, "windows-service").ConfigureAwait(false);
+            await builder.CreateActionPropertiesAsync(action.Id,
+                ("Squid.Action.WindowsService.CreateOrUpdateService", "True"),
+                ("Squid.Action.WindowsService.ServiceName", "#{WindowsServiceName}"),
+                ("Squid.Action.WindowsService.DisplayName", "Order Worker"),
+                ("Squid.Action.WindowsService.Description", "Processes queued orders"),
+                ("Squid.Action.WindowsService.ExecutablePath", "Order.Worker.exe"),
+                ("Squid.Action.WindowsService.Arguments", "--port #{WindowsServicePort} --mode prod"),
+                ("Squid.Action.WindowsService.ServiceAccount", "SpecificUser"),
+                ("Squid.Action.WindowsService.CustomAccountName", @"DOMAIN\order-worker"),
+                ("Squid.Action.WindowsService.CustomAccountPassword", "#{WindowsServicePassword}"),
+                ("Squid.Action.WindowsService.StartMode", "Automatic"),
+                ("Squid.Action.WindowsService.DesiredStatus", "Started"),
+                ("Squid.Action.WindowsService.Dependencies", "EventLog"),
+                ("Squid.Action.WindowsService.Package.ExtractTo", $@"C:\Squid\Services\OrderWorker-{suffix}"),
+                ("Squid.Action.WindowsService.Package.PurgeBeforeExtract", "True")).ConfigureAwait(false);
+
+            var channel = await builder.CreateChannelAsync(project.Id, project.LifecycleId).ConfigureAwait(false);
+            var environment = await builder.CreateEnvironmentAsync($"Windows Service Env {suffix}").ConfigureAwait(false);
+            var feed = await CreateFeedAsync(repository, unitOfWork, suffix).ConfigureAwait(false);
+            var release = await builder.CreateReleaseAsync(project.Id, channel.Id, "1.0.0").ConfigureAwait(false);
+
+            await repository.InsertAsync(new ReleaseSelectedPackage
+            {
+                ReleaseId = release.Id,
+                FeedId = feed.Id,
+                ActionName = "Deploy Worker",
+                PackageReferenceName = "Order.Worker",
+                Version = "2.3.4"
+            }).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var endpointJson = JsonSerializer.Serialize(new
+            {
+                CommunicationStyle = "TentaclePolling",
+                SubscriptionId = $"windows-service-sub-{suffix}",
+                Thumbprint = $"WINDOWS-SERVICE-THUMBPRINT-{suffix}"
+            });
+
+            var machine = new Machine
+            {
+                Name = $"Windows Service Target {suffix}",
+                IsDisabled = false,
+                Roles = DeploymentTargetFinder.SerializeRoles(new[] { "windows-service" }),
+                EnvironmentIds = DeploymentTargetFinder.SerializeIds(new[] { environment.Id }),
+                Endpoint = endpointJson,
+                SpaceId = 1,
+                Slug = $"windows-service-target-{suffix}"
+            };
+
+            await repository.InsertAsync(machine).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            var deployment = await CreateDeploymentAsync(repository, unitOfWork, project, channel, environment, release, suffix).ConfigureAwait(false);
+            var serverTask = await CreateServerTaskAsync(repository, unitOfWork, project, environment, suffix).ConfigureAwait(false);
+
+            deployment.TaskId = serverTask.Id;
+            await repository.UpdateAsync(deployment).ConfigureAwait(false);
+            await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+
+            result = new SeededDeployment(serverTask.Id, deployment.Id, machine.Id, step.Id, action.Id, feed.Id, servicePassword);
+        }).ConfigureAwait(false);
+
+        return result!;
+    }
+
+    private static async Task<ExternalFeed> CreateFeedAsync(IRepository repository, IUnitOfWork unitOfWork, string suffix)
+    {
+        var feed = new ExternalFeed
+        {
+            FeedType = "NuGet",
+            Properties = "{}",
+            FeedUri = "https://packages.example.test/nuget",
+            Username = string.Empty,
+            Password = string.Empty,
+            Name = $"Windows Service Feed {suffix}",
+            Slug = $"windows-service-feed-{suffix}",
+            PackageAcquisitionLocationOptions = string.Empty,
+            SpaceId = 1,
+            CreatedDate = DateTimeOffset.UtcNow,
+            CreatedBy = 0,
+            LastModifiedDate = DateTimeOffset.UtcNow,
+            LastModifiedBy = 0
+        };
+
+        await repository.InsertAsync(feed).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+        return feed;
+    }
+
+    private static async Task<Deployment> CreateDeploymentAsync(
+        IRepository repository,
+        IUnitOfWork unitOfWork,
+        Project project,
+        Channel channel,
+        Environment environment,
+        Release release,
+        string suffix)
+    {
+        var deployment = new Deployment
+        {
+            Name = $"Windows Service Deployment {suffix}",
+            SpaceId = 1,
+            ChannelId = channel.Id,
+            ProjectId = project.Id,
+            ReleaseId = release.Id,
+            EnvironmentId = environment.Id,
+            DeployedBy = 1,
+            CreatedDate = DateTimeOffset.UtcNow,
+            Json = string.Empty
+        };
+
+        await repository.InsertAsync(deployment).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+        return deployment;
+    }
+
+    private static async Task<ServerTask> CreateServerTaskAsync(
+        IRepository repository,
+        IUnitOfWork unitOfWork,
+        Project project,
+        Environment environment,
+        string suffix)
+    {
+        var serverTask = new ServerTask
+        {
+            Name = $"Windows Service Task {suffix}",
+            Description = "Integration Windows service deploy",
+            QueueTime = DateTimeOffset.UtcNow,
+            State = TaskState.Pending,
+            ServerTaskType = "Deploy",
+            ProjectId = project.Id,
+            EnvironmentId = environment.Id,
+            SpaceId = 1,
+            LastModifiedDate = DateTimeOffset.UtcNow,
+            BusinessProcessState = "Queued",
+            StateOrder = 1,
+            Weight = 1,
+            BatchId = 0,
+            JSON = string.Empty,
+            HasWarningsOrErrors = false,
+            ServerNodeId = Guid.NewGuid(),
+            DurationSeconds = 0,
+            DataVersion = Array.Empty<byte>()
+        };
+
+        await repository.InsertAsync(serverTask).ConfigureAwait(false);
+        await unitOfWork.SaveChangesAsync().ConfigureAwait(false);
+        return serverTask;
+    }
+
+    private async Task AssertTaskStateAsync(int serverTaskId, string expectedState)
+    {
+        await Run<IServerTaskDataProvider>(async taskDataProvider =>
+        {
+            var task = await taskDataProvider.GetServerTaskByIdAsync(serverTaskId, CancellationToken.None).ConfigureAwait(false);
+
+            task.ShouldNotBeNull();
+            task.State.ShouldBe(expectedState, $"Expected task {serverTaskId} state '{expectedState}' but was '{task.State}'");
+        }).ConfigureAwait(false);
+    }
+
+    private sealed record SeededDeployment(
+        int ServerTaskId,
+        int DeploymentId,
+        int MachineId,
+        int StepId,
+        int ActionId,
+        int FeedId,
+        string ServicePassword);
+
+    private sealed class CapturingExecutionStrategy : IExecutionStrategy
+    {
+        private readonly List<ScriptExecutionRequest> _capturedRequests = new();
+
+        public IReadOnlyList<ScriptExecutionRequest> CapturedRequests => _capturedRequests;
+
+        public Task<ScriptExecutionResult> ExecuteScriptAsync(ScriptExecutionRequest request, CancellationToken ct)
+        {
+            _capturedRequests.Add(request);
+
+            return Task.FromResult(new ScriptExecutionResult
+            {
+                Success = true,
+                ExitCode = 0,
+                LogLines = new List<string>()
+            });
+        }
+    }
+
+    private sealed class CapturingPackageAcquisitionService : IPackageAcquisitionService
+    {
+        public CapturingPackageAcquisitionService(PackageAcquisitionResult result) => Result = result;
+
+        public PackageAcquisitionResult Result { get; }
+        public List<PackageAcquisitionCall> Calls { get; } = new();
+
+        public Task<PackageAcquisitionResult> AcquireAsync(ExternalFeed feed, string packageId, string version, int deploymentId, CancellationToken ct)
+        {
+            Calls.Add(new PackageAcquisitionCall(feed.Id, packageId, version, deploymentId));
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed record PackageAcquisitionCall(int FeedId, string PackageId, string Version, int DeploymentId);
+
+    private sealed class CapturingTentacleTransportRegistry : ITransportRegistry
+    {
+        private readonly Dictionary<CommunicationStyle, IDeploymentTransport> _transports;
+
+        public CapturingTentacleTransportRegistry(IMachineRuntimeCapabilitiesCache capabilities, IExecutionStrategy strategy)
+        {
+            _transports = new Dictionary<CommunicationStyle, IDeploymentTransport>
+            {
+                [CommunicationStyle.TentaclePolling] = new CapturingTentacleTransport(
+                    CommunicationStyle.TentaclePolling,
+                    new TentacleEndpointVariableContributor(capabilities),
+                    strategy,
+                    TentaclePollingTransport.Capability),
+                [CommunicationStyle.TentacleListening] = new CapturingTentacleTransport(
+                    CommunicationStyle.TentacleListening,
+                    new TentacleEndpointVariableContributor(capabilities),
+                    strategy,
+                    TentacleListeningTransport.Capability)
+            };
+        }
+
+        public IDeploymentTransport Resolve(CommunicationStyle style)
+            => _transports.TryGetValue(style, out var transport) ? transport : null;
+    }
+
+    private sealed class CapturingTentacleTransport : DeploymentTransport
+    {
+        public CapturingTentacleTransport(
+            CommunicationStyle communicationStyle,
+            IEndpointVariableContributor variables,
+            IExecutionStrategy strategy,
+            ITransportCapabilities capabilities)
+            : base(communicationStyle, variables, strategy, capabilities)
+        {
+        }
+    }
+}

--- a/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
@@ -3,6 +3,7 @@ using Squid.Core.Services.Deployments.Process.Action;
 using Squid.Core.Services.Deployments.Process.Step;
 using Squid.IntegrationTests.Helpers;
 using Squid.Message.Commands.Deployments.Process.Step;
+using Squid.Message.Constants;
 using Squid.Message.Events.Deployments.Step;
 using Squid.Message.Models.Deployments.Process;
 
@@ -145,6 +146,55 @@ public class DeploymentStepServiceTests : TestBase
             properties.Count.ShouldBe(2);
             properties.ShouldAllBe(p => p.ActionId == actionId);
             properties.ShouldAllBe(p => p.ActionId != 0);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task CreateStep_WithDuplicateActionProperties_DeduplicatesBeforePersisting()
+    {
+        var processId = await SeedProcessAsync();
+
+        var result = await Run<IDeploymentStepService, DeploymentStepCreatedEvent>(async service =>
+        {
+            var command = new CreateDeploymentStepCommand
+            {
+                ProcessId = processId,
+                Step = new CreateOrUpdateDeploymentStepModel
+                {
+                    Name = "Deploy Windows Service",
+                    StepType = "Action",
+                    Condition = "Success",
+                    StartTrigger = "",
+                    PackageRequirement = "",
+                    Actions =
+                    [
+                        new CreateOrUpdateDeploymentActionModel
+                        {
+                            Name = "Deploy Windows Service",
+                            ActionType = SpecialVariables.ActionTypes.DeployWindowsService,
+                            Properties =
+                            [
+                                new ActionPropertyModel { PropertyName = "Squid.Action.WindowsService.ServiceName", PropertyValue = "OldService" },
+                                new ActionPropertyModel { PropertyName = "squid.action.windowsservice.servicename", PropertyValue = "DemoWindowsService" },
+                                new ActionPropertyModel { PropertyName = "Squid.Action.WindowsService.ExecutablePath", PropertyValue = "Demo.WindowsService.exe" }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            return await service.CreateDeploymentStepAsync(command, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var actionId = result.Data.Actions[0].Id;
+
+        await Run<IDeploymentActionPropertyDataProvider>(async provider =>
+        {
+            var properties = await provider.GetDeploymentActionPropertiesByActionIdAsync(actionId, CancellationToken.None).ConfigureAwait(false);
+
+            properties.Count.ShouldBe(2);
+            properties.ShouldContain(p => p.PropertyName == "Squid.Action.WindowsService.ServiceName" && p.PropertyValue == "DemoWindowsService");
+            properties.ShouldContain(p => p.PropertyName == "Squid.Action.WindowsService.ExecutablePath" && p.PropertyValue == "Demo.WindowsService.exe");
         }).ConfigureAwait(false);
     }
 

--- a/tests/Squid.Tentacle.Tests/Support/Fakes/FakeMachineRegistrationServer.cs
+++ b/tests/Squid.Tentacle.Tests/Support/Fakes/FakeMachineRegistrationServer.cs
@@ -162,8 +162,24 @@ public sealed class FakeMachineRegistrationServer : IAsyncDisposable
         }
         finally
         {
-            _listener.Close();
+            CloseListener();
             _cts.Dispose();
+        }
+    }
+
+    private void CloseListener()
+    {
+        try
+        {
+            _listener.Close();
+        }
+        catch (HttpListenerException)
+        {
+            // The listener is already shutting down; cleanup must not fail the test.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The listener is already disposed.
         }
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Kubernetes;
+using Squid.Core.Services.DeploymentExecution.OpenClaw;
+using Squid.Core.Services.DeploymentExecution.Ssh;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Transport;
+using Squid.Message.Constants;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class WindowsServiceActionRegistrationTests
+{
+    [Fact]
+    public void ActionTypeConstant_IsStable_AndIncludedInAll()
+    {
+        SpecialVariables.ActionTypes.DeployWindowsService.ShouldBe("Squid.DeployWindowsService");
+        SpecialVariables.ActionTypes.All.ShouldContain(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
+    [Fact]
+    public void WindowsServiceDeployProperties_PinSupportedContract()
+    {
+        var expectedProperties = new[]
+        {
+            WindowsServiceDeployProperties.CreateOrUpdateService,
+            WindowsServiceDeployProperties.ServiceName,
+            WindowsServiceDeployProperties.DisplayName,
+            WindowsServiceDeployProperties.Description,
+            WindowsServiceDeployProperties.ExecutablePath,
+            WindowsServiceDeployProperties.Arguments,
+            WindowsServiceDeployProperties.ServiceAccount,
+            WindowsServiceDeployProperties.CustomAccountName,
+            WindowsServiceDeployProperties.CustomAccountPassword,
+            WindowsServiceDeployProperties.StartMode,
+            WindowsServiceDeployProperties.DesiredStatus,
+            WindowsServiceDeployProperties.Dependencies,
+            WindowsServiceDeployProperties.PackageSourcePath,
+            WindowsServiceDeployProperties.PackageExtractTo,
+            WindowsServiceDeployProperties.PackagePurgeBeforeExtract,
+            WindowsServiceDeployProperties.TentacleOS
+        };
+
+        expectedProperties.ShouldBe(new[]
+        {
+            "Squid.Action.WindowsService.CreateOrUpdateService",
+            "Squid.Action.WindowsService.ServiceName",
+            "Squid.Action.WindowsService.DisplayName",
+            "Squid.Action.WindowsService.Description",
+            "Squid.Action.WindowsService.ExecutablePath",
+            "Squid.Action.WindowsService.Arguments",
+            "Squid.Action.WindowsService.ServiceAccount",
+            "Squid.Action.WindowsService.CustomAccountName",
+            "Squid.Action.WindowsService.CustomAccountPassword",
+            "Squid.Action.WindowsService.StartMode",
+            "Squid.Action.WindowsService.DesiredStatus",
+            "Squid.Action.WindowsService.Dependencies",
+            "Squid.Action.WindowsService.Package.SourcePath",
+            "Squid.Action.WindowsService.Package.ExtractTo",
+            "Squid.Action.WindowsService.Package.PurgeBeforeExtract",
+            "Squid.Tentacle.OS"
+        });
+
+        expectedProperties.Distinct(StringComparer.OrdinalIgnoreCase).Count().ShouldBe(expectedProperties.Length);
+    }
+
+    [Fact]
+    public void DeployWindowsService_IsSupportedOnlyByTentacleTransports()
+    {
+        var supported = new[]
+        {
+            TentaclePollingTransport.Capability,
+            TentacleListeningTransport.Capability
+        };
+
+        foreach (var capability in supported)
+            capability.SupportedActionTypes.ShouldContain(SpecialVariables.ActionTypes.DeployWindowsService);
+
+        var unsupported = new ITransportCapabilities[]
+        {
+            ServerTransport.Capability,
+            SshTransport.Capability,
+            KubernetesApiTransport.Capability,
+            KubernetesAgentTransport.Capability,
+            OpenClawTransport.Capability
+        };
+
+        foreach (var capability in unsupported)
+            capability.SupportedActionTypes.ShouldNotContain(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
@@ -1,9 +1,12 @@
 using System.Linq;
 using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
 using Squid.Core.Services.DeploymentExecution.OpenClaw;
 using Squid.Core.Services.DeploymentExecution.Ssh;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Message.Constants;
 
@@ -87,5 +90,38 @@ public class WindowsServiceActionRegistrationTests
 
         foreach (var capability in unsupported)
             capability.SupportedActionTypes.ShouldNotContain(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
+    [Fact]
+    public void DeployWindowsService_ResolvesAsTargetLevel()
+    {
+        IActionHandler handler = new WindowsServiceDeployActionHandler();
+        var registry = new ActionHandlerRegistry(new[] { handler });
+        var action = new Message.Models.Deployments.Process.DeploymentActionDto
+        {
+            ActionType = SpecialVariables.ActionTypes.DeployWindowsService
+        };
+
+        handler.ExecutionScope.ShouldBe(ExecutionScope.TargetLevel);
+        registry.ResolveScope(action).ShouldBe(ExecutionScope.TargetLevel);
+    }
+
+    [Fact]
+    public void DeployWindowsService_DoesNotMakeDeploymentServerOnly()
+    {
+        IActionHandler handler = new WindowsServiceDeployActionHandler();
+        var registry = new ActionHandlerRegistry(new[] { handler });
+        var steps = new List<Message.Models.Deployments.Process.DeploymentStepDto>
+        {
+            new()
+            {
+                Actions = new List<Message.Models.Deployments.Process.DeploymentActionDto>
+                {
+                    new() { ActionType = SpecialVariables.ActionTypes.DeployWindowsService }
+                }
+            }
+        };
+
+        RunOnServerEvaluator.IsEntireDeploymentServerOnly(steps, registry.ResolveScope).ShouldBeFalse();
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
@@ -50,7 +50,9 @@ public class WindowsServiceDeployActionHandlerTests
         runScript.ActionName.ShouldBe("Windows Service");
         runScript.Syntax.ShouldBe(ScriptSyntax.PowerShell);
         runScript.InjectRuntimeBundle.ShouldBeFalse();
-        runScript.ScriptBody.ShouldContain("script generation is not implemented yet");
+        runScript.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'OrderWorker'");
+        runScript.ScriptBody.ShouldContain("function Resolve-PackageRoot");
+        runScript.ScriptBody.ShouldContain("Invoke-Sc create $serviceName");
     }
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
@@ -1,0 +1,162 @@
+using System.Linq;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class WindowsServiceDeployActionHandlerTests
+{
+    [Fact]
+    public void ActionType_MatchesPublishedConstant()
+    {
+        new WindowsServiceDeployActionHandler().ActionType.ShouldBe("Squid.DeployWindowsService");
+        new WindowsServiceDeployActionHandler().ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
+    [Fact]
+    public void StaticRequirements_RequireWindowsAndPowerShell()
+    {
+        var requirements = new WindowsServiceDeployActionHandler().StaticRequirements;
+
+        requirements.Keys.ShouldBe(new[] { CapabilityKeys.OsSlot, CapabilityKeys.Shell.PowerShell }, ignoreOrder: true);
+        requirements[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Windows);
+        requirements[CapabilityKeys.Shell.PowerShell].ShouldContain(CapabilityKeys.Present);
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_ReturnsPowerShellRunScriptIntent_WithStableShape()
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            stepName: "Deploy worker",
+            actionName: "Windows Service");
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+
+        intent.ShouldBeOfType<RunScriptIntent>();
+        var runScript = (RunScriptIntent)intent;
+
+        runScript.Name.ShouldBe("deploy-windows-service");
+        runScript.StepName.ShouldBe("Deploy worker");
+        runScript.ActionName.ShouldBe("Windows Service");
+        runScript.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+        runScript.InjectRuntimeBundle.ShouldBeFalse();
+        runScript.ScriptBody.ShouldContain("script generation is not implemented yet");
+    }
+
+    [Theory]
+    [InlineData("Linux")]
+    [InlineData("Darwin")]
+    [InlineData("FreeBSD")]
+    public async Task DescribeIntentAsync_NonWindowsTentacle_ThrowsWithActionableMessage(string os)
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            action: BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            stepName: "Deploy worker",
+            actionName: "Windows Service",
+            tentacleOs: os);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => handler.DescribeIntentAsync(ctx, CancellationToken.None));
+
+        ex.Message.ShouldContain("Squid.DeployWindowsService");
+        ex.Message.ShouldContain("Deploy worker");
+        ex.Message.ShouldContain("Windows Service");
+        ex.Message.ShouldContain(os);
+        ex.Message.ShouldContain("Windows Tentacle");
+        ex.Message.ShouldContain("health check");
+    }
+
+    [Theory]
+    [InlineData("Windows")]
+    [InlineData("windows")]
+    [InlineData("WINDOWS")]
+    [InlineData("Microsoft Windows NT 10.0.19045.0")]
+    [InlineData("Microsoft Windows NT 10.0.22631.0")]
+    [InlineData("Microsoft Windows NT 10.0.17763.0")]
+    [InlineData("Microsoft Windows NT 10.0.20348.0")]
+    public async Task DescribeIntentAsync_WindowsTentacle_ProceedsSuccessfully(string os)
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            tentacleOs: os);
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_OsCacheMiss_ProceedsOptimistically()
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            tentacleOs: null);
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Theory]
+    [InlineData("Windows", true)]
+    [InlineData("Microsoft Windows NT 10.0.19045.0", true)]
+    [InlineData("Linux", false)]
+    [InlineData("macOS", false)]
+    [InlineData("Darwin", false)]
+    [InlineData("LinuxOnWindowsSubsystem", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void LooksLikeWindowsOsString_PinnedBehaviour(string osValue, bool expected)
+    {
+        WindowsServiceDeployActionHandler.LooksLikeWindowsOsString(osValue).ShouldBe(expected);
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "Windows Service",
+            ActionType = SpecialVariables.ActionTypes.DeployWindowsService,
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+
+    private static ActionExecutionContext BuildContext(
+        DeploymentActionDto action,
+        string stepName = "Deploy",
+        string actionName = "Windows Service",
+        string tentacleOs = "Windows")
+    {
+        var variables = new List<VariableDto>();
+
+        if (tentacleOs != null)
+            variables.Add(new VariableDto { Name = WindowsServiceDeployProperties.TentacleOS, Value = tentacleOs });
+
+        return new ActionExecutionContext
+        {
+            Step = new DeploymentStepDto { Name = stepName },
+            Action = new DeploymentActionDto
+            {
+                Id = action.Id,
+                Name = actionName,
+                ActionType = action.ActionType,
+                Properties = action.Properties
+            },
+            Variables = variables
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -44,7 +44,7 @@ public class WindowsServiceDeployScriptBuilderTests
     }
 
     [Fact]
-    public void Build_EmbeddedScriptStopsExistingService_BeforePackageExtraction()
+    public void Build_EmbeddedScriptStopsExistingService_BeforePackageDirectoryCopy()
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
 
@@ -56,11 +56,11 @@ public class WindowsServiceDeployScriptBuilderTests
         stopExistingServiceIndex.ShouldBeGreaterThanOrEqualTo(0);
         packageRootIndex.ShouldBeGreaterThanOrEqualTo(0);
         stopExistingServiceIndex.ShouldBeLessThan(packageRootIndex,
-            customMessage: "Existing services must be stopped before package purge/extract touches the install directory.");
+            customMessage: "Existing services must be stopped before package copy touches the install directory.");
     }
 
     [Fact]
-    public void Build_EmbeddedScriptWaitsForStoppedServiceProcess_BeforePackageExtraction()
+    public void Build_EmbeddedScriptWaitsForStoppedServiceProcess_BeforePackageDirectoryCopy()
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
 
@@ -72,7 +72,7 @@ public class WindowsServiceDeployScriptBuilderTests
         waitProcessCallIndex.ShouldBeGreaterThanOrEqualTo(0);
         packageRootIndex.ShouldBeGreaterThanOrEqualTo(0);
         waitProcessCallIndex.ShouldBeLessThan(packageRootIndex,
-            customMessage: "Existing service processes must exit before package purge/extract can safely replace locked binaries.");
+            customMessage: "Existing service processes must exit before package copy can safely replace locked binaries.");
     }
 
     [Fact]
@@ -83,7 +83,18 @@ public class WindowsServiceDeployScriptBuilderTests
         script.ShouldContain("function Invoke-WithRetry");
         script.ShouldContain("Invoke-WithRetry -Description \"Removing existing package extract directory '$extractTo'\"");
         script.ShouldContain("Invoke-WithRetry -Description \"Copying package content from '$($sourceItem.FullName)' to '$extractTo'\"");
-        script.ShouldContain("Invoke-WithRetry -Description \"Expanding package '$($sourceItem.FullName)' to '$extractTo'\"");
+        script.ShouldNotContain("Expand-Archive");
+        script.ShouldContain("Deploy Windows Service expects package acquisition to provide an extracted package directory");
+    }
+
+    [Fact]
+    public void Build_EmbeddedScriptFailsWhenNoPackageSourceIsAvailable()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        script.ShouldContain("No Windows service package source was available for this action.");
+        script.ShouldContain("Verify the release selected package is bound to this action name");
+        script.ShouldNotContain("return (Get-Location).Path");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -44,6 +44,22 @@ public class WindowsServiceDeployScriptBuilderTests
     }
 
     [Fact]
+    public void Build_EmbeddedScriptStopsExistingService_BeforePackageExtraction()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        var existingServiceIndex = script.IndexOf("$existingService = Get-Service", StringComparison.Ordinal);
+        var stopExistingServiceIndex = script.IndexOf("Stop-ServiceIfRunning -Name $serviceName", existingServiceIndex, StringComparison.Ordinal);
+        var packageRootIndex = script.IndexOf("$packageRoot = Resolve-PackageRoot", StringComparison.Ordinal);
+
+        existingServiceIndex.ShouldBeGreaterThanOrEqualTo(0);
+        stopExistingServiceIndex.ShouldBeGreaterThanOrEqualTo(0);
+        packageRootIndex.ShouldBeGreaterThanOrEqualTo(0);
+        stopExistingServiceIndex.ShouldBeLessThan(packageRootIndex,
+            customMessage: "Existing services must be stopped before package purge/extract touches the install directory.");
+    }
+
+    [Fact]
     public void Build_AllRecognisedProperties_HaveExplicitEntryInHashtable_EvenWhenUnset()
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -37,6 +37,8 @@ public class WindowsServiceDeployScriptBuilderTests
         preambleIndex.ShouldBeGreaterThanOrEqualTo(0);
         bodyIndex.ShouldBeGreaterThanOrEqualTo(0);
         preambleIndex.ShouldBeLessThan(bodyIndex);
+        script.ShouldContain("function Resolve-AcquiredPackageSourcePath");
+        script.ShouldContain("package-references.json");
         script.ShouldContain("Invoke-Sc create $serviceName");
         script.ShouldContain("Invoke-Sc config $serviceName");
     }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -149,6 +149,15 @@ public class WindowsServiceDeployScriptBuilderTests
     }
 
     [Fact]
+    public void Build_EmbeddedScriptTreatsEmptyDependenciesAsArrayUnderStrictMode()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        script.ShouldContain("$dependencies = @(Split-Dependencies (Get-SquidParameter 'Squid.Action.WindowsService.Dependencies'))");
+        script.ShouldContain("if ($dependencies.Count -gt 0)");
+    }
+
+    [Fact]
     public void Build_EmitsSquidVariablesHashtable()
     {
         var variables = new[]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -1,0 +1,161 @@
+using System.Linq;
+using System.Text;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Release;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class WindowsServiceDeployScriptBuilderTests
+{
+    [Fact]
+    public void Build_EmitsSquidParametersHashtable_AtTopOfScript()
+    {
+        var action = BuildAction(
+            (WindowsServiceDeployProperties.ServiceName, "OrderWorker"),
+            (WindowsServiceDeployProperties.ExecutablePath, "Order.Worker.exe"));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("# BEGIN GENERATED PREAMBLE");
+        script.ShouldContain("$SquidParameters = @{}");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'OrderWorker'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ExecutablePath'] = 'Order.Worker.exe'");
+    }
+
+    [Fact]
+    public void Build_AppendsEmbeddedScriptBody_AfterPreamble()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        var preambleIndex = script.IndexOf("# BEGIN GENERATED PREAMBLE", StringComparison.Ordinal);
+        var bodyIndex = script.IndexOf("function Resolve-PackageRoot", StringComparison.Ordinal);
+
+        preambleIndex.ShouldBeGreaterThanOrEqualTo(0);
+        bodyIndex.ShouldBeGreaterThanOrEqualTo(0);
+        preambleIndex.ShouldBeLessThan(bodyIndex);
+        script.ShouldContain("Invoke-Sc create $serviceName");
+        script.ShouldContain("Invoke-Sc config $serviceName");
+    }
+
+    [Fact]
+    public void Build_AllRecognisedProperties_HaveExplicitEntryInHashtable_EvenWhenUnset()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        foreach (var propertyName in WindowsServiceDeployScriptBuilder.RecognisedProperties)
+            script.ShouldContain($"$SquidParameters['{propertyName}']");
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("plain", "plain")]
+    [InlineData("C:\\Services\\Order", "C:\\Services\\Order")]
+    [InlineData("$env:TEMP", "$env:TEMP")]
+    [InlineData("O'Brien", "O''Brien")]
+    [InlineData("'; Stop-Service X; '", "''; Stop-Service X; ''")]
+    public void EscapeForPowerShellSingleQuote_FollowsPowerShellLiteralRules(string input, string expected)
+    {
+        WindowsServiceDeployScriptBuilder.EscapeForPowerShellSingleQuote(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Build_MultilineDescription_PreservesNewlinesViaBase64()
+    {
+        var description = "line 1\nline 2";
+        var action = BuildAction((WindowsServiceDeployProperties.Description, description));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(description));
+
+        script.ShouldContain($"FromBase64String('{encoded}')");
+        script.ShouldContain("Squid.Action.WindowsService.Description");
+    }
+
+    [Fact]
+    public void Build_Dependencies_PreservesNewlineSeparatedListViaBase64()
+    {
+        var dependencies = "MSSQLSERVER\nEventLog";
+        var action = BuildAction((WindowsServiceDeployProperties.Dependencies, dependencies));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(dependencies));
+
+        script.ShouldContain($"FromBase64String('{encoded}')");
+    }
+
+    [Fact]
+    public void Build_EmitsSquidVariablesHashtable()
+    {
+        var variables = new[]
+        {
+            new VariableDto { Name = "ConnString", Value = "Server='prod';" },
+            new VariableDto { Name = "Empty", Value = null }
+        };
+
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction(), variables, Array.Empty<SelectedPackageDto>());
+
+        script.ShouldContain("$SquidVariables = @{}");
+        script.ShouldContain("$SquidVariables['ConnString'] = 'Server=''prod'';'");
+        script.ShouldContain("$SquidVariables['Empty'] = ''");
+    }
+
+    [Fact]
+    public void Build_EmitsSelectedPackageMetadata_AndActionMatchedPrimaryPackage()
+    {
+        var action = BuildAction(actionName: "Deploy worker");
+        var packages = new[]
+        {
+            new SelectedPackageDto { ActionName = "Other action", PackageReferenceName = "Other.Package", Version = "1.0.0" },
+            new SelectedPackageDto { ActionName = "Deploy worker", PackageReferenceName = "Order.Worker", Version = "2.3.4" }
+        };
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action, Array.Empty<VariableDto>(), packages);
+
+        script.ShouldContain("$SquidSelectedPackages = @()");
+        script.ShouldContain("PackageReferenceName = 'Order.Worker'");
+        script.ShouldContain("Version = '2.3.4'");
+        script.ShouldContain("if ($package['ActionName'] -ieq 'Deploy worker')");
+        script.ShouldContain("$SquidSelectedPackage = $package");
+    }
+
+    [Fact]
+    public void Build_ServiceAccountAndLifecycleProperties_FlowThroughPreamble()
+    {
+        var action = BuildAction(
+            (WindowsServiceDeployProperties.ServiceAccount, "SpecificUser"),
+            (WindowsServiceDeployProperties.CustomAccountName, "DOMAIN\\worker"),
+            (WindowsServiceDeployProperties.CustomAccountPassword, "p@ss'word"),
+            (WindowsServiceDeployProperties.StartMode, "Manual"),
+            (WindowsServiceDeployProperties.DesiredStatus, "Stopped"),
+            (WindowsServiceDeployProperties.Arguments, "--listen 9000"));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceAccount'] = 'SpecificUser'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.CustomAccountName'] = 'DOMAIN\\worker'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.CustomAccountPassword'] = 'p@ss''word'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.StartMode'] = 'Manual'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.DesiredStatus'] = 'Stopped'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.Arguments'] = '--listen 9000'");
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+        => BuildAction("Windows Service", properties);
+
+    private static DeploymentActionDto BuildAction(string actionName, params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = actionName,
+            ActionType = "Squid.DeployWindowsService",
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -60,6 +60,49 @@ public class WindowsServiceDeployScriptBuilderTests
     }
 
     [Fact]
+    public void Build_EmbeddedScriptWaitsForStoppedServiceProcess_BeforePackageExtraction()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        var waitProcessDefinitionIndex = script.IndexOf("function Wait-ServiceProcessExit", StringComparison.Ordinal);
+        var waitProcessCallIndex = script.IndexOf("Wait-ServiceProcessExit -ProcessId $processId", StringComparison.Ordinal);
+        var packageRootIndex = script.IndexOf("$packageRoot = Resolve-PackageRoot", StringComparison.Ordinal);
+
+        waitProcessDefinitionIndex.ShouldBeGreaterThanOrEqualTo(0);
+        waitProcessCallIndex.ShouldBeGreaterThanOrEqualTo(0);
+        packageRootIndex.ShouldBeGreaterThanOrEqualTo(0);
+        waitProcessCallIndex.ShouldBeLessThan(packageRootIndex,
+            customMessage: "Existing service processes must exit before package purge/extract can safely replace locked binaries.");
+    }
+
+    [Fact]
+    public void Build_EmbeddedScriptRetriesPackageFileOperations()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        script.ShouldContain("function Invoke-WithRetry");
+        script.ShouldContain("Invoke-WithRetry -Description \"Removing existing package extract directory '$extractTo'\"");
+        script.ShouldContain("Invoke-WithRetry -Description \"Copying package content from '$($sourceItem.FullName)' to '$extractTo'\"");
+        script.ShouldContain("Invoke-WithRetry -Description \"Expanding package '$($sourceItem.FullName)' to '$extractTo'\"");
+    }
+
+    [Fact]
+    public void Build_EmbeddedScriptWaitsForCreatedService_BeforeStart()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        var createIndex = script.IndexOf("Invoke-Sc create $serviceName", StringComparison.Ordinal);
+        var waitExistsIndex = script.IndexOf("Wait-ServiceExists -Name $serviceName", createIndex, StringComparison.Ordinal);
+        var startIndex = script.IndexOf("Start-Service -Name $serviceName", StringComparison.Ordinal);
+
+        createIndex.ShouldBeGreaterThanOrEqualTo(0);
+        waitExistsIndex.ShouldBeGreaterThanOrEqualTo(0);
+        startIndex.ShouldBeGreaterThanOrEqualTo(0);
+        waitExistsIndex.ShouldBeLessThan(startIndex,
+            customMessage: "Newly-created services should be visible to Get-Service before Start-Service runs.");
+    }
+
+    [Fact]
     public void Build_AllRecognisedProperties_HaveExplicitEntryInHashtable_EvenWhenUnset()
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ActionHandlerRegistryTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ActionHandlerRegistryTests.cs
@@ -132,7 +132,15 @@ public class ActionHandlerRegistryTests
     }
 
     [Fact]
-    public void ResolveScope_UnknownAction_DefaultsToStepLevel()
+    public void ResolveScope_UnknownAction_DefaultsToTargetLevel()
+    {
+        var registry = new ActionHandlerRegistry(Enumerable.Empty<IActionHandler>());
+
+        registry.ResolveScope(CreateAction("Squid.UnknownAction")).ShouldBe(ExecutionScope.TargetLevel);
+    }
+
+    [Fact]
+    public void ResolveScope_SyntheticPackageAcquisitionAction_IsStepLevel()
     {
         var registry = new ActionHandlerRegistry(Enumerable.Empty<IActionHandler>());
 

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhaseCapabilityFilterTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhaseCapabilityFilterTests.cs
@@ -212,7 +212,12 @@ public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
         Dispatches = dispatches
     };
 
-    private static PlannedTargetDispatch BuildDispatch(int machineId, string machineName, bool isValid, string violationMessage = null) => new()
+    private static PlannedTargetDispatch BuildDispatch(
+        int machineId,
+        string machineName,
+        bool isValid,
+        string violationMessage = null,
+        string violationCode = ViolationCodes.UnsupportedActionType) => new()
     {
         Target = new PlannedTarget { MachineId = machineId, MachineName = machineName },
         Intent = new RunScriptIntent { Name = "test", ScriptBody = "echo 1", Syntax = ScriptSyntax.Bash },
@@ -224,7 +229,7 @@ public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
                 {
                     new CapabilityViolation
                     {
-                        Code = ViolationCodes.UnsupportedActionType,
+                        Code = violationCode,
                         Message = violationMessage ?? "transport does not support this action type"
                     }
                 }
@@ -271,6 +276,41 @@ public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
         evt.Context.ActionName.ShouldBe("Helm Upgrade");
         evt.Context.MachineName.ShouldBe("ssh-target");
         evt.Context.Message.ShouldContain("Squid.HelmChartUpgrade");
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_SkippedWhenDispatchValidationFails_BeforeHandlerRendererOrStrategy()
+    {
+        _handlerRegistryMock.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>())).Returns(ExecutionScope.TargetLevel);
+
+        var action = BuildAction(1, "Deploy Windows Service", SpecialVariables.ActionTypes.DeployWindowsService);
+        var target = BuildTarget(1, "linux-target");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy Service", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, SpecialVariables.ActionTypes.DeployWindowsService,
+                BuildDispatch(
+                    1,
+                    "linux-target",
+                    isValid: false,
+                    "target is missing required Windows service capability 'os:windows'",
+                    ViolationCodes.MissingCapability))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        _handlerRegistryMock.Verify(r => r.Resolve(It.Is<DeploymentActionDto>(a =>
+            a.ActionType == SpecialVariables.ActionTypes.DeployWindowsService)), Times.Never);
+        _sshRenderer.CapturedIntents.ShouldBeEmpty();
+        _k8sRenderer.CapturedIntents.ShouldBeEmpty();
+        _strategyMock.Verify(s => s.ExecuteScriptAsync(It.IsAny<ScriptExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var evt = _emittedEvents.OfType<ActionCapabilityFilteredEvent>().Single();
+        evt.Context.ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+        evt.Context.ActionName.ShouldBe("Deploy Windows Service");
+        evt.Context.MachineName.ShouldBe("linux-target");
+        evt.Context.Message.ShouldContain("Windows service capability");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhasePackageReferencesTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhasePackageReferencesTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Handlers;
@@ -10,6 +11,7 @@ using Squid.Core.Services.Deployments.Checkpoints;
 using Squid.Core.Services.Deployments.ExternalFeeds;
 using Squid.Core.Services.Deployments.Interruptions;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Message.Constants;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Process;
 using Squid.Message.Models.Deployments.Variable;
@@ -83,7 +85,7 @@ public class ExecuteStepsPhasePackageReferencesTests : IDisposable
 
     public void Dispose() { }
 
-    private DeploymentStepDto MakeStep(string actionName) => new()
+    private DeploymentStepDto MakeStep(string actionName, string actionType = "Squid.Script") => new()
     {
         Id = 1,
         StepOrder = 1,
@@ -99,7 +101,7 @@ public class ExecuteStepsPhasePackageReferencesTests : IDisposable
                 Id = 1,
                 ActionOrder = 1,
                 Name = actionName,
-                ActionType = "Squid.Script",
+                ActionType = actionType,
                 IsDisabled = false,
                 Properties = new List<DeploymentActionPropertyDto>
                 {
@@ -201,6 +203,35 @@ public class ExecuteStepsPhasePackageReferencesTests : IDisposable
         request.PackageReferences.Count.ShouldBe(2);
         request.PackageReferences.ShouldContain(p => p.PackageId == "nginx" && p.Version == "1.21.0");
         request.PackageReferences.ShouldContain(p => p.PackageId == "redis" && p.Version == "7.0.0");
+    }
+
+    [Fact]
+    public async Task BuildPackageReferences_WindowsServiceAction_PreservesSelectedPackageOrder()
+    {
+        const string actionName = "Deploy Worker";
+        _ctx.SelectedPackages = new List<ReleaseSelectedPackage>
+        {
+            new() { Id = 1, ReleaseId = 1, FeedId = 10, ActionName = actionName, PackageReferenceName = "Order.Worker", Version = "1.2.3" },
+            new() { Id = 2, ReleaseId = 1, FeedId = 10, ActionName = actionName, PackageReferenceName = "Order.Config", Version = "4.5.6" }
+        };
+        _ctx.AcquiredPackages = new Dictionary<string, PackageAcquisitionResult>
+        {
+            ["Order.Config"] = new PackageAcquisitionResult("/tmp/order-config.4.5.6.nupkg", "Order.Config", "4.5.6", 2000, "config-hash"),
+            ["order.worker"] = new PackageAcquisitionResult("/tmp/order-worker.1.2.3.nupkg", "Order.Worker", "1.2.3", 5000, "worker-hash")
+        };
+        _ctx.Steps = new List<DeploymentStepDto>
+        {
+            MakeStep(actionName, actionType: SpecialVariables.ActionTypes.DeployWindowsService)
+        };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { MakeTargetContext() };
+
+        SetupActionHandler(actionName);
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        _capturedRequests.Count.ShouldBe(1);
+        _capturedRequests[0].ActionName.ShouldBe(actionName);
+        _capturedRequests[0].PackageReferences.Select(p => p.PackageId).ShouldBe(new[] { "Order.Worker", "Order.Config" });
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/PackageAcquisitionInjectorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/PackageAcquisitionInjectorTests.cs
@@ -46,6 +46,23 @@ public class PackageAcquisitionInjectorTests
         result[1].Name.ShouldBe("Deploy");
     }
 
+    [Fact]
+    public void Inject_WindowsServiceActionWithSelectedPackage_InjectsAcquireStep()
+    {
+        var steps = new List<DeploymentStepDto>
+        {
+            BuildStep("Deploy Worker", "Deploy Worker", actionType: SpecialVariables.ActionTypes.DeployWindowsService)
+        };
+        var packages = new List<ReleaseSelectedPackage> { new() { ActionName = "Deploy Worker" } };
+
+        var result = PackageAcquisitionInjector.InjectAcquisitionSteps(steps, packages);
+
+        result.Count.ShouldBe(2);
+        result[0].Name.ShouldBe("Acquire Packages");
+        result[0].Actions[0].ActionType.ShouldBe(SpecialVariables.ActionTypes.TentaclePackage);
+        result[1].Actions[0].ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
     // === Pre-acquisition steps skip injection ===
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerStaticRequirementsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerStaticRequirementsTests.cs
@@ -5,6 +5,7 @@ using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Intents;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
@@ -301,6 +302,105 @@ public class DeploymentPlannerStaticRequirementsTests
                 ]), CancellationToken.None));
     }
 
+    // -- Windows service concrete action coverage ----------------------------
+
+    [Fact]
+    public async Task WindowsServiceAction_WindowsWithPowerShellCapabilities_NoViolation()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "powershell,pwsh,cmd"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "win-tentacle", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue(
+            customMessage: "Windows service deploy requires both Windows OS and PowerShell capability slots.");
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_NonWindowsCapabilities_EmitsOsViolation()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Linux,
+            InstalledShells = "powershell"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "linux-target", "web", CommunicationStyle.Ssh)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+
+        dispatch.Validation.IsValid.ShouldBeFalse();
+        dispatch.Validation.Violations.ShouldContain(v =>
+            v.Code == ViolationCodes.MissingCapability && v.Detail == CapabilityKeys.OsSlot);
+        plan.BlockingReasons.ShouldContain(r => r.Code == PlanBlockingReasonCodes.CapabilityViolation);
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_WindowsWithoutPowerShell_EmitsShellViolation()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "cmd"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "win-without-powershell", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+
+        dispatch.Validation.IsValid.ShouldBeFalse();
+        dispatch.Validation.Violations.ShouldContain(v =>
+            v.Code == ViolationCodes.MissingCapability && v.Detail == CapabilityKeys.Shell.PowerShell);
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_ColdCache_OptimisticAllow()
+    {
+        StubWindowsServiceHandler();
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "fresh-windows-target", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue(
+            customMessage: "Fresh targets with no cached runtime capabilities remain preview-allowed.");
+    }
+
+    [Fact]
+    public async Task ExecuteMode_WindowsServiceActionRequirementUnmet_ThrowsDeploymentPlanValidationException()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "cmd"
+        });
+
+        await Should.ThrowAsync<Squid.Core.Services.DeploymentExecution.Planning.Exceptions.DeploymentPlanValidationException>(
+            () => BuildPlanner().PlanAsync(BuildWindowsServiceRequest(
+                mode: PlanMode.Execute,
+                targets:
+                [
+                    BuildTargetContext(1, "win-without-powershell", "web", CommunicationStyle.TentacleListening)
+                ]), CancellationToken.None));
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -325,12 +425,29 @@ public class DeploymentPlannerStaticRequirementsTests
         _registry.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>())).Returns(handler.Object);
     }
 
+    private void StubWindowsServiceHandler()
+        => _registry.Setup(r => r.Resolve(It.Is<DeploymentActionDto>(a =>
+                a.ActionType == SpecialVariables.ActionTypes.DeployWindowsService)))
+            .Returns(new WindowsServiceDeployActionHandler());
+
     private void StubCache(int machineId, MachineRuntimeCapabilities caps)
         => _capabilitiesCache.Setup(c => c.TryGet(machineId)).Returns(caps);
 
     private static DeploymentPlanRequest BuildRequest(
         PlanMode mode = PlanMode.Preview,
         IList<DeploymentTargetContext> targets = null)
+        => BuildRequest(TestActionType, "Run", mode, targets);
+
+    private static DeploymentPlanRequest BuildWindowsServiceRequest(
+        PlanMode mode = PlanMode.Preview,
+        IList<DeploymentTargetContext> targets = null)
+        => BuildRequest(SpecialVariables.ActionTypes.DeployWindowsService, "Deploy Windows Service", mode, targets);
+
+    private static DeploymentPlanRequest BuildRequest(
+        string actionType,
+        string actionName,
+        PlanMode mode,
+        IList<DeploymentTargetContext> targets)
     {
         var step = new DeploymentStepDto
         {
@@ -347,8 +464,8 @@ public class DeploymentPlannerStaticRequirementsTests
                 {
                     Id = 100,
                     ActionOrder = 1,
-                    ActionType = TestActionType,
-                    Name = "Run"
+                    ActionType = actionType,
+                    Name = actionName
                 }
             }
         };

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/TransportCapabilitiesTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/TransportCapabilitiesTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
 using Squid.Core.Services.DeploymentExecution.OpenClaw;
 using Squid.Core.Services.DeploymentExecution.Ssh;
+using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Message.Constants;
 using Squid.Message.Enums;
@@ -86,6 +87,18 @@ public class TransportCapabilitiesTests
         capability.ExecutionBackend.ShouldBe(ExecutionBackend.LocalProcess);
         capability.RequiresContextPreparationForPackagedPayload.ShouldBeFalse();
         capability.SupportedActionTypes.ShouldContain(SpecialVariables.ActionTypes.Script);
+    }
+
+    [Theory]
+    [InlineData("polling")]
+    [InlineData("listening")]
+    public void TentacleTransport_Capability_DeclaresWindowsServiceActionType(string transport)
+    {
+        var capability = transport == "polling"
+            ? TentaclePollingTransport.Capability
+            : TentacleListeningTransport.Capability;
+
+        capability.SupportedActionTypes.ShouldContain(SpecialVariables.ActionTypes.DeployWindowsService);
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using Halibut;
 using Squid.Core.Persistence.Entities.Deployments;
@@ -285,7 +286,11 @@ public class HalibutMachineExecutionStrategyTests
             .ReturnsAsync(NewStartResponse("package-ref"));
 
         var packagePath = Path.Combine(Path.GetTempPath(), $"Order.Worker.{Guid.NewGuid():N}.nupkg");
-        await File.WriteAllBytesAsync(packagePath, new byte[] { 1, 2, 3 }, CancellationToken.None);
+        CreatePackageArchive(packagePath, new Dictionary<string, string>
+        {
+            ["Demo.WindowsService.exe"] = "fake executable",
+            ["appsettings.json"] = "{}"
+        });
 
         try
         {
@@ -299,7 +304,8 @@ public class HalibutMachineExecutionStrategyTests
 
             capturedCommand.ShouldNotBeNull();
             capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references.json");
-            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3.nupkg");
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3/Demo.WindowsService.exe");
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3/appsettings.json");
 
             var manifest = capturedCommand.Files.Single(f => f.Name == "package-references.json");
             var manifestPath = Path.Combine(Path.GetTempPath(), $"package-references-{Guid.NewGuid():N}.json");
@@ -310,7 +316,7 @@ public class HalibutMachineExecutionStrategyTests
                 var manifestJson = await File.ReadAllTextAsync(manifestPath, CancellationToken.None);
                 manifestJson.ShouldContain("\"PackageId\":\"Order.Worker\"");
                 manifestJson.ShouldContain("\"Version\":\"1.2.3\"");
-                manifestJson.ShouldContain("\"PackagePath\":\"package-references/Order.Worker.1.2.3.nupkg\"");
+                manifestJson.ShouldContain("\"PackagePath\":\"package-references/Order.Worker.1.2.3\"");
             }
             finally
             {
@@ -320,6 +326,19 @@ public class HalibutMachineExecutionStrategyTests
         finally
         {
             File.Delete(packagePath);
+        }
+    }
+
+    private static void CreatePackageArchive(string path, IReadOnlyDictionary<string, string> files)
+    {
+        using var stream = File.Create(path);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+
+        foreach (var file in files)
+        {
+            var entry = archive.CreateEntry(file.Key);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(file.Value);
         }
     }
 

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Halibut;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Common;
@@ -7,6 +9,7 @@ using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
+using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Message.Contracts.Tentacle;
 using Squid.Message.Models.Deployments.Execution;
@@ -268,6 +271,56 @@ public class HalibutMachineExecutionStrategyTests
             It.IsAny<SensitiveValueMasker>(),
             It.IsAny<ScriptStatusResponse>(),
             It.IsAny<global::Halibut.ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteScriptAsync_DirectScript_AttachesPackageReferencesAsScriptFiles()
+    {
+        var machine = CreateValidMachine();
+        StartScriptCommand capturedCommand = null;
+        var scriptClient = SetupScriptClient("poll://sub-test/");
+
+        scriptClient.Setup(s => s.StartScriptAsync(It.IsAny<StartScriptCommand>()))
+            .Callback<StartScriptCommand>(cmd => capturedCommand = cmd)
+            .ReturnsAsync(NewStartResponse("package-ref"));
+
+        var packagePath = Path.Combine(Path.GetTempPath(), $"Order.Worker.{Guid.NewGuid():N}.nupkg");
+        await File.WriteAllBytesAsync(packagePath, new byte[] { 1, 2, 3 }, CancellationToken.None);
+
+        try
+        {
+            var request = CreateRequest(machine);
+            request.PackageReferences = new List<PackageAcquisitionResult>
+            {
+                new(packagePath, "Order.Worker", "1.2.3", 3, "abc123")
+            };
+
+            await _strategy.ExecuteScriptAsync(request, CancellationToken.None);
+
+            capturedCommand.ShouldNotBeNull();
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references.json");
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3.nupkg");
+
+            var manifest = capturedCommand.Files.Single(f => f.Name == "package-references.json");
+            var manifestPath = Path.Combine(Path.GetTempPath(), $"package-references-{Guid.NewGuid():N}.json");
+            await manifest.Contents.Receiver().SaveToAsync(manifestPath, CancellationToken.None);
+
+            try
+            {
+                var manifestJson = await File.ReadAllTextAsync(manifestPath, CancellationToken.None);
+                manifestJson.ShouldContain("\"PackageId\":\"Order.Worker\"");
+                manifestJson.ShouldContain("\"Version\":\"1.2.3\"");
+                manifestJson.ShouldContain("\"PackagePath\":\"package-references/Order.Worker.1.2.3.nupkg\"");
+            }
+            finally
+            {
+                File.Delete(manifestPath);
+            }
+        }
+        finally
+        {
+            File.Delete(packagePath);
+        }
     }
 
     // === Request Timeout Override ===

--- a/tests/Squid.UnitTests/Services/Deployments/Process/DeploymentActionPropertyDataProviderTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Process/DeploymentActionPropertyDataProviderTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Process.Action;
+
+namespace Squid.UnitTests.Services.Deployments.Process;
+
+public class DeploymentActionPropertyDataProviderTests
+{
+    [Fact]
+    public async Task AddDeploymentActionPropertiesAsync_DeduplicatesByActionIdAndPropertyName_LastValueWins()
+    {
+        var repository = new Mock<IRepository>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var inserted = new List<DeploymentActionProperty>();
+
+        repository
+            .Setup(r => r.InsertAllAsync(It.IsAny<IEnumerable<DeploymentActionProperty>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<DeploymentActionProperty>, CancellationToken>((entities, _) => inserted = entities.ToList())
+            .Returns(Task.CompletedTask);
+
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var provider = new DeploymentActionPropertyDataProvider(repository.Object, unitOfWork.Object);
+
+        await provider.AddDeploymentActionPropertiesAsync(
+            [
+                new DeploymentActionProperty { ActionId = 10, PropertyName = "Squid.Action.WindowsService.ServiceName", PropertyValue = "old-service" },
+                new DeploymentActionProperty { ActionId = 10, PropertyName = "squid.action.windowsservice.servicename", PropertyValue = "new-service" },
+                new DeploymentActionProperty { ActionId = 10, PropertyName = "Squid.Action.WindowsService.ExecutablePath", PropertyValue = "Demo.WindowsService.exe" },
+                new DeploymentActionProperty { ActionId = 11, PropertyName = "Squid.Action.WindowsService.ServiceName", PropertyValue = "other-action-service" }
+            ],
+            CancellationToken.None);
+
+        inserted.Count.ShouldBe(3);
+        inserted.ShouldContain(p => p.ActionId == 10
+                                    && p.PropertyName == "Squid.Action.WindowsService.ServiceName"
+                                    && p.PropertyValue == "new-service");
+        inserted.ShouldContain(p => p.ActionId == 10
+                                    && p.PropertyName == "Squid.Action.WindowsService.ExecutablePath"
+                                    && p.PropertyValue == "Demo.WindowsService.exe");
+        inserted.ShouldContain(p => p.ActionId == 11
+                                    && p.PropertyName == "Squid.Action.WindowsService.ServiceName"
+                                    && p.PropertyValue == "other-action-service");
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
@@ -25,27 +25,10 @@ public sealed class WindowsServiceDeployRealHostE2ETests
 
         using var ctx = new DeployServiceTestContext("1.0.0");
 
-        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction(
-            (WindowsServiceDeployProperties.CreateOrUpdateService, "True"),
-            (WindowsServiceDeployProperties.ServiceName, ctx.Fixture.ServiceName),
-            (WindowsServiceDeployProperties.DisplayName, $"Squid Deploy E2E {ctx.Suffix}"),
-            (WindowsServiceDeployProperties.Description, "Installed by Squid.DeployWindowsService real-host E2E"),
-            (WindowsServiceDeployProperties.ExecutablePath, "SquidUpgradeE2ETestService.exe"),
-            (WindowsServiceDeployProperties.ServiceAccount, "LocalSystem"),
-            (WindowsServiceDeployProperties.StartMode, "Manual"),
-            (WindowsServiceDeployProperties.DesiredStatus, "Started"),
-            (WindowsServiceDeployProperties.PackageSourcePath, ctx.PackageDir),
-            (WindowsServiceDeployProperties.PackageExtractTo, ctx.Fixture.InstallDir),
-            (WindowsServiceDeployProperties.PackagePurgeBeforeExtract, "True")));
+        var result = DeployPackage(ctx, ctx.PackageDir, $"Squid Deploy E2E {ctx.Suffix}",
+            "Installed by Squid.DeployWindowsService real-host E2E");
 
-        var result = RunPowerShell(script);
-
-        result.ExitCode.ShouldBe(0,
-            customMessage:
-                $"Squid Windows service deploy script failed on real Windows host. " +
-                $"Service: {ctx.Fixture.ServiceName}\n" +
-                $"InstallDir: {ctx.Fixture.InstallDir}\n\n" +
-                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+        AssertDeploySucceeded(result, ctx);
 
         File.Exists(ctx.Fixture.ServiceExePath).ShouldBeTrue(
             customMessage: "The deploy script must copy the package service binary into the configured install directory.");
@@ -59,6 +42,74 @@ public sealed class WindowsServiceDeployRealHostE2ETests
             customMessage:
                 $"marker file at {ctx.Fixture.MarkerFilePath} did not contain '1.0.0' within 30s. " +
                 "This marker proves SCM started the service process and the test service read version.txt from deployed package content.");
+    }
+
+    [Fact]
+    public void RealWindowsHost_UpdateDeployment_ReconfiguresRestartsExistingServiceWithoutDuplicate()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new DeployServiceTestContext("1.0.0");
+
+        var firstResult = DeployPackage(ctx, ctx.PackageDir, $"Squid Deploy E2E {ctx.Suffix} v1",
+            "Initial Windows service deployment from package v1.");
+
+        AssertDeploySucceeded(firstResult, ctx);
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage: $"initial marker at {ctx.Fixture.MarkerFilePath} did not contain '1.0.0' within 30s.");
+
+        PowerShellSingleLine($"(Get-Service | Where-Object {{ $_.Name -eq '{EscapePowerShellSingleQuoted(ctx.Fixture.ServiceName)}' }} | Measure-Object).Count")
+            .ShouldBe("1", customMessage: "First deploy should create exactly one service with the generated E2E service name.");
+
+        var v2PackageDir = ctx.StagePackage("package-v2", "2.0.0");
+        var secondDisplayName = $"Squid Deploy E2E {ctx.Suffix} v2";
+
+        var secondResult = DeployPackage(ctx, v2PackageDir, secondDisplayName,
+            "Updated Windows service deployment from package v2.");
+
+        AssertDeploySucceeded(secondResult, ctx);
+
+        PowerShellSingleLine($"(Get-Service | Where-Object {{ $_.Name -eq '{EscapePowerShellSingleQuoted(ctx.Fixture.ServiceName)}' }} | Measure-Object).Count")
+            .ShouldBe("1", customMessage: "Second deploy must update the existing service, not create a duplicate.");
+        PowerShellSingleLine($"(Get-Service -Name '{EscapePowerShellSingleQuoted(ctx.Fixture.ServiceName)}').DisplayName")
+            .ShouldBe(secondDisplayName, customMessage: "Second deploy should reconfigure service metadata via sc.exe config.");
+        PowerShellSingleLine($"(Get-Service -Name '{EscapePowerShellSingleQuoted(ctx.Fixture.ServiceName)}').Status")
+            .ShouldBe("Running", customMessage: "The updated service must be running after DesiredStatus=Started.");
+
+        File.ReadAllText(ctx.Fixture.VersionFilePath).Trim().ShouldBe("2.0.0",
+            customMessage: "The v2 package version.txt must replace the v1 package content in the install directory.");
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "2.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage:
+                $"marker file at {ctx.Fixture.MarkerFilePath} did not change to '2.0.0' within 30s. " +
+                "This proves the existing service was stopped, package content was replaced, and SCM restarted the service process.");
+    }
+
+    private static PsResult DeployPackage(DeployServiceTestContext ctx, string packageDir, string displayName, string description)
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction(
+            (WindowsServiceDeployProperties.CreateOrUpdateService, "True"),
+            (WindowsServiceDeployProperties.ServiceName, ctx.Fixture.ServiceName),
+            (WindowsServiceDeployProperties.DisplayName, displayName),
+            (WindowsServiceDeployProperties.Description, description),
+            (WindowsServiceDeployProperties.ExecutablePath, "SquidUpgradeE2ETestService.exe"),
+            (WindowsServiceDeployProperties.ServiceAccount, "LocalSystem"),
+            (WindowsServiceDeployProperties.StartMode, "Manual"),
+            (WindowsServiceDeployProperties.DesiredStatus, "Started"),
+            (WindowsServiceDeployProperties.PackageSourcePath, packageDir),
+            (WindowsServiceDeployProperties.PackageExtractTo, ctx.Fixture.InstallDir),
+            (WindowsServiceDeployProperties.PackagePurgeBeforeExtract, "True")));
+
+        return RunPowerShell(script);
+    }
+
+    private static void AssertDeploySucceeded(PsResult result, DeployServiceTestContext ctx)
+    {
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Squid Windows service deploy script failed on real Windows host. " +
+                $"Service: {ctx.Fixture.ServiceName}\n" +
+                $"InstallDir: {ctx.Fixture.InstallDir}\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
     }
 
     private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
@@ -189,17 +240,23 @@ public sealed class WindowsServiceDeployRealHostE2ETests
             Suffix = Guid.NewGuid().ToString("N")[..8];
             _rootDir = Path.Combine(Path.GetTempPath(), "SquidWindowsServiceDeployE2E", Suffix);
 
-            PackageDir = Path.Combine(_rootDir, "package-v1");
             Fixture = new WindowsServiceFixture(
                 serviceName: $"SquidDeploySvcE2E_{Suffix}",
                 installDir: Path.Combine(_rootDir, "install"));
 
-            StagePackageContent(LocateTestServiceExe(), PackageDir, version);
+            PackageDir = StagePackage("package-v1", version);
         }
 
         public string Suffix { get; }
         public string PackageDir { get; }
         public WindowsServiceFixture Fixture { get; }
+
+        public string StagePackage(string packageDirectoryName, string version)
+        {
+            var packageDir = Path.Combine(_rootDir, packageDirectoryName);
+            StagePackageContent(LocateTestServiceExe(), packageDir, version);
+            return packageDir;
+        }
 
         public void Dispose()
         {

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
@@ -1,0 +1,221 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Process;
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// Real-host E2E for the Squid.DeployWindowsService PowerShell payload.
+/// The server-side pipeline contract is covered in Squid.E2ETests; this
+/// class proves the rendered script can install and start a real Windows
+/// service from package content on a Windows host.
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.WindowsServiceDeploy)]
+public sealed class WindowsServiceDeployRealHostE2ETests
+{
+    [Fact]
+    public void RealWindowsHost_FirstDeployment_InstallsAndStartsServiceFromPackageContent()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new DeployServiceTestContext("1.0.0");
+
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction(
+            (WindowsServiceDeployProperties.CreateOrUpdateService, "True"),
+            (WindowsServiceDeployProperties.ServiceName, ctx.Fixture.ServiceName),
+            (WindowsServiceDeployProperties.DisplayName, $"Squid Deploy E2E {ctx.Suffix}"),
+            (WindowsServiceDeployProperties.Description, "Installed by Squid.DeployWindowsService real-host E2E"),
+            (WindowsServiceDeployProperties.ExecutablePath, "SquidUpgradeE2ETestService.exe"),
+            (WindowsServiceDeployProperties.ServiceAccount, "LocalSystem"),
+            (WindowsServiceDeployProperties.StartMode, "Manual"),
+            (WindowsServiceDeployProperties.DesiredStatus, "Started"),
+            (WindowsServiceDeployProperties.PackageSourcePath, ctx.PackageDir),
+            (WindowsServiceDeployProperties.PackageExtractTo, ctx.Fixture.InstallDir),
+            (WindowsServiceDeployProperties.PackagePurgeBeforeExtract, "True")));
+
+        var result = RunPowerShell(script);
+
+        result.ExitCode.ShouldBe(0,
+            customMessage:
+                $"Squid Windows service deploy script failed on real Windows host. " +
+                $"Service: {ctx.Fixture.ServiceName}\n" +
+                $"InstallDir: {ctx.Fixture.InstallDir}\n\n" +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+
+        File.Exists(ctx.Fixture.ServiceExePath).ShouldBeTrue(
+            customMessage: "The deploy script must copy the package service binary into the configured install directory.");
+        File.ReadAllText(ctx.Fixture.VersionFilePath).Trim().ShouldBe("1.0.0",
+            customMessage: "The staged package version.txt must land beside the service binary.");
+
+        PowerShellSingleLine($"(Get-Service -Name '{EscapePowerShellSingleQuoted(ctx.Fixture.ServiceName)}').Status")
+            .ShouldBe("Running", customMessage: "The deployed service must be running after DesiredStatus=Started.");
+
+        WaitForFileContent(ctx.Fixture.MarkerFilePath, "1.0.0", TimeSpan.FromSeconds(30)).ShouldBeTrue(
+            customMessage:
+                $"marker file at {ctx.Fixture.MarkerFilePath} did not contain '1.0.0' within 30s. " +
+                "This marker proves SCM started the service process and the test service read version.txt from deployed package content.");
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "Deploy Windows Service (E2E)",
+            ActionType = SpecialVariables.ActionTypes.DeployWindowsService,
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+
+    private static string PowerShellSingleLine(string command)
+    {
+        var result = RunPowerShell($"Write-Host -NoNewline ({command})");
+        result.ExitCode.ShouldBe(0, $"PowerShell query failed: {result.StdErr}");
+        return result.StdOut.Trim();
+    }
+
+    private static PsResult RunPowerShell(string script)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardInputEncoding = Encoding.UTF8,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
+        };
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to launch powershell.exe");
+
+        process.StandardInput.Write(script);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        if (!process.WaitForExit(TimeSpan.FromMinutes(2)))
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best-effort cleanup */ }
+            return new PsResult(124, stdout, stderr + "\nPowerShell script timed out after 2 minutes.");
+        }
+
+        return new PsResult(process.ExitCode, stdout, stderr);
+    }
+
+    private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    var actual = File.ReadAllText(path).Trim();
+                    if (actual == expectedContent) return true;
+                }
+            }
+            catch
+            {
+                // The service might be writing the marker while we poll.
+            }
+
+            Thread.Sleep(200);
+        }
+
+        return false;
+    }
+
+    private static string EscapePowerShellSingleQuoted(string value)
+        => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static string LocateTestServiceExe()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var configDir = Path.GetDirectoryName(thisAssemblyDir)!;
+        var binDir = Path.GetDirectoryName(configDir)!;
+        var testProjectDir = Path.GetDirectoryName(binDir)!;
+        var testsDir = Path.GetDirectoryName(testProjectDir)!;
+        var configName = Path.GetFileName(configDir);
+        var tfmName = Path.GetFileName(thisAssemblyDir);
+
+        var candidate = Path.Combine(testsDir, "Squid.WindowsTentacleE2E.TestService", "bin", configName, tfmName, "SquidUpgradeE2ETestService.exe");
+
+        if (!File.Exists(candidate))
+            throw new FileNotFoundException(
+                $"test-service exe not found at expected location: {candidate}. " +
+                "Verify the project reference from Squid.WindowsTentacleE2ETests to Squid.WindowsTentacleE2E.TestService is wired and built.");
+
+        return candidate;
+    }
+
+    private static void StagePackageContent(string testServiceExePath, string packageDir, string version)
+    {
+        var sourceDir = Path.GetDirectoryName(testServiceExePath)
+            ?? throw new InvalidOperationException($"Test service source path has no directory: {testServiceExePath}");
+
+        Directory.CreateDirectory(packageDir);
+
+        foreach (var sourceFile in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDir, sourceFile);
+            var destFile = Path.Combine(packageDir, relativePath);
+            var destDir = Path.GetDirectoryName(destFile);
+            if (!string.IsNullOrEmpty(destDir)) Directory.CreateDirectory(destDir);
+            File.Copy(sourceFile, destFile, overwrite: true);
+        }
+
+        File.WriteAllText(Path.Combine(packageDir, "version.txt"), version);
+    }
+
+    private sealed class DeployServiceTestContext : IDisposable
+    {
+        private readonly string _rootDir;
+
+        public DeployServiceTestContext(string version)
+        {
+            Suffix = Guid.NewGuid().ToString("N")[..8];
+            _rootDir = Path.Combine(Path.GetTempPath(), "SquidWindowsServiceDeployE2E", Suffix);
+
+            PackageDir = Path.Combine(_rootDir, "package-v1");
+            Fixture = new WindowsServiceFixture(
+                serviceName: $"SquidDeploySvcE2E_{Suffix}",
+                installDir: Path.Combine(_rootDir, "install"));
+
+            StagePackageContent(LocateTestServiceExe(), PackageDir, version);
+        }
+
+        public string Suffix { get; }
+        public string PackageDir { get; }
+        public WindowsServiceFixture Fixture { get; }
+
+        public void Dispose()
+        {
+            try { Fixture.Dispose(); } catch { /* best-effort cleanup */ }
+
+            try
+            {
+                if (Directory.Exists(_rootDir))
+                    Directory.Delete(_rootDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort: Windows may keep service files locked briefly after SCM stop/delete.
+            }
+        }
+    }
+
+    private sealed record PsResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
@@ -84,14 +84,43 @@ public sealed class WindowsServiceDeployRealHostE2ETests
                 "This proves the existing service was stopped, package content was replaced, and SCM restarted the service process.");
     }
 
-    private static PsResult DeployPackage(DeployServiceTestContext ctx, string packageDir, string displayName, string description)
+    [Fact]
+    public void RealWindowsHost_InvalidExecutablePath_FailsBeforeServiceCreate()
+    {
+        if (!WindowsServiceFixture.IsAvailable) return;
+
+        using var ctx = new DeployServiceTestContext("1.0.0");
+
+        var result = DeployPackage(
+            ctx,
+            ctx.PackageDir,
+            $"Squid Deploy E2E {ctx.Suffix}",
+            "Invalid executable path deployment should fail.",
+            executablePath: "missing-service-binary.exe");
+
+        result.ExitCode.ShouldNotBe(0,
+            customMessage:
+                "Deploy Windows Service must fail when the configured executable path does not exist in package content. " +
+                $"STDOUT:\n{result.StdOut}\n\nSTDERR:\n{result.StdErr}");
+        (result.StdOut + result.StdErr).ShouldContain("Windows service executable",
+            customMessage: "Failure output should point operators at the missing executable path.");
+        PowerShellSingleLine($"(Get-Service | Where-Object {{ $_.Name -eq '{EscapePowerShellSingleQuoted(ctx.Fixture.ServiceName)}' }} | Measure-Object).Count")
+            .ShouldBe("0", customMessage: "The deploy script validates the executable before sc.exe create, so no broken service should be left behind.");
+    }
+
+    private static PsResult DeployPackage(
+        DeployServiceTestContext ctx,
+        string packageDir,
+        string displayName,
+        string description,
+        string executablePath = "SquidUpgradeE2ETestService.exe")
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction(
             (WindowsServiceDeployProperties.CreateOrUpdateService, "True"),
             (WindowsServiceDeployProperties.ServiceName, ctx.Fixture.ServiceName),
             (WindowsServiceDeployProperties.DisplayName, displayName),
             (WindowsServiceDeployProperties.Description, description),
-            (WindowsServiceDeployProperties.ExecutablePath, "SquidUpgradeE2ETestService.exe"),
+            (WindowsServiceDeployProperties.ExecutablePath, executablePath),
             (WindowsServiceDeployProperties.ServiceAccount, "LocalSystem"),
             (WindowsServiceDeployProperties.StartMode, "Manual"),
             (WindowsServiceDeployProperties.DesiredStatus, "Started"),

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsServiceDeployRealHostE2ETests.cs
@@ -134,35 +134,47 @@ public sealed class WindowsServiceDeployRealHostE2ETests
 
     private static PsResult RunPowerShell(string script)
     {
+        // Windows PowerShell 5.1 can misparse UTF-8 stdin that begins with a preamble
+        // comment; run a BOM-less script file to match the real Tentacle script path.
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"squid-windows-service-deploy-e2e-{Guid.NewGuid():N}.ps1");
+        File.WriteAllText(scriptPath, script, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
         var startInfo = new ProcessStartInfo
         {
             FileName = "powershell.exe",
-            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -",
-            RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
-            StandardInputEncoding = Encoding.UTF8,
             StandardOutputEncoding = Encoding.UTF8,
             StandardErrorEncoding = Encoding.UTF8
         };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-ExecutionPolicy");
+        startInfo.ArgumentList.Add("Bypass");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(scriptPath);
 
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to launch powershell.exe");
-
-        process.StandardInput.Write(script);
-        process.StandardInput.Close();
-
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
-        if (!process.WaitForExit(TimeSpan.FromMinutes(2)))
+        try
         {
-            try { process.Kill(entireProcessTree: true); } catch { /* best-effort cleanup */ }
-            return new PsResult(124, stdout, stderr + "\nPowerShell script timed out after 2 minutes.");
-        }
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to launch powershell.exe");
 
-        return new PsResult(process.ExitCode, stdout, stderr);
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            if (!process.WaitForExit(TimeSpan.FromMinutes(2)))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best-effort cleanup */ }
+                return new PsResult(124, stdout, stderr + "\nPowerShell script timed out after 2 minutes.");
+            }
+
+            return new PsResult(process.ExitCode, stdout, stderr);
+        }
+        finally
+        {
+            try { if (File.Exists(scriptPath)) File.Delete(scriptPath); } catch { /* best-effort cleanup */ }
+        }
     }
 
     private static bool WaitForFileContent(string path, string expectedContent, TimeSpan timeout)

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
@@ -255,4 +255,18 @@ public static class WindowsUpgradeE2ECategories
     /// <c>Get-WindowsFeature</c> probe.</para>
     /// </summary>
     public const string IISDeploy = "IISDeployE2E";
+
+    /// <summary>
+    /// E2E coverage for the production <c>Squid.DeployWindowsService</c>
+    /// action's PowerShell payload against a real Windows host. Drives
+    /// <c>WindowsServiceDeployScriptBuilder.Build(action)</c> to produce the
+    /// same script the dispatch path would ship, then executes it via real
+    /// <c>powershell.exe</c> and verifies SCM state plus the
+    /// <c>SquidUpgradeE2ETestService</c> marker/version contract.
+    ///
+    /// <para>Windows-only — requires SCM service-control permissions. Tests
+    /// no-op on non-Windows hosts via <c>WindowsServiceFixture.IsAvailable</c>.
+    /// </para>
+    /// </summary>
+    public const string WindowsServiceDeploy = "WindowsServiceDeployE2E";
 }


### PR DESCRIPTION
**Summary**  
Branch: `feature/deploy-windows-service`  
Add first-class `Squid.DeployWindowsService` support for Windows Tentacle targets.

This PR adds the Windows service deploy action handler, embedded PowerShell payload, script builder, and package-reference bridge for Halibut direct script execution.  
The new action supports Tentacle Polling and Tentacle Listening transports, requires Windows + PowerShell capabilities, and rejects known non-Windows Tentacle targets with an actionable error.  
The deployment script can create or reconfigure a Windows service, set display name/description/start mode/dependencies/account args, resolve package content from `package-references.json`, and start or stop the service based on `DesiredStatus`.  
Coverage was added across unit, integration, contract E2E, and Windows real-host E2E layers.

Review found 2 blocking issues to fix before merge:

1. Existing services are stopped after package purge/extract, which can fail when service files are locked.
2. Action-level package references with empty `PackageReferenceName` are filtered out, so standard selected packages may not be uploaded.

**Test plan**  
Diff hygiene:  
`git diff main...HEAD --check`  
Result: passed.

Focused unit coverage:  
`dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --no-restore --filter "FullyQualifiedName~WindowsServiceDeploy|FullyQualifiedName~WindowsServiceActionRegistration|FullyQualifiedName~ExecuteStepsPhasePackageReferences|FullyQualifiedName~PackageAcquisitionInjector"`  
Result: 57 passed, 0 failed.

Note: first sandboxed run failed on MSBuild named-pipe permissions; rerun with elevated execution succeeded. Windows real-host E2E was not run in this local macOS review environment.