### PR TITLE
Skip the pause transition when a task is no longer Executing

### DIFF
--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
@@ -75,30 +75,14 @@ public sealed class DeploymentCompletionHandler(
     /// row keeps occupying the environment's concurrency slot and blocks every other deployment
     /// to that environment. So the outcome is written here, once, for every suspend site.</para>
     ///
-    /// <para>The transition fires ONLY from <see cref="TaskState.Executing"/>, the sole legal
-    /// source of a <c>→ Paused</c> edge. Every other state is left
-    /// alone deliberately: <c>Paused</c> is the self-transitioning sites' common case and
-    /// <c>Paused → Paused</c> is not legal; <c>Cancelling</c> means an operator cancelled while
-    /// the pipeline was unwinding and that cancel must win rather than be overwritten by a pause;
-    /// and a terminal task has already recorded its outcome. Transitioning blindly would throw
-    /// <see cref="ServerTaskStateTransitionException"/> in each of those cases.</para>
+    /// <para>See <see cref="PauseIfStillExecutingAsync"/> for which states are written and why
+    /// the rest are deliberately left alone.</para>
     /// </summary>
     public async Task OnPausedAsync(DeploymentTaskContext ctx, CancellationToken ct)
     {
         Log.Information("[Deploy] Task {TaskId} paused, checkpoint preserved for resume", ctx.ServerTaskId);
 
-        var fromState = await ResolveCurrentActiveStateAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
-
-        if (!string.Equals(fromState, TaskState.Executing, StringComparison.OrdinalIgnoreCase))
-        {
-            Log.Information("[Deploy] Task {TaskId} is {State}, not Executing — leaving the state as-is for the pause", ctx.ServerTaskId, fromState);
-            return;
-        }
-
-        await genericDataProvider.ExecuteInTransactionAsync(async cancellationToken =>
-        {
-            await serverTaskService.TransitionStateAsync(ctx.ServerTaskId, fromState, TaskState.Paused, cancellationToken).ConfigureAwait(false);
-        }, ct).ConfigureAwait(false);
+        await PauseIfStillExecutingAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -118,12 +102,7 @@ public sealed class DeploymentCompletionHandler(
     {
         Log.Warning(ex, "[Deploy] Task {TaskId} timed out; pausing for resume, checkpoint preserved", ctx.ServerTaskId);
 
-        var fromState = await ResolveCurrentActiveStateAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
-
-        await genericDataProvider.ExecuteInTransactionAsync(async cancellationToken =>
-        {
-            await serverTaskService.TransitionStateAsync(ctx.ServerTaskId, fromState, TaskState.Paused, cancellationToken).ConfigureAwait(false);
-        }, ct).ConfigureAwait(false);
+        await PauseIfStillExecutingAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -134,19 +113,50 @@ public sealed class DeploymentCompletionHandler(
     /// pointer preserved, so a resume re-attaches to the still-running script
     /// instead of re-dispatching a duplicate. Like <see cref="OnTimedOutAsync"/> we
     /// deliberately do NOT delete the checkpoint and do NOT write a
-    /// <c>DeploymentCompletion</c> record (the deployment has not completed). This is
-    /// unconditional — there is no opt-out, because failing fast on a transient blip
-    /// would discard already-completed progress and risk a duplicate run.
+    /// <c>DeploymentCompletion</c> record (the deployment has not completed). Pausing on a
+    /// transient blip has no env-var opt-out (unlike the timeout's
+    /// <c>SQUID_DEPLOYMENT_TIMEOUT_RESUMABLE</c>), because failing fast here would discard
+    /// already-completed progress and risk a duplicate run. That is separate from WHICH states
+    /// the pause is written from — see <see cref="PauseIfStillExecutingAsync"/>.
     /// </summary>
     public async Task OnTransientPauseAsync(DeploymentTaskContext ctx, Exception ex, CancellationToken ct)
     {
         Log.Warning(ex, "[Deploy] Task {TaskId} hit a transient infrastructure failure; pausing for resume, checkpoint preserved", ctx.ServerTaskId);
 
-        var fromState = await ResolveCurrentActiveStateAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
+        await PauseIfStillExecutingAsync(ctx.ServerTaskId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves the task to <see cref="TaskState.Paused"/>, but ONLY from
+    /// <see cref="TaskState.Executing"/> — the sole legal source of that edge.
+    ///
+    /// <para>Shared by all three pause outcomes (suspend, timeout, transient) because the
+    /// decision is identical for each and getting it wrong is expensive. A blind transition
+    /// throws <see cref="ServerTaskStateTransitionException"/> for every other state, and that
+    /// throw is swallowed by the runner's SafeCompleteAsync — leaving the task in whatever
+    /// state it was, with no further processing. The costly case is <c>Cancelling</c>: an
+    /// operator cancelling while the pipeline unwinds would leave the row stuck there
+    /// permanently, holding the environment's concurrency slot and blocking every other
+    /// deployment to that environment, with no reaper to free it.</para>
+    ///
+    /// <para>Skipping is also the RIGHT semantic, not merely the safe one: a cancel that lands
+    /// mid-pause should win, and a task that already reached a terminal state has recorded its
+    /// outcome. <c>Paused</c> is skipped because the suspend sites that self-transition are the
+    /// common case and <c>Paused → Paused</c> is not legal either.</para>
+    /// </summary>
+    private async Task PauseIfStillExecutingAsync(int serverTaskId, CancellationToken ct)
+    {
+        var fromState = await ResolveCurrentActiveStateAsync(serverTaskId, ct).ConfigureAwait(false);
+
+        if (!string.Equals(fromState, TaskState.Executing, StringComparison.OrdinalIgnoreCase))
+        {
+            Log.Information("[Deploy] Task {TaskId} is {State}, not Executing — leaving the state as-is rather than forcing a pause", serverTaskId, fromState);
+            return;
+        }
 
         await genericDataProvider.ExecuteInTransactionAsync(async cancellationToken =>
         {
-            await serverTaskService.TransitionStateAsync(ctx.ServerTaskId, fromState, TaskState.Paused, cancellationToken).ConfigureAwait(false);
+            await serverTaskService.TransitionStateAsync(serverTaskId, TaskState.Executing, TaskState.Paused, cancellationToken).ConfigureAwait(false);
         }, ct).ConfigureAwait(false);
     }
 

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
@@ -149,10 +149,17 @@ public sealed class DeploymentCompletionHandler(
     /// keeps holding the environment's concurrency slot, its only edges out
     /// (<c>Cancelled</c>, <c>Failed</c>) need a live pipeline, re-cancel no-ops and resume
     /// rejects it, and there is no reaper. Freeing it needs cross-pod cancel propagation or a
-    /// stale-active-task reaper — neither of which exists, and both out of scope here. The same
-    /// wedge reaches the success path, which transitions from a hardcoded <c>Executing</c>.
-    /// The <c>Cancelling</c> skip is therefore logged at Warning: it is the only remaining
-    /// signal that an environment just lost a concurrency slot with no automatic recovery.</para>
+    /// stale-active-task reaper — neither of which exists, and both out of scope here. The
+    /// <c>Cancelling</c> skip is therefore logged at Warning: it is the only remaining signal
+    /// that an environment just lost a concurrency slot with no automatic recovery.</para>
+    ///
+    /// <para><b>The success path does not share this.</b> <see cref="OnSuccessAsync"/> also
+    /// transitions from a hardcoded <c>Executing</c>, but it is the one completion callback the
+    /// runner invokes directly rather than through <c>SafeCompleteAsync</c>, so its
+    /// <see cref="ServerTaskStateTransitionException"/> is not swallowed: it reaches the runner's
+    /// general catch, which routes to <see cref="OnFailureAsync"/>, and that resolves the current
+    /// state and performs the legal <c>Cancelling → Failed</c>. The row ends terminal and the slot
+    /// is freed — at the cost of a deployment that succeeded being recorded as failed.</para>
     /// </summary>
     private async Task PauseIfStillExecutingAsync(int serverTaskId, CancellationToken ct)
     {
@@ -173,10 +180,16 @@ public sealed class DeploymentCompletionHandler(
     /// <summary>
     /// A skipped pause is routine for <c>Paused</c> and for a terminal task, but for
     /// <c>Cancelling</c> it means the task is wedged: it holds the environment's concurrency
-    /// slot and nothing will free it. Before the guard, that case at least surfaced as an
-    /// Error from the swallowed transition exception; logging it at Warning keeps an alert on
-    /// the only path that indefinitely blocks an environment, without making the routine
-    /// <c>Paused</c> case noisy.
+    /// slot and nothing will free it. Warning is the level for that one case, Information for
+    /// the rest, so the routine <c>Paused</c> case cannot bury it.
+    ///
+    /// <para>The two outcomes arrive here from different places, and Warning is right for both
+    /// for different reasons. Timeout and transient pauses previously transitioned blind, so a
+    /// <c>Cancelling</c> row raised an illegal-transition exception that the runner's
+    /// <c>SafeCompleteAsync</c> logged at Error — Warning is what stops the guard silently
+    /// deleting that alert. The suspend outcome already had this guard and already logged at
+    /// Information, so for it Warning is a deliberate uplift, not a preservation: the same
+    /// wedged state deserves the same level whichever outcome walked into it.</para>
     /// </summary>
     private static void LogSkippedPause(int serverTaskId, string fromState)
     {

--- a/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
+++ b/src/Squid.Core/Services/DeploymentExecution/Pipeline/DeploymentCompletionHandler.cs
@@ -131,18 +131,28 @@ public sealed class DeploymentCompletionHandler(
     /// <see cref="TaskState.Executing"/> — the sole legal source of that edge.
     ///
     /// <para>Shared by all three pause outcomes (suspend, timeout, transient) because the
-    /// decision is identical for each and getting it wrong is expensive. A blind transition
-    /// throws <see cref="ServerTaskStateTransitionException"/> for every other state, and that
-    /// throw is swallowed by the runner's SafeCompleteAsync — leaving the task in whatever
-    /// state it was, with no further processing. The costly case is <c>Cancelling</c>: an
-    /// operator cancelling while the pipeline unwinds would leave the row stuck there
-    /// permanently, holding the environment's concurrency slot and blocking every other
-    /// deployment to that environment, with no reaper to free it.</para>
+    /// decision is identical for each. Skipping is the RIGHT semantic, not merely the safe one:
+    /// a cancel that lands mid-pause should win, and a task that already reached a terminal
+    /// state has recorded its outcome. <c>Paused</c> is skipped because the suspend sites that
+    /// self-transition are the common case and <c>Paused → Paused</c> is not legal either.</para>
     ///
-    /// <para>Skipping is also the RIGHT semantic, not merely the safe one: a cancel that lands
-    /// mid-pause should win, and a task that already reached a terminal state has recorded its
-    /// outcome. <c>Paused</c> is skipped because the suspend sites that self-transition are the
-    /// common case and <c>Paused → Paused</c> is not legal either.</para>
+    /// <para><b>What this does NOT do.</b> It does not rescue a task that is already
+    /// <c>Cancelling</c>. A blind transition threw
+    /// <see cref="ServerTaskStateTransitionException"/> from
+    /// <c>TaskState.EnsureValidTransition</c> — the first statement of
+    /// <c>TransitionStateAsync</c>, before any SQL — and the runner's <c>SafeCompleteAsync</c>
+    /// swallowed it, so the row stayed <c>Cancelling</c> with an empty transaction rolled back.
+    /// The guarded skip leaves it <c>Cancelling</c> too. The database outcome is byte-identical;
+    /// what changes is that an expected race is no longer signalled by an exception.</para>
+    ///
+    /// <para>That row is genuinely stuck: <c>Cancelling</c> counts as an active state so it
+    /// keeps holding the environment's concurrency slot, its only edges out
+    /// (<c>Cancelled</c>, <c>Failed</c>) need a live pipeline, re-cancel no-ops and resume
+    /// rejects it, and there is no reaper. Freeing it needs cross-pod cancel propagation or a
+    /// stale-active-task reaper — neither of which exists, and both out of scope here. The same
+    /// wedge reaches the success path, which transitions from a hardcoded <c>Executing</c>.
+    /// The <c>Cancelling</c> skip is therefore logged at Warning: it is the only remaining
+    /// signal that an environment just lost a concurrency slot with no automatic recovery.</para>
     /// </summary>
     private async Task PauseIfStillExecutingAsync(int serverTaskId, CancellationToken ct)
     {
@@ -150,7 +160,7 @@ public sealed class DeploymentCompletionHandler(
 
         if (!string.Equals(fromState, TaskState.Executing, StringComparison.OrdinalIgnoreCase))
         {
-            Log.Information("[Deploy] Task {TaskId} is {State}, not Executing — leaving the state as-is rather than forcing a pause", serverTaskId, fromState);
+            LogSkippedPause(serverTaskId, fromState);
             return;
         }
 
@@ -158,6 +168,25 @@ public sealed class DeploymentCompletionHandler(
         {
             await serverTaskService.TransitionStateAsync(serverTaskId, TaskState.Executing, TaskState.Paused, cancellationToken).ConfigureAwait(false);
         }, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// A skipped pause is routine for <c>Paused</c> and for a terminal task, but for
+    /// <c>Cancelling</c> it means the task is wedged: it holds the environment's concurrency
+    /// slot and nothing will free it. Before the guard, that case at least surfaced as an
+    /// Error from the swallowed transition exception; logging it at Warning keeps an alert on
+    /// the only path that indefinitely blocks an environment, without making the routine
+    /// <c>Paused</c> case noisy.
+    /// </summary>
+    private static void LogSkippedPause(int serverTaskId, string fromState)
+    {
+        if (string.Equals(fromState, TaskState.Cancelling, StringComparison.OrdinalIgnoreCase))
+        {
+            Log.Warning("[Deploy] Task {TaskId} is Cancelling, not Executing — skipping the pause so the cancel wins. The task stays Cancelling and keeps holding its environment's concurrency slot; there is no automatic recovery for this state", serverTaskId);
+            return;
+        }
+
+        Log.Information("[Deploy] Task {TaskId} is {State}, not Executing — leaving the state as-is rather than forcing a pause", serverTaskId, fromState);
     }
 
     private async Task<string> ResolveCurrentActiveStateAsync(int serverTaskId, CancellationToken ct)

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerSkipLogTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerSkipLogTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog;
+using Serilog.Events;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.Common;
+using Squid.Core.Services.DeploymentExecution;
+using Squid.Core.Services.DeploymentExecution.Pipeline;
+using Squid.Core.Services.Deployments.Checkpoints;
+using Squid.Core.Services.Deployments.DeploymentCompletions;
+using Squid.Core.Services.Deployments.Deployments;
+using Squid.Core.Services.Deployments.LifeCycle;
+using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Message.Models.Deployments.ServerTask;
+using Squid.UnitTests.Support;
+
+namespace Squid.UnitTests.Services.Deployments.Pipeline;
+
+/// <summary>
+/// Pins the log LEVEL of a skipped pause, which is load-bearing rather than cosmetic.
+///
+/// <para>Before the guard, a pause attempted against a <c>Cancelling</c> task threw an illegal-
+/// transition exception that the runner's <c>SafeCompleteAsync</c> logged at Error. The guard
+/// removes the exception, so that Error goes away — and with it the only signal that a task just
+/// became permanently stuck holding its environment's concurrency slot. Warning on the
+/// <c>Cancelling</c> branch is what keeps the alert; Information everywhere else is what keeps
+/// the routine <c>Paused</c> case from crying wolf.</para>
+///
+/// <para>Separate class from <c>DeploymentCompletionHandlerTests</c> because asserting levels
+/// means swapping the global <c>Log.Logger</c>, which requires
+/// <see cref="GlobalStateSerialisedCollection"/> — no reason to serialise the other forty tests
+/// alongside it.</para>
+/// </summary>
+[Collection(GlobalStateSerialisedCollection.Name)]
+public sealed class DeploymentCompletionHandlerSkipLogTests
+{
+    [Theory]
+    [InlineData(PauseKind.Suspended)]
+    [InlineData(PauseKind.TimedOut)]
+    [InlineData(PauseKind.Transient)]
+    public async Task SkippingBecauseTheTaskIsCancelling_WarnsThatTheSlotIsStuck(PauseKind kind)
+    {
+        var (sink, restore) = InstallCapturingLogger();
+
+        try
+        {
+            await InvokeWithCurrentStateAsync(kind, TaskState.Cancelling);
+
+            var skip = SingleSkipEvent(sink);
+
+            skip.Level.ShouldBe(LogEventLevel.Warning,
+                customMessage: "This is the only remaining trace that an environment lost a concurrency slot with " +
+                               "no automatic recovery — the guard removed the Error that the swallowed transition " +
+                               "exception used to produce. At Information it will not reach an operator.");
+
+            var rendered = skip.RenderMessage();
+            rendered.ShouldContain("concurrency slot",
+                customMessage: "The message has to name the consequence; 'skipping the pause' alone is not actionable.");
+        }
+        finally
+        {
+            restore();
+        }
+    }
+
+    [Theory]
+    [InlineData(PauseKind.Suspended, TaskState.Paused)]
+    [InlineData(PauseKind.Suspended, TaskState.Success)]
+    [InlineData(PauseKind.TimedOut, TaskState.Paused)]
+    [InlineData(PauseKind.TimedOut, TaskState.Success)]
+    [InlineData(PauseKind.Transient, TaskState.Paused)]
+    [InlineData(PauseKind.Transient, TaskState.Success)]
+    public async Task SkippingForAnyOtherReason_StaysAtInformation(PauseKind kind, string currentState)
+    {
+        // Paused is the ordinary case — the suspend sites that self-transition hit it on every
+        // manual intervention. Warning here would bury the Cancelling signal in routine noise.
+        var (sink, restore) = InstallCapturingLogger();
+
+        try
+        {
+            await InvokeWithCurrentStateAsync(kind, currentState);
+
+            SingleSkipEvent(sink).Level.ShouldBe(LogEventLevel.Information);
+        }
+        finally
+        {
+            restore();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    public enum PauseKind { Suspended, TimedOut, Transient }
+
+    private static LogEvent SingleSkipEvent(CapturingLogSink sink)
+    {
+        var events = sink.Events.Where(e => e.RenderMessage().Contains("not Executing")).ToList();
+
+        events.Count.ShouldBe(1, "the skip should be reported exactly once per pause attempt");
+
+        return events[0];
+    }
+
+    private static async Task InvokeWithCurrentStateAsync(PauseKind kind, string currentState)
+    {
+        var serverTaskService = new Mock<IServerTaskService>();
+        serverTaskService.Setup(s => s.GetTaskAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = 1, State = currentState });
+
+        var genericDataProvider = new Mock<IGenericDataProvider>();
+        genericDataProvider.Setup(g => g.ExecuteInTransactionAsync(It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            .Returns<Func<CancellationToken, Task>, CancellationToken>(async (action, ct) => await action(ct));
+
+        var sut = new DeploymentCompletionHandler(genericDataProvider.Object, serverTaskService.Object,
+            Mock.Of<IDeploymentDataProvider>(), Mock.Of<IDeploymentCompletionDataProvider>(),
+            Mock.Of<IAutoDeployService>(), Mock.Of<IDeploymentCheckpointService>());
+
+        var ctx = new DeploymentTaskContext { ServerTaskId = 1, Deployment = new Deployment { Id = 1, SpaceId = 1 } };
+
+        await (kind switch
+        {
+            PauseKind.Suspended => sut.OnPausedAsync(ctx, CancellationToken.None),
+            PauseKind.TimedOut => sut.OnTimedOutAsync(ctx, new Exception("timeout"), CancellationToken.None),
+            PauseKind.Transient => sut.OnTransientPauseAsync(ctx, new Exception("blip"), CancellationToken.None),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        });
+    }
+
+    private static (CapturingLogSink Sink, Action Restore) InstallCapturingLogger()
+    {
+        var original = Log.Logger;
+        var sink = new CapturingLogSink();
+
+        Log.Logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Sink(sink).CreateLogger();
+
+        return (sink, () => Log.Logger = original);
+    }
+
+    private sealed class CapturingLogSink : Serilog.Core.ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = new();
+
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+}

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerSkipLogTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerSkipLogTests.cs
@@ -20,12 +20,17 @@ namespace Squid.UnitTests.Services.Deployments.Pipeline;
 /// <summary>
 /// Pins the log LEVEL of a skipped pause, which is load-bearing rather than cosmetic.
 ///
-/// <para>Before the guard, a pause attempted against a <c>Cancelling</c> task threw an illegal-
-/// transition exception that the runner's <c>SafeCompleteAsync</c> logged at Error. The guard
-/// removes the exception, so that Error goes away — and with it the only signal that a task just
-/// became permanently stuck holding its environment's concurrency slot. Warning on the
-/// <c>Cancelling</c> branch is what keeps the alert; Information everywhere else is what keeps
-/// the routine <c>Paused</c> case from crying wolf.</para>
+/// <para>Warning on the <c>Cancelling</c> branch, Information everywhere else. The two halves of
+/// that split are load-bearing for different reasons, and the reason differs per outcome.</para>
+///
+/// <para>Timeout and transient pauses previously transitioned blind, so a <c>Cancelling</c> row
+/// raised an illegal-transition exception that the runner's <c>SafeCompleteAsync</c> logged at
+/// Error. The guard removes the exception, so Warning is what stops it silently deleting the only
+/// signal that a task became permanently stuck holding its environment's concurrency slot. The
+/// suspend outcome already had this guard and already logged at Information, so there Warning is a
+/// deliberate uplift rather than a preservation — the same wedged state should not be reported at
+/// two different levels depending on which outcome walked into it. Information everywhere else is
+/// what keeps the routine <c>Paused</c> case from crying wolf.</para>
 ///
 /// <para>Separate class from <c>DeploymentCompletionHandlerTests</c> because asserting levels
 /// means swapping the global <c>Log.Logger</c>, which requires
@@ -51,8 +56,10 @@ public sealed class DeploymentCompletionHandlerSkipLogTests
 
             skip.Level.ShouldBe(LogEventLevel.Warning,
                 customMessage: "This is the only remaining trace that an environment lost a concurrency slot with " +
-                               "no automatic recovery — the guard removed the Error that the swallowed transition " +
-                               "exception used to produce. At Information it will not reach an operator.");
+                               "no automatic recovery. For the timeout and transient outcomes the guard removed the " +
+                               "Error that the swallowed transition exception used to produce; for the suspend " +
+                               "outcome this is an uplift from Information. Either way, at Information it will not " +
+                               "reach an operator.");
 
             var rendered = skip.RenderMessage();
             rendered.ShouldContain("concurrency slot",

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerTests.cs
@@ -141,6 +141,76 @@ public class DeploymentCompletionHandlerTests
         _serverTaskService.Verify(s => s.TransitionStateAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ── The guard is shared by all three pause outcomes ──────────────────
+
+    /// <summary>Which pause outcome is being driven; all three share PauseIfStillExecutingAsync.</summary>
+    public enum PauseOutcome { Suspended, TimedOut, Transient }
+
+    private Task InvokePauseAsync(PauseOutcome outcome, DeploymentTaskContext ctx) => outcome switch
+    {
+        PauseOutcome.Suspended => _sut.OnPausedAsync(ctx, CancellationToken.None),
+        PauseOutcome.TimedOut => _sut.OnTimedOutAsync(ctx, new Exception("timeout"), CancellationToken.None),
+        PauseOutcome.Transient => _sut.OnTransientPauseAsync(ctx, new Exception("blip"), CancellationToken.None),
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+    };
+
+    [Theory]
+    [InlineData(PauseOutcome.Suspended)]
+    [InlineData(PauseOutcome.TimedOut)]
+    [InlineData(PauseOutcome.Transient)]
+    public async Task AnyPauseOutcome_RacedByACancel_LeavesTheCancelToWin(PauseOutcome outcome)
+    {
+        // The wedge this closes: Cancelling -> Paused is not a legal edge, so a blind transition
+        // throws, the runner's SafeCompleteAsync swallows it, and the task stays Cancelling
+        // FOREVER — holding the environment-wide concurrency slot with no reaper to free it.
+        // Every deployment to that environment is blocked from then on.
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Cancelling });
+
+        await Should.NotThrowAsync(() => InvokePauseAsync(outcome, ctx),
+            customMessage: $"{outcome} must not attempt the illegal Cancelling -> Paused transition.");
+
+        _serverTaskService.Verify(s => s.TransitionStateAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(PauseOutcome.Suspended, TaskState.Paused)]
+    [InlineData(PauseOutcome.Suspended, TaskState.Pending)]
+    [InlineData(PauseOutcome.Suspended, TaskState.Success)]
+    [InlineData(PauseOutcome.TimedOut, TaskState.Paused)]
+    [InlineData(PauseOutcome.TimedOut, TaskState.Pending)]
+    [InlineData(PauseOutcome.TimedOut, TaskState.Success)]
+    [InlineData(PauseOutcome.Transient, TaskState.Paused)]
+    [InlineData(PauseOutcome.Transient, TaskState.Pending)]
+    [InlineData(PauseOutcome.Transient, TaskState.Success)]
+    public async Task AnyPauseOutcome_NotExecuting_LeavesTheStateAlone(PauseOutcome outcome, string currentState)
+    {
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = currentState });
+
+        await Should.NotThrowAsync(() => InvokePauseAsync(outcome, ctx));
+
+        _serverTaskService.Verify(s => s.TransitionStateAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(PauseOutcome.Suspended)]
+    [InlineData(PauseOutcome.TimedOut)]
+    [InlineData(PauseOutcome.Transient)]
+    public async Task AnyPauseOutcome_StillExecuting_TransitionsToPaused(PauseOutcome outcome)
+    {
+        // The positive half: guarding must not stop the pause happening on the normal path.
+        var ctx = CreateContext();
+        _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Executing });
+
+        await InvokePauseAsync(outcome, ctx);
+
+        _serverTaskService.Verify(s => s.TransitionStateAsync(ctx.ServerTaskId, TaskState.Executing, TaskState.Paused, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Fact]
     public async Task OnPaused_StillExecuting_TransitionsToPaused()
     {

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentCompletionHandlerTests.cs
@@ -160,10 +160,13 @@ public class DeploymentCompletionHandlerTests
     [InlineData(PauseOutcome.Transient)]
     public async Task AnyPauseOutcome_RacedByACancel_LeavesTheCancelToWin(PauseOutcome outcome)
     {
-        // The wedge this closes: Cancelling -> Paused is not a legal edge, so a blind transition
-        // throws, the runner's SafeCompleteAsync swallows it, and the task stays Cancelling
-        // FOREVER — holding the environment-wide concurrency slot with no reaper to free it.
-        // Every deployment to that environment is blocked from then on.
+        // What this pins: the pause does not overwrite a cancel that landed mid-unwind, and it
+        // stops reaching for an illegal edge to discover that. Cancelling -> Paused is not legal,
+        // so a blind transition threw and the runner's SafeCompleteAsync swallowed it.
+        //
+        // It does NOT pin that the task recovers. The row stays Cancelling either way — this
+        // handler cannot free it, and nothing else does today (see PauseIfStillExecutingAsync).
+        // The Times.Never below is the whole claim: no illegal transition is attempted.
         var ctx = CreateContext();
         _serverTaskService.Setup(s => s.GetTaskAsync(ctx.ServerTaskId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ServerTaskSummaryDto { Id = ctx.ServerTaskId, State = TaskState.Cancelling });

--- a/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Pipeline/DeploymentPipelineRunnerTests.cs
@@ -6,6 +6,7 @@ using Squid.Core.Services.DeploymentExecution.Lifecycle;
 using Squid.Core.Services.DeploymentExecution.Pipeline;
 using Squid.Core.Services.DeploymentExecution.Script;
 using Squid.Core.Services.Deployments.ServerTask;
+using Squid.Core.Services.Deployments.ServerTask.Exceptions;
 using Squid.Core.Services.Jobs;
 
 namespace Squid.UnitTests.Services.Deployments.Pipeline;
@@ -94,5 +95,35 @@ public class DeploymentPipelineRunnerTests
 
         completion.Verify(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()), Times.Once);
         completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnSuccessThrowingAnIllegalTransition_FallsThroughToOnFailure()
+    {
+        // OnSuccessAsync transitions from a hardcoded Executing, so a task cancelled mid-pipeline
+        // makes it throw. Unlike every other completion callback it is invoked directly rather than
+        // through SafeCompleteAsync, so the exception is NOT swallowed — it reaches the general
+        // catch, which routes to OnFailureAsync, and that resolves the current state and performs
+        // the legal Cancelling -> Failed. That is why a Cancelling row does NOT wedge on the
+        // success path, which PauseIfStillExecutingAsync's doc-comment states; pinned here so the
+        // claim cannot quietly become false if the runner's call shape changes.
+        var lifecycle = new Mock<IDeploymentLifecycle>();
+        var completion = new Mock<IDeploymentCompletionHandler>();
+        completion.Setup(c => c.OnSuccessAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ServerTaskStateTransitionException(TaskState.Cancelling, TaskState.Success));
+        completion.Setup(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var okPhase = new Mock<IDeploymentPipelinePhase>();
+        okPhase.Setup(p => p.Order).Returns(1);
+        okPhase.Setup(p => p.ExecuteAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var registry = new TaskCancellationRegistry();
+        var runner = new DeploymentPipelineRunner(new[] { okPhase.Object }, lifecycle.Object, completion.Object, registry, _taskDataProvider.Object, Mock.Of<ISquidBackgroundJobClient>());
+
+        await Should.ThrowAsync<ServerTaskStateTransitionException>(() => runner.ProcessAsync(1, CancellationToken.None));
+
+        completion.Verify(c => c.OnFailureAsync(It.IsAny<DeploymentTaskContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

- All three pause outcomes (suspend, timeout, transient) share one guard that writes `Paused` only from `Executing`, the sole legal source of that edge. The timeout and transient handlers previously transitioned blind; `OnPausedAsync` already had the check.
- **The database outcome is unchanged in every case.** `TaskState.EnsureValidTransition` is the first statement of `TransitionStateAsync`, before any SQL, and `DeploymentPipelineRunner.SafeCompleteAsync` swallows what it throws — so a blind transition left the row exactly as the guard now leaves it, with an empty transaction rolled back. What changes is that an expected race stops being signalled by an exception.
- Removing the exception removes the Error that `SafeCompleteAsync` logged, which on the timeout and transient paths was the only trace that a `Cancelling` task had permanently lost its environment's concurrency slot. The `Cancelling` skip is now logged at Warning naming that consequence; other skipped states stay Information so the routine `Paused` case does not bury it. For the suspend outcome, which already skipped and logged Information, Warning is a deliberate uplift — the same wedged state should not be reported at two levels depending on which outcome reached it.

### What this does not fix

A task left `Cancelling` is still stuck: it holds the environment's concurrency slot, its only edges out (`Cancelled`, `Failed`) exist solely in `DeploymentCompletionHandler` and so need a live pipeline, `CancelTaskAsync` returns early on `Cancelling`, `ResumeTaskAsync` throws unless `Paused`, and no recurring job reaps it. Freeing it needs cross-pod cancel propagation or a stale-active-task reaper; both are pre-existing and out of scope here.

The success path does **not** share this. `OnSuccessAsync` also transitions from a hardcoded `Executing`, but it is the one completion callback the runner invokes directly rather than through `SafeCompleteAsync`, so its exception reaches the general catch, which routes to `OnFailureAsync`; that resolves the current state and performs the legal `Cancelling → Failed`. The row ends terminal and the slot is freed — at the cost of a deployment that succeeded being recorded as failed.

## Test plan

- [x] Unit: 3 Theories over all three pause outcomes × (raced by cancel / not Executing / still Executing)
- [x] Unit: 9 log-level cases pinning Warning for `Cancelling`, Information for every other skipped state
- [x] Unit: runner test pinning that an illegal transition out of `OnSuccessAsync` falls through to `OnFailureAsync`
- [x] Mutation: downgrading the `Cancelling` alert, warning on every skip, and dropping the consequence from the message each fail tests (3 / 9 / 3); routing `OnSuccessAsync` through `SafeCompleteAsync` fails the new runner test
- [x] Full unit suite green (6200)
