### PR TITLE
Forward Calamari service messages so the server sees output variables

### DIFF
--- a/src/Squid.Calamari/Execution/Output/ConsoleProcessOutputSink.cs
+++ b/src/Squid.Calamari/Execution/Output/ConsoleProcessOutputSink.cs
@@ -1,15 +1,17 @@
-using Squid.Calamari.ServiceMessages;
-
 namespace Squid.Calamari.Execution.Output;
 
 public sealed class ConsoleProcessOutputSink : IProcessOutputSink
 {
     public void WriteStdout(string line)
     {
-        // Service messages are handled by a dedicated sink and should stay out of user-facing stdout.
-        if (ServiceMessageParser.IsServiceMessage(line))
-            return;
-
+        // Service messages are forwarded, NOT suppressed. This process's stdout is not a
+        // user-facing surface — it is the wire back to the server: the Tentacle captures it
+        // into the script's log lines, and those lines are the server's ONLY source of output
+        // variables (ExecuteStepsPhase.CaptureOutputVariables -> ParseOutputVariables). Dropping
+        // the line here silently lost every output variable a Calamari-run script emitted, while
+        // the direct (non-Calamari) path passed the same line straight through. The dedicated
+        // service-message sink still collects the variable for this process's own conventions;
+        // forwarding is what lets the SERVER see it too.
         Console.WriteLine(line);
     }
 

--- a/src/Squid.Calamari/Execution/ScriptOutputProcessor.cs
+++ b/src/Squid.Calamari/Execution/ScriptOutputProcessor.cs
@@ -4,8 +4,10 @@ using Squid.Calamari.Execution.Output;
 namespace Squid.Calamari.Execution;
 
 /// <summary>
-/// Routes script output lines: service messages are parsed and suppressed from stdout;
-/// plain log lines are forwarded to the console.
+/// Routes script output lines: service messages are parsed into the output-variable collector
+/// AND forwarded to stdout, because stdout is how they reach the server; plain log lines are
+/// forwarded unchanged. See <see cref="Output.ConsoleProcessOutputSink.WriteStdout"/> for why
+/// forwarding rather than suppressing is required.
 /// </summary>
 public class ScriptOutputProcessor
 {

--- a/tests/Squid.Calamari.Tests/Calamari/Cli/CliSmokeTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Cli/CliSmokeTests.cs
@@ -32,7 +32,10 @@ public class CliSmokeTests
 
             result.ExitCode.ShouldBe(0);
             result.Stdout.ShouldContain("hello-from-cli");
-            result.Stdout.ShouldNotContain("##squid[setVariable");
+            // Forwarded on purpose: the real binary's stdout is what the Tentacle captures and
+            // the server parses output variables from. This is the end-to-end proof that a
+            // Calamari-run script's output variable actually escapes the process.
+            result.Stdout.ShouldContain("##squid[setVariable name='X' value='1']");
             result.Stderr.ShouldBeEmpty();
         }
         finally

--- a/tests/Squid.Calamari.Tests/Calamari/Execution/Output/ConsoleProcessOutputSinkTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Execution/Output/ConsoleProcessOutputSinkTests.cs
@@ -33,35 +33,6 @@ public class ConsoleProcessOutputSinkTests
     }
 
     [Fact]
