### PR TITLE
Fix Windows Calamari path resolution

### DIFF
--- a/.github/workflows/tentacle-linux-e2e.yml
+++ b/.github/workflows/tentacle-linux-e2e.yml
@@ -24,7 +24,7 @@ on:
       test_filter:
         description: "xUnit --filter for the Squid.LinuxTentacleE2ETests step"
         required: false
-        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleInstallScriptE2E|Category=LinuxTentacleBinaryE2E"
+        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleInstallScriptE2E|Category=LinuxTentacleBinaryE2E|Category=LinuxTentacleCalamariLookupE2E"
 
 permissions:
   contents: read
@@ -59,7 +59,7 @@ jobs:
       - name: Run Squid.LinuxTentacleE2ETests
         run: |
           FILTER="${{ github.event.inputs.test_filter }}"
-          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E"; fi
+          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxServiceFixtureE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleInstallScriptE2E|Category=LinuxTentacleBinaryE2E|Category=LinuxTentacleCalamariLookupE2E"; fi
           dotnet test tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj \
             --configuration Release --no-restore \
             --filter "$FILTER" \

--- a/.github/workflows/tentacle-linux-smoke-e2e.yml
+++ b/.github/workflows/tentacle-linux-smoke-e2e.yml
@@ -33,7 +33,7 @@ on:
       test_filter:
         description: "xUnit --filter override for the smoke subset"
         required: false
-        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxTentacleUpgradeLifecycleE2E"
+        default: "Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleCalamariLookupE2E"
 
 permissions:
   contents: read
@@ -65,7 +65,7 @@ jobs:
           files=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json files --jq '.files[].path')
           echo "Changed files:"; printf '%s\n' "$files"
 
-          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-linux-tentacle\.sh|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.LinuxTentacleE2ETests/|\.github/workflows/tentacle-linux-smoke-e2e\.yml)'; then
+          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-linux-tentacle\.sh|src/Squid\.Core/Services/Machines/Upgrade/|src/Squid\.Core/TentaclesScripts/|deploy/scripts/install-tentacle\.sh|tests/Squid\.LinuxTentacleE2ETests/|\.github/workflows/tentacle-linux-smoke-e2e\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "-> relevant=true (versioned-upgrade paths changed)"
           else
@@ -105,7 +105,7 @@ jobs:
       - name: Run Linux versioned-upgrade smoke subset
         run: |
           FILTER="${{ github.event.inputs.test_filter }}"
-          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxTentacleUpgradeLifecycleE2E"; fi
+          if [ -z "$FILTER" ]; then FILTER="Category=LinuxTentacleUpgradeScriptE2E|Category=LinuxTentacleUpgradeLifecycleE2E|Category=LinuxTentacleCalamariLookupE2E"; fi
           dotnet test tests/Squid.LinuxTentacleE2ETests/Squid.LinuxTentacleE2ETests.csproj \
             --configuration Release --no-restore \
             --filter "$FILTER" \

--- a/.github/workflows/tentacle-windows-e2e.yml
+++ b/.github/workflows/tentacle-windows-e2e.yml
@@ -31,7 +31,7 @@ on:
       upgrade_test_filter:
         description: "xUnit --filter for the Squid.WindowsTentacleE2ETests step (defaults to wrapper + service categories)"
         required: false
-        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E"
+        default: "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E|Category=CalamariLookupE2E"
 
 permissions:
   contents: read
