### PR TITLE
Windows service script builder

### DIFF
--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -1,0 +1,241 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-SquidParameter {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ''
+    )
+
+    if ($SquidParameters.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($SquidParameters[$Name])) {
+        return [string]$SquidParameters[$Name]
+    }
+
+    return $Default
+}
+
+function Test-True {
+    param([string]$Value)
+    return [string]::Equals($Value, 'true', [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Invoke-Sc {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+    & sc.exe @Arguments | Write-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "sc.exe $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Wait-ServiceStatus {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][System.ServiceProcess.ServiceControllerStatus]$Status,
+        [int]$TimeoutSeconds = 60
+    )
+
+    $service = Get-Service -Name $Name -ErrorAction Stop
+    $service.WaitForStatus($Status, [TimeSpan]::FromSeconds($TimeoutSeconds))
+    $service.Refresh()
+
+    if ($service.Status -ne $Status) {
+        throw "Service '$Name' did not reach state '$Status' within $TimeoutSeconds seconds. Current state: '$($service.Status)'."
+    }
+}
+
+function Stop-ServiceIfRunning {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $service = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $service) {
+        return
+    }
+
+    if ($service.Status -ne [System.ServiceProcess.ServiceControllerStatus]::Stopped) {
+        Write-Host "Stopping Windows service '$Name' before reconfiguration."
+        Stop-Service -Name $Name -Force -ErrorAction Stop
+        Wait-ServiceStatus -Name $Name -Status ([System.ServiceProcess.ServiceControllerStatus]::Stopped)
+    }
+}
+
+function Convert-StartModeForSc {
+    param([string]$StartMode)
+
+    switch ($StartMode.ToLowerInvariant()) {
+        'automatic' { return 'auto' }
+        'manual' { return 'demand' }
+        'disabled' { return 'disabled' }
+        default { throw "Unsupported Windows service start mode '$StartMode'. Expected Automatic, Manual, or Disabled." }
+    }
+}
+
+function Split-Dependencies {
+    param([string]$Dependencies)
+
+    if ([string]::IsNullOrWhiteSpace($Dependencies)) {
+        return @()
+    }
+
+    return $Dependencies -split "[,;`r`n]+" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Resolve-PackageRoot {
+    $sourcePath = Get-SquidParameter 'Squid.Action.WindowsService.Package.SourcePath'
+    $extractTo = Get-SquidParameter 'Squid.Action.WindowsService.Package.ExtractTo'
+    $purgeBeforeExtract = Test-True (Get-SquidParameter 'Squid.Action.WindowsService.Package.PurgeBeforeExtract' 'False')
+
+    if (-not [string]::IsNullOrWhiteSpace($sourcePath) -and (Test-Path -LiteralPath $sourcePath)) {
+        $sourceItem = Get-Item -LiteralPath $sourcePath
+
+        if ($sourceItem.PSIsContainer) {
+            if ([string]::IsNullOrWhiteSpace($extractTo)) {
+                return $sourceItem.FullName
+            }
+
+            if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
+                Remove-Item -LiteralPath $extractTo -Recurse -Force
+            }
+
+            New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
+            Copy-Item -Path (Join-Path $sourceItem.FullName '*') -Destination $extractTo -Recurse -Force
+            return (Resolve-Path -LiteralPath $extractTo).Path
+        }
+
+        if ([string]::IsNullOrWhiteSpace($extractTo)) {
+            $extractTo = Join-Path $sourceItem.DirectoryName ([System.IO.Path]::GetFileNameWithoutExtension($sourceItem.Name))
+        }
+
+        if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
+            Remove-Item -LiteralPath $extractTo -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
+        Expand-Archive -LiteralPath $sourceItem.FullName -DestinationPath $extractTo -Force
+        return (Resolve-Path -LiteralPath $extractTo).Path
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($extractTo) -and (Test-Path -LiteralPath $extractTo)) {
+        return (Resolve-Path -LiteralPath $extractTo).Path
+    }
+
+    return (Get-Location).Path
+}
+
+function Resolve-ExecutablePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$PackageRoot,
+        [Parameter(Mandatory = $true)][string]$ExecutablePath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($ExecutablePath)) {
+        return $ExecutablePath
+    }
+
+    return Join-Path $PackageRoot $ExecutablePath
+}
+
+function Build-BinaryPathName {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExecutablePath,
+        [string]$Arguments
+    )
+
+    $binary = '"' + $ExecutablePath + '"'
+    if (-not [string]::IsNullOrWhiteSpace($Arguments)) {
+        $binary += ' ' + $Arguments
+    }
+
+    return $binary
+}
+
+function Get-ServiceAccountArgs {
+    $serviceAccount = Get-SquidParameter 'Squid.Action.WindowsService.ServiceAccount' 'LocalSystem'
+    $customAccountName = Get-SquidParameter 'Squid.Action.WindowsService.CustomAccountName'
+    $customAccountPassword = Get-SquidParameter 'Squid.Action.WindowsService.CustomAccountPassword'
+
+    switch ($serviceAccount.ToLowerInvariant()) {
+        'localsystem' { return @('obj=', 'LocalSystem') }
+        'networkservice' { return @('obj=', 'NT AUTHORITY\NetworkService') }
+        'localservice' { return @('obj=', 'NT AUTHORITY\LocalService') }
+        'specificuser' {
+            if ([string]::IsNullOrWhiteSpace($customAccountName)) {
+                throw "Windows service account 'SpecificUser' requires Squid.Action.WindowsService.CustomAccountName."
+            }
+
+            if ([string]::IsNullOrWhiteSpace($customAccountPassword)) {
+                throw "Windows service account 'SpecificUser' requires Squid.Action.WindowsService.CustomAccountPassword."
+            }
+
+            return @('obj=', $customAccountName, 'password=', $customAccountPassword)
+        }
+        default { throw "Unsupported Windows service account '$serviceAccount'. Expected LocalSystem, NetworkService, LocalService, or SpecificUser." }
+    }
+}
+
+$createOrUpdate = Get-SquidParameter 'Squid.Action.WindowsService.CreateOrUpdateService' 'True'
+if (-not (Test-True $createOrUpdate)) {
+    Write-Host "Windows service create/update is disabled for this action."
+    return
+}
+
+$serviceName = Get-SquidParameter 'Squid.Action.WindowsService.ServiceName'
+if ([string]::IsNullOrWhiteSpace($serviceName)) {
+    throw "Squid.Action.WindowsService.ServiceName is required."
+}
+
+$displayName = Get-SquidParameter 'Squid.Action.WindowsService.DisplayName' $serviceName
+$description = Get-SquidParameter 'Squid.Action.WindowsService.Description'
+$relativeExecutablePath = Get-SquidParameter 'Squid.Action.WindowsService.ExecutablePath'
+if ([string]::IsNullOrWhiteSpace($relativeExecutablePath)) {
+    throw "Squid.Action.WindowsService.ExecutablePath is required."
+}
+
+$arguments = Get-SquidParameter 'Squid.Action.WindowsService.Arguments'
+$startMode = Get-SquidParameter 'Squid.Action.WindowsService.StartMode' 'Automatic'
+$desiredStatus = Get-SquidParameter 'Squid.Action.WindowsService.DesiredStatus' 'Started'
+$dependencies = Split-Dependencies (Get-SquidParameter 'Squid.Action.WindowsService.Dependencies')
+
+$packageRoot = Resolve-PackageRoot
+$executablePath = Resolve-ExecutablePath -PackageRoot $packageRoot -ExecutablePath $relativeExecutablePath
+if (-not (Test-Path -LiteralPath $executablePath)) {
+    throw "Windows service executable '$executablePath' was not found. Package root: '$packageRoot'."
+}
+
+$binaryPathName = Build-BinaryPathName -ExecutablePath $executablePath -Arguments $arguments
+$scStartMode = Convert-StartModeForSc $startMode
+$accountArgs = Get-ServiceAccountArgs
+$existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+
+if ($null -eq $existingService) {
+    Write-Host "Creating Windows service '$serviceName'."
+    Invoke-Sc create $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
+} else {
+    Stop-ServiceIfRunning -Name $serviceName
+    Write-Host "Reconfiguring Windows service '$serviceName'."
+    Invoke-Sc config $serviceName binPath= $binaryPathName DisplayName= $displayName start= $scStartMode @accountArgs
+}
+
+if (-not [string]::IsNullOrWhiteSpace($description)) {
+    Invoke-Sc description $serviceName $description
+}
+
+if ($dependencies.Count -gt 0) {
+    Invoke-Sc config $serviceName depend= ($dependencies -join '/')
+}
+
+switch ($desiredStatus.ToLowerInvariant()) {
+    'started' {
+        Write-Host "Starting Windows service '$serviceName'."
+        Start-Service -Name $serviceName -ErrorAction Stop
+        Wait-ServiceStatus -Name $serviceName -Status ([System.ServiceProcess.ServiceControllerStatus]::Running)
+    }
+    'stopped' {
+        Stop-ServiceIfRunning -Name $serviceName
+    }
+    default {
+        throw "Unsupported Windows service desired status '$desiredStatus'. Expected Started or Stopped."
+    }
+}

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
@@ -24,12 +24,14 @@ public class WindowsServiceDeployActionHandler : IActionHandler
 
         EnsureWindowsTentacleTarget(ctx);
 