-    public void ScriptOutputProcessor_ServiceMessage_IsBothCollectedAndForwarded()
-    {
-        // Both halves matter and they serve different consumers: the collector feeds THIS
-        // process's own conventions (PostDeploy reading a value the main script computed),
-        // while stdout is what carries the variable back to the server. Losing either one is
-        // a silent failure, so pin them together at the level that wires them.
-        var processor = new global::Squid.Calamari.Execution.ScriptOutputProcessor();
-        using var stdout = new StringWriter();
-        var originalOut = Console.Out;
-
-        try
-        {
-            Console.SetOut(stdout);
-
-            processor.ProcessLine("##squid[setVariable name='Url' value='https://web.test']");
-            processor.ProcessLine("ordinary log line");
-
-            processor.OutputVariables.ShouldContain(v => v.Name == "Url" && v.Value == "https://web.test",
-                "the collector feeds this process's own conventions");
-            stdout.ToString().ShouldContain("##squid[setVariable name='Url' value='https://web.test']");
-            stdout.ToString().ShouldContain("ordinary log line");
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
-    }
-
-    [Fact]
     public void WriteStderr_WritesToConsoleError()
     {
         var sink = new ConsoleProcessOutputSink();

--- a/tests/Squid.Calamari.Tests/Calamari/Execution/Output/ConsoleProcessOutputSinkTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Execution/Output/ConsoleProcessOutputSinkTests.cs
@@ -6,8 +6,12 @@ namespace Squid.Calamari.Tests.Calamari.Execution.Output;
 public class ConsoleProcessOutputSinkTests
 {
     [Fact]
-    public void WriteStdout_ServiceMessage_IsSuppressed()
+    public void WriteStdout_ServiceMessage_IsForwardedSoTheServerCanSeeIt()
     {
+        // This process's stdout is the wire back to the server: the Tentacle captures it into
+        // the script's log lines, which are the server's ONLY source of output variables.
+        // Suppressing the line here silently lost every output variable a Calamari-run script
+        // emitted, while the direct (non-Calamari) path forwarded the identical line.
         var sink = new ConsoleProcessOutputSink();
         using var stdout = new StringWriter();
         var originalOut = Console.Out;
@@ -20,7 +24,36 @@ public class ConsoleProcessOutputSinkTests
             sink.WriteStdout("visible");
 
             stdout.ToString().ShouldContain("visible");
-            stdout.ToString().ShouldNotContain("##squid[setVariable");
+            stdout.ToString().ShouldContain("##squid[setVariable name='X' value='1']");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void ScriptOutputProcessor_ServiceMessage_IsBothCollectedAndForwarded()
+    {
+        // Both halves matter and they serve different consumers: the collector feeds THIS
+        // process's own conventions (PostDeploy reading a value the main script computed),
+        // while stdout is what carries the variable back to the server. Losing either one is
+        // a silent failure, so pin them together at the level that wires them.
+        var processor = new global::Squid.Calamari.Execution.ScriptOutputProcessor();
+        using var stdout = new StringWriter();
+        var originalOut = Console.Out;
+
+        try
+        {
+            Console.SetOut(stdout);
+
+            processor.ProcessLine("##squid[setVariable name='Url' value='https://web.test']");
+            processor.ProcessLine("ordinary log line");
+
+            processor.OutputVariables.ShouldContain(v => v.Name == "Url" && v.Value == "https://web.test",
+                "the collector feeds this process's own conventions");
+            stdout.ToString().ShouldContain("##squid[setVariable name='Url' value='https://web.test']");
+            stdout.ToString().ShouldContain("ordinary log line");
         }
         finally
         {

--- a/tests/Squid.Calamari.Tests/Calamari/Execution/ScriptOutputProcessorTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Execution/ScriptOutputProcessorTests.cs
@@ -6,7 +6,7 @@ namespace Squid.Calamari.Tests.Calamari.Execution;
 public class ScriptOutputProcessorTests
 {
     [Fact]
-    public void ProcessLine_ServiceMessage_IsCollectedAndNotPrinted()
+    public void ProcessLine_ServiceMessage_IsCollectedAndAlsoForwardedToStdout()
     {
         var processor = new ScriptOutputProcessor();
         using var stdout = new StringWriter();
@@ -21,7 +21,10 @@ public class ScriptOutputProcessorTests
             processor.OutputVariables.Count.ShouldBe(1);
             processor.OutputVariables[0].Name.ShouldBe("BuildId");
             processor.OutputVariables[0].Value.ShouldBe("42");
-            stdout.ToString().ShouldNotContain("##squid[setVariable");
+            // Forwarded, not suppressed: stdout is how the variable reaches the SERVER
+            // (Tentacle -> log lines -> ExecuteStepsPhase.CaptureOutputVariables). The collector
+            // above serves only this process's own conventions.
+            stdout.ToString().ShouldContain("##squid[setVariable name='BuildId' value='42']");
         }
         finally
         {

--- a/tests/Squid.Calamari.Tests/Calamari/Host/ProgramEntryPointTests.cs
+++ b/tests/Squid.Calamari.Tests/Calamari/Host/ProgramEntryPointTests.cs
@@ -64,7 +64,7 @@ public class ProgramEntryPointTests
     }
 
     [Fact]
-    public async Task RunScript_HappyPath_Returns0_AndSuppressesServiceMessage()
+    public async Task RunScript_HappyPath_Returns0_AndForwardsServiceMessage()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "squid-calamari-tests-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
@@ -79,7 +79,9 @@ public class ProgramEntryPointTests
 
             result.ExitCode.ShouldBe(0);
             result.Stdout.ShouldContain("hello-from-inprocess");
-            result.Stdout.ShouldNotContain("##squid[setVariable");
+            // Forwarded on purpose — stdout is the transport the server reads output variables
+            // from. Suppressing it here silently lost every Calamari-path output variable.
+            result.Stdout.ShouldContain("##squid[setVariable name='BuildId' value='42']");
             result.Stderr.ShouldBeEmpty();
         }
         finally

--- a/tests/Squid.UnitTests/Services/Deployments/Execution/CalamariToServerOutputVariableSeamTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Execution/CalamariToServerOutputVariableSeamTests.cs
@@ -1,0 +1,135 @@
+using System.Linq;
+using Squid.Core.Services.DeploymentExecution.Script.ServiceMessages;
+using Squid.UnitTests.Support;
+using CalamariOutputProcessor = Squid.Calamari.Execution.ScriptOutputProcessor;
+
+namespace Squid.UnitTests.Services.Deployments.Execution;
+
+/// <summary>
+/// Pins the SEAM between Calamari's stdout and the server's output-variable capture — the join
+/// the bug actually lived in.
+///
+/// <para>Each side was individually correct and individually tested: Calamari collected the
+/// variable for its own conventions, and the server parsed service messages out of log lines
+/// faultlessly. Nothing asserted that what Calamari <i>writes</i> is what the server can
+/// <i>read</i>, so a suppression on the Calamari side dropped every output variable a
+/// Calamari-run script emitted and no test noticed.</para>
+///
+/// <para>These drive the real <c>Squid.Calamari.Execution.ScriptOutputProcessor</c>, capture the
+/// bytes it puts on stdout (exactly what the Tentacle collects into the script's log lines), and
+/// feed those captured lines to the production server-side
+/// <see cref="ServiceMessageParser.ParseOutputVariables"/>. No hand-written line in between — if
+/// either side changes its wire format independently, these fail.</para>
+///
+/// <para>Member of <see cref="GlobalStateSerialisedCollection"/>: redirecting
+/// <c>Console.Out</c> mutates a process global, so parallel classes would capture each
+/// other's writes.</para>
+/// </summary>
+[Collection(GlobalStateSerialisedCollection.Name)]
+public sealed class CalamariToServerOutputVariableSeamTests
+{
+    private static readonly ServiceMessageParser ServerParser = new();
+
+    [Fact]
+    public void AVariableSetByACalamariRunScript_ReachesTheServer()
+    {
+        var captured = RunThroughCalamari("##squid[setVariable name='Url' value='https://web.test']");
+
+        var serverSaw = ServerParser.ParseOutputVariables(captured);
+
+        serverSaw.ShouldContainKey("Url",
+            customMessage: "Calamari wrote the service message somewhere, but not to stdout — which is the only " +
+                           "channel the Tentacle collects and therefore the server's only source of output " +
+                           "variables. This is the exact failure the seam exists to catch.");
+        serverSaw["Url"].Value.ShouldBe("https://web.test");
+    }
+
+    [Fact]
+    public void TheSensitiveFlagSurvivesTheCrossing()
+    {
+        // A sensitive variable that arrives unflagged is worse than one that never arrives: the
+        // server would treat the secret as ordinary and write it to task logs in plaintext.
+        var captured = RunThroughCalamari("##squid[setVariable name='DbPassword' value='hunter2' sensitive='True']");
+
+        var serverSaw = ServerParser.ParseOutputVariables(captured);
+
+        serverSaw.ShouldContainKey("DbPassword");
+        serverSaw["DbPassword"].IsSensitive.ShouldBeTrue(
+            "a secret that crosses the seam unflagged gets logged in plaintext");
+        serverSaw["DbPassword"].Value.ShouldBe("hunter2");
+    }
+
+    [Fact]
+    public void TheBase64WireFormatCrossesUnmangled()
+    {
+        // The server accepts a double-quoted base64 value (used for anything containing quotes or
+        // newlines); Calamari's own parser only recognises the single-quoted plaintext form. So
+        // this line is, to Calamari, an ordinary log line — and it must still arrive byte-exact.
+        var encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("value with 'quotes' and\nnewline"));
+
+        var captured = RunThroughCalamari($"##squid[setVariable name=\"{Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("Multiline"))}\" value=\"{encoded}\"]");
+
+        var serverSaw = ServerParser.ParseOutputVariables(captured);
+
+        serverSaw.ShouldContainKey("Multiline",
+            customMessage: "Calamari must forward lines it does not itself recognise byte-exact; anything that " +
+                           "rewrites or re-quotes stdout breaks the server's base64 wire format.");
+        serverSaw["Multiline"].Value.ShouldBe("value with 'quotes' and\nnewline");
+    }
+
+    [Fact]
+    public void CalamariStillCollectsTheVariableForItsOwnConventions()
+    {
+        // The two consumers are independent and both matter: this one feeds a later Calamari
+        // convention in the same run (PostDeploy reading what the main script computed). Fixing
+        // the server side by moving collection to stdout-only would silently break it.
+        var processor = new CalamariOutputProcessor();
+
+        CaptureStdout(() => processor.ProcessLine("##squid[setVariable name='Url' value='https://web.test']"));
+
+        processor.OutputVariables.ShouldContain(v => v.Name == "Url" && v.Value == "https://web.test");
+    }
+
+    [Fact]
+    public void AnOrdinaryLogLineDoesNotBecomeAVariable()
+    {
+        // Control: proves the tests above pass because the seam carries service messages, not
+        // because the server manufactures a variable from any line Calamari happens to print.
+        var captured = RunThroughCalamari("Deploying release 1.2.3 to production");
+
+        ServerParser.ParseOutputVariables(captured).ShouldBeEmpty();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Puts <paramref name="scriptLine"/> through the real Calamari output pipeline and returns
+    /// the stdout lines it produced — i.e. precisely what the Tentacle hands the server.
+    /// </summary>
+    private static string[] RunThroughCalamari(string scriptLine)
+    {
+        var processor = new CalamariOutputProcessor();
+
+        var stdout = CaptureStdout(() => processor.ProcessLine(scriptLine));
+
+        return stdout.Split('\n').Select(l => l.TrimEnd('\r')).Where(l => l.Length > 0).ToArray();
+    }
+
+    private static string CaptureStdout(Action action)
+    {
+        var originalOut = Console.Out;
+        using var writer = new System.IO.StringWriter();
+
+        try
+        {
+            Console.SetOut(writer);
+            action();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        return writer.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

- `ConsoleProcessOutputSink.WriteStdout` suppressed every `##squid[...]` service message. That process's stdout is not a user-facing surface — it is the wire back to the server: the Tentacle captures it into the script's log lines, and those lines are the server's only source of output variables (`ExecuteStepsPhase.CaptureOutputVariables` → `ServiceMessageParser.ParseOutputVariables`). So a script run through Calamari silently lost every output variable it set, while the identical line on the direct path passed straight through.
- Forward the line instead. The dedicated service-message sink still collects the variable for this process's own conventions; forwarding is what lets the server see it too. Both consumers are independent and both matter.

## Test plan

- [x] Unit: sink, processor, entry point and CLI smoke all assert the message reaches stdout
- [x] Unit: new seam tests drive the real `ScriptOutputProcessor`, capture its stdout, and feed those exact lines to the production server-side `ServiceMessageParser` — plaintext, sensitive-flag, and base64 wire format, plus two controls
- [x] Mutation: restoring the suppression fails 3 of the 5 seam tests; the two controls are deliberately insensitive to it
- [x] Mutation: suppressing only `sensitive='True'` messages passes all 557 Calamari tests but fails the seam test — the escape the seam tests exist to close
- [x] Full unit suite and Calamari suite green
