### PR TITLE
Deploy windows service package flow

### DIFF
--- a/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
+++ b/src/Squid.Core/Resources/Deploy/WindowsService/DeployWindowsService.ps1
@@ -232,28 +232,15 @@ function Resolve-PackageRoot {
             return (Resolve-Path -LiteralPath $extractTo).Path
         }
 
-        if ([string]::IsNullOrWhiteSpace($extractTo)) {
-            $extractTo = Join-Path $sourceItem.DirectoryName ([System.IO.Path]::GetFileNameWithoutExtension($sourceItem.Name))
-        }
-
-        if ($purgeBeforeExtract -and (Test-Path -LiteralPath $extractTo)) {
-            Invoke-WithRetry -Description "Removing existing package extract directory '$extractTo'" -ScriptBlock {
-                Remove-Item -LiteralPath $extractTo -Recurse -Force
-            }
-        }
-
-        New-Item -ItemType Directory -Path $extractTo -Force | Out-Null
-        Invoke-WithRetry -Description "Expanding package '$($sourceItem.FullName)' to '$extractTo'" -ScriptBlock {
-            Expand-Archive -LiteralPath $sourceItem.FullName -DestinationPath $extractTo -Force
-        }
-        return (Resolve-Path -LiteralPath $extractTo).Path
+        throw "Windows service package source '$($sourceItem.FullName)' is a file. Deploy Windows Service expects package acquisition to provide an extracted package directory; do not pass a raw .nupkg/.zip archive to the action script."
     }
 
     if (-not [string]::IsNullOrWhiteSpace($extractTo) -and (Test-Path -LiteralPath $extractTo)) {
         return (Resolve-Path -LiteralPath $extractTo).Path
     }
 
-    return (Get-Location).Path
+    $workingDirectory = (Get-Location).Path
+    throw "No Windows service package source was available for this action. Squid expected either Squid.Action.WindowsService.Package.SourcePath, a package-references.json entry, a package-references directory, or an existing Squid.Action.WindowsService.Package.ExtractTo path. Working directory: '$workingDirectory'. Verify the release selected package is bound to this action name and that the Acquire Packages step completed."
 }
 
 function Resolve-ExecutablePath {

--- a/src/Squid.Core/Services/DeploymentExecution/Handlers/ActionHandlerRegistry.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Handlers/ActionHandlerRegistry.cs
@@ -1,3 +1,4 @@
+using Squid.Message.Constants;
 using Squid.Message.Models.Deployments.Process;
 
 namespace Squid.Core.Services.DeploymentExecution.Handlers;
@@ -33,6 +34,17 @@ public class ActionHandlerRegistry : IActionHandlerRegistry
     {
         var handler = Resolve(action);
 
-        return handler?.ExecutionScope ?? ExecutionScope.StepLevel;
+        if (handler != null)
+            return handler.ExecutionScope;
+
+        // Package acquisition is an internally injected synthetic step. It has no
+        // IActionHandler because ExecuteStepsPhase handles it directly.
+        if (string.Equals(action?.ActionType, SpecialVariables.ActionTypes.TentaclePackage, StringComparison.OrdinalIgnoreCase))
+            return ExecutionScope.StepLevel;
+
+        // An unregistered action must not be silently reclassified as server-only.
+        // Target-level is conservative: the pipeline will expose the missing handler
+        // as a configuration error instead of reporting a successful no-op deploy.
+        return ExecutionScope.TargetLevel;
     }
 }

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/Phases/6_ExecuteStepsPhase.Prepare.cs
@@ -1,5 +1,6 @@
 using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Exceptions;
 using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Core.Services.DeploymentExecution.Planning;
 using Squid.Core.VariableSubstitution;
