### PR TITLE
Windows service handler guard

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
@@ -1,0 +1,67 @@
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Execution;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+/// <summary>
+/// Handles the <c>Squid.DeployWindowsService</c> action for Windows Tentacle targets.
+/// </summary>
+public class WindowsServiceDeployActionHandler : IActionHandler
+{
+    public string ActionType => SpecialVariables.ActionTypes.DeployWindowsService;
+
+    public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
+        CapabilityRequirements.Empty
+            .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)
+            .Require(CapabilityKeys.Shell.PowerShell, CapabilityKeys.Present);
+
+    Task<ExecutionIntent> IActionHandler.DescribeIntentAsync(ActionExecutionContext ctx, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        EnsureWindowsTentacleTarget(ctx);
+
+        var intent = new RunScriptIntent
+        {
+            Name = "deploy-windows-service",
+            StepName = ctx.Step?.Name ?? string.Empty,
+            ActionName = ctx.Action?.Name ?? string.Empty,
+            ScriptBody = BuildScriptBuilderPendingBody(),
+            Syntax = ScriptSyntax.PowerShell,
+            InjectRuntimeBundle = false
+        };
+
+        return Task.FromResult<ExecutionIntent>(intent);
+    }
+
+    private static void EnsureWindowsTentacleTarget(ActionExecutionContext ctx)
+    {
+        var osVariable = ctx.Variables?
+            .FirstOrDefault(v => string.Equals(v.Name, WindowsServiceDeployProperties.TentacleOS, StringComparison.OrdinalIgnoreCase));
+
+        if (osVariable == null || string.IsNullOrEmpty(osVariable.Value))
+            return;
+
+        if (WindowsOsStringHelper.IsWindows(osVariable.Value))
+            return;
+
+        var stepName = ctx.Step?.Name ?? "(unknown)";
+        var actionName = ctx.Action?.Name ?? "(unknown)";
+
+        throw new InvalidOperationException(
+            $"Action '{actionName}' (type '{SpecialVariables.ActionTypes.DeployWindowsService}') in step '{stepName}' " +
+            $"requires a Windows Tentacle target. The configured target reports '{WindowsServiceDeployProperties.TentacleOS}'='{osVariable.Value}'. " +
+            $"To deploy a Windows service, configure a Windows Tentacle (Polling or Listening) and assign it the role this step targets. " +
+            $"If you believe the target IS Windows, run a health check against it so the runtime-capabilities cache refreshes.");
+    }
+
+    private static string BuildScriptBuilderPendingBody() =>
+        "throw 'Squid.DeployWindowsService script generation is not implemented yet. " +
+        "Complete WindowsServiceDeployScriptBuilder and the embedded PowerShell resource before executing this action.'";
+
+    internal static bool LooksLikeWindowsOsString(string osValue)
+        => WindowsOsStringHelper.IsWindows(osValue);
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
@@ -1,0 +1,162 @@
+using System.Linq;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.DeploymentExecution.Intents;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Core.Services.DeploymentExecution.Validation;
+using Squid.Message.Constants;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class WindowsServiceDeployActionHandlerTests
+{
+    [Fact]
+    public void ActionType_MatchesPublishedConstant()
+    {
+        new WindowsServiceDeployActionHandler().ActionType.ShouldBe("Squid.DeployWindowsService");
+        new WindowsServiceDeployActionHandler().ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
+    [Fact]
+    public void StaticRequirements_RequireWindowsAndPowerShell()
+    {
+        var requirements = new WindowsServiceDeployActionHandler().StaticRequirements;
+
+        requirements.Keys.ShouldBe(new[] { CapabilityKeys.OsSlot, CapabilityKeys.Shell.PowerShell }, ignoreOrder: true);
+        requirements[CapabilityKeys.OsSlot].ShouldContain(CapabilityKeys.Os.Windows);
+        requirements[CapabilityKeys.Shell.PowerShell].ShouldContain(CapabilityKeys.Present);
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_ReturnsPowerShellRunScriptIntent_WithStableShape()
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            stepName: "Deploy worker",
+            actionName: "Windows Service");
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+
+        intent.ShouldBeOfType<RunScriptIntent>();
+        var runScript = (RunScriptIntent)intent;
+
+        runScript.Name.ShouldBe("deploy-windows-service");
+        runScript.StepName.ShouldBe("Deploy worker");
+        runScript.ActionName.ShouldBe("Windows Service");
+        runScript.Syntax.ShouldBe(ScriptSyntax.PowerShell);
+        runScript.InjectRuntimeBundle.ShouldBeFalse();
+        runScript.ScriptBody.ShouldContain("script generation is not implemented yet");
+    }
+
+    [Theory]
+    [InlineData("Linux")]
+    [InlineData("Darwin")]
+    [InlineData("FreeBSD")]
+    public async Task DescribeIntentAsync_NonWindowsTentacle_ThrowsWithActionableMessage(string os)
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            action: BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            stepName: "Deploy worker",
+            actionName: "Windows Service",
+            tentacleOs: os);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => handler.DescribeIntentAsync(ctx, CancellationToken.None));
+
+        ex.Message.ShouldContain("Squid.DeployWindowsService");
+        ex.Message.ShouldContain("Deploy worker");
+        ex.Message.ShouldContain("Windows Service");
+        ex.Message.ShouldContain(os);
+        ex.Message.ShouldContain("Windows Tentacle");
+        ex.Message.ShouldContain("health check");
+    }
+
+    [Theory]
+    [InlineData("Windows")]
+    [InlineData("windows")]
+    [InlineData("WINDOWS")]
+    [InlineData("Microsoft Windows NT 10.0.19045.0")]
+    [InlineData("Microsoft Windows NT 10.0.22631.0")]
+    [InlineData("Microsoft Windows NT 10.0.17763.0")]
+    [InlineData("Microsoft Windows NT 10.0.20348.0")]
+    public async Task DescribeIntentAsync_WindowsTentacle_ProceedsSuccessfully(string os)
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            tentacleOs: os);
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Fact]
+    public async Task DescribeIntentAsync_OsCacheMiss_ProceedsOptimistically()
+    {
+        var handler = (IActionHandler)new WindowsServiceDeployActionHandler();
+        var ctx = BuildContext(
+            BuildAction((WindowsServiceDeployProperties.ServiceName, "OrderWorker")),
+            tentacleOs: null);
+
+        var intent = await handler.DescribeIntentAsync(ctx, CancellationToken.None);
+        intent.ShouldBeOfType<RunScriptIntent>();
+    }
+
+    [Theory]
+    [InlineData("Windows", true)]
+    [InlineData("Microsoft Windows NT 10.0.19045.0", true)]
+    [InlineData("Linux", false)]
+    [InlineData("macOS", false)]
+    [InlineData("Darwin", false)]
+    [InlineData("LinuxOnWindowsSubsystem", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void LooksLikeWindowsOsString_PinnedBehaviour(string osValue, bool expected)
+    {
+        WindowsServiceDeployActionHandler.LooksLikeWindowsOsString(osValue).ShouldBe(expected);
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = "Windows Service",
+            ActionType = SpecialVariables.ActionTypes.DeployWindowsService,
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+
+    private static ActionExecutionContext BuildContext(
+        DeploymentActionDto action,
+        string stepName = "Deploy",
+        string actionName = "Windows Service",
+        string tentacleOs = "Windows")
+    {
+        var variables = new List<VariableDto>();
+
+        if (tentacleOs != null)
+            variables.Add(new VariableDto { Name = WindowsServiceDeployProperties.TentacleOS, Value = tentacleOs });
+
+        return new ActionExecutionContext
+        {
+            Step = new DeploymentStepDto { Name = stepName },
+            Action = new DeploymentActionDto
+            {
+                Id = action.Id,
+                Name = actionName,
+                ActionType = action.ActionType,
+                Properties = action.Properties
+            },
+            Variables = variables
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Added `WindowsServiceDeployActionHandler : IActionHandler` for `Squid.DeployWindowsService`, establishing the handler boundary for Windows Tentacle service deployment.
- Declared static runtime requirements for Windows OS and PowerShell availability using the existing capability requirements model, so scheduling/validation can reject incompatible targets before execution where capability data is available.
- Added a dispatch-time OS guard that reads the Tentacle OS variable and blocks clearly non-Windows targets with an actionable error message, while allowing missing OS data to fall back to static capability validation.
- Centralized Windows OS string recognition through `WindowsOsStringHelper`, including support for canonical and legacy Windows OS string forms.
- Returned a stable PowerShell `RunScriptIntent` shape with intent name, step/action observability fields, PowerShell syntax, and runtime bundle disabled; the script body remained a deliberate fail-fast placeholder for the following script-builder branch.

## Test plan

- [x] Unit: `WindowsServiceDeployActionHandlerTests` verifies the handler exposes the correct action type.
- [x] Unit: handler static requirements include Windows OS and PowerShell presence.
- [x] Unit: handler returns a `RunScriptIntent` with stable name, step/action names, PowerShell syntax, and runtime bundle disabled.
- [x] Unit: dispatch-time OS guard accepts Windows/canonical/legacy values and rejects non-Windows values with an actionable error.
- [x] Regression: `ActionTypesDriftTests` included in the targeted run to keep action type registration aligned with the handler.
- [x] Targeted test run: `DOTNET_ROLL_FORWARD=Major dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~WindowsServiceDeployActionHandlerTests|FullyQualifiedName~ActionTypesDriftTests"` passed, 24 tests green.