@@ -130,7 +130,7 @@ jobs:
       - name: Run Squid.WindowsTentacleE2ETests
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E" }
+          $filter = if ("${{ github.event.inputs.upgrade_test_filter }}") { "${{ github.event.inputs.upgrade_test_filter }}" } else { "Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsServiceHostE2E|Category=StubSquidServerE2E|Category=TentacleRegisterE2E|Category=TentacleDeployE2E|Category=TentacleUpgradeE2E|Category=TentacleInstallScriptE2E|Category=TentacleMultiInstanceE2E|Category=TentacleCapabilitiesE2E|Category=TentacleUpgradeLifecycleE2E|Category=TentacleDiagnosticE2E|Category=WindowsTentacleBinaryE2E|Category=IISDeployE2E|Category=WindowsServiceDeployE2E|Category=CalamariLookupE2E" }
           $resultsDir = Join-Path $env:RUNNER_TEMP "windows-e2e-results"
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `

--- a/.github/workflows/tentacle-windows-smoke-e2e.yml
+++ b/.github/workflows/tentacle-windows-smoke-e2e.yml
@@ -79,7 +79,7 @@ jobs:
           # upgrade script, the Windows service deploy payload/handler, the
           # server-side upgrade strategy, the Windows E2E project, and this
           # workflow itself).
-          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|tests/Squid\.WindowsTentacleE2E\.CalamariShim/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
+          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|src/Squid\.Core/TentaclesScripts/|tests/Squid\.WindowsTentacleE2ETests/|tests/Squid\.WindowsTentacleE2E\.CalamariShim/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "-> relevant=true (Tentacle paths changed)"
           else

--- a/.github/workflows/tentacle-windows-smoke-e2e.yml
+++ b/.github/workflows/tentacle-windows-smoke-e2e.yml
@@ -41,7 +41,7 @@ on:
       test_filter:
         description: "xUnit --filter override for the smoke subset"
         required: false
-        default: "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E"
+        default: "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E|Category=CalamariLookupE2E"
 
 permissions:
   contents: read
@@ -79,7 +79,7 @@ jobs:
           # upgrade script, the Windows service deploy payload/handler, the
           # server-side upgrade strategy, the Windows E2E project, and this
           # workflow itself).
-          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
+          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|tests/Squid\.WindowsTentacleE2ETests/|tests/Squid\.WindowsTentacleE2E\.CalamariShim/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "-> relevant=true (Tentacle paths changed)"
           else
@@ -122,7 +122,7 @@ jobs:
       - name: Run Windows lifecycle smoke subset
         shell: pwsh
         run: |
-          $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E" }
+          $filter = if ("${{ github.event.inputs.test_filter }}") { "${{ github.event.inputs.test_filter }}" } else { "Category=WindowsServiceHostE2E|Category=TentacleUpgradeLifecycleE2E|Category=WindowsUpgradeShaVerifyE2E|Category=WindowsUpgradeWrapperE2E|Category=WindowsUpgradeServiceE2E|Category=TentacleInstallScriptE2E|Category=WindowsServiceDeployE2E|Category=CalamariLookupE2E" }
           $resultsDir = Join-Path $env:RUNNER_TEMP "windows-lifecycle-smoke-results"
           dotnet test tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj `
             --configuration Release --no-restore `

--- a/.github/workflows/tentacle-windows-smoke-e2e.yml
+++ b/.github/workflows/tentacle-windows-smoke-e2e.yml
@@ -79,7 +79,7 @@ jobs:
           # upgrade script, the Windows service deploy payload/handler, the
           # server-side upgrade strategy, the Windows E2E project, and this
           # workflow itself).
-          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|src/Squid\.Core/TentaclesScripts/|tests/Squid\.WindowsTentacleE2ETests/|tests/Squid\.WindowsTentacleE2E\.CalamariShim/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
+          if printf '%s\n' "$files" | grep -qE '^(src/Squid\.Tentacle/|src/Squid\.Core/Resources/Upgrade/upgrade-windows-tentacle\.ps1|src/Squid\.Core/Resources/Deploy/WindowsService/|src/Squid\.Core/Services/DeploymentExecution/(Constants/WindowsServiceDeployProperties\.cs|Infrastructure/|Targets/Tentacle/Handlers/WindowsServiceDeploy)|deploy/scripts/install-tentacle\.ps1|src/Squid\.Core/Services/Machines/Upgrade/|src/Squid\.Core/TentaclesScripts/|tests/Squid\.WindowsTentacleE2ETests/|tests/Squid\.WindowsTentacleE2E\.CalamariShim/|\.github/workflows/tentacle-windows-smoke-e2e\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "-> relevant=true (Tentacle paths changed)"
           else

--- a/deploy/scripts/install-tentacle.sh
+++ b/deploy/scripts/install-tentacle.sh
@@ -297,7 +297,7 @@ fi
 
 # Make binaries executable. Calamari is spawned by Tentacle at runtime, so it also needs +x.
 chmod +x "$BIN_DIR/Squid.Tentacle"
-[ -f "$BIN_DIR/Squid.Calamari" ] && chmod +x "$BIN_DIR/Squid.Calamari"
+[ -f "$BIN_DIR/squid-calamari" ] && chmod +x "$BIN_DIR/squid-calamari"
 
 # Well-known-name symlink at the install root. Stable across upgrades — for versioned
 # installs it resolves through `current`, so the path survives a version swap.

--- a/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
+++ b/src/Squid.Core/Resources/Upgrade/upgrade-linux-tentacle.sh
@@ -621,7 +621,7 @@ if [ "$IS_VERSIONED" = "1" ]; then
     fi
 
     sudo chmod +x "$NEW_VER_DIR/Squid.Tentacle"
-    [ -f "$NEW_VER_DIR/Squid.Calamari" ] && sudo chmod +x "$NEW_VER_DIR/Squid.Calamari"
+    [ -f "$NEW_VER_DIR/squid-calamari" ] && sudo chmod +x "$NEW_VER_DIR/squid-calamari"
 
     if id "$SERVICE_USER" >/dev/null 2>&1; then
       sudo chown -R "$SERVICE_USER:$SERVICE_USER" "$NEW_VER_DIR" 2>/dev/null || true
@@ -668,7 +668,7 @@ elif [ "$INSTALL_METHOD" = "tarball" ]; then
   fi
 
   sudo chmod +x "$INSTALL_DIR/Squid.Tentacle"
-  [ -f "$INSTALL_DIR/Squid.Calamari" ] && sudo chmod +x "$INSTALL_DIR/Squid.Calamari"
+  [ -f "$INSTALL_DIR/squid-calamari" ] && sudo chmod +x "$INSTALL_DIR/squid-calamari"
   sudo ln -sf "$INSTALL_DIR/Squid.Tentacle" "$INSTALL_DIR/squid-tentacle"
   sudo ln -sf "$INSTALL_DIR/squid-tentacle" /usr/local/bin/squid-tentacle 2>/dev/null || true
 

--- a/src/Squid.Core/TentaclesScripts/DeployByCalamari.ps1
+++ b/src/Squid.Core/TentaclesScripts/DeployByCalamari.ps1
@@ -14,17 +14,13 @@ if ($env:OS -eq 'Windows_NT' -and -not [string]::IsNullOrWhiteSpace($env:Program
                 }
             }
         } catch {
-            Write-Verbose "Could not read Tentacle install-info.json: $($_.Exception.Message)"
+            Write-Warning "Could not read Tentacle install-info.json: $($_.Exception.Message)"
         }
     }
 }
 
 if (-not $squidCalamari) {
-    $squidCalamariCommand = if ($env:OS -eq 'Windows_NT') {
-        Get-Command -Name 'squid-calamari.exe' -CommandType Application -ErrorAction SilentlyContinue
-    } else {
-        Get-Command -Name 'squid-calamari' -CommandType Application -ErrorAction SilentlyContinue
-    }
+    $squidCalamariCommand = Get-Command -Name 'squid-calamari' -CommandType Application -ErrorAction SilentlyContinue
 
     if ($squidCalamariCommand) {
         $squidCalamari = $squidCalamariCommand.Path

--- a/src/Squid.Core/TentaclesScripts/DeployByCalamari.ps1
+++ b/src/Squid.Core/TentaclesScripts/DeployByCalamari.ps1
@@ -1,7 +1,38 @@
-# 检查 squid-calamari 是否存在（Kubernetes Agent / host runtime 需提供）
-$squidCalamari = Get-Command "squid-calamari" -ErrorAction SilentlyContinue
-if ($null -eq $squidCalamari) {
-    Write-Error "squid-calamari not found in PATH"
+# Windows Tentacle installation records the active binary under ProgramData.
+# Prefer its sibling bundled Calamari so deployment does not depend on machine PATH.
+$squidCalamari = $null
+if ($env:OS -eq 'Windows_NT' -and -not [string]::IsNullOrWhiteSpace($env:ProgramData)) {
+    $installInfoPath = Join-Path $env:ProgramData 'Squid\Tentacle\install-info.json'
+
+    if (Test-Path -LiteralPath $installInfoPath) {
+        try {
+            $installInfo = Get-Content -LiteralPath $installInfoPath -Raw | ConvertFrom-Json
+            if (-not [string]::IsNullOrWhiteSpace($installInfo.BinaryPath)) {
+                $candidate = Join-Path (Split-Path -Parent $installInfo.BinaryPath) 'squid-calamari.exe'
+                if (Test-Path -LiteralPath $candidate) {
+                    $squidCalamari = $candidate
+                }
+            }
+        } catch {
+            Write-Verbose "Could not read Tentacle install-info.json: $($_.Exception.Message)"
+        }
+    }
+}
+
+if (-not $squidCalamari) {
+    $squidCalamariCommand = if ($env:OS -eq 'Windows_NT') {
+        Get-Command -Name 'squid-calamari.exe' -CommandType Application -ErrorAction SilentlyContinue
+    } else {
+        Get-Command -Name 'squid-calamari' -CommandType Application -ErrorAction SilentlyContinue
+    }
+
+    if ($squidCalamariCommand) {
+        $squidCalamari = $squidCalamariCommand.Path
+    }
+}
+
+if (-not $squidCalamari) {
+    Write-Error "Bundled squid-calamari was not found beside the installed Tentacle, and no squid-calamari command was found in PATH."
     Exit 1
 }
 
@@ -27,4 +58,4 @@ if ("{{SensitiveVariableFile}}" -ne "") {
 }
 
 # 调用 squid-calamari 原生命令（--file 支持 yaml/zip/nupkg）
-& $squidCalamari.Source @commandArgs
+& $squidCalamari @commandArgs

--- a/src/Squid.Core/TentaclesScripts/DeployByCalamari.sh
+++ b/src/Squid.Core/TentaclesScripts/DeployByCalamari.sh
@@ -3,7 +3,22 @@ set -e
 
 export PATH="/squid/bin:$PATH"
 
-if ! command -v squid-calamari &> /dev/null; then
+squidCalamari=""
+tentacleCommand="$(command -v squid-tentacle 2>/dev/null || true)"
+
+if [ -n "$tentacleCommand" ]; then
+    resolvedTentacle="$(readlink -f "$tentacleCommand" 2>/dev/null || printf '%s' "$tentacleCommand")"
+    bundledCalamari="$(dirname "$resolvedTentacle")/squid-calamari"
+    if [ -x "$bundledCalamari" ]; then
+        squidCalamari="$bundledCalamari"
+    fi
+fi
+
+if [ -z "$squidCalamari" ]; then
+    squidCalamari="$(command -v squid-calamari 2>/dev/null || true)"
+fi
+
+if [ -z "$squidCalamari" ]; then
     echo "squid-calamari not found in PATH" >&2
     exit 1
 fi
@@ -19,4 +34,4 @@ if [ -n "{{SensitiveVariableFile}}" ]; then
     ARGS+=("--sensitive={{SensitiveVariableFile}}" "--password={{SensitiveVariablePassword}}")
 fi
 
-squid-calamari "${ARGS[@]}"
+"$squidCalamari" "${ARGS[@]}"

--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -1354,7 +1354,7 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
     {
         var psi = new ProcessStartInfo
         {
-            FileName = "squid-calamari",
+            FileName = ResolveCalamariExecutable(),
             WorkingDirectory = workDir,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -1392,6 +1392,24 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
 
         return psi;
     }
+
+    internal static string ResolveCalamariExecutable(string tentacleDirectory, Func<string, bool> fileExists)
+    {
+        ArgumentNullException.ThrowIfNull(fileExists);
+
+        var bundledFileName = OperatingSystem.IsWindows() ? "squid-calamari.exe" : "squid-calamari";
+        if (!string.IsNullOrWhiteSpace(tentacleDirectory))
+        {
+            var bundledPath = Path.Combine(tentacleDirectory, bundledFileName);
+            if (fileExists(bundledPath))
+                return bundledPath;
+        }
+
+        return bundledFileName;
+    }
+
+    private static string ResolveCalamariExecutable() =>
+        ResolveCalamariExecutable(AppContext.BaseDirectory, File.Exists);
 
     /// <summary>
     /// Runs <c>python3 script.py</c>. <c>python3</c> must be on PATH; the

--- a/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
+++ b/src/Squid.Tentacle/ScriptExecution/LocalScriptService.cs
@@ -1350,11 +1350,12 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
         string? sensitivePassword,
         bool sensitiveCiphertextExists,
         ScriptType syntax,
-        string[] arguments)
+        string[] arguments,
+        string? tentacleDirectory = null)
     {
         var psi = new ProcessStartInfo
         {
-            FileName = ResolveCalamariExecutable(),
+            FileName = ResolveCalamariExecutable(tentacleDirectory ?? AppContext.BaseDirectory, File.Exists),
             WorkingDirectory = workDir,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -1407,9 +1408,6 @@ public class LocalScriptService : IScriptService, ITentacleScriptBackend, IGrace
 
         return bundledFileName;
     }
-
-    private static string ResolveCalamariExecutable() =>
-        ResolveCalamariExecutable(AppContext.BaseDirectory, File.Exists);
 
     /// <summary>
     /// Runs <c>python3 script.py</c>. <c>python3</c> must be on PATH; the

--- a/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxInstallScriptContext.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/Infrastructure/LinuxInstallScriptContext.cs
@@ -65,21 +65,22 @@ public sealed class LinuxInstallScriptContext : IDisposable
     /// install-tentacle.sh expects this exact shape: <c>tar xzf "$ARCHIVE"
     /// -C "$INSTALL_DIR"</c> with no <c>--strip-components</c>.</para>
     /// </summary>
-    public byte[] BuildInstallTarGz(string version)
+    public byte[] BuildInstallTarGz(string version, string calamariScript = null)
     {
         var binaryBytes = File.ReadAllBytes(TestServiceScript);
 
-        // Single entry: Squid.Tentacle (the placeholder binary).
-        // No version.txt needed — install-tentacle.sh doesn't read it
-        // (only the upgrade flow's marker mechanism does). Keeping the
-        // tarball minimal matches what the production release pipeline
-        // ships for fresh installs.
-        var entries = new (string Name, byte[] Content)[]
+        // The placeholder reports its version from version.txt so the real
+        // installer follows the production versioned-layout branch.
+        var entries = new List<(string Name, byte[] Content)>
         {
-            ("Squid.Tentacle", binaryBytes)
+            ("Squid.Tentacle", binaryBytes),
+            ("version.txt", System.Text.Encoding.UTF8.GetBytes(version))
         };
 
-        return BuildTarGz(entries);
+        if (calamariScript != null)
+            entries.Add(("squid-calamari", System.Text.Encoding.UTF8.GetBytes(calamariScript)));
+
+        return BuildTarGz(entries.ToArray());
     }
 
     /// <summary>

--- a/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/LinuxTentacleE2ECategories.cs
@@ -78,4 +78,11 @@ public static class LinuxTentacleE2ECategories
     /// cleanup via the fixture's IDisposable per Rule 12.3.</para>
     /// </summary>
     public const string InstallScript = "LinuxTentacleInstallScriptE2E";
+
+    /// <summary>
+    /// E2E coverage for resolving the Calamari binary bundled beside a native
+    /// Linux Tentacle installation. The test runs the production installer and
+    /// rendered deployment template with Calamari absent from PATH.
+    /// </summary>
+    public const string CalamariLookup = "LinuxTentacleCalamariLookupE2E";
 }

--- a/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
+++ b/tests/Squid.LinuxTentacleE2ETests/TentacleLinuxInstallScriptE2ETests.cs
@@ -27,6 +27,100 @@ namespace Squid.LinuxTentacleE2ETests;
 [Collection(LinuxTentacleHostStateCollection.Name)]
 public sealed class TentacleLinuxInstallScriptE2ETests
 {
+    [Fact]
+    [Trait("Category", LinuxTentacleE2ECategories.CalamariLookup)]
+    public void CalamariTemplate_NativeInstall_UsesBundledSiblingWithoutCalamariOnPath()
+    {
+        if (!LinuxInstallScriptContext.IsAvailable) return;
+
+        using var ctx = new LinuxInstallScriptContext();
+        var executionDir = Path.Combine(Path.GetTempPath(), $"squid-calamari-template-{Guid.NewGuid():N}");
+
+        try
+        {
+            const string version = "1.6.0-calamari-path";
+            const string calamariShim = """
+                #!/usr/bin/env bash
+                set -euo pipefail
+                printf 'ProcessPath:%s\nArgs:%s\n' "$0" "$*" > "$SQUID_CALAMARI_E2E_MARKER"
+                """;
+            ctx.Mirror.StagePreBuiltArchive(ctx.BuildInstallTarGz(version, calamariShim));
+
+            var (installExit, installOutput) = ctx.RunInstallScript(version);
+            installExit.ShouldBe(0,
+                customMessage: $"native install MUST succeed before rendering the Calamari template. output:\n{installOutput}");
+
+            var bundledCalamari = Path.Combine(ctx.InstallDir, "versions", version, "squid-calamari");
+            File.Exists(bundledCalamari).ShouldBeTrue(
+                customMessage: "the installed version directory must contain the bundled Calamari binary");
+            File.GetUnixFileMode(bundledCalamari).HasFlag(UnixFileMode.UserExecute).ShouldBeTrue(
+                customMessage: "install-tentacle.sh must mark the bundled squid-calamari executable");
+
+            Directory.CreateDirectory(executionDir);
+            var toolsDirectory = Path.Combine(executionDir, "tools");
+            Directory.CreateDirectory(toolsDirectory);
+            var kubectlPath = Path.Combine(toolsDirectory, "kubectl");
+            File.WriteAllText(kubectlPath, "#!/usr/bin/env bash\nexit 0\n");
+            File.SetUnixFileMode(kubectlPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            File.CreateSymbolicLink(
+                Path.Combine(toolsDirectory, "squid-tentacle"),
+                Path.Combine(ctx.InstallDir, "squid-tentacle"));
+
+            var markerPath = Path.Combine(executionDir, "calamari-marker.txt");
+            var packagePath = Path.Combine(executionDir, "package.yaml");
+            var variablesPath = Path.Combine(executionDir, "variables.json");
+            var sensitiveVariablesPath = Path.Combine(executionDir, "sensitive-variables.json");
+            var scriptPath = Path.Combine(executionDir, "resolve-calamari.sh");
+            File.WriteAllText(packagePath, "apiVersion: v1\n");
+            File.WriteAllText(variablesPath, "{}");
+            File.WriteAllText(sensitiveVariablesPath, "{}");
+
+            var payload = new Squid.Core.Services.DeploymentExecution.Infrastructure.CalamariPayload
+            {
+                TemplateBody = Squid.Core.Services.Common.UtilService.GetEmbeddedScriptContent("DeployByCalamari.sh"),
+                SensitivePassword = "test-sensitive-password"
+            };
+            var renderedTemplate = payload.FillTemplate(packagePath, variablesPath, sensitiveVariablesPath);
+            renderedTemplate.ShouldNotContain("{{", customMessage: "rendered production template must not retain placeholders");
+            File.WriteAllText(scriptPath, renderedTemplate);
+
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            psi.Environment["PATH"] = $"{toolsDirectory}:/usr/bin:/bin";
+            psi.Environment["SQUID_CALAMARI_E2E_MARKER"] = markerPath;
+            psi.ArgumentList.Add(scriptPath);
+
+            using var process = System.Diagnostics.Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to launch the rendered Calamari template");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit(30_000).ShouldBeTrue("the rendered Calamari template must complete within 30 seconds");
+            process.ExitCode.ShouldBe(0,
+                customMessage: $"the Linux template must resolve bundled Calamari without PATH. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+            File.Exists(markerPath).ShouldBeTrue(
+                customMessage: $"the bundled Calamari shim must have been invoked. stdout:\n{stdout}\nstderr:\n{stderr}");
+            var marker = File.ReadAllText(markerPath);
+            marker.ShouldContain(Path.GetFullPath(bundledCalamari),
+                customMessage: $"the template must execute Calamari beside the resolved Tentacle. marker:\n{marker}");
+            marker.ShouldContain("apply-yaml", customMessage: $"the rendered arguments must reach Calamari. marker:\n{marker}");
+            marker.ShouldContain($"--file={packagePath}", customMessage: $"the package path must be rendered. marker:\n{marker}");
+
+            ctx.MarkClean();
+        }
+        finally
+        {
+            try { if (Directory.Exists(executionDir)) Directory.Delete(executionDir, recursive: true); }
+            catch { /* best-effort */ }
+        }
+    }
+
     // ========================================================================
     // A2.u1-Linux — Bogus version → exit 1, clean error message, no partial install
     //
@@ -203,9 +297,8 @@ public sealed class TentacleLinuxInstallScriptE2ETests
                           $"output tail:\n{(output.Length > 2000 ? "..." + output.Substring(output.Length - 2000) : output)}");
 
         // Versioned layout: the binary lives under versions/<v>, selected by a stable
-        // `current` symlink. (The placeholder reports "unknown" — no version.txt in the
-        // install tarball — so the dir is versions/unknown; the test asserts the
-        // structure, not the specific name.)
+        // `current` symlink. The fixture adds version.txt so the placeholder reports
+        // the requested version and exercises the production versioned-layout branch.
         var versionsDir = Path.Combine(ctx.InstallDir, "versions");
         Directory.Exists(versionsDir).ShouldBeTrue(
             customMessage: $"versioned install MUST create {versionsDir}. If absent: the .sh fell back to flat layout (binary couldn't report a version) OR the versioned extract regressed.");

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
@@ -126,6 +126,33 @@ public sealed class CalamariRoutingTests
     }
 
     [Fact]
+    public void ResolveCalamariExecutable_BundledBinaryExists_PrefersAbsolutePath()
+    {
+        var tentacleDirectory = Path.Combine(Path.GetTempPath(), "squid-tentacle-current");
+        var bundledCalamari = Path.Combine(
+            tentacleDirectory,
+            OperatingSystem.IsWindows() ? "squid-calamari.exe" : "squid-calamari");
+
+        var resolved = LocalScriptService.ResolveCalamariExecutable(
+            tentacleDirectory,
+            candidate => candidate == bundledCalamari);
+
+        resolved.ShouldBe(bundledCalamari,
+            customMessage: "Tentacle must launch the Calamari bundled beside its own binary before considering PATH.");
+    }
+
+    [Fact]
+    public void ResolveCalamariExecutable_BundledBinaryMissing_FallsBackToPathCommand()
+    {
+        var resolved = LocalScriptService.ResolveCalamariExecutable(
+            Path.Combine(Path.GetTempPath(), "squid-tentacle-current"),
+            _ => false);
+
+        resolved.ShouldBe(OperatingSystem.IsWindows() ? "squid-calamari.exe" : "squid-calamari",
+            customMessage: "PATH lookup remains the compatibility fallback when a legacy install has no bundled Calamari binary.");
+    }
+
+    [Fact]
     public void BuildCalamariProcessStartInfo_PowerShell_UsesScriptPs1()
     {
         // PR-8 co-dependent fix: the per-syntax --script path. Without this,

--- a/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
+++ b/tests/Squid.Tentacle.Tests/ScriptExecution/CalamariRoutingTests.cs
@@ -142,6 +142,38 @@ public sealed class CalamariRoutingTests
     }
 
     [Fact]
+    public void BuildCalamariProcessStartInfo_BundledBinaryExists_UsesAbsolutePath()
+    {
+        var tentacleDirectory = Path.Combine(Path.GetTempPath(), $"squid-calamari-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tentacleDirectory);
+
+        try
+        {
+            var bundledCalamari = Path.Combine(
+                tentacleDirectory,
+                OperatingSystem.IsWindows() ? "squid-calamari.exe" : "squid-calamari");
+            File.WriteAllText(bundledCalamari, string.Empty);
+
+            var psi = LocalScriptService.BuildCalamariProcessStartInfo(
+                workDir: "/tmp/work",
+                variablesPath: "/tmp/work/variables.json",
+                sensitiveVariablesPath: "/tmp/work/sensitiveVariables.json",
+                sensitivePassword: null,
+                sensitiveCiphertextExists: false,
+                syntax: ScriptType.Bash,
+                arguments: Array.Empty<string>(),
+                tentacleDirectory: tentacleDirectory);
+
+            psi.FileName.ShouldBe(bundledCalamari,
+                customMessage: "The production Calamari process must use the bundled executable's absolute path when it exists beside Tentacle.");
+        }
+        finally
+        {
+            Directory.Delete(tentacleDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ResolveCalamariExecutable_BundledBinaryMissing_FallsBackToPathCommand()
     {
         var resolved = LocalScriptService.ResolveCalamariExecutable(

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/CalamariPayloadBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/CalamariPayloadBuilderTests.cs
@@ -137,7 +137,8 @@ public class CalamariPayloadBuilderTests
     {
         var payload = _builder.Build(CreateRequest());
 
-        payload.TemplateBody.ShouldContain("Get-Command -Name 'squid-calamari.exe' -CommandType Application");
+        payload.TemplateBody.ShouldContain("Get-Command -Name 'squid-calamari' -CommandType Application");
+        payload.TemplateBody.ShouldContain("Write-Warning \"Could not read Tentacle install-info.json:");
         payload.TemplateBody.ShouldContain("$commandArgs = @(");
     }
 
@@ -150,7 +151,7 @@ public class CalamariPayloadBuilderTests
             "Join-Path (Split-Path -Parent $installInfo.BinaryPath) 'squid-calamari.exe'",
             StringComparison.Ordinal);
         var pathFallback = payload.TemplateBody.IndexOf(
-            "Get-Command -Name 'squid-calamari.exe' -CommandType Application",
+            "Get-Command -Name 'squid-calamari' -CommandType Application",
             StringComparison.Ordinal);
 
         bundledLookup.ShouldBeGreaterThanOrEqualTo(0,
@@ -167,7 +168,7 @@ public class CalamariPayloadBuilderTests
 
         payload.TemplateBody.ShouldContain("#!/usr/bin/env bash");
         payload.TemplateBody.ShouldContain("export PATH=\"/squid/bin:$PATH\"");
-        payload.TemplateBody.ShouldContain("squid-calamari \"${ARGS[@]}\"");
+        payload.TemplateBody.ShouldContain("\"$squidCalamari\" \"${ARGS[@]}\"");
     }
 
     [Fact]
@@ -175,6 +176,9 @@ public class CalamariPayloadBuilderTests
     {
         var payload = _builder.Build(CreateRequest(), ScriptSyntax.Bash);
 
+        payload.TemplateBody.ShouldContain("command -v squid-tentacle");
+        payload.TemplateBody.ShouldContain("readlink -f");
+        payload.TemplateBody.ShouldContain("squidCalamari");
         payload.TemplateBody.ShouldContain("command -v squid-calamari");
         payload.TemplateBody.ShouldContain("command -v kubectl");
     }

--- a/tests/Squid.UnitTests/Services/Deployments/Kubernetes/CalamariPayloadBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Kubernetes/CalamariPayloadBuilderTests.cs
@@ -137,7 +137,7 @@ public class CalamariPayloadBuilderTests
     {
         var payload = _builder.Build(CreateRequest());
 
-        payload.TemplateBody.ShouldContain("Get-Command \"squid-calamari\"");
+        payload.TemplateBody.ShouldContain("Get-Command -Name 'squid-calamari.exe' -CommandType Application");
         payload.TemplateBody.ShouldContain("$commandArgs = @(");
     }
 
@@ -146,8 +146,18 @@ public class CalamariPayloadBuilderTests
     {
         var payload = _builder.Build(CreateRequest(), ScriptSyntax.PowerShell);
 
-        payload.TemplateBody.ShouldContain("Get-Command \"squid-calamari\"");
-        payload.TemplateBody.ShouldContain("& $squidCalamari.Source @commandArgs");
+        var bundledLookup = payload.TemplateBody.IndexOf(
+            "Join-Path (Split-Path -Parent $installInfo.BinaryPath) 'squid-calamari.exe'",
+            StringComparison.Ordinal);
+        var pathFallback = payload.TemplateBody.IndexOf(
+            "Get-Command -Name 'squid-calamari.exe' -CommandType Application",
+            StringComparison.Ordinal);
+
+        bundledLookup.ShouldBeGreaterThanOrEqualTo(0,
+            customMessage: "Windows Tentacle deployments must derive the bundled squid-calamari.exe path from install-info.json.");
+        pathFallback.ShouldBeGreaterThan(bundledLookup,
+            customMessage: "PATH lookup must remain a fallback after the deterministic bundled Calamari path.");
+        payload.TemplateBody.ShouldContain("& $squidCalamari @commandArgs");
     }
 
     [Fact]

--- a/tests/Squid.WindowsTentacleE2E.CalamariShim/Program.cs
+++ b/tests/Squid.WindowsTentacleE2E.CalamariShim/Program.cs
@@ -26,6 +26,12 @@ foreach (var arg in args)
         passthrough.Add(arg);
 }
 
+if (passthrough.Count == 1 && passthrough[0].Equals("version", StringComparison.OrdinalIgnoreCase))
+{
+    Console.WriteLine("1.6.0-test");
+    return 0;
+}
+
 if (markerPath is not null)
 {
     var content = new System.Text.StringBuilder();

--- a/tests/Squid.WindowsTentacleE2E.CalamariShim/Program.cs
+++ b/tests/Squid.WindowsTentacleE2E.CalamariShim/Program.cs
@@ -1,0 +1,37 @@
+// Calamari shim for E2E testing — records its invocation to a marker file.
+//
+// The DeployByCalamari.ps1 template resolves `squid-calamari.exe` and
+// invokes it with `& $squidCalamari @commandArgs`.  This shim intercepts
+// that call, writes a marker file so the test can prove:
+//   • the shim was actually invoked (not a PATH-fallback miss)
+//   • the resolved path was an absolute path (install-info.json sibling)
+//   • the expected arguments were forwarded
+//
+// Usage: squid-calamari.exe [--marker=<path>] <calamari-args...>
+//
+// The --marker argument is consumed by the shim and never forwarded to
+// "calamari logic" (there is none — this is a test double).  When absent
+// the shim silently exits 0 so tests that don't need a marker still work.
+
+string markerPath = null;
+var passthrough = new List<string>();
+
+foreach (var arg in args)
+{
+    if (arg.StartsWith("--marker=", StringComparison.OrdinalIgnoreCase))
+        markerPath = arg["--marker=".Length..];
+    else
+        passthrough.Add(arg);
+}
+
+if (markerPath is not null)
+{
+    var content = new System.Text.StringBuilder();
+    content.AppendLine($"ProcessPath:{Environment.ProcessPath}");
+    content.AppendLine($"Args:{string.Join("|", passthrough)}");
+    content.AppendLine($"AllArgs:{string.Join("|", args)}");
+    Directory.CreateDirectory(Path.GetDirectoryName(markerPath)!);
+    File.WriteAllText(markerPath, content.ToString());
+}
+
+return 0;

--- a/tests/Squid.WindowsTentacleE2E.CalamariShim/Program.cs
+++ b/tests/Squid.WindowsTentacleE2E.CalamariShim/Program.cs
@@ -7,13 +7,15 @@
 //   • the resolved path was an absolute path (install-info.json sibling)
 //   • the expected arguments were forwarded
 //
-// Usage: squid-calamari.exe [--marker=<path>] <calamari-args...>
+// Usage: SQUID_CALAMARI_E2E_MARKER=<path> squid-calamari.exe [--marker=<path>] <calamari-args...>
 //
-// The --marker argument is consumed by the shim and never forwarded to
-// "calamari logic" (there is none — this is a test double).  When absent
-// the shim silently exits 0 so tests that don't need a marker still work.
+// The environment variable keeps the marker mechanism separate from the
+// production command contract. --marker remains backward-compatible for
+// existing callers. Both are consumed by the shim and never forwarded to
+// "calamari logic" (there is none — this is a test double). When absent the
+// shim silently exits 0 so tests that don't need a marker still work.
 
-string markerPath = null;
+var markerPath = Environment.GetEnvironmentVariable("SQUID_CALAMARI_E2E_MARKER");
 var passthrough = new List<string>();
 
 foreach (var arg in args)

--- a/tests/Squid.WindowsTentacleE2E.CalamariShim/Squid.WindowsTentacleE2E.CalamariShim.csproj
+++ b/tests/Squid.WindowsTentacleE2E.CalamariShim/Squid.WindowsTentacleE2E.CalamariShim.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Purpose-built squid-calamari.exe shim used by the CalamariLookupE2E test.
+    See the test class for the full rationale.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <!-- Match the filename the DeployByCalamari.ps1 template looks for. -->
+    <AssemblyName>squid-calamari</AssemblyName>
+    <RootNamespace>Squid.WindowsTentacleE2E.CalamariShim</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
@@ -48,8 +48,7 @@ public sealed class CalamariLookupE2ETests : IDisposable
         // Build a zip containing both the (fake) Tentacle binary and the real
         // squid-calamari.exe shim, and stage it as the release archive.
         var shimPath = LocateCalamariShim();
-        var shimBytes = await File.ReadAllBytesAsync(shimPath);
-        var zipBytes = BuildReleaseZip(shimBytes);
+        var zipBytes = BuildReleaseZip(shimPath);
         mirror.StagePreBuiltArchive(zipBytes);
 
         // Install Tentacle with -NoServiceInstall; install-info.json is written
@@ -104,18 +103,28 @@ public sealed class CalamariLookupE2ETests : IDisposable
 
     // ── Helpers ─────────────────────────────────────────────────────────────
 
-    private static byte[] BuildReleaseZip(byte[] shimBytes)
+    private static byte[] BuildReleaseZip(string shimExePath)
     {
         using var ms = new MemoryStream();
         using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
         {
+            // The shim is a framework-dependent apphost: without its sibling
+            // .dll / .runtimeconfig.json / .deps.json it cannot start after
+            // extraction, so bundle the whole build output like the other
+            // Windows E2E fixtures do.
+            var shimOutputDir = Path.GetDirectoryName(shimExePath)!;
+            foreach (var sourceFile in Directory.EnumerateFiles(shimOutputDir, "*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(shimOutputDir, sourceFile);
+                var entry = zip.CreateEntry(relativePath, CompressionLevel.Fastest);
+                using var entryStream = entry.Open();
+                using var fileStream = File.OpenRead(sourceFile);
+                fileStream.CopyTo(entryStream);
+            }
+
             var tentacleEntry = zip.CreateEntry("Squid.Tentacle.exe", CompressionLevel.Fastest);
             using (var writer = new StreamWriter(tentacleEntry.Open(), Encoding.UTF8))
                 writer.Write("# fake Squid.Tentacle.exe for E2E test\n");
-
-            var calamariEntry = zip.CreateEntry("squid-calamari.exe", CompressionLevel.Fastest);
-            using var calamariStream = calamariEntry.Open();
-            calamariStream.Write(shimBytes, 0, shimBytes.Length);
         }
 
         return ms.ToArray();

--- a/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
@@ -57,6 +57,67 @@ public sealed class CalamariLookupE2ETests : IDisposable
         await VerifyBundledCalamariResolutionAsync(useVersionedTentacle: true);
     }
 
+    [Fact]
+    public async Task DeployByCalamari_CorruptInstallInfo_FallsBackToPathCommandWrapper()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var ctx = new InstallDirContext();
+        var installInfoDirectory = Path.Combine(_programData, "Squid", "Tentacle");
+        Directory.CreateDirectory(installInfoDirectory);
+        await File.WriteAllTextAsync(
+            Path.Combine(installInfoDirectory, "install-info.json"),
+            "{ malformed install info",
+            Encoding.UTF8);
+
+        Directory.CreateDirectory(ctx.InstallDir);
+        var markerPath = Path.Combine(ctx.InstallDir, "calamari-marker.txt");
+        var resolutionScript = Path.Combine(ctx.InstallDir, "resolve-calamari.ps1");
+        var packagePath = Path.Combine(ctx.InstallDir, "package.yaml");
+        var variablesPath = Path.Combine(ctx.InstallDir, "variables.json");
+        var sensitiveVariablesPath = Path.Combine(ctx.InstallDir, "sensitive-variables.json");
+        await File.WriteAllTextAsync(packagePath, "apiVersion: v1", Encoding.UTF8);
+        await File.WriteAllTextAsync(variablesPath, "{}", Encoding.UTF8);
+        await File.WriteAllTextAsync(sensitiveVariablesPath, "{}", Encoding.UTF8);
+
+        Directory.CreateDirectory(ctx.ToolsDirectory);
+        await File.WriteAllTextAsync(Path.Combine(ctx.ToolsDirectory, "kubectl.cmd"), "@exit /b 0", Encoding.ASCII);
+        await File.WriteAllTextAsync(Path.Combine(ctx.ToolsDirectory, "bash.cmd"), "@exit /b 0", Encoding.ASCII);
+
+        var shimPath = LocateCalamariShim();
+        await File.WriteAllTextAsync(
+            Path.Combine(ctx.ToolsDirectory, "squid-calamari.cmd"),
+            $"@echo off\r\n\"{shimPath}\" %*\r\n",
+            Encoding.ASCII);
+
+        var payload = new CalamariPayload
+        {
+            TemplateBody = UtilService.GetEmbeddedScriptContent("DeployByCalamari.ps1"),
+            SensitivePassword = "test-sensitive-password"
+        };
+        var renderedTemplate = payload.FillTemplate(packagePath, variablesPath, sensitiveVariablesPath);
+        renderedTemplate.ShouldNotContain("{{", customMessage: "rendered production template must not retain placeholders");
+        await File.WriteAllTextAsync(resolutionScript, renderedTemplate, Encoding.UTF8);
+
+        var (resExit, resOut, resErr) = await RunPowerShellAsync(
+            resolutionScript,
+            prependPathEntry: ctx.ToolsDirectory,
+            markerPath: markerPath);
+
+        resExit.ShouldBe(0,
+            customMessage: $"corrupt install-info.json MUST fall back to a PATH command wrapper. stdout:\n{resOut}\nstderr:\n{resErr}");
+        (resOut + resErr).ShouldContain("WARNING: Could not read Tentacle install-info.json:",
+            customMessage: "a corrupt discovery file must be visible in deployment output before PATH fallback is used");
+        File.Exists(markerPath).ShouldBeTrue(
+            customMessage: $"PATH wrapper must invoke the Calamari shim. stdout:\n{resOut}\nstderr:\n{resErr}");
+
+        var marker = await File.ReadAllTextAsync(markerPath);
+        marker.ShouldContain("apply-yaml", customMessage: $"calamari args must be forwarded through the wrapper:\n{marker}");
+        marker.ShouldContain($"--file={packagePath}", customMessage: $"package path must be rendered into wrapper args:\n{marker}");
+        marker.ShouldContain(Path.GetFullPath(shimPath),
+            customMessage: $"the PATH wrapper must invoke the Calamari shim. marker:\n{marker}");
+    }
+
     private async Task VerifyBundledCalamariResolutionAsync(bool useVersionedTentacle)
     {
         using var mirror = LocalReleaseMirror.Start();

--- a/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using Squid.Core.Services.Common;
 using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.WindowsTentacleE2ETests.Infrastructure;
@@ -13,7 +14,8 @@ namespace Squid.WindowsTentacleE2ETests;
 /// is installed beside <c>Squid.Tentacle.exe</c> (recorded via
 /// <c>install-info.json</c>), the DeployByCalamari resolution MUST pick the
 /// sibling via absolute path — even when <c>squid-calamari.exe</c> is NOT in
-/// PATH.
+/// PATH. Both the legacy flat layout and the production versioned
+/// <c>current</c>-junction layout are covered.
 ///
 /// <para><b>Tier</b>: 🟢 High-fidelity. Real <c>install-tentacle.ps1</c>
 /// against a <see cref="LocalReleaseMirror"/> serving a pre-built zip that
@@ -40,17 +42,31 @@ public sealed class CalamariLookupE2ETests : IDisposable
     }
 
     [Fact]
-    public async Task DeployByCalamari_BundledCalamariBesideTentacle_ResolvedViaAbsolutePath()
+    public async Task DeployByCalamari_BundledCalamariBesideFlatTentacle_ResolvedViaAbsolutePath()
     {
         if (!OperatingSystem.IsWindows()) return;
 
+        await VerifyBundledCalamariResolutionAsync(useVersionedTentacle: false);
+    }
+
+    [Fact]
+    public async Task DeployByCalamari_BundledCalamariBesideVersionedTentacle_ResolvedViaCurrentPointer()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        await VerifyBundledCalamariResolutionAsync(useVersionedTentacle: true);
+    }
+
+    private async Task VerifyBundledCalamariResolutionAsync(bool useVersionedTentacle)
+    {
         using var mirror = LocalReleaseMirror.Start();
         using var ctx = new InstallDirContext();
 
-        // Build a zip containing both the (fake) Tentacle binary and the real
-        // squid-calamari.exe shim, and stage it as the release archive.
+        // Build a zip containing the real squid-calamari.exe shim plus either
+        // a non-runnable fake Tentacle (flat fallback) or a runnable copy of
+        // the shim as Squid.Tentacle.exe (versioned current-junction layout).
         var shimPath = LocateCalamariShim();
-        var zipBytes = BuildReleaseZip(shimPath);
+        var zipBytes = BuildReleaseZip(shimPath, useVersionedTentacle);
         mirror.StagePreBuiltArchive(zipBytes);
 
         // Install Tentacle with -NoServiceInstall; install-info.json is written
@@ -65,19 +81,39 @@ public sealed class CalamariLookupE2ETests : IDisposable
         exitCode.ShouldBe(0,
             customMessage: $"install-tentacle.ps1 MUST exit 0. stdout:\n{stdout}\nstderr:\n{stderr}");
 
-        // Both binaries must be present beside each other in the install dir.
-        var tentacleExe = Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe");
-        var calamariExe = Path.Combine(ctx.InstallDir, "squid-calamari.exe");
+        var activeDirectory = useVersionedTentacle
+            ? Path.Combine(ctx.InstallDir, "current")
+            : ctx.InstallDir;
+        var tentacleExe = Path.Combine(activeDirectory, "Squid.Tentacle.exe");
+        var calamariExe = Path.Combine(activeDirectory, "squid-calamari.exe");
         File.Exists(tentacleExe).ShouldBeTrue(
             customMessage: $"Squid.Tentacle.exe MUST exist at {tentacleExe}. stdout:\n{stdout}");
         File.Exists(calamariExe).ShouldBeTrue(
             customMessage: $"squid-calamari.exe MUST exist at {calamariExe}. stdout:\n{stdout}");
+
+        if (useVersionedTentacle)
+        {
+            var versionDirectory = Path.Combine(ctx.InstallDir, "versions", "1.6.0-test");
+            Directory.Exists(versionDirectory).ShouldBeTrue(
+                customMessage: $"versioned install MUST create {versionDirectory}. stdout:\n{stdout}");
+            new DirectoryInfo(activeDirectory).Attributes.HasFlag(FileAttributes.ReparsePoint).ShouldBeTrue(
+                customMessage: $"current MUST be a junction to the active version. stdout:\n{stdout}");
+        }
+        else
+        {
+            Directory.Exists(Path.Combine(ctx.InstallDir, "current")).ShouldBeFalse(
+                customMessage: $"flat fallback MUST not create a current junction. stdout:\n{stdout}");
+        }
 
         // install-info.json must point at the installed Tentacle binary so the
         // resolution logic can derive the sibling calamari path.
         var installInfoPath = Path.Combine(_programData, "Squid", "Tentacle", "install-info.json");
         File.Exists(installInfoPath).ShouldBeTrue(
             customMessage: $"install-info.json MUST exist at {installInfoPath}. stdout:\n{stdout}");
+        var installInfo = await File.ReadAllTextAsync(installInfoPath);
+        using var installInfoDocument = JsonDocument.Parse(installInfo);
+        installInfoDocument.RootElement.GetProperty("BinaryPath").GetString().ShouldBe(tentacleExe,
+            customMessage: $"install-info.json MUST identify the active {GetLayoutName(useVersionedTentacle)} Tentacle binary. Contents:\n{installInfo}");
 
         // Render and run the actual embedded production template. The child
         // PATH deliberately excludes the install dir and every directory that
@@ -128,7 +164,7 @@ public sealed class CalamariLookupE2ETests : IDisposable
 
     // ── Helpers ─────────────────────────────────────────────────────────────
 
-    private static byte[] BuildReleaseZip(string shimExePath)
+    private static byte[] BuildReleaseZip(string shimExePath, bool useVersionedTentacle)
     {
         using var ms = new MemoryStream();
         using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
@@ -148,12 +184,24 @@ public sealed class CalamariLookupE2ETests : IDisposable
             }
 
             var tentacleEntry = zip.CreateEntry("Squid.Tentacle.exe", CompressionLevel.Fastest);
-            using (var writer = new StreamWriter(tentacleEntry.Open(), Encoding.UTF8))
+            using var tentacleStream = tentacleEntry.Open();
+            if (useVersionedTentacle)
+            {
+                using var shimStream = File.OpenRead(shimExePath);
+                shimStream.CopyTo(tentacleStream);
+            }
+            else
+            {
+                using var writer = new StreamWriter(tentacleStream, Encoding.UTF8);
                 writer.Write("# fake Squid.Tentacle.exe for E2E test\n");
+            }
         }
 
         return ms.ToArray();
     }
+
+    private static string GetLayoutName(bool useVersionedTentacle) =>
+        useVersionedTentacle ? "versioned current-junction" : "flat";
 
     private async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
     {

--- a/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
@@ -1,0 +1,279 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using Squid.WindowsTentacleE2ETests.Infrastructure;
+
+namespace Squid.WindowsTentacleE2ETests;
+
+/// <summary>
+/// E2E coverage for the Calamari lookup fix: when <c>squid-calamari.exe</c>
+/// is installed beside <c>Squid.Tentacle.exe</c> (recorded via
+/// <c>install-info.json</c>), the DeployByCalamari resolution MUST pick the
+/// sibling via absolute path — even when <c>squid-calamari.exe</c> is NOT in
+/// PATH.
+///
+/// <para><b>Tier</b>: 🟢 High-fidelity. Real <c>install-tentacle.ps1</c>
+/// against a <see cref="LocalReleaseMirror"/> serving a pre-built zip that
+/// contains both binaries, then a real <c>powershell.exe</c> process runs the
+/// same resolution logic that <c>DeployByCalamari.ps1</c> contains and invokes
+/// the resolved shim. The shim (a real PE executable built by the
+/// CalamariShim project) writes a marker file so the test can assert the
+/// absolute path was used.</para>
+///
+/// <para><b>Windows-only</b>: requires <c>install-tentacle.ps1</c> and a real
+/// Windows PowerShell host. Non-Windows hosts no-op via
+/// <c>if (!OperatingSystem.IsWindows()) return;</c>.</para>
+/// </summary>
+[Trait("Category", WindowsUpgradeE2ECategories.CalamariLookup)]
+public sealed class CalamariLookupE2ETests : IDisposable
+{
+    private readonly string _programData =
+        Path.Combine(Path.GetTempPath(), $"squid-calamari-pd-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_programData)) Directory.Delete(_programData, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task DeployByCalamari_BundledCalamariBesideTentacle_ResolvedViaAbsolutePath()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var mirror = LocalReleaseMirror.Start();
+        using var ctx = new InstallDirContext();
+
+        // Build a zip containing both the (fake) Tentacle binary and the real
+        // squid-calamari.exe shim, and stage it as the release archive.
+        var shimPath = LocateCalamariShim();
+        var shimBytes = await File.ReadAllBytesAsync(shimPath);
+        var zipBytes = BuildReleaseZip(shimBytes);
+        mirror.StagePreBuiltArchive(zipBytes);
+
+        // Install Tentacle with -NoServiceInstall; install-info.json is written
+        // to the test-isolated %ProgramData% with BinaryPath = installDir.
+        var (exitCode, stdout, stderr) = await RunInstallScriptAsync(
+            "-Version", "1.6.0-test",
+            "-InstallDir", ctx.InstallDir,
+            "-DownloadBase", mirror.BaseUri.ToString().TrimEnd('/'),
+            "-NoServiceInstall"
+        );
+
+        exitCode.ShouldBe(0,
+            customMessage: $"install-tentacle.ps1 MUST exit 0. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        // Both binaries must be present beside each other in the install dir.
+        var tentacleExe = Path.Combine(ctx.InstallDir, "Squid.Tentacle.exe");
+        var calamariExe = Path.Combine(ctx.InstallDir, "squid-calamari.exe");
+        File.Exists(tentacleExe).ShouldBeTrue(
+            customMessage: $"Squid.Tentacle.exe MUST exist at {tentacleExe}. stdout:\n{stdout}");
+        File.Exists(calamariExe).ShouldBeTrue(
+            customMessage: $"squid-calamari.exe MUST exist at {calamariExe}. stdout:\n{stdout}");
+
+        // install-info.json must point at the installed Tentacle binary so the
+        // resolution logic can derive the sibling calamari path.
+        var installInfoPath = Path.Combine(_programData, "Squid", "Tentacle", "install-info.json");
+        File.Exists(installInfoPath).ShouldBeTrue(
+            customMessage: $"install-info.json MUST exist at {installInfoPath}. stdout:\n{stdout}");
+
+        // Run the same resolution + invocation logic DeployByCalamari.ps1
+        // performs. The child PATH deliberately excludes the install dir, so
+        // only the install-info.json sibling lookup can succeed.
+        var markerPath = Path.Combine(ctx.InstallDir, "calamari-marker.txt");
+        var resolutionScript = Path.Combine(ctx.InstallDir, "resolve-calamari.ps1");
+        await File.WriteAllTextAsync(resolutionScript, BuildResolutionScript(markerPath), Encoding.UTF8);
+
+        var (resExit, resOut, resErr) = await RunPowerShellAsync(
+            resolutionScript,
+            excludeDirFromPath: ctx.InstallDir);
+
+        resExit.ShouldBe(0,
+            customMessage: $"resolution script MUST exit 0. stdout:\n{resOut}\nstderr:\n{resErr}");
+
+        File.Exists(markerPath).ShouldBeTrue(
+            customMessage: $"calamari marker MUST exist at {markerPath}. stdout:\n{resOut}\nstderr:\n{resErr}");
+
+        var marker = await File.ReadAllTextAsync(markerPath);
+        marker.ShouldContain("ProcessPath", customMessage: $"unexpected marker content:\n{marker}");
+        marker.ShouldContain("apply-yaml", customMessage: $"calamari args must be forwarded:\n{marker}");
+        marker.ShouldContain(Path.GetFullPath(calamariExe),
+            customMessage: $"shim must be invoked via absolute path. marker:\n{marker}");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static byte[] BuildReleaseZip(byte[] shimBytes)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var tentacleEntry = zip.CreateEntry("Squid.Tentacle.exe", CompressionLevel.Fastest);
+            using (var writer = new StreamWriter(tentacleEntry.Open(), Encoding.UTF8))
+                writer.Write("# fake Squid.Tentacle.exe for E2E test\n");
+
+            var calamariEntry = zip.CreateEntry("squid-calamari.exe", CompressionLevel.Fastest);
+            using var calamariStream = calamariEntry.Open();
+            calamariStream.Write(shimBytes, 0, shimBytes.Length);
+        }
+
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Mirrors the resolution block in <c>src/Squid.Core/TentaclesScripts/
+    /// DeployByCalamari.ps1</c>, then invokes the resolved calamari with the
+    /// same command shape the production template uses.
+    /// </summary>
+    private static string BuildResolutionScript(string markerPath)
+    {
+        const string script = """
+            $ErrorActionPreference = 'Stop'
+
+            $squidCalamari = $null
+            $installInfoPath = Join-Path $env:ProgramData 'Squid\Tentacle\install-info.json'
+
+            if (Test-Path -LiteralPath $installInfoPath) {
+                $installInfo = Get-Content -LiteralPath $installInfoPath -Raw | ConvertFrom-Json
+                if (-not [string]::IsNullOrWhiteSpace($installInfo.BinaryPath)) {
+                    $candidate = Join-Path (Split-Path -Parent $installInfo.BinaryPath) 'squid-calamari.exe'
+                    if (Test-Path -LiteralPath $candidate) {
+                        $squidCalamari = $candidate
+                    }
+                }
+            }
+
+            if (-not $squidCalamari) {
+                $squidCalamariCommand = Get-Command -Name 'squid-calamari.exe' -CommandType Application -ErrorAction SilentlyContinue
+                if ($squidCalamariCommand) {
+                    $squidCalamari = $squidCalamariCommand.Path
+                }
+            }
+
+            if (-not $squidCalamari) {
+                Write-Error 'squid-calamari was not found beside Tentacle nor in PATH'
+                exit 1
+            }
+
+            & $squidCalamari --marker='__MARKER_PATH__' apply-yaml --file=test.yaml --variables=test.json
+            exit $LASTEXITCODE
+            """;
+
+        return script.Replace("__MARKER_PATH__", markerPath);
+    }
+
+    private async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
+    {
+        var scriptPath = LocateInstallScript();
+        return await RunPowerShellAsync(
+            scriptPath,
+            additionalArgs: scriptArgs);
+    }
+
+    private async Task<(int exitCode, string stdout, string stderr)> RunPowerShellAsync(
+        string scriptPath,
+        string[]? additionalArgs = null,
+        string? excludeDirFromPath = null)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        // Redirect %ProgramData% so install-info.json lands in the isolated dir.
+        psi.EnvironmentVariables["ProgramData"] = _programData;
+
+        // Optionally strip a directory from PATH to prove the bundled lookup
+        // works without relying on PATH resolution.
+        if (excludeDirFromPath != null)
+        {
+            var pathEntries = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+                .Where(p => !string.Equals(p.TrimEnd('\\'), excludeDirFromPath.TrimEnd('\\'), StringComparison.OrdinalIgnoreCase));
+            psi.EnvironmentVariables["PATH"] = string.Join(';', pathEntries);
+        }
+
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-NonInteractive");
+        psi.ArgumentList.Add("-ExecutionPolicy");
+        psi.ArgumentList.Add("Bypass");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(scriptPath);
+        if (additionalArgs != null)
+            foreach (var arg in additionalArgs) psi.ArgumentList.Add(arg);
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch powershell.exe");
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+
+        if (!p.WaitForExit(60_000))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"PowerShell script did not exit within 60s: {scriptPath}");
+        }
+
+        return (p.ExitCode, await stdoutTask, await stderrTask);
+    }
+
+    private static string LocateInstallScript()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "deploy", "scripts", "install-tentacle.ps1");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException("Could not locate deploy/scripts/install-tentacle.ps1 from the test assembly's directory tree");
+    }
+
+    private static string LocateCalamariShim()
+    {
+        var thisAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var dir = thisAssemblyDir;
+
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var shimProjectDir = Path.Combine(dir, "tests", "Squid.WindowsTentacleE2E.CalamariShim");
+            if (Directory.Exists(shimProjectDir))
+            {
+                foreach (var config in new[] { "Release", "Debug" })
+                {
+                    var candidate = Path.Combine(
+                        shimProjectDir, "bin", config, "net9.0", "squid-calamari.exe");
+                    if (File.Exists(candidate)) return candidate;
+                }
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException(
+            "Could not locate squid-calamari.exe shim. Build the CalamariShim project first.");
+    }
+
+    private sealed class InstallDirContext : IDisposable
+    {
+        public string InstallDir { get; } =
+            Path.Combine(Path.GetTempPath(), $"squid-calamari-install-{Guid.NewGuid():N}");
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(InstallDir))
+                    Directory.Delete(InstallDir, recursive: true);
+            }
+            catch { /* best-effort */ }
+        }
+    }
+}

--- a/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/CalamariLookupE2ETests.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Reflection;
 using System.Text;
+using Squid.Core.Services.Common;
+using Squid.Core.Services.DeploymentExecution.Infrastructure;
 using Squid.WindowsTentacleE2ETests.Infrastructure;
 
 namespace Squid.WindowsTentacleE2ETests;
@@ -16,8 +18,8 @@ namespace Squid.WindowsTentacleE2ETests;
 /// <para><b>Tier</b>: 🟢 High-fidelity. Real <c>install-tentacle.ps1</c>
 /// against a <see cref="LocalReleaseMirror"/> serving a pre-built zip that
 /// contains both binaries, then a real <c>powershell.exe</c> process runs the
-/// same resolution logic that <c>DeployByCalamari.ps1</c> contains and invokes
-/// the resolved shim. The shim (a real PE executable built by the
+/// rendered, embedded <c>DeployByCalamari.ps1</c> template and invokes the
+/// resolved shim. The shim (a real PE executable built by the
 /// CalamariShim project) writes a marker file so the test can assert the
 /// absolute path was used.</para>
 ///
@@ -77,16 +79,37 @@ public sealed class CalamariLookupE2ETests : IDisposable
         File.Exists(installInfoPath).ShouldBeTrue(
             customMessage: $"install-info.json MUST exist at {installInfoPath}. stdout:\n{stdout}");
 
-        // Run the same resolution + invocation logic DeployByCalamari.ps1
-        // performs. The child PATH deliberately excludes the install dir, so
-        // only the install-info.json sibling lookup can succeed.
+        // Render and run the actual embedded production template. The child
+        // PATH deliberately excludes the install dir and every directory that
+        // contains squid-calamari.exe, so only the install-info.json sibling
+        // lookup can succeed.
         var markerPath = Path.Combine(ctx.InstallDir, "calamari-marker.txt");
         var resolutionScript = Path.Combine(ctx.InstallDir, "resolve-calamari.ps1");
-        await File.WriteAllTextAsync(resolutionScript, BuildResolutionScript(markerPath), Encoding.UTF8);
+        var packagePath = Path.Combine(ctx.InstallDir, "package.yaml");
+        var variablesPath = Path.Combine(ctx.InstallDir, "variables.json");
+        var sensitiveVariablesPath = Path.Combine(ctx.InstallDir, "sensitive-variables.json");
+        await File.WriteAllTextAsync(packagePath, "apiVersion: v1", Encoding.UTF8);
+        await File.WriteAllTextAsync(variablesPath, "{}", Encoding.UTF8);
+        await File.WriteAllTextAsync(sensitiveVariablesPath, "{}", Encoding.UTF8);
+
+        Directory.CreateDirectory(ctx.ToolsDirectory);
+        await File.WriteAllTextAsync(Path.Combine(ctx.ToolsDirectory, "kubectl.cmd"), "@exit /b 0", Encoding.ASCII);
+        await File.WriteAllTextAsync(Path.Combine(ctx.ToolsDirectory, "bash.cmd"), "@exit /b 0", Encoding.ASCII);
+
+        var payload = new CalamariPayload
+        {
+            TemplateBody = UtilService.GetEmbeddedScriptContent("DeployByCalamari.ps1"),
+            SensitivePassword = "test-sensitive-password"
+        };
+        var renderedTemplate = payload.FillTemplate(packagePath, variablesPath, sensitiveVariablesPath);
+        renderedTemplate.ShouldNotContain("{{", customMessage: "rendered production template must not retain placeholders");
+        await File.WriteAllTextAsync(resolutionScript, renderedTemplate, Encoding.UTF8);
 
         var (resExit, resOut, resErr) = await RunPowerShellAsync(
             resolutionScript,
-            excludeDirFromPath: ctx.InstallDir);
+            excludeDirFromPath: ctx.InstallDir,
+            prependPathEntry: ctx.ToolsDirectory,
+            markerPath: markerPath);
 
         resExit.ShouldBe(0,
             customMessage: $"resolution script MUST exit 0. stdout:\n{resOut}\nstderr:\n{resErr}");
@@ -97,6 +120,8 @@ public sealed class CalamariLookupE2ETests : IDisposable
         var marker = await File.ReadAllTextAsync(markerPath);
         marker.ShouldContain("ProcessPath", customMessage: $"unexpected marker content:\n{marker}");
         marker.ShouldContain("apply-yaml", customMessage: $"calamari args must be forwarded:\n{marker}");
+        marker.ShouldContain($"--file={packagePath}", customMessage: $"package path must be rendered into calamari args:\n{marker}");
+        marker.ShouldContain($"--variables={variablesPath}", customMessage: $"variables path must be rendered into calamari args:\n{marker}");
         marker.ShouldContain(Path.GetFullPath(calamariExe),
             customMessage: $"shim must be invoked via absolute path. marker:\n{marker}");
     }
@@ -130,48 +155,6 @@ public sealed class CalamariLookupE2ETests : IDisposable
         return ms.ToArray();
     }
 
-    /// <summary>
-    /// Mirrors the resolution block in <c>src/Squid.Core/TentaclesScripts/
-    /// DeployByCalamari.ps1</c>, then invokes the resolved calamari with the
-    /// same command shape the production template uses.
-    /// </summary>
-    private static string BuildResolutionScript(string markerPath)
-    {
-        const string script = """
-            $ErrorActionPreference = 'Stop'
-
-            $squidCalamari = $null
-            $installInfoPath = Join-Path $env:ProgramData 'Squid\Tentacle\install-info.json'
-
-            if (Test-Path -LiteralPath $installInfoPath) {
-                $installInfo = Get-Content -LiteralPath $installInfoPath -Raw | ConvertFrom-Json
-                if (-not [string]::IsNullOrWhiteSpace($installInfo.BinaryPath)) {
-                    $candidate = Join-Path (Split-Path -Parent $installInfo.BinaryPath) 'squid-calamari.exe'
-                    if (Test-Path -LiteralPath $candidate) {
-                        $squidCalamari = $candidate
-                    }
-                }
-            }
-
-            if (-not $squidCalamari) {
-                $squidCalamariCommand = Get-Command -Name 'squid-calamari.exe' -CommandType Application -ErrorAction SilentlyContinue
-                if ($squidCalamariCommand) {
-                    $squidCalamari = $squidCalamariCommand.Path
-                }
-            }
-
-            if (-not $squidCalamari) {
-                Write-Error 'squid-calamari was not found beside Tentacle nor in PATH'
-                exit 1
-            }
-
-            & $squidCalamari --marker='__MARKER_PATH__' apply-yaml --file=test.yaml --variables=test.json
-            exit $LASTEXITCODE
-            """;
-
-        return script.Replace("__MARKER_PATH__", markerPath);
-    }
-
     private async Task<(int exitCode, string stdout, string stderr)> RunInstallScriptAsync(params string[] scriptArgs)
     {
         var scriptPath = LocateInstallScript();
@@ -183,7 +166,9 @@ public sealed class CalamariLookupE2ETests : IDisposable
     private async Task<(int exitCode, string stdout, string stderr)> RunPowerShellAsync(
         string scriptPath,
         string[]? additionalArgs = null,
-        string? excludeDirFromPath = null)
+        string? excludeDirFromPath = null,
+        string? prependPathEntry = null,
+        string? markerPath = null)
     {
         var psi = new ProcessStartInfo
         {
@@ -197,13 +182,25 @@ public sealed class CalamariLookupE2ETests : IDisposable
         // Redirect %ProgramData% so install-info.json lands in the isolated dir.
         psi.EnvironmentVariables["ProgramData"] = _programData;
 
-        // Optionally strip a directory from PATH to prove the bundled lookup
-        // works without relying on PATH resolution.
-        if (excludeDirFromPath != null)
+        if (markerPath != null)
+        {
+            psi.EnvironmentVariables["SQUID_CALAMARI_E2E_MARKER"] = markerPath;
+        }
+
+        // Keep the commands required by the real template available, but
+        // remove the Tentacle directory and any PATH-provided Calamari binary.
+        if (excludeDirFromPath != null || prependPathEntry != null)
         {
             var pathEntries = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
-                .Where(p => !string.Equals(p.TrimEnd('\\'), excludeDirFromPath.TrimEnd('\\'), StringComparison.OrdinalIgnoreCase));
+                .Select(p => p.Trim().Trim('"'))
+                .Where(p => excludeDirFromPath == null ||
+                    !string.Equals(p.TrimEnd('\\', '/'), excludeDirFromPath.TrimEnd('\\', '/'), StringComparison.OrdinalIgnoreCase))
+                .Where(p => !File.Exists(Path.Combine(p, "squid-calamari.exe")));
+
+            if (prependPathEntry != null)
+                pathEntries = new[] { prependPathEntry }.Concat(pathEntries);
+
             psi.EnvironmentVariables["PATH"] = string.Join(';', pathEntries);
         }
 
@@ -275,12 +272,22 @@ public sealed class CalamariLookupE2ETests : IDisposable
         public string InstallDir { get; } =
             Path.Combine(Path.GetTempPath(), $"squid-calamari-install-{Guid.NewGuid():N}");
 
+        public string ToolsDirectory { get; } =
+            Path.Combine(Path.GetTempPath(), $"squid-calamari-tools-{Guid.NewGuid():N}");
+
         public void Dispose()
         {
             try
             {
                 if (Directory.Exists(InstallDir))
                     Directory.Delete(InstallDir, recursive: true);
+            }
+            catch { /* best-effort */ }
+
+            try
+            {
+                if (Directory.Exists(ToolsDirectory))
+                    Directory.Delete(ToolsDirectory, recursive: true);
             }
             catch { /* best-effort */ }
         }

--- a/tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj
+++ b/tests/Squid.WindowsTentacleE2ETests/Squid.WindowsTentacleE2ETests.csproj
@@ -73,6 +73,15 @@
     <ProjectReference Include="..\Squid.WindowsTentacleE2E.VersionStampedShim\Squid.WindowsTentacleE2E.VersionStampedShim.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+
+    <!--
+      squid-calamari.exe shim used by CalamariLookupE2ETests. The test copies
+      the built PE beside a fake Squid.Tentacle.exe inside a pre-built release
+      zip and proves DeployByCalamari resolves the sibling via absolute path.
+    -->
+    <ProjectReference Include="..\Squid.WindowsTentacleE2E.CalamariShim\Squid.WindowsTentacleE2E.CalamariShim.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsServiceHostE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsServiceHostE2ETests.cs
@@ -197,9 +197,10 @@ public sealed class WindowsServiceHostE2ETests
     // ========================================================================
     // Test 5 — Uninstall removes the service from the SCM database.
     //
-    // sc delete on an installed service returns 0 + future `sc query` returns
-    // 1060 ("specified service does not exist"). This is the rollback target
-    // for upgrades + the cleanup contract operators rely on.
+    // sc delete on an installed service returns 0, then the SCM finalizes the
+    // deletion asynchronously before `sc query` returns 1060 ("specified
+    // service does not exist"). This is the rollback target for upgrades +
+    // the cleanup contract operators rely on.
     // ========================================================================
 
     [Fact]
@@ -218,9 +219,8 @@ public sealed class WindowsServiceHostE2ETests
         uninstallExit.ShouldBe(0,
             customMessage: $"WindowsServiceHost.Uninstall must return 0 on success");
 
-        // sc query a deleted service returns 1060.
-        ScQueryExitCode(ctx.ServiceName).ShouldNotBe(0,
-            customMessage: $"after Uninstall, `sc query {ctx.ServiceName}` must return non-zero (typically 1060). If still 0, the service is still in the SCM database and a re-install would fail with 1073 (already exists).");
+        WaitForScGone(ctx.ServiceName, TimeSpan.FromSeconds(15)).ShouldBeTrue(
+            customMessage: $"after Uninstall, `sc query {ctx.ServiceName}` must return non-zero (typically 1060) within 15s. If still 0, the service is still in the SCM database and a re-install would fail with 1073 (already exists).");
 
         // Mark uninstalled so the context's finally-block doesn't double-delete.
         ctx.MarkUninstalled();
@@ -609,6 +609,18 @@ public sealed class WindowsServiceHostE2ETests
         {
             var (exitCode, stdout, _) = RunSc("query", serviceName);
             if (exitCode == 0 && stdout.Contains(expectedState, StringComparison.OrdinalIgnoreCase))
+                return true;
+            Thread.Sleep(200);
+        }
+        return false;
+    }
+
+    private static bool WaitForScGone(string serviceName, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (ScQueryExitCode(serviceName) != 0)
                 return true;
             Thread.Sleep(200);
         }

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeE2ECategories.cs
@@ -269,4 +269,14 @@ public static class WindowsUpgradeE2ECategories
     /// </para>
     /// </summary>
     public const string WindowsServiceDeploy = "WindowsServiceDeployE2E";
+
+    /// <summary>
+    /// E2E coverage for the Calamari lookup fix: after a real
+    /// <c>install-tentacle.ps1</c> run, the DeployByCalamari resolution MUST
+    /// find <c>squid-calamari.exe</c> beside the installed Tentacle binary via
+    /// <c>install-info.json</c> (absolute path) even when the binary is not in
+    /// PATH. Windows-only — drives a real <c>powershell.exe</c> process plus
+    /// the real install script against <c>LocalReleaseMirror</c>.
+    /// </summary>
+    public const string CalamariLookup = "CalamariLookupE2E";
 }

--- a/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeWrapperE2ETests.cs
+++ b/tests/Squid.WindowsTentacleE2ETests/WindowsUpgradeWrapperE2ETests.cs
@@ -18,7 +18,7 @@ namespace Squid.WindowsTentacleE2ETests;
 ///         gives admin rights by default).</item>
 ///   <item>The dispatched inner script actually runs in a separate Task
 ///         Scheduler process tree as SYSTEM, surviving the wrapper's exit.</item>
-///   <item><c>/Z</c> auto-delete actually removes the task from the Task
+///   <item>the configured auto-delete settings remove the task from the Task
 ///         Scheduler library after run.</item>
 ///   <item>Concurrent dispatches with GUID-suffixed task names don't collide.</item>
 ///   <item>Inner-script failure does NOT propagate to the wrapper's exit code
@@ -160,11 +160,11 @@ exit 0
     }
 
     // ========================================================================
-    // Test 3: /Z auto-delete actually removes the task
+    // Test 3: auto-delete removes the task after its trigger expires
     // ========================================================================
 
     [Fact]
-    public void Wrapper_ScheduledTask_AutoDeletesAfterRun_ZFlag()
+    public void Wrapper_ScheduledTask_AutoDeletesAfterRun()
     {
         if (!OperatingSystem.IsWindows()) return;
 
@@ -181,12 +181,13 @@ exit 0
         WaitForFileExists(markerPath, TimeSpan.FromSeconds(60))
             .ShouldBeTrue("inner must complete before we check auto-delete");
 
-        // Task Scheduler /Z deletes "after expiration". A one-shot run with
-        // /SC ONCE expires immediately after the run completes, so the delete
-        // typically happens within seconds. Poll up to 60s.
-        WaitForTaskGone(taskName, TimeSpan.FromSeconds(60))
+        // The production wrapper's EndBoundary + DeleteExpiredTaskAfter
+        // settings schedule deletion for about 60s after registration. This
+        // wait begins only after the inner marker appears, so leave headroom
+        // for Task Scheduler load and query latency.
+        WaitForTaskGone(taskName, TimeSpan.FromSeconds(90))
             .ShouldBeTrue(
-                customMessage: $"task '{taskName}' should auto-delete via /Z after run completes; Task Scheduler library would otherwise accumulate orphan upgrade tasks across every dispatch");
+                customMessage: $"task '{taskName}' should auto-delete after its run completes; Task Scheduler library would otherwise accumulate orphan upgrade tasks across every dispatch");
     }
 
     // ========================================================================
@@ -484,7 +485,16 @@ exit 0
         };
         using var proc = Process.Start(psi);
         if (proc == null) return false;
-        proc.WaitForExit(5_000);
+
+        if (!proc.WaitForExit(5_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+
+            // A timed-out query is inconclusive, not evidence that auto-delete
+            // removed the task. Keep polling so this test cannot pass spuriously.
+            return true;
+        }
+
         return proc.ExitCode == 0;
     }
 


### PR DESCRIPTION
## 概要

- Windows：部署模板优先从 `%ProgramData%\Squid\Tentacle\install-info.json` 的 `BinaryPath` 推导同目录 `squid-calamari.exe`。安装记录损坏时会输出可见 warning，再回退到 PATH；PATH 回退使用无扩展名命令，兼容 `.exe`、`.cmd` 与 `.bat` 包装器。
- Linux 原生安装：Bash 模板先解析 `squid-tentacle` 实际二进制位置并优先执行同目录的 `squid-calamari`；保留 Docker `/squid/bin` 与 PATH 回退。安装与升级脚本同步修正小写 `squid-calamari` 的可执行权限。
- 测试：Windows 和 Linux E2E 均渲染真实嵌入模板并通过 `CalamariPayload.FillTemplate(...)` 执行，覆盖 flat/current 布局、损坏安装记录后的 Windows 包装器回退，以及 Linux 原生安装时 Calamari 不在 PATH 的场景。
- CI：将 Calamari 查找测试接入 Windows/Linux smoke 与 Linux 定时 E2E；变更检测覆盖生产模板和安装脚本目录。

## 本地验证

- `git diff --check` 与相关 Bash 脚本语法检查
- `CalamariPayloadBuilderTests`：12/12 通过
- `CalamariLookupE2ETests`：3/3 通过（macOS 仅编译、发现与非 Windows 安全短路）
- `CalamariTemplate_NativeInstall_UsesBundledSiblingWithoutCalamariOnPath`：1/1 通过（macOS 仅编译、发现与非 Linux 安全短路）

## GitHub Actions

- Windows Lifecycle Smoke：通过
- Linux Lifecycle Smoke：通过
- E2E Upgrade Matrix 的 AlmaLinux 9、Fedora 40、Rocky Linux 9 在启动容器前失败：引用的 `jrei/systemd-*` Docker 镜像不存在或无访问权限，安装脚本尚未执行。
- K8s Pipeline E2E：运行中。

Closes #468