### PR TITLE
Unit Test Coverage

### DIFF
--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhaseCapabilityFilterTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ExecuteStepsPhaseCapabilityFilterTests.cs
@@ -212,7 +212,12 @@ public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
         Dispatches = dispatches
     };
 
-    private static PlannedTargetDispatch BuildDispatch(int machineId, string machineName, bool isValid, string violationMessage = null) => new()
+    private static PlannedTargetDispatch BuildDispatch(
+        int machineId,
+        string machineName,
+        bool isValid,
+        string violationMessage = null,
+        string violationCode = ViolationCodes.UnsupportedActionType) => new()
     {
         Target = new PlannedTarget { MachineId = machineId, MachineName = machineName },
         Intent = new RunScriptIntent { Name = "test", ScriptBody = "echo 1", Syntax = ScriptSyntax.Bash },
@@ -224,7 +229,7 @@ public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
                 {
                     new CapabilityViolation
                     {
-                        Code = ViolationCodes.UnsupportedActionType,
+                        Code = violationCode,
                         Message = violationMessage ?? "transport does not support this action type"
                     }
                 }
@@ -271,6 +276,41 @@ public class ExecuteStepsPhaseCapabilityFilterTests : IDisposable
         evt.Context.ActionName.ShouldBe("Helm Upgrade");
         evt.Context.MachineName.ShouldBe("ssh-target");
         evt.Context.Message.ShouldContain("Squid.HelmChartUpgrade");
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_SkippedWhenDispatchValidationFails_BeforeHandlerRendererOrStrategy()
+    {
+        _handlerRegistryMock.Setup(r => r.ResolveScope(It.IsAny<DeploymentActionDto>())).Returns(ExecutionScope.TargetLevel);
+
+        var action = BuildAction(1, "Deploy Windows Service", SpecialVariables.ActionTypes.DeployWindowsService);
+        var target = BuildTarget(1, "linux-target");
+
+        _ctx.Steps = new List<DeploymentStepDto> { BuildStep(10, "Deploy Service", action) };
+        _ctx.AllTargetsContext = new List<DeploymentTargetContext> { target };
+
+        SeedPlan(BuildPlannedStep(10,
+            BuildPlannedAction(1, SpecialVariables.ActionTypes.DeployWindowsService,
+                BuildDispatch(
+                    1,
+                    "linux-target",
+                    isValid: false,
+                    "target is missing required Windows service capability 'os:windows'",
+                    ViolationCodes.MissingCapability))));
+
+        await _phase.ExecuteAsync(_ctx, CancellationToken.None);
+
+        _handlerRegistryMock.Verify(r => r.Resolve(It.Is<DeploymentActionDto>(a =>
+            a.ActionType == SpecialVariables.ActionTypes.DeployWindowsService)), Times.Never);
+        _sshRenderer.CapturedIntents.ShouldBeEmpty();
+        _k8sRenderer.CapturedIntents.ShouldBeEmpty();
+        _strategyMock.Verify(s => s.ExecuteScriptAsync(It.IsAny<ScriptExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var evt = _emittedEvents.OfType<ActionCapabilityFilteredEvent>().Single();
+        evt.Context.ActionType.ShouldBe(SpecialVariables.ActionTypes.DeployWindowsService);
+        evt.Context.ActionName.ShouldBe("Deploy Windows Service");
+        evt.Context.MachineName.ShouldBe("linux-target");
+        evt.Context.Message.ShouldContain("Windows service capability");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerStaticRequirementsTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/Planning/DeploymentPlannerStaticRequirementsTests.cs
@@ -5,6 +5,7 @@ using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Intents;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Core.Services.DeploymentExecution.Validation;
 using Squid.Message.Constants;
@@ -301,6 +302,105 @@ public class DeploymentPlannerStaticRequirementsTests
                 ]), CancellationToken.None));
     }
 