@@ -51,11 +52,20 @@ public sealed partial class ExecuteStepsPhase
 
             if (handler == null)
             {
-                Log.Warning("[Deploy] No handler found for action {ActionType}, skipping", action.ActionType);
+                var message =
+                    $"No action handler is registered for action '{action.Name}' (type '{action.ActionType}') " +
+                    $"in step '{step.Name}'. Update the action type or deploy a Squid build that includes its handler.";
 
-                await lifecycle.EmitAsync(new ActionNoHandlerEvent(new DeploymentEventContext { StepDisplayOrder = stepDisplayOrder, ActionType = action.ActionType }), ct).ConfigureAwait(false);
+                Log.Error("[Deploy] {Message}", message);
 
-                continue;
+                await lifecycle.EmitAsync(new ActionNoHandlerEvent(new DeploymentEventContext
+                {
+                    StepDisplayOrder = stepDisplayOrder,
+                    ActionType = action.ActionType,
+                    Message = message
+                }), ct).ConfigureAwait(false);
+
+                throw new DeploymentValidationException(message);
             }
 
             await lifecycle.EmitAsync(new ActionRunningEvent(new DeploymentEventContext { StepDisplayOrder = stepDisplayOrder, ActionName = action.Name, MachineName = tc.Machine.Name }), ct).ConfigureAwait(false);
@@ -92,7 +102,18 @@ public sealed partial class ExecuteStepsPhase
         if (string.IsNullOrEmpty(actionName) || _ctx.SelectedPackages.Count == 0)
             return new List<PackageAcquisitionResult>();
 
-        return _ctx.SelectedPackages
+        var selectedActionNames = _ctx.SelectedPackages
+            .Select(p => p.ActionName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Log.Information(
+            "[Deploy] BuildPackageReferences called for action '{ActionName}'. Selected package action names: {SelectedActionNames}",
+            actionName,
+            selectedActionNames);
+
+        var resolved = _ctx.SelectedPackages
             .Where(p => string.Equals(p.ActionName, actionName, StringComparison.OrdinalIgnoreCase))
             .Select(p => p.PackageReferenceName)
             .Where(packageReferenceName => !string.IsNullOrWhiteSpace(packageReferenceName))
@@ -100,6 +121,16 @@ public sealed partial class ExecuteStepsPhase
             .Select(FindAcquiredPackage)
             .Where(package => package != null)
             .ToList();
+
+        if (resolved.Count == 0)
+        {
+            Log.Warning(
+                "[Deploy] No package references resolved for action '{ActionName}'. Selected package action names were: {SelectedActionNames}",
+                actionName,
+                selectedActionNames);
+        }
+
+        return resolved;
     }
 
     private PackageAcquisitionResult? FindAcquiredPackage(string packageReferenceName)

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Handlers/WindowsServiceDeployActionHandler.cs
@@ -13,6 +13,8 @@ public class WindowsServiceDeployActionHandler : IActionHandler
 {
     public string ActionType => SpecialVariables.ActionTypes.DeployWindowsService;
 
+    public ExecutionScope ExecutionScope => ExecutionScope.TargetLevel;
+
     public IReadOnlyDictionary<string, IReadOnlySet<string>> StaticRequirements { get; } =
         CapabilityRequirements.Empty
             .Require(CapabilityKeys.OsSlot, CapabilityKeys.Os.Windows)

--- a/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Targets/Tentacle/Transport/PackageReferenceScriptFileBridge.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.IO.Compression;
 using Halibut;
 using Squid.Core.Services.DeploymentExecution.Packages;
 using Squid.Message.Contracts.Tentacle;
@@ -18,7 +19,8 @@ internal static class PackageReferenceScriptFileBridge
 
         var files = new List<ScriptFile>();
         var manifest = new List<PackageReferenceManifestEntry>();
-        var usedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var usedPackageRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var usedFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var packageReference in packageReferences)
         {
@@ -30,14 +32,14 @@ internal static class PackageReferenceScriptFileBridge
             if (!File.Exists(packageReference.LocalPath))
                 throw new FileNotFoundException($"Acquired package '{packageReference.PackageId}' was not found at '{packageReference.LocalPath}'.", packageReference.LocalPath);
 
-            var packagePath = BuildPackageRelativePath(packageReference, usedPaths);
-            var packageBytes = File.ReadAllBytes(packageReference.LocalPath);
+            var packageRootPath = BuildPackageRelativePath(packageReference, usedPackageRoots);
+            var packageFiles = BuildExtractedPackageFiles(packageReference.LocalPath, packageRootPath, usedFilePaths);
 
-            files.Add(new ScriptFile(packagePath, DataStream.FromBytes(packageBytes), null));
+            files.AddRange(packageFiles);
             manifest.Add(new PackageReferenceManifestEntry(
                 packageReference.PackageId,
                 packageReference.Version,
-                packagePath,
+                packageRootPath,
                 packageReference.SizeBytes,
                 packageReference.Hash));
         }