+        var scriptBody = WindowsServiceDeployScriptBuilder.Build(ctx.Action, ctx.Variables, ctx.SelectedPackages);
+
         var intent = new RunScriptIntent
         {
             Name = "deploy-windows-service",
             StepName = ctx.Step?.Name ?? string.Empty,
             ActionName = ctx.Action?.Name ?? string.Empty,
-            ScriptBody = BuildScriptBuilderPendingBody(),
+            ScriptBody = scriptBody,
             Syntax = ScriptSyntax.PowerShell,
             InjectRuntimeBundle = false
         };
@@ -57,10 +59,6 @@ public class WindowsServiceDeployActionHandler : IActionHandler
             $"To deploy a Windows service, configure a Windows Tentacle (Polling or Listening) and assign it the role this step targets. " +
             $"If you believe the target IS Windows, run a health check against it so the runtime-capabilities cache refreshes.");
     }
-
-    private static string BuildScriptBuilderPendingBody() =>
-        "throw 'Squid.DeployWindowsService script generation is not implemented yet. " +
-        "Complete WindowsServiceDeployScriptBuilder and the embedded PowerShell resource before executing this action.'";
 
     internal static bool LooksLikeWindowsOsString(string osValue)
         => WindowsOsStringHelper.IsWindows(osValue);

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployScriptBuilder.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployScriptBuilder.cs
@@ -1,0 +1,180 @@
+using System.Reflection;
+using System.Text;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Release;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+
+internal static class WindowsServiceDeployScriptBuilder
+{
+    private const string EmbeddedScriptName = "Squid.Core.Resources.Deploy.WindowsService.DeployWindowsService.ps1";
+
+    internal static readonly IReadOnlyList<string> RecognisedProperties = new[]
+    {
+        WindowsServiceDeployProperties.CreateOrUpdateService,
+        WindowsServiceDeployProperties.ServiceName,
+        WindowsServiceDeployProperties.DisplayName,
+        WindowsServiceDeployProperties.Description,
+        WindowsServiceDeployProperties.ExecutablePath,
+        WindowsServiceDeployProperties.Arguments,
+        WindowsServiceDeployProperties.ServiceAccount,
+        WindowsServiceDeployProperties.CustomAccountName,
+        WindowsServiceDeployProperties.CustomAccountPassword,
+        WindowsServiceDeployProperties.StartMode,
+        WindowsServiceDeployProperties.DesiredStatus,
+        WindowsServiceDeployProperties.Dependencies,
+        WindowsServiceDeployProperties.PackageSourcePath,
+        WindowsServiceDeployProperties.PackageExtractTo,
+        WindowsServiceDeployProperties.PackagePurgeBeforeExtract
+    };
+
+    private static readonly HashSet<string> MultilineProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        WindowsServiceDeployProperties.Description,
+        WindowsServiceDeployProperties.Dependencies
+    };
+
+    internal static string Build(DeploymentActionDto action)
+        => Build(action, Array.Empty<VariableDto>(), Array.Empty<SelectedPackageDto>());
+
+    internal static string Build(
+        DeploymentActionDto action,
+        IReadOnlyList<VariableDto>? variables,
+        IReadOnlyList<SelectedPackageDto>? selectedPackages)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var preamble = BuildPreamble(action, variables ?? Array.Empty<VariableDto>(), selectedPackages ?? Array.Empty<SelectedPackageDto>());
+        var body = LoadEmbeddedScriptBody();
+
+        return preamble + body;
+    }
+
+    private static string BuildPreamble(
+        DeploymentActionDto action,
+        IReadOnlyList<VariableDto> variables,
+        IReadOnlyList<SelectedPackageDto> selectedPackages)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("# BEGIN GENERATED PREAMBLE (Squid WindowsServiceDeployScriptBuilder)");
+        sb.AppendLine("$SquidParameters = @{}");
+
+        foreach (var propertyName in RecognisedProperties)
+        {
+            var rawValue = ReadProperty(action, propertyName);
+
+            if (MultilineProperties.Contains(propertyName))
+                EmitMultilineAssignment(sb, propertyName, rawValue);
+            else
+                EmitDataAssignment(sb, propertyName, rawValue);
+        }
+
+        EmitSquidVariablesHashtable(sb, variables);
+        EmitSelectedPackages(sb, action, selectedPackages);
+
+        sb.AppendLine("# END GENERATED PREAMBLE");
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static void EmitDataAssignment(StringBuilder sb, string propertyName, string rawValue)
+    {
+        sb.Append("$SquidParameters['");
+        sb.Append(propertyName);
+        sb.Append("'] = '");
+        sb.Append(EscapeForPowerShellSingleQuote(rawValue));
+        sb.AppendLine("'");
+    }
+
+    private static void EmitMultilineAssignment(StringBuilder sb, string propertyName, string rawValue)
+    {
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            EmitDataAssignment(sb, propertyName, string.Empty);
+            return;
+        }
+
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(rawValue));
+        sb.Append("$SquidParameters['");
+        sb.Append(propertyName);
+        sb.Append("'] = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('");
+        sb.Append(base64);
+        sb.AppendLine("'))");
+    }
+
+    private static void EmitSquidVariablesHashtable(StringBuilder sb, IReadOnlyList<VariableDto> variables)
+    {
+        sb.AppendLine("$SquidVariables = @{}");
+
+        foreach (var variable in variables)
+        {
+            if (string.IsNullOrEmpty(variable?.Name)) continue;
+
+            sb.Append("$SquidVariables['");
+            sb.Append(EscapeForPowerShellSingleQuote(variable.Name));
+            sb.Append("'] = '");
+            sb.Append(EscapeForPowerShellSingleQuote(variable.Value ?? string.Empty));
+            sb.AppendLine("'");
+        }
+    }
+
+    private static void EmitSelectedPackages(StringBuilder sb, DeploymentActionDto action, IReadOnlyList<SelectedPackageDto> selectedPackages)
+    {
+        sb.AppendLine("$SquidSelectedPackages = @()");
+
+        foreach (var package in selectedPackages)
+        {
+            if (package == null) continue;
+
+            sb.Append("$SquidSelectedPackages += @{ ActionName = '");
+            sb.Append(EscapeForPowerShellSingleQuote(package.ActionName ?? string.Empty));
+            sb.Append("'; PackageReferenceName = '");
+            sb.Append(EscapeForPowerShellSingleQuote(package.PackageReferenceName ?? string.Empty));
+            sb.Append("'; Version = '");
+            sb.Append(EscapeForPowerShellSingleQuote(package.Version ?? string.Empty));
+            sb.AppendLine("' }");
+        }
+
+        sb.AppendLine("$SquidSelectedPackage = $null");
+        sb.Append("foreach ($package in $SquidSelectedPackages) { if ($package['ActionName'] -ieq '");
+        sb.Append(EscapeForPowerShellSingleQuote(action.Name ?? string.Empty));
+        sb.AppendLine("') { $SquidSelectedPackage = $package; break } }");
+    }
+
+    private static string ReadProperty(DeploymentActionDto action, string propertyName)
+    {
+        var prop = action.Properties?
+            .FirstOrDefault(p => string.Equals(p.PropertyName, propertyName, StringComparison.OrdinalIgnoreCase));
+
+        return prop?.PropertyValue ?? string.Empty;
+    }
+
+    internal static string EscapeForPowerShellSingleQuote(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var collapsed = value
+            .Replace("\r\n", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal);
+
+        return collapsed.Replace("'", "''", StringComparison.Ordinal);
+    }
+
+    private static string LoadEmbeddedScriptBody()
+    {
+        var assembly = typeof(WindowsServiceDeployScriptBuilder).Assembly;
+
+        using var stream = assembly.GetManifestResourceStream(EmbeddedScriptName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{EmbeddedScriptName}' not found in assembly '{assembly.GetName().Name}'. " +
+                $"Verify Squid.Core.csproj has '<EmbeddedResource Include=\"Resources\\Deploy\\WindowsService\\*.ps1\" />' " +
+                $"and the .ps1 file exists at src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1.");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Squid.Core/Squid.Core.csproj
+++ b/src/Squid.Core/Squid.Core.csproj
@@ -58,6 +58,7 @@
     <EmbeddedResource Include="Services\DeploymentExecution\Runtime\Bundles\Resources\*" />
     <EmbeddedResource Include="Resources\Upgrade\*" />
     <EmbeddedResource Include="Resources\Deploy\IIS\*.ps1" />
+    <EmbeddedResource Include="Resources\Deploy\WindowsService\*.ps1" />
   </ItemGroup>
 
   <ItemGroup Label="DbUp">

--- a/tests/Squid.Tentacle.Tests/Support/Fakes/FakeMachineRegistrationServer.cs
+++ b/tests/Squid.Tentacle.Tests/Support/Fakes/FakeMachineRegistrationServer.cs
@@ -162,8 +162,24 @@ public sealed class FakeMachineRegistrationServer : IAsyncDisposable
         }
         finally
         {
-            _listener.Close();
+            CloseListener();
             _cts.Dispose();
+        }
+    }
+
+    private void CloseListener()
+    {
+        try
+        {
+            _listener.Close();
+        }
+        catch (HttpListenerException)
+        {
+            // The listener is already shutting down; cleanup must not fail the test.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The listener is already disposed.
         }
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployActionHandlerTests.cs
@@ -50,7 +50,9 @@ public class WindowsServiceDeployActionHandlerTests
         runScript.ActionName.ShouldBe("Windows Service");
         runScript.Syntax.ShouldBe(ScriptSyntax.PowerShell);
         runScript.InjectRuntimeBundle.ShouldBeFalse();
-        runScript.ScriptBody.ShouldContain("script generation is not implemented yet");
+        runScript.ScriptBody.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'OrderWorker'");
+        runScript.ScriptBody.ShouldContain("function Resolve-PackageRoot");
+        runScript.ScriptBody.ShouldContain("Invoke-Sc create $serviceName");
     }
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -1,0 +1,161 @@
+using System.Linq;
+using System.Text;
+using Shouldly;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.Deployments.Release;
+using Squid.Message.Models.Deployments.Variable;
+
+namespace Squid.UnitTests.Services.DeploymentExecution.Targets.Tentacle;
+
+public class WindowsServiceDeployScriptBuilderTests
+{
+    [Fact]
+    public void Build_EmitsSquidParametersHashtable_AtTopOfScript()
+    {
+        var action = BuildAction(
+            (WindowsServiceDeployProperties.ServiceName, "OrderWorker"),
+            (WindowsServiceDeployProperties.ExecutablePath, "Order.Worker.exe"));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("# BEGIN GENERATED PREAMBLE");
+        script.ShouldContain("$SquidParameters = @{}");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceName'] = 'OrderWorker'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ExecutablePath'] = 'Order.Worker.exe'");
+    }
+
+    [Fact]
+    public void Build_AppendsEmbeddedScriptBody_AfterPreamble()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        var preambleIndex = script.IndexOf("# BEGIN GENERATED PREAMBLE", StringComparison.Ordinal);
+        var bodyIndex = script.IndexOf("function Resolve-PackageRoot", StringComparison.Ordinal);
+
+        preambleIndex.ShouldBeGreaterThanOrEqualTo(0);
+        bodyIndex.ShouldBeGreaterThanOrEqualTo(0);
+        preambleIndex.ShouldBeLessThan(bodyIndex);
+        script.ShouldContain("Invoke-Sc create $serviceName");
+        script.ShouldContain("Invoke-Sc config $serviceName");
+    }
+
+    [Fact]
+    public void Build_AllRecognisedProperties_HaveExplicitEntryInHashtable_EvenWhenUnset()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        foreach (var propertyName in WindowsServiceDeployScriptBuilder.RecognisedProperties)
+            script.ShouldContain($"$SquidParameters['{propertyName}']");
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("plain", "plain")]
+    [InlineData("C:\\Services\\Order", "C:\\Services\\Order")]
+    [InlineData("$env:TEMP", "$env:TEMP")]
+    [InlineData("O'Brien", "O''Brien")]
+    [InlineData("'; Stop-Service X; '", "''; Stop-Service X; ''")]
+    public void EscapeForPowerShellSingleQuote_FollowsPowerShellLiteralRules(string input, string expected)
+    {
+        WindowsServiceDeployScriptBuilder.EscapeForPowerShellSingleQuote(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Build_MultilineDescription_PreservesNewlinesViaBase64()
+    {
+        var description = "line 1\nline 2";
+        var action = BuildAction((WindowsServiceDeployProperties.Description, description));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(description));
+
+        script.ShouldContain($"FromBase64String('{encoded}')");
+        script.ShouldContain("Squid.Action.WindowsService.Description");
+    }
+
+    [Fact]
+    public void Build_Dependencies_PreservesNewlineSeparatedListViaBase64()
+    {
+        var dependencies = "MSSQLSERVER\nEventLog";
+        var action = BuildAction((WindowsServiceDeployProperties.Dependencies, dependencies));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(dependencies));
+
+        script.ShouldContain($"FromBase64String('{encoded}')");
+    }
+
+    [Fact]
+    public void Build_EmitsSquidVariablesHashtable()
+    {
+        var variables = new[]
+        {
+            new VariableDto { Name = "ConnString", Value = "Server='prod';" },
+            new VariableDto { Name = "Empty", Value = null }
+        };
+
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction(), variables, Array.Empty<SelectedPackageDto>());
+
+        script.ShouldContain("$SquidVariables = @{}");
+        script.ShouldContain("$SquidVariables['ConnString'] = 'Server=''prod'';'");
+        script.ShouldContain("$SquidVariables['Empty'] = ''");
+    }
+
+    [Fact]
+    public void Build_EmitsSelectedPackageMetadata_AndActionMatchedPrimaryPackage()
+    {
+        var action = BuildAction(actionName: "Deploy worker");
+        var packages = new[]
+        {
+            new SelectedPackageDto { ActionName = "Other action", PackageReferenceName = "Other.Package", Version = "1.0.0" },
+            new SelectedPackageDto { ActionName = "Deploy worker", PackageReferenceName = "Order.Worker", Version = "2.3.4" }
+        };
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action, Array.Empty<VariableDto>(), packages);
+
+        script.ShouldContain("$SquidSelectedPackages = @()");
+        script.ShouldContain("PackageReferenceName = 'Order.Worker'");
+        script.ShouldContain("Version = '2.3.4'");
+        script.ShouldContain("if ($package['ActionName'] -ieq 'Deploy worker')");
+        script.ShouldContain("$SquidSelectedPackage = $package");
+    }
+
+    [Fact]
+    public void Build_ServiceAccountAndLifecycleProperties_FlowThroughPreamble()
+    {
+        var action = BuildAction(
+            (WindowsServiceDeployProperties.ServiceAccount, "SpecificUser"),
+            (WindowsServiceDeployProperties.CustomAccountName, "DOMAIN\\worker"),
+            (WindowsServiceDeployProperties.CustomAccountPassword, "p@ss'word"),
+            (WindowsServiceDeployProperties.StartMode, "Manual"),
+            (WindowsServiceDeployProperties.DesiredStatus, "Stopped"),
+            (WindowsServiceDeployProperties.Arguments, "--listen 9000"));
+
+        var script = WindowsServiceDeployScriptBuilder.Build(action);
+
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.ServiceAccount'] = 'SpecificUser'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.CustomAccountName'] = 'DOMAIN\\worker'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.CustomAccountPassword'] = 'p@ss''word'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.StartMode'] = 'Manual'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.DesiredStatus'] = 'Stopped'");
+        script.ShouldContain("$SquidParameters['Squid.Action.WindowsService.Arguments'] = '--listen 9000'");
+    }
+
+    private static DeploymentActionDto BuildAction(params (string Name, string Value)[] properties)
+        => BuildAction("Windows Service", properties);
+
+    private static DeploymentActionDto BuildAction(string actionName, params (string Name, string Value)[] properties)
+    {
+        return new DeploymentActionDto
+        {
+            Id = 1,
+            Name = actionName,
+            ActionType = "Squid.DeployWindowsService",
+            Properties = properties
+                .Select(p => new DeploymentActionPropertyDto { PropertyName = p.Name, PropertyValue = p.Value })
+                .ToList()
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Implemented the Windows Service deploy script generation path for `Squid.DeployWindowsService`: the handler now returns a real PowerShell `RunScriptIntent` instead of the previous “not implemented” stub.
- Added `WindowsServiceDeployScriptBuilder` as the single C# generation point for the script preamble: action properties, Squid variables, selected package metadata, scalar PowerShell escaping, and base64 preservation for multiline fields.
- Added the embedded `DeployWindowsService.ps1` resource for idempotent service deployment behavior: resolve package/executable paths, stop/reconfigure existing services, create missing services, set display name/description/start mode/dependencies/account, and apply desired started/stopped state.
- Registered the Windows Service PowerShell resource in `Squid.Core.csproj`, so the generated intent is self-contained and stable at runtime.
- Stabilized `FakeMachineRegistrationServer` cleanup after CI exposed an unrelated `HttpListener` teardown race: cleanup no longer fails a passing registration test if `HttpListener.Close()` throws during shutdown.

## Test plan

- [x] Unit: `WindowsServiceDeployActionHandlerTests` verifies the handler emits a PowerShell `RunScriptIntent` containing generated Windows Service script content.
- [x] Unit: `WindowsServiceDeployScriptBuilderTests` covers preamble generation, recognized property emission, escaping, multiline preservation, variables, selected package metadata, and service-account/lifecycle properties.
- [x] Regression: targeted Windows Service tests green, 36 passed.
- [x] CI failure follow-up: exact failing test `KubernetesAgentRegistrarTests.RegisterAsync_Maps_Server_Response_To_TentacleRegistration` passes locally after the fake server cleanup fix.