+    // -- Windows service concrete action coverage ----------------------------
+
+    [Fact]
+    public async Task WindowsServiceAction_WindowsWithPowerShellCapabilities_NoViolation()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "powershell,pwsh,cmd"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "win-tentacle", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue(
+            customMessage: "Windows service deploy requires both Windows OS and PowerShell capability slots.");
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_NonWindowsCapabilities_EmitsOsViolation()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Linux,
+            InstalledShells = "powershell"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "linux-target", "web", CommunicationStyle.Ssh)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+
+        dispatch.Validation.IsValid.ShouldBeFalse();
+        dispatch.Validation.Violations.ShouldContain(v =>
+            v.Code == ViolationCodes.MissingCapability && v.Detail == CapabilityKeys.OsSlot);
+        plan.BlockingReasons.ShouldContain(r => r.Code == PlanBlockingReasonCodes.CapabilityViolation);
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_WindowsWithoutPowerShell_EmitsShellViolation()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "cmd"
+        });
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "win-without-powershell", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        var dispatch = plan.Steps.Single().Actions.Single().Dispatches.Single();
+
+        dispatch.Validation.IsValid.ShouldBeFalse();
+        dispatch.Validation.Violations.ShouldContain(v =>
+            v.Code == ViolationCodes.MissingCapability && v.Detail == CapabilityKeys.Shell.PowerShell);
+    }
+
+    [Fact]
+    public async Task WindowsServiceAction_ColdCache_OptimisticAllow()
+    {
+        StubWindowsServiceHandler();
+
+        var plan = await BuildPlanner().PlanAsync(BuildWindowsServiceRequest(targets:
+        [
+            BuildTargetContext(1, "fresh-windows-target", "web", CommunicationStyle.TentacleListening)
+        ]), CancellationToken.None);
+
+        plan.Steps.Single().Actions.Single().Dispatches.Single().Validation.IsValid.ShouldBeTrue(
+            customMessage: "Fresh targets with no cached runtime capabilities remain preview-allowed.");
+    }
+
+    [Fact]
+    public async Task ExecuteMode_WindowsServiceActionRequirementUnmet_ThrowsDeploymentPlanValidationException()
+    {
+        StubWindowsServiceHandler();
+        StubCache(1, new MachineRuntimeCapabilities
+        {
+            Os = AgentOperatingSystems.Windows,
+            InstalledShells = "cmd"
+        });
+
+        await Should.ThrowAsync<Squid.Core.Services.DeploymentExecution.Planning.Exceptions.DeploymentPlanValidationException>(
+            () => BuildPlanner().PlanAsync(BuildWindowsServiceRequest(
+                mode: PlanMode.Execute,
+                targets:
+                [
+                    BuildTargetContext(1, "win-without-powershell", "web", CommunicationStyle.TentacleListening)
+                ]), CancellationToken.None));
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -325,12 +425,29 @@ public class DeploymentPlannerStaticRequirementsTests
         _registry.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>())).Returns(handler.Object);
     }
 
+    private void StubWindowsServiceHandler()
+        => _registry.Setup(r => r.Resolve(It.Is<DeploymentActionDto>(a =>
+                a.ActionType == SpecialVariables.ActionTypes.DeployWindowsService)))
+            .Returns(new WindowsServiceDeployActionHandler());
+
     private void StubCache(int machineId, MachineRuntimeCapabilities caps)
         => _capabilitiesCache.Setup(c => c.TryGet(machineId)).Returns(caps);
 
     private static DeploymentPlanRequest BuildRequest(
         PlanMode mode = PlanMode.Preview,
         IList<DeploymentTargetContext> targets = null)
+        => BuildRequest(TestActionType, "Run", mode, targets);
+
+    private static DeploymentPlanRequest BuildWindowsServiceRequest(
+        PlanMode mode = PlanMode.Preview,
+        IList<DeploymentTargetContext> targets = null)
+        => BuildRequest(SpecialVariables.ActionTypes.DeployWindowsService, "Deploy Windows Service", mode, targets);
+
+    private static DeploymentPlanRequest BuildRequest(
+        string actionType,
+        string actionName,
+        PlanMode mode,
+        IList<DeploymentTargetContext> targets)
     {
         var step = new DeploymentStepDto
         {
@@ -347,8 +464,8 @@ public class DeploymentPlannerStaticRequirementsTests
                 {
                     Id = 100,
                     ActionOrder = 1,
-                    ActionType = TestActionType,
-                    Name = "Run"
+                    ActionType = actionType,
+                    Name = actionName
                 }
             }
         };


### PR DESCRIPTION
## Summary

- Branch: `codex/windows-service-capability-tests`.
- Added concrete Windows Service planner/static-requirement coverage using the real `WindowsServiceDeployActionHandler`: Windows + PowerShell passes, non-Windows blocks, missing PowerShell blocks, cold cache allows, and execute mode throws.
- Added executor capability-filter regression for `Squid.DeployWindowsService`: invalid dispatch is skipped before handler resolution, renderer, or execution strategy.
- Marked OpenSpec 5.1-5.4 complete locally; `openspec/` is ignored, so this is only local progress tracking.

## Test plan

- [x] Focused unit tests: 61 passed.
  - `WindowsServiceDeployActionHandlerTests`
  - `WindowsServiceDeployScriptBuilderTests`
  - `DeploymentPlannerStaticRequirementsTests`
  - `ExecuteStepsPhaseCapabilityFilterTests`
- [x] `git diff --check`