@@ -57,8 +59,7 @@ internal static class PackageReferenceScriptFileBridge
 
         var packageId = SafePathSegment(packageReference.PackageId, "package");
         var version = SafePathSegment(packageReference.Version, "version");
-        var extension = SafeExtension(packageReference.LocalPath);
-        var baseName = $"{packageId}.{version}{extension}";
+        var baseName = $"{packageId}.{version}";
         var relativePath = Path.Combine(PackageReferencesDirectory, baseName).Replace('\\', '/');
 
         if (usedPaths == null)
@@ -70,12 +71,71 @@ internal static class PackageReferenceScriptFileBridge
         var suffix = 2;
         while (true)
         {
-            var candidate = Path.Combine(PackageReferencesDirectory, $"{packageId}.{version}.{suffix}{extension}").Replace('\\', '/');
+            var candidate = Path.Combine(PackageReferencesDirectory, $"{packageId}.{version}.{suffix}").Replace('\\', '/');
             if (usedPaths.Add(candidate))
                 return candidate;
 
             suffix++;
         }
+    }
+
+    private static List<ScriptFile> BuildExtractedPackageFiles(string localPath, string packageRootPath, ISet<string> usedFilePaths)
+    {
+        try
+        {
+            using var archive = ZipFile.OpenRead(localPath);
+            var files = new List<ScriptFile>();
+
+            foreach (var entry in archive.Entries)
+            {
+                if (string.IsNullOrEmpty(entry.Name))
+                    continue;
+
+                var entryPath = NormalizeArchiveEntryPath(entry.FullName);
+                if (string.IsNullOrEmpty(entryPath))
+                    continue;
+
+                var relativePath = $"{packageRootPath}/{entryPath}";
+                if (!usedFilePaths.Add(relativePath))
+                    throw new InvalidOperationException($"Package archive '{localPath}' contains duplicate entry '{entry.FullName}'.");
+
+                using var stream = entry.Open();
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+                files.Add(new ScriptFile(relativePath, DataStream.FromBytes(buffer.ToArray()), null));
+            }
+
+            if (files.Count == 0)
+                throw new InvalidOperationException($"Package archive '{localPath}' does not contain any files.");
+
+            return files;
+        }
+        catch (InvalidDataException ex)
+        {
+            throw new InvalidOperationException($"Package archive '{localPath}' could not be read as a zip/nupkg archive.", ex);
+        }
+    }
+
+    private static string NormalizeArchiveEntryPath(string entryPath)
+    {
+        var candidate = entryPath.Replace('\\', '/');
+        if (candidate.StartsWith("/", StringComparison.Ordinal) || candidate.Contains(":", StringComparison.Ordinal))
+            throw new InvalidOperationException($"Package archive contains unsafe entry path '{entryPath}'.");
+
+        var normalized = candidate.Trim('/');
+        if (string.IsNullOrEmpty(normalized))
+            return string.Empty;
+
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Any(segment =>
+                segment == "." ||
+                segment == ".." ||
+                Path.IsPathRooted(segment)))
+        {
+            throw new InvalidOperationException($"Package archive contains unsafe entry path '{entryPath}'.");
+        }
+
+        return string.Join('/', segments);
     }
 
     private static string SafePathSegment(string? value, string fallback)
@@ -89,21 +149,6 @@ internal static class PackageReferenceScriptFileBridge
         var sanitized = new string(chars).Trim('.', '_', '-');
 
         return string.IsNullOrEmpty(sanitized) ? fallback : sanitized;
