### PR TITLE
Bridge Tentacle package references to Windows service deploy

### DIFF
--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -82,10 +82,50 @@ function Split-Dependencies {
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
 }
 
+function Resolve-AcquiredPackageSourcePath {
+    $manifestPath = Join-Path (Get-Location) 'package-references.json'
+
+    if (Test-Path -LiteralPath $manifestPath) {
+        try {
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            $entry = @($manifest) | Select-Object -First 1
+
+            if ($null -ne $entry -and -not [string]::IsNullOrWhiteSpace([string]$entry.PackagePath)) {
+                $candidate = [string]$entry.PackagePath
+
+                if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+                    $candidate = Join-Path (Get-Location) $candidate
+                }
+
+                if (Test-Path -LiteralPath $candidate) {
+                    return (Resolve-Path -LiteralPath $candidate).Path
+                }
+            }
+        }
+        catch {
+            Write-Host "Unable to read package-references.json; falling back to package-references directory. $($_.Exception.Message)"
+        }
+    }
+
+    $packageReferencesDir = Join-Path (Get-Location) 'package-references'
+    if (Test-Path -LiteralPath $packageReferencesDir) {
+        $candidate = Get-ChildItem -LiteralPath $packageReferencesDir | Sort-Object Name | Select-Object -First 1
+        if ($null -ne $candidate) {
+            return $candidate.FullName
+        }
+    }
+
+    return ''
+}
+
 function Resolve-PackageRoot {
     $sourcePath = Get-SquidParameter 'Squid.Action.WindowsService.Package.SourcePath'
     $extractTo = Get-SquidParameter 'Squid.Action.WindowsService.Package.ExtractTo'
     $purgeBeforeExtract = Test-True (Get-SquidParameter 'Squid.Action.WindowsService.Package.PurgeBeforeExtract' 'False')
+
+    if ([string]::IsNullOrWhiteSpace($sourcePath)) {
+        $sourcePath = Resolve-AcquiredPackageSourcePath
+    }
 
     if (-not [string]::IsNullOrWhiteSpace($sourcePath) -and (Test-Path -LiteralPath $sourcePath)) {
         $sourceItem = Get-Item -LiteralPath $sourcePath

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
@@ -92,15 +92,24 @@ public sealed partial class ExecuteStepsPhase
         if (string.IsNullOrEmpty(actionName) || _ctx.SelectedPackages.Count == 0)
             return new List<PackageAcquisitionResult>();
 
-        var names = _ctx.SelectedPackages
+        return _ctx.SelectedPackages
             .Where(p => string.Equals(p.ActionName, actionName, StringComparison.OrdinalIgnoreCase))
             .Select(p => p.PackageReferenceName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .Where(packageReferenceName => !string.IsNullOrWhiteSpace(packageReferenceName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(FindAcquiredPackage)
+            .Where(package => package != null)
+            .ToList();
+    }
+
+    private PackageAcquisitionResult? FindAcquiredPackage(string packageReferenceName)
+    {
+        if (_ctx.AcquiredPackages.TryGetValue(packageReferenceName, out var package))
+            return package;
 
         return _ctx.AcquiredPackages
-            .Where(kv => names.Contains(kv.Key))
-            .Select(kv => kv.Value)
-            .ToList();
+            .FirstOrDefault(kv => string.Equals(kv.Key, packageReferenceName, StringComparison.OrdinalIgnoreCase))
+            .Value;
     }
 
     private static SensitiveValueMasker BuildSensitiveMasker(List<VariableDto> variables)

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/HalibutMachineExecutionStrategy.cs
@@ -2,6 +2,7 @@ using Halibut;
 using Halibut.Diagnostics;
 using Squid.Core.Halibut.Resilience;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
+using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.DeploymentExecution.Script.Files;
 using Squid.Core.Services.DeploymentExecution.Transport;
@@ -185,7 +186,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         var (variableBytes, sensitiveBytes, password) =
             ScriptExecutionHelper.CreateVariableFileContents(request.Variables);
 
-        var scriptFiles = BuildDirectScriptFiles(request.DeploymentFiles, variableBytes, sensitiveBytes, password);
+        var scriptFiles = BuildDirectScriptFiles(request.DeploymentFiles, request.PackageReferences, variableBytes, sensitiveBytes, password);
         var scriptTimeout = request.Timeout ?? _defaultScriptTimeout;
         // See ExecuteCalamariViaHalibutAsync above for the ticket-vs-mutex-name
         // rationale: ticket is Guid-per-attempt; IsolationMutexName (arg 5) is the
@@ -361,6 +362,7 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
 
     private static ScriptFile[] BuildDirectScriptFiles(
         DeploymentFileCollection deploymentFiles,
+        IReadOnlyList<PackageAcquisitionResult> packageReferences,
         byte[] variableBytes,
         byte[] sensitiveBytes,
         string password)
@@ -368,6 +370,8 @@ public class HalibutMachineExecutionStrategy : IExecutionStrategy
         var files = deploymentFiles
             .Select(file => new ScriptFile(file.RelativePath, DataStream.FromBytes(file.Content), null))
             .ToList();
+
+        files.AddRange(PackageReferenceScriptFileBridge.BuildScriptFiles(packageReferences));
 
         files.Add(new ScriptFile("variables.json", DataStream.FromBytes(variableBytes), null));
 

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using System.Text.Json;
+using Halibut;
+using Squid.Core.Services.DeploymentExecution.Packages;
+using Squid.Message.Contracts.Tentacle;
+
+namespace Squid.Core.Services.DeploymentExecution.Tentacle;
+
+internal static class PackageReferenceScriptFileBridge
+{
+    internal const string ManifestFileName = "package-references.json";
+    internal const string PackageReferencesDirectory = "package-references";
+
+    internal static IReadOnlyList<ScriptFile> BuildScriptFiles(IReadOnlyList<PackageAcquisitionResult>? packageReferences)
+    {
+        if (packageReferences == null || packageReferences.Count == 0)
+            return Array.Empty<ScriptFile>();
+
+        var files = new List<ScriptFile>();
+        var manifest = new List<PackageReferenceManifestEntry>();
+        var usedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var packageReference in packageReferences)
+        {
+            if (packageReference == null) continue;
+
+            if (string.IsNullOrWhiteSpace(packageReference.LocalPath))
+                throw new InvalidOperationException($"Package '{packageReference.PackageId}' has no acquired local path.");
+
+            if (!File.Exists(packageReference.LocalPath))
+                throw new FileNotFoundException($"Acquired package '{packageReference.PackageId}' was not found at '{packageReference.LocalPath}'.", packageReference.LocalPath);
+
+            var packagePath = BuildPackageRelativePath(packageReference, usedPaths);
+            var packageBytes = File.ReadAllBytes(packageReference.LocalPath);
+
+            files.Add(new ScriptFile(packagePath, DataStream.FromBytes(packageBytes), null));
+            manifest.Add(new PackageReferenceManifestEntry(
+                packageReference.PackageId,
+                packageReference.Version,
+                packagePath,
+                packageReference.SizeBytes,
+                packageReference.Hash));
+        }
+
+        if (manifest.Count == 0)
+            return Array.Empty<ScriptFile>();
+
+        var manifestBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifest));
+        files.Insert(0, new ScriptFile(ManifestFileName, DataStream.FromBytes(manifestBytes), null));
+
+        return files;
+    }
+
+    internal static string BuildPackageRelativePath(PackageAcquisitionResult packageReference, ISet<string>? usedPaths = null)
+    {
+        ArgumentNullException.ThrowIfNull(packageReference);
+
+        var packageId = SafePathSegment(packageReference.PackageId, "package");
+        var version = SafePathSegment(packageReference.Version, "version");
+        var extension = SafeExtension(packageReference.LocalPath);
+        var baseName = $"{packageId}.{version}{extension}";
+        var relativePath = Path.Combine(PackageReferencesDirectory, baseName).Replace('\\', '/');
+
+        if (usedPaths == null)
+            return relativePath;
+
+        if (usedPaths.Add(relativePath))
+            return relativePath;
+
+        var suffix = 2;
+        while (true)
+        {
+            var candidate = Path.Combine(PackageReferencesDirectory, $"{packageId}.{version}.{suffix}{extension}").Replace('\\', '/');
+            if (usedPaths.Add(candidate))
+                return candidate;
+
+            suffix++;
+        }
+    }
+
+    private static string SafePathSegment(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        var chars = value
+            .Select(c => char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_' ? c : '_')
+            .ToArray();
+        var sanitized = new string(chars).Trim('.', '_', '-');
+
+        return string.IsNullOrEmpty(sanitized) ? fallback : sanitized;
+    }
+
+    private static string SafeExtension(string localPath)
+    {
+        var extension = Path.GetExtension(localPath);
+
+        if (string.IsNullOrWhiteSpace(extension))
+            return ".package";
+
+        var chars = extension
+            .Select(c => char.IsAsciiLetterOrDigit(c) || c == '.' ? c : '_')
+            .ToArray();
+        var sanitized = new string(chars);
+
+        return sanitized == "." ? ".package" : sanitized;
+    }
+
+    private sealed record PackageReferenceManifestEntry(
+        string PackageId,
+        string Version,
+        string PackagePath,
+        long SizeBytes,
+        string Hash);
+}

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -37,6 +37,8 @@ public class WindowsServiceDeployScriptBuilderTests
         preambleIndex.ShouldBeGreaterThanOrEqualTo(0);
         bodyIndex.ShouldBeGreaterThanOrEqualTo(0);
         preambleIndex.ShouldBeLessThan(bodyIndex);
+        script.ShouldContain("function Resolve-AcquiredPackageSourcePath");
+        script.ShouldContain("package-references.json");
         script.ShouldContain("Invoke-Sc create $serviceName");
         script.ShouldContain("Invoke-Sc config $serviceName");
     }

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhasePackageReferencesTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhasePackageReferencesTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Handlers;
@@ -10,6 +11,7 @@ using Squid.Core.Services.Deployments.Checkpoints;
 using Squid.Core.Services.Deployments.ExternalFeeds;
 using Squid.Core.Services.Deployments.Interruptions;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Message.Constants;
 using Squid.Message.Enums;
 using Squid.Message.Models.Deployments.Process;
 using Squid.Message.Models.Deployments.Variable;
@@ -83,7 +85,7 @@ public class ExecuteStepsPhasePackageReferencesTests : IDisposable
 
     public void Dispose() { }
 
-    private DeploymentStepDto MakeStep(string actionName) => new()
+    private DeploymentStepDto MakeStep(string actionName, string actionType = "Squid.Script") => new()
     {
         Id = 1,
         StepOrder = 1,
@@ -99,7 +101,7 @@ public class ExecuteStepsPhasePackageReferencesTests : IDisposable
                 Id = 1,
                 ActionOrder = 1,
                 Name = actionName,
-                ActionType = "Squid.Script",
+                ActionType = actionType,
                 IsDisabled = false,
                 Properties = new List<DeploymentActionPropertyDto>
                 {
@@ -201,6 +203,35 @@ public class ExecuteStepsPhasePackageReferencesTests : IDisposable
         request.PackageReferences.Count.ShouldBe(2);
         request.PackageReferences.ShouldContain(p => p.PackageId == "nginx" && p.Version == "1.21.0");
         request.PackageReferences.ShouldContain(p => p.PackageId == "redis" && p.Version == "7.0.0");
+    }
+
+    [Fact]
+    public async Task BuildPackageReferences_WindowsServiceAction_PreservesSelectedPackageOrder()
+    {
+        const string actionName = "Deploy Worker";
+        _ctx.SelectedPackages = new List<ReleaseSelectedPackage>
+        {
+            new() { Id = 1, ReleaseId = 1, FeedId = 10, ActionName = actionName, PackageReferenceName = "Order.Worker", Version = "1.2.3" },
+            new() { Id = 2, ReleaseId = 1, FeedId = 10, ActionName = actionName, PackageReferenceName = "Order.Config", Version = "4.5.6" }
+        };
+        _ctx.AcquiredPackages = new Dictionary<string, PackageAcquisitionResult>
+        {
+            ["Order.Config"] = new PackageAcquisitionResult("/tmp/order-config.4.5.6.nupkg", "Order.Config", "4.5.6", 2000, "config-hash"),
+            ["order.worker"] = new PackageAcquisitionResult("/tmp/order-worker.1.2.3.nupkg", "Order.Worker", "1.2.3", 5000, "worker-hash")
+        };
+        _ctx.Steps = new List<DeploymentStepDto>
+        {
+            MakeStep(actionName, actionType: SpecialVariables.ActionTypes.DeployWindowsService)
+        };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { MakeTargetContext() };
+
+        SetupActionHandler(actionName);
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        _capturedRequests.Count.ShouldBe(1);
+        _capturedRequests[0].ActionName.ShouldBe(actionName);
+        _capturedRequests[0].PackageReferences.Select(p => p.PackageId).ShouldBe(new[] { "Order.Worker", "Order.Config" });
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/PackageAcquisitionInjectorTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/PackageAcquisitionInjectorTests.cs
@@ -46,6 +46,23 @@ public class PackageAcquisitionInjectorTests
         result[1].Name.ShouldBe("Deploy");
     }
 
+    [Fact]
+    public void Inject_WindowsServiceActionWithSelectedPackage_InjectsAcquireStep()
+    {
+        var steps = new List<DeploymentStepDto>
+        {
+            BuildStep("Deploy Worker", "Deploy Worker", actionType: SpecialVariables.ActionTypes.DeployWindowsService)
+        };
+        var packages = new List<ReleaseSelectedPackage> { new() { ActionName = "Deploy Worker" } };
+
+        var result = PackageAcquisitionInjector.InjectAcquisitionSteps(steps, packages);
+
+        result.Count.ShouldBe(2);
+        result[0].Name.ShouldBe("Acquire Packages");
+        result[0].Actions[0].ActionType.ShouldBe(SpecialVariables.ActionTypes.TentaclePackage);
+        result[1].Actions[0].ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
     // === Pre-acquisition steps skip injection ===
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Halibut;
 using Squid.Core.Persistence.Entities.Deployments;
 using Squid.Core.Services.Common;
@@ -7,6 +9,7 @@ using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
+using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
 using Squid.Message.Contracts.Tentacle;
 using Squid.Message.Models.Deployments.Execution;
@@ -268,6 +271,56 @@ public class HalibutMachineExecutionStrategyTests
             It.IsAny<SensitiveValueMasker>(),
             It.IsAny<ScriptStatusResponse>(),
             It.IsAny<global::Halibut.ServiceEndPoint>(), It.IsAny<ScriptOutputSink>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteScriptAsync_DirectScript_AttachesPackageReferencesAsScriptFiles()
+    {
+        var machine = CreateValidMachine();
+        StartScriptCommand capturedCommand = null;
+        var scriptClient = SetupScriptClient("poll://sub-test/");
+
+        scriptClient.Setup(s => s.StartScriptAsync(It.IsAny<StartScriptCommand>()))
+            .Callback<StartScriptCommand>(cmd => capturedCommand = cmd)
+            .ReturnsAsync(NewStartResponse("package-ref"));
+
+        var packagePath = Path.Combine(Path.GetTempPath(), $"Order.Worker.{Guid.NewGuid():N}.nupkg");
+        await File.WriteAllBytesAsync(packagePath, new byte[] { 1, 2, 3 }, CancellationToken.None);
+
+        try
+        {
+            var request = CreateRequest(machine);
+            request.PackageReferences = new List<PackageAcquisitionResult>
+            {
+                new(packagePath, "Order.Worker", "1.2.3", 3, "abc123")
+            };
+
+            await _strategy.ExecuteScriptAsync(request, CancellationToken.None);
+
+            capturedCommand.ShouldNotBeNull();
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references.json");
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3.nupkg");
+
+            var manifest = capturedCommand.Files.Single(f => f.Name == "package-references.json");
+            var manifestPath = Path.Combine(Path.GetTempPath(), $"package-references-{Guid.NewGuid():N}.json");
+            await manifest.Contents.Receiver().SaveToAsync(manifestPath, CancellationToken.None);
+
+            try
+            {
+                var manifestJson = await File.ReadAllTextAsync(manifestPath, CancellationToken.None);
+                manifestJson.ShouldContain("\"PackageId\":\"Order.Worker\"");
+                manifestJson.ShouldContain("\"Version\":\"1.2.3\"");
+                manifestJson.ShouldContain("\"PackagePath\":\"package-references/Order.Worker.1.2.3.nupkg\"");
+            }
+            finally
+            {
+                File.Delete(manifestPath);
+            }
+        }
+        finally
+        {
+            File.Delete(packagePath);
+        }
     }
 
     // === Request Timeout Override ===


### PR DESCRIPTION
## Summary

- Verified the current package flow: selected packages trigger `PackageAcquisitionInjector`, `ExecuteStepsPhase` matches acquired packages by action name, Tentacle renderers copy them onto `ScriptExecutionRequest.PackageReferences`.
- Added the missing generic Tentacle direct-script bridge: matched package references are now attached to `StartScriptCommand.Files` under `package-references/`, with a `package-references.json` manifest describing package id, version, relative path, size, and hash.
- Tightened package-reference matching to preserve selected-package order and retain case-insensitive matching, so the primary package remains deterministic for package-aware actions like Windows Service deploy.
- Updated the Windows Service PowerShell resource to keep explicit `Squid.Action.WindowsService.Package.SourcePath` as highest priority, then fall back to the package-reference manifest/files staged into the Tentacle workdir.
- Marked OpenSpec tasks `4.1`-`4.4` complete with package-flow notes in `tasks.md`.

## Test plan

- [x] Unit: `PackageAcquisitionInjectorTests` verifies a Windows Service action with a selected package injects `Acquire Packages` before the deploy step.
- [x] Unit: `ExecuteStepsPhasePackageReferencesTests` verifies Windows Service action-name/package-reference matching preserves selected package order and handles case-insensitive acquired package keys.
- [x] Unit: `HalibutMachineExecutionStrategyTests` verifies Tentacle direct-script dispatch attaches `package-references.json` and the matched package file to `StartScriptCommand.Files`.
- [x] Unit: `WindowsServiceDeployScriptBuilderTests` verifies the embedded Windows Service script contains the package-reference manifest fallback.
- [x] Focused regression: `DOTNET_ROLL_FORWARD=Major dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~PackageAcquisitionInjectorTests|FullyQualifiedName~ExecuteStepsPhasePackageReferencesTests|FullyQualifiedName~HalibutMachineExecutionStrategyTests|FullyQualifiedName~WindowsServiceDeployScriptBuilderTests" --logger "console;verbosity=minimal"` passed, 50 tests green.
- [ ] CI: remote CI not run in this turn.