-    }
-
-    private static string SafeExtension(string localPath)
-    {
-        var extension = Path.GetExtension(localPath);
-
-        if (string.IsNullOrWhiteSpace(extension))
-            return ".package";
-
-        var chars = extension
-            .Select(c => char.IsAsciiLetterOrDigit(c) || c == '.' ? c : '_')
-            .ToArray();
-        var sanitized = new string(chars);
-
-        return sanitized == "." ? ".package" : sanitized;
     }
 
     private sealed record PackageReferenceManifestEntry(

--- a/src/Squid.Core/Services/Deployments/Process/Action/DeploymentActionPropertyDataProvider.cs
+++ b/src/Squid.Core/Services/Deployments/Process/Action/DeploymentActionPropertyDataProvider.cs
@@ -31,7 +31,11 @@ public class DeploymentActionPropertyDataProvider : IDeploymentActionPropertyDat
 
     public async Task AddDeploymentActionPropertiesAsync(List<DeploymentActionProperty> properties, CancellationToken cancellationToken = default)
     {
-        await _repository.InsertAllAsync(properties, cancellationToken).ConfigureAwait(false);
+        var normalized = NormalizeProperties(properties);
+
+        if (normalized.Count == 0) return;
+
+        await _repository.InsertAllAsync(normalized, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -73,5 +77,49 @@ public class DeploymentActionPropertyDataProvider : IDeploymentActionPropertyDat
         return await _repository.Query<DeploymentActionProperty>()
             .Where(p => actionIds.Contains(p.ActionId))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static List<DeploymentActionProperty> NormalizeProperties(List<DeploymentActionProperty> properties)
+    {
+        if (properties == null || properties.Count == 0) return new List<DeploymentActionProperty>();
+
+        var normalized = new List<DeploymentActionProperty>();
+        var indexesByKey = new Dictionary<ActionPropertyKey, int>(ActionPropertyKeyComparer.Instance);
+
+        foreach (var property in properties)
+        {
+            if (property == null) continue;
+
+            var key = new ActionPropertyKey(property.ActionId, property.PropertyName);
+
+            if (indexesByKey.TryGetValue(key, out var index))
+            {
+                normalized[index].PropertyValue = property.PropertyValue;
+                continue;
+            }
+
+            indexesByKey[key] = normalized.Count;
+            normalized.Add(property);
+        }
+
+        return normalized;
+    }
+
+    private readonly record struct ActionPropertyKey(int ActionId, string PropertyName);
+
+    private sealed class ActionPropertyKeyComparer : IEqualityComparer<ActionPropertyKey>
+    {
+        public static readonly ActionPropertyKeyComparer Instance = new();
+
+        public bool Equals(ActionPropertyKey x, ActionPropertyKey y)
+        {
+            return x.ActionId == y.ActionId
+                   && string.Equals(x.PropertyName, y.PropertyName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(ActionPropertyKey obj)
+        {
+            return HashCode.Combine(obj.ActionId, StringComparer.OrdinalIgnoreCase.GetHashCode(obj.PropertyName ?? string.Empty));
+        }
     }
 }

--- a/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
+++ b/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
@@ -283,6 +283,9 @@ public partial class ReleaseService : IReleaseService
         DeploymentProcessSnapshotDto deploymentProcessSnapshot,
         List<CreateReleaseSelectedPackageDto> selectedPackages)
     {
+        if (deploymentProcessSnapshot?.Data?.StepSnapshots == null)
+            return;
+
         var windowsServiceActions = deploymentProcessSnapshot.Data.StepSnapshots
             .SelectMany(step => step.ActionSnapshots.Select(action => new
             {

--- a/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
+++ b/src/Squid.Core/Services/Deployments/Release/ReleaseService.cs
@@ -8,8 +8,10 @@ using Squid.Core.Services.Deployments.Project;
 using Squid.Core.Services.Deployments.Releases.Exceptions;
 using Squid.Core.Services.Deployments.Snapshots;
 using Squid.Message.Commands.Deployments.Release;
+using Squid.Message.Constants;
 using Squid.Message.Events.Deployments.Release;
 using Squid.Message.Models.Deployments.Release;
+using Squid.Message.Models.Deployments.Snapshots;
 using Squid.Message.Requests.Deployments.Release;
 
 namespace Squid.Core.Services.Deployments.Release;
@@ -125,6 +127,8 @@ public partial class ReleaseService : IReleaseService
         release.ProjectDeploymentProcessSnapshotId = deploymentProcessSnapshot.Id;
         
         await _releaseDataProvider.CreateReleaseAsync(release, forceSave: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        LogSelectedPackageActionNameComparison(release.Id, deploymentProcessSnapshot, command.SelectedPackages);
 
         await PersistSelectedPackagesAsync(release.Id, command.SelectedPackages, cancellationToken).ConfigureAwait(false);
 
@@ -255,9 +259,56 @@ public partial class ReleaseService : IReleaseService
                 FeedId = sp.FeedId,
                 PackageReferenceName = sp.PackageReferenceName ?? string.Empty,
                 Version = sp.Version ?? string.Empty
-            });
+            })
+            .ToList();
+
+        if (entities.Count == 0) return;
+
+        Log.Information(
+            "[Release] Persisting selected packages for release {ReleaseId}: {SelectedPackages}",
+            releaseId,
+            entities.Select(p => new
+            {
+                p.ActionName,
+                p.PackageReferenceName,
+                p.Version,
+                p.FeedId
+            }).ToList());
 
         await _releaseSelectedPackageDataProvider.InsertAllAsync(entities, ct).ConfigureAwait(false);
+    }
+
+    private static void LogSelectedPackageActionNameComparison(
+        int releaseId,
+        DeploymentProcessSnapshotDto deploymentProcessSnapshot,
+        List<CreateReleaseSelectedPackageDto> selectedPackages)
+    {
+        var windowsServiceActions = deploymentProcessSnapshot.Data.StepSnapshots
+            .SelectMany(step => step.ActionSnapshots.Select(action => new
+            {
+                StepName = step.Name,
+                action.Name,
+                action.ActionType
+            }))
+            .Where(action => string.Equals(
+                action.ActionType,
+                SpecialVariables.ActionTypes.DeployWindowsService,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (windowsServiceActions.Count == 0) return;
+
+        var selectedPackageActionNames = (selectedPackages ?? new List<CreateReleaseSelectedPackageDto>())
+            .Select(package => package.ActionName)
+            .Where(actionName => !string.IsNullOrWhiteSpace(actionName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Log.Information(
+            "[Release] Windows Service action/package action-name comparison for release {ReleaseId}: SnapshotActions={SnapshotActions}; SelectedPackageActionNames={SelectedPackageActionNames}",
+            releaseId,
+            windowsServiceActions,
+            selectedPackageActionNames);
     }
 
     private async Task ValidateChannelVersionRulesAsync(int channelId, List<CreateReleaseSelectedPackageDto> selectedPackages, CancellationToken ct)

--- a/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
@@ -3,6 +3,7 @@ using Squid.Core.Services.Deployments.Process.Action;
 using Squid.Core.Services.Deployments.Process.Step;
 using Squid.IntegrationTests.Helpers;
 using Squid.Message.Commands.Deployments.Process.Step;
+using Squid.Message.Constants;
 using Squid.Message.Events.Deployments.Step;
 using Squid.Message.Models.Deployments.Process;
 
@@ -145,6 +146,55 @@ public class DeploymentStepServiceTests : TestBase
             properties.Count.ShouldBe(2);
             properties.ShouldAllBe(p => p.ActionId == actionId);
             properties.ShouldAllBe(p => p.ActionId != 0);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task CreateStep_WithDuplicateActionProperties_DeduplicatesBeforePersisting()
+    {
+        var processId = await SeedProcessAsync();
+
+        var result = await Run<IDeploymentStepService, DeploymentStepCreatedEvent>(async service =>
+        {
+            var command = new CreateDeploymentStepCommand
+            {
+                ProcessId = processId,
+                Step = new CreateOrUpdateDeploymentStepModel
+                {
+                    Name = "Deploy Windows Service",
+                    StepType = "Action",
+                    Condition = "Success",
+                    StartTrigger = "",
+                    PackageRequirement = "",
+                    Actions =
+                    [
+                        new CreateOrUpdateDeploymentActionModel
+                        {
+                            Name = "Deploy Windows Service",
+                            ActionType = SpecialVariables.ActionTypes.DeployWindowsService,
+                            Properties =
+                            [
+                                new ActionPropertyModel { PropertyName = "Squid.Action.WindowsService.ServiceName", PropertyValue = "OldService" },
+                                new ActionPropertyModel { PropertyName = "squid.action.windowsservice.servicename", PropertyValue = "DemoWindowsService" },
+                                new ActionPropertyModel { PropertyName = "Squid.Action.WindowsService.ExecutablePath", PropertyValue = "Demo.WindowsService.exe" }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            return await service.CreateDeploymentStepAsync(command, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        var actionId = result.Data.Actions[0].Id;
+
+        await Run<IDeploymentActionPropertyDataProvider>(async provider =>
+        {
+            var properties = await provider.GetDeploymentActionPropertiesByActionIdAsync(actionId, CancellationToken.None).ConfigureAwait(false);
+
+            properties.Count.ShouldBe(2);
+            properties.ShouldContain(p => p.PropertyName == "Squid.Action.WindowsService.ServiceName" && p.PropertyValue == "DemoWindowsService");
+            properties.ShouldContain(p => p.PropertyName == "Squid.Action.WindowsService.ExecutablePath" && p.PropertyValue == "Demo.WindowsService.exe");
         }).ConfigureAwait(false);
     }
 

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceActionRegistrationTests.cs
@@ -1,9 +1,12 @@
 using System.Linq;
 using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Filtering;
+using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
 using Squid.Core.Services.DeploymentExecution.OpenClaw;
 using Squid.Core.Services.DeploymentExecution.Ssh;
 using Squid.Core.Services.DeploymentExecution.Tentacle;
+using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
 using Squid.Core.Services.DeploymentExecution.Transport;
 using Squid.Message.Constants;
 
@@ -87,5 +90,38 @@ public class WindowsServiceActionRegistrationTests
 
         foreach (var capability in unsupported)
             capability.SupportedActionTypes.ShouldNotContain(SpecialVariables.ActionTypes.DeployWindowsService);
+    }
+
+    [Fact]
+    public void DeployWindowsService_ResolvesAsTargetLevel()
+    {
+        IActionHandler handler = new WindowsServiceDeployActionHandler();
+        var registry = new ActionHandlerRegistry(new[] { handler });
+        var action = new Message.Models.Deployments.Process.DeploymentActionDto
+        {
+            ActionType = SpecialVariables.ActionTypes.DeployWindowsService
+        };
+
+        handler.ExecutionScope.ShouldBe(ExecutionScope.TargetLevel);
+        registry.ResolveScope(action).ShouldBe(ExecutionScope.TargetLevel);
+    }
+
+    [Fact]
+    public void DeployWindowsService_DoesNotMakeDeploymentServerOnly()
+    {
+        IActionHandler handler = new WindowsServiceDeployActionHandler();
+        var registry = new ActionHandlerRegistry(new[] { handler });
+        var steps = new List<Message.Models.Deployments.Process.DeploymentStepDto>
+        {
+            new()
+            {
+                Actions = new List<Message.Models.Deployments.Process.DeploymentActionDto>
+                {
+                    new() { ActionType = SpecialVariables.ActionTypes.DeployWindowsService }
+                }
+            }
+        };
+
+        RunOnServerEvaluator.IsEntireDeploymentServerOnly(steps, registry.ResolveScope).ShouldBeFalse();
     }
 }

--- a/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/DeploymentExecution/Targets/Tentacle/WindowsServiceDeployScriptBuilderTests.cs
@@ -44,7 +44,7 @@ public class WindowsServiceDeployScriptBuilderTests
     }
 
     [Fact]
-    public void Build_EmbeddedScriptStopsExistingService_BeforePackageExtraction()
+    public void Build_EmbeddedScriptStopsExistingService_BeforePackageDirectoryCopy()
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
 
@@ -56,11 +56,11 @@ public class WindowsServiceDeployScriptBuilderTests
         stopExistingServiceIndex.ShouldBeGreaterThanOrEqualTo(0);
         packageRootIndex.ShouldBeGreaterThanOrEqualTo(0);
         stopExistingServiceIndex.ShouldBeLessThan(packageRootIndex,
-            customMessage: "Existing services must be stopped before package purge/extract touches the install directory.");
+            customMessage: "Existing services must be stopped before package copy touches the install directory.");
     }
 
     [Fact]
-    public void Build_EmbeddedScriptWaitsForStoppedServiceProcess_BeforePackageExtraction()
+    public void Build_EmbeddedScriptWaitsForStoppedServiceProcess_BeforePackageDirectoryCopy()
     {
         var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
 
@@ -72,7 +72,7 @@ public class WindowsServiceDeployScriptBuilderTests
         waitProcessCallIndex.ShouldBeGreaterThanOrEqualTo(0);
         packageRootIndex.ShouldBeGreaterThanOrEqualTo(0);
         waitProcessCallIndex.ShouldBeLessThan(packageRootIndex,
-            customMessage: "Existing service processes must exit before package purge/extract can safely replace locked binaries.");
+            customMessage: "Existing service processes must exit before package copy can safely replace locked binaries.");
     }
 
     [Fact]
@@ -83,7 +83,18 @@ public class WindowsServiceDeployScriptBuilderTests
         script.ShouldContain("function Invoke-WithRetry");
         script.ShouldContain("Invoke-WithRetry -Description \"Removing existing package extract directory '$extractTo'\"");
         script.ShouldContain("Invoke-WithRetry -Description \"Copying package content from '$($sourceItem.FullName)' to '$extractTo'\"");
-        script.ShouldContain("Invoke-WithRetry -Description \"Expanding package '$($sourceItem.FullName)' to '$extractTo'\"");
+        script.ShouldNotContain("Expand-Archive");
+        script.ShouldContain("Deploy Windows Service expects package acquisition to provide an extracted package directory");
+    }
+
+    [Fact]
+    public void Build_EmbeddedScriptFailsWhenNoPackageSourceIsAvailable()
+    {
+        var script = WindowsServiceDeployScriptBuilder.Build(BuildAction());
+
+        script.ShouldContain("No Windows service package source was available for this action.");
+        script.ShouldContain("Verify the release selected package is bound to this action name");
+        script.ShouldNotContain("return (Get-Location).Path");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/ActionHandlerRegistryTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/ActionHandlerRegistryTests.cs
@@ -132,7 +132,15 @@ public class ActionHandlerRegistryTests
     }
 
     [Fact]
-    public void ResolveScope_UnknownAction_DefaultsToStepLevel()
+    public void ResolveScope_UnknownAction_DefaultsToTargetLevel()
+    {
+        var registry = new ActionHandlerRegistry(Enumerable.Empty<IActionHandler>());
+
+        registry.ResolveScope(CreateAction("Squid.UnknownAction")).ShouldBe(ExecutionScope.TargetLevel);
+    }
+
+    [Fact]
+    public void ResolveScope_SyntheticPackageAcquisitionAction_IsStepLevel()
     {
         var registry = new ActionHandlerRegistry(Enumerable.Empty<IActionHandler>());
 

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/HalibutMachineExecutionStrategyTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using Halibut;
 using Squid.Core.Persistence.Entities.Deployments;
@@ -285,7 +286,11 @@ public class HalibutMachineExecutionStrategyTests
             .ReturnsAsync(NewStartResponse("package-ref"));
 
         var packagePath = Path.Combine(Path.GetTempPath(), $"Order.Worker.{Guid.NewGuid():N}.nupkg");
-        await File.WriteAllBytesAsync(packagePath, new byte[] { 1, 2, 3 }, CancellationToken.None);
+        CreatePackageArchive(packagePath, new Dictionary<string, string>
+        {
+            ["Demo.WindowsService.exe"] = "fake executable",
+            ["appsettings.json"] = "{}"
+        });
 
         try
         {
@@ -299,7 +304,8 @@ public class HalibutMachineExecutionStrategyTests
 
             capturedCommand.ShouldNotBeNull();
             capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references.json");
-            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3.nupkg");
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3/Demo.WindowsService.exe");
+            capturedCommand.Files.Select(f => f.Name).ShouldContain("package-references/Order.Worker.1.2.3/appsettings.json");
 
             var manifest = capturedCommand.Files.Single(f => f.Name == "package-references.json");
             var manifestPath = Path.Combine(Path.GetTempPath(), $"package-references-{Guid.NewGuid():N}.json");
@@ -310,7 +316,7 @@ public class HalibutMachineExecutionStrategyTests
                 var manifestJson = await File.ReadAllTextAsync(manifestPath, CancellationToken.None);
                 manifestJson.ShouldContain("\"PackageId\":\"Order.Worker\"");
                 manifestJson.ShouldContain("\"Version\":\"1.2.3\"");
-                manifestJson.ShouldContain("\"PackagePath\":\"package-references/Order.Worker.1.2.3.nupkg\"");
+                manifestJson.ShouldContain("\"PackagePath\":\"package-references/Order.Worker.1.2.3\"");
             }
             finally
             {
@@ -320,6 +326,19 @@ public class HalibutMachineExecutionStrategyTests
         finally
         {
             File.Delete(packagePath);
+        }
+    }
+
+    private static void CreatePackageArchive(string path, IReadOnlyDictionary<string, string> files)
+    {
+        using var stream = File.Create(path);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+
+        foreach (var file in files)
+        {
+            var entry = archive.CreateEntry(file.Key);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(file.Value);
         }
     }
 

--- a/tests/Squid.UnitTests/Services/Deployments/Process/DeploymentActionPropertyDataProviderTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Process/DeploymentActionPropertyDataProviderTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Deployments.Process.Action;
+
+namespace Squid.UnitTests.Services.Deployments.Process;
+
+public class DeploymentActionPropertyDataProviderTests
+{
+    [Fact]
+    public async Task AddDeploymentActionPropertiesAsync_DeduplicatesByActionIdAndPropertyName_LastValueWins()
+    {
+        var repository = new Mock<IRepository>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var inserted = new List<DeploymentActionProperty>();
+
+        repository
+            .Setup(r => r.InsertAllAsync(It.IsAny<IEnumerable<DeploymentActionProperty>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<DeploymentActionProperty>, CancellationToken>((entities, _) => inserted = entities.ToList())
+            .Returns(Task.CompletedTask);
+
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var provider = new DeploymentActionPropertyDataProvider(repository.Object, unitOfWork.Object);
+
+        await provider.AddDeploymentActionPropertiesAsync(
+            [
+                new DeploymentActionProperty { ActionId = 10, PropertyName = "Squid.Action.WindowsService.ServiceName", PropertyValue = "old-service" },
+                new DeploymentActionProperty { ActionId = 10, PropertyName = "squid.action.windowsservice.servicename", PropertyValue = "new-service" },
+                new DeploymentActionProperty { ActionId = 10, PropertyName = "Squid.Action.WindowsService.ExecutablePath", PropertyValue = "Demo.WindowsService.exe" },
+                new DeploymentActionProperty { ActionId = 11, PropertyName = "Squid.Action.WindowsService.ServiceName", PropertyValue = "other-action-service" }
+            ],
+            CancellationToken.None);
+
+        inserted.Count.ShouldBe(3);
+        inserted.ShouldContain(p => p.ActionId == 10
+                                    && p.PropertyName == "Squid.Action.WindowsService.ServiceName"
+                                    && p.PropertyValue == "new-service");
+        inserted.ShouldContain(p => p.ActionId == 10
+                                    && p.PropertyName == "Squid.Action.WindowsService.ExecutablePath"
+                                    && p.PropertyValue == "Demo.WindowsService.exe");
+        inserted.ShouldContain(p => p.ActionId == 11
+                                    && p.PropertyName == "Squid.Action.WindowsService.ServiceName"
+                                    && p.PropertyValue == "other-action-service");
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Branch: `codex/deploy-windows-service-package-flow`
- Add target-level execution support for `Squid.DeployWindowsService`, so the step runs on deployment targets instead of being treated as server-only.
- Fail loudly when an action handler is missing, instead of silently skipping unsupported actions during deployment execution.
- Fix duplicate `DeploymentActionProperty` tracking by normalizing duplicate action properties before insert.
- Add Release/package diagnostics to compare `SelectedPackages.ActionName` with deployment process snapshot action names.
- Add `BuildPackageReferences(actionName)` diagnostics so package-reference mismatches are visible in deployment logs.
- Update Tentacle package reference handling to send extracted package contents instead of attaching raw `.nupkg` files.
- Update `DeployWindowsService.ps1` to consume an extracted package directory and reject raw `.nupkg/.zip` archive input.
- Keep the Windows Service package layout expectation as package-root executable, for example `Demo.WindowsService.exe` at nupkg root.
- Current changes are on the new branch working tree and are not committed yet.

## Test plan

- [x] Focused Tentacle/package-reference + Windows Service script tests: `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --no-restore --filter "FullyQualifiedName~HalibutMachineExecutionStrategyTests|FullyQualifiedName~WindowsServiceDeployScriptBuilderTests" -m:1 /nodeReuse:false`
- [x] Result: 38 passed, 0 failed, 0 skipped.
- [x] `git diff --check`
- [x] Earlier focused package-reference resolution tests passed.
- [x] Earlier Windows Service deploy script builder tests passed.
- [x] Earlier duplicate deployment action property handling tests passed.
- [x] Earlier process/save integration coverage passed.
- [ ] Full test suite not run in this turn.