### PR TITLE
Refuse to serve the Halibut identity committed to this repository

### DIFF
--- a/src/Squid.Core/Halibut/HalibutModule.cs
+++ b/src/Squid.Core/Halibut/HalibutModule.cs
@@ -4,6 +4,7 @@ using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Squid.Core.Settings.Halibut;
 using Squid.Core.Settings.SelfCert;
+using Squid.Message.Hardening;
 
 namespace Squid.Core.Halibut;
 
@@ -49,8 +50,14 @@ public class HalibutModule : Module
         {
             var selfCertSetting = ctx.Resolve<SelfCertSetting>();
 
+            // Fail with an actionable message before the loader turns a missing/committed
+            // identity into an opaque FormatException or a silently-public server key.
+            SelfCertValidator.EnsureConfigured(selfCertSetting.Base64);
+
             var certBytes = Convert.FromBase64String(selfCertSetting.Base64);
             var serverCert = X509CertificateLoader.LoadPkcs12(certBytes, selfCertSetting.Password, X509KeyStorageFlags.MachineKeySet);
+
+            SelfCertValidator.EnsureNotPublishedIdentity(serverCert, SelfCertValidator.ResolveMode());
 
             var services = new DelegateServiceFactory();
 

--- a/src/Squid.Core/Settings/SelfCert/SelfCertValidator.cs
+++ b/src/Squid.Core/Settings/SelfCert/SelfCertValidator.cs
@@ -1,0 +1,124 @@
+using System.Security.Cryptography.X509Certificates;
+using Squid.Message.Hardening;
+
+namespace Squid.Core.Settings.SelfCert;
+
+/// <summary>
+/// Guards the Halibut server identity — the certificate whose thumbprint every Tentacle pins
+/// for mTLS — against being served from the value committed to this repository.
+///
+/// <para><b>Why this exists</b>: <c>appsettings.json</c> ships a real, working PKCS#12 under
+/// <c>SelfCert:Base64</c> with its password beside it. A deployment is expected to override both,
+/// but nothing enforced that, so a deploy that simply forgot would silently serve the public
+/// identity: anyone with repository read access could then impersonate the server to every agent
+/// that trusts that thumbprint and dispatch scripts to the whole fleet. The
+/// <c>Security:VariableEncryption:MasterKey</c> setting got exactly this class of guard; this is
+/// the same treatment for a strictly more dangerous secret.</para>
+///
+/// <para><b>Behaviour matrix</b> (mirrors <c>VariableEncryptionService.ValidateMasterKey</c>):</para>
+/// <list type="table">
+///   <item><term>null / empty / whitespace Base64</term>
+///         <description>ALWAYS throw — no mode helps, Halibut cannot start without an
+///         identity, and the alternative is an opaque failure deep inside the loader.</description></item>
+///   <item><term>a known-published thumbprint</term>
+///         <description>Off → allow silently; Warn → allow + warn; Strict (default) → throw.</description></item>
+///   <item><term>any other certificate</term>
+///         <description>All modes allow silently.</description></item>
+/// </list>
+/// </summary>
+public static class SelfCertValidator
+{
+    /// <summary>
+    /// Operator escape hatch (Rule 8): selects how a known-published server identity is handled.
+    /// Recognised values <c>off</c> / <c>warn</c> / <c>strict</c>; unset defaults to
+    /// <see cref="EnforcementMode.Strict"/>.
+    ///
+    /// <para>Pinned literal — renaming it silently re-arms the rejection for every operator who
+    /// set it by its documented name.</para>
+    /// </summary>
+    public const string EnforcementEnvVar = "SQUID_SELFCERT_ENFORCEMENT";
+
+    public const string SettingPath = "SelfCert:Base64";
+
+    /// <summary>
+    /// Mode used when <see cref="EnforcementEnvVar"/> is unset. Deliberately stricter than the
+    /// shared <see cref="EnforcementModeReader.Read(string, EnforcementMode)"/> default of
+    /// <see cref="EnforcementMode.Warn"/>: a warning about a published server identity is easy to
+    /// miss, and the consequence of missing it is fleet-wide impersonation. Same posture the
+    /// master-key guard settled on.
+    /// </summary>
+    public const EnforcementMode DefaultMode = EnforcementMode.Strict;
+
+    /// <summary>Resolves the configured mode, defaulting to <see cref="DefaultMode"/>.</summary>
+    public static EnforcementMode ResolveMode() => EnforcementModeReader.Read(EnforcementEnvVar, DefaultMode);
+
+    /// <summary>
+    /// Thumbprints of server identities whose private key is public knowledge, so they can never
+    /// be trusted again. A set rather than a single value: rotating the committed certificate
+    /// must ADD the old thumbprint here, never replace it — an operator still running the
+    /// previous one has to keep being told.
+    ///
+    /// <para><c>FAF0…AB33</c> is the <c>CN=squid-server</c> certificate committed to
+    /// <c>appsettings.json</c>, whose PKCS#12 and password are both in the repository.</para>
+    /// </summary>
+    public static readonly IReadOnlySet<string> KnownPublishedThumbprints =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "FAF04764A5574B7DC939568818A8B8F1F168AB33" };
+
+    /// <summary>
+    /// Throws when <paramref name="rawBase64"/> cannot yield a server identity at all. Separated
+    /// from the certificate check so the caller fails with an actionable message instead of a
+    /// <see cref="FormatException"/> or <see cref="ArgumentNullException"/> from the loader.
+    /// </summary>
+    public static void EnsureConfigured(string rawBase64)
+    {
+        if (!string.IsNullOrWhiteSpace(rawBase64)) return;
+
+        throw new InvalidOperationException(
+            $"{SettingPath} is empty — the server has no Halibut identity and cannot accept agent connections. " +
+            "Supply a base64-encoded PKCS#12 via deployment config / environment / secret store, together with " +
+            "SelfCert:Password. This rejection is unconditional: no value of " + EnforcementEnvVar + " can " +
+            "substitute for a missing identity.");
+    }
+
+    /// <summary>
+    /// Rejects a server identity whose private key is published, according to
+    /// <paramref name="mode"/>. Exposed <c>internal</c>-friendly (public static) so the unit suite
+    /// can exercise the full (certificate × mode) matrix without building a DI container or a
+    /// Halibut runtime.
+    /// </summary>
+    public static void EnsureNotPublishedIdentity(X509Certificate2 certificate, EnforcementMode mode)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        if (!KnownPublishedThumbprints.Contains(certificate.Thumbprint)) return;
+
+        switch (mode)
+        {
+            case EnforcementMode.Off:
+                return;
+
+            case EnforcementMode.Warn:
+                Log.Warning(
+                    "Halibut server identity {Thumbprint} ({Subject}) is the certificate committed to the Squid " +
+                    "repository — its private key and password are public. Anyone who can read the repository can " +
+                    "impersonate this server to every agent that trusts this thumbprint. Replace {SettingPath} (and " +
+                    "SelfCert:Password) with a deployment-specific certificate, then re-register or re-trust your " +
+                    "agents. Set {EnvVar}=strict to refuse to serve it.",
+                    certificate.Thumbprint, certificate.Subject, SettingPath, EnforcementEnvVar);
+                return;
+
+            case EnforcementMode.Strict:
+                throw new InvalidOperationException(
+                    $"Refusing to use Halibut server identity {certificate.Thumbprint} ({certificate.Subject}): it is " +
+                    $"the certificate committed to the Squid repository, so its private key and password are public " +
+                    $"knowledge. Anyone who can read the repository could impersonate this server to every agent that " +
+                    $"trusts this thumbprint and run scripts across the fleet. Replace {SettingPath} and " +
+                    $"SelfCert:Password with a deployment-specific certificate, then re-register or re-trust your " +
+                    $"agents against the new thumbprint. To proceed anyway set {EnforcementEnvVar}=warn (allow + log) " +
+                    $"or {EnforcementEnvVar}=off (silent) — only sensible for local development.");
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unrecognised EnforcementMode");
+        }
+    }
+}

--- a/tests/Squid.UnitTests/Settings/HalibutModuleSelfCertWiringTests.cs
+++ b/tests/Squid.UnitTests/Settings/HalibutModuleSelfCertWiringTests.cs
@@ -6,6 +6,7 @@ using Halibut;
 using Shouldly;
 using Squid.Core.Halibut;
 using Squid.Core.Settings.SelfCert;
+using Squid.UnitTests.Support;
 using Xunit;
 
 namespace Squid.UnitTests.Settings;
@@ -23,29 +24,44 @@ namespace Squid.UnitTests.Settings;
 /// <para>These resolve the real registration. The guard runs before any Halibut runtime or
 /// listener is constructed, so a rejected identity fails without opening a socket.</para>
 /// </summary>
+[Collection(GlobalStateSerialisedCollection.Name)]
 public sealed class HalibutModuleSelfCertWiringTests
 {
     [Fact]
     public void ResolvingHalibutRuntime_WithTheCommittedIdentity_IsRejected()
     {
-        // The end-to-end statement: with the repository's own certificate configured and no
-        // enforcement env var set, the server must refuse to build its Halibut identity.
-        var committed = ReadCommittedSelfCert();
+        // Pins WIRING, not the default, so the mode is set explicitly — leaving it ambient would
+        // make this test go red on a developer machine that exported the documented dev opt-out.
+        var restore = SetEnforcementEnvVar("strict");
 
-        using var container = BuildContainer(committed.Base64, committed.Password);
+        try
+        {
+            var committed = ReadCommittedSelfCert();
 
-        var ex = Should.Throw<Exception>(() => container.Resolve<HalibutRuntime>());
-        var message = Unwrap(ex).Message;
+            using var container = BuildContainer(committed.Base64, committed.Password);
 
-        message.ShouldContain(SelfCertValidator.EnforcementEnvVar,
-            customMessage: "Resolving the runtime with the committed identity must surface the SelfCert guard's " +
-                           "rejection (which names its escape hatch). A different failure means HalibutModule is " +
-                           "no longer calling EnsureNotPublishedIdentity.");
+            var ex = Should.Throw<Exception>(() => container.Resolve<HalibutRuntime>());
+            var message = Unwrap(ex).Message;
+
+            // NOT the env-var name: EnsureConfigured's message names it too, so asserting on it
+            // would pass just as happily if the identity were missing entirely and the published-
+            // identity check had been deleted. The thumbprint appears in only one of the two.
+            message.ShouldContain(CommittedThumbprint(),
+                customMessage: "Resolving the runtime with the committed identity must surface the published-" +
+                               "identity rejection, which names the offending thumbprint. A different failure " +
+                               "means HalibutModule is no longer calling EnsureNotPublishedIdentity.");
+        }
+        finally
+        {
+            restore();
+        }
     }
 
     [Fact]
     public void ResolvingHalibutRuntime_WithNoIdentityConfigured_FailsWithAnActionableMessage()
     {
+        // Unconditional by design — no mode substitutes for an absent identity — so this one is
+        // genuinely mode-independent and needs no env pinning.
         using var container = BuildContainer(base64: string.Empty, password: string.Empty);
 
         var ex = Should.Throw<Exception>(() => container.Resolve<HalibutRuntime>());
@@ -63,13 +79,22 @@ public sealed class HalibutModuleSelfCertWiringTests
         // Guards against 'fix by rejecting everything': a properly configured deployment must
         // still get a runtime. Also proves the two tests above fail for the RIGHT reason rather
         // than because resolution is broken in this harness.
-        var (base64, password) = CreateDeploymentSpecificPkcs12();
+        var restore = SetEnforcementEnvVar("strict");
 
-        using var container = BuildContainer(base64, password);
+        try
+        {
+            var (base64, password) = CreateDeploymentSpecificPkcs12();
 
-        var runtime = container.Resolve<HalibutRuntime>();
+            using var container = BuildContainer(base64, password);
 
-        runtime.ShouldNotBeNull();
+            var runtime = container.Resolve<HalibutRuntime>();
+
+            runtime.ShouldNotBeNull();
+        }
+        finally
+        {
+            restore();
+        }
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
@@ -91,13 +116,38 @@ public sealed class HalibutModuleSelfCertWiringTests
         return builder.Build();
     }
 
+    private static Action SetEnforcementEnvVar(string value)
+    {
+        var name = SelfCertValidator.EnforcementEnvVar;
+        var prior = Environment.GetEnvironmentVariable(name);
+
+        Environment.SetEnvironmentVariable(name, value);
+
+        return () => Environment.SetEnvironmentVariable(name, prior);
+    }
+
     private static (string Base64, string Password) ReadCommittedSelfCert()
     {
         var path = Path.Combine(RepoRoot(), "src", "Squid.Api", "appsettings.json");
         using var doc = JsonDocument.Parse(File.ReadAllText(path));
         var selfCert = doc.RootElement.GetProperty("SelfCert");
+        var base64 = selfCert.GetProperty("Base64").GetString();
 
-        return (selfCert.GetProperty("Base64").GetString(), selfCert.GetProperty("Password").GetString());
+        // Without this, a future appsettings.json that drops SelfCert:Base64 would silently turn
+        // the rejection test into an EnsureConfigured test that still passes for the wrong reason.
+        base64.ShouldNotBeNullOrWhiteSpace("the committed appsettings.json is expected to still carry a SelfCert");
+
+        return (base64, selfCert.GetProperty("Password").GetString());
+    }
+
+    /// <summary>Recomputed, not hardcoded, so it tracks a rotated committed certificate.</summary>
+    private static string CommittedThumbprint()
+    {
+        var committed = ReadCommittedSelfCert();
+        using var cert = System.Security.Cryptography.X509Certificates.X509CertificateLoader
+            .LoadPkcs12(Convert.FromBase64String(committed.Base64), committed.Password);
+
+        return cert.Thumbprint;
     }
 
     private static (string Base64, string Password) CreateDeploymentSpecificPkcs12()

--- a/tests/Squid.UnitTests/Settings/HalibutModuleSelfCertWiringTests.cs
+++ b/tests/Squid.UnitTests/Settings/HalibutModuleSelfCertWiringTests.cs
@@ -118,10 +118,15 @@ public sealed class HalibutModuleSelfCertWiringTests
         return (Convert.ToBase64String(bytes), password);
     }
 
+    /// <summary>
+    /// Walks up to the repository root. Accepts <c>.git</c> as either a directory (normal clone)
+    /// or a file (linked worktree, which is how review/agent tooling checks the branch out) —
+    /// a directory-only probe walks straight past a worktree root and fails spuriously there.
+    /// </summary>
     private static string RepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")) && !File.Exists(Path.Combine(dir.FullName, ".git")))
             dir = dir.Parent;
 
         return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid repo working tree");

--- a/tests/Squid.UnitTests/Settings/HalibutModuleSelfCertWiringTests.cs
+++ b/tests/Squid.UnitTests/Settings/HalibutModuleSelfCertWiringTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Autofac;
+using Halibut;
+using Shouldly;
+using Squid.Core.Halibut;
+using Squid.Core.Settings.SelfCert;
+using Xunit;
+
+namespace Squid.UnitTests.Settings;
+
+/// <summary>
+/// Pins that <see cref="HalibutModule"/> actually CALLS the SelfCert guard.
+///
+/// <para><b>Why this exists separately from <c>SelfCertValidatorTests</c></b>: those exercise the
+/// validator in isolation, which proves it makes the right decision but nothing about whether it
+/// is on the path that serves the identity. Deleting both call sites from <c>HalibutModule</c>
+/// left the entire suite green — the validator would still be perfect and production still
+/// unprotected. The bug class this whole guard exists to prevent is a seam nobody tested across,
+/// so the seam itself is pinned here.</para>
+///
+/// <para>These resolve the real registration. The guard runs before any Halibut runtime or
+/// listener is constructed, so a rejected identity fails without opening a socket.</para>
+/// </summary>
+public sealed class HalibutModuleSelfCertWiringTests
+{
+    [Fact]
+    public void ResolvingHalibutRuntime_WithTheCommittedIdentity_IsRejected()
+    {
+        // The end-to-end statement: with the repository's own certificate configured and no
+        // enforcement env var set, the server must refuse to build its Halibut identity.
+        var committed = ReadCommittedSelfCert();
+
+        using var container = BuildContainer(committed.Base64, committed.Password);
+
+        var ex = Should.Throw<Exception>(() => container.Resolve<HalibutRuntime>());
+        var message = Unwrap(ex).Message;
+
+        message.ShouldContain(SelfCertValidator.EnforcementEnvVar,
+            customMessage: "Resolving the runtime with the committed identity must surface the SelfCert guard's " +
+                           "rejection (which names its escape hatch). A different failure means HalibutModule is " +
+                           "no longer calling EnsureNotPublishedIdentity.");
+    }
+
+    [Fact]
+    public void ResolvingHalibutRuntime_WithNoIdentityConfigured_FailsWithAnActionableMessage()
+    {
+        using var container = BuildContainer(base64: string.Empty, password: string.Empty);
+
+        var ex = Should.Throw<Exception>(() => container.Resolve<HalibutRuntime>());
+        var message = Unwrap(ex).Message;
+
+        message.ShouldContain(SelfCertValidator.SettingPath,
+            customMessage: "An absent identity must name the setting to populate, not surface an opaque " +
+                           "FormatException from inside the PKCS#12 loader. A different message means " +
+                           "HalibutModule is no longer calling EnsureConfigured.");
+    }
+
+    [Fact]
+    public void ResolvingHalibutRuntime_WithADeploymentSpecificIdentity_Succeeds()
+    {
+        // Guards against 'fix by rejecting everything': a properly configured deployment must
+        // still get a runtime. Also proves the two tests above fail for the RIGHT reason rather
+        // than because resolution is broken in this harness.
+        var (base64, password) = CreateDeploymentSpecificPkcs12();
+
+        using var container = BuildContainer(base64, password);
+
+        var runtime = container.Resolve<HalibutRuntime>();
+
+        runtime.ShouldNotBeNull();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>Autofac unwraps registration failures in DependencyResolutionException.</summary>
+    private static Exception Unwrap(Exception ex)
+    {
+        while (ex.InnerException != null) ex = ex.InnerException;
+
+        return ex;
+    }
+
+    private static IContainer BuildContainer(string base64, string password)
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(new SelfCertSetting { Base64 = base64, Password = password }).AsSelf().SingleInstance();
+        builder.RegisterModule(new HalibutModule());
+
+        return builder.Build();
+    }
+
+    private static (string Base64, string Password) ReadCommittedSelfCert()
+    {
+        var path = Path.Combine(RepoRoot(), "src", "Squid.Api", "appsettings.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var selfCert = doc.RootElement.GetProperty("SelfCert");
+
+        return (selfCert.GetProperty("Base64").GetString(), selfCert.GetProperty("Password").GetString());
+    }
+
+    private static (string Base64, string Password) CreateDeploymentSpecificPkcs12()
+    {
+        const string password = "test-password";
+
+        using var rsa = System.Security.Cryptography.RSA.Create(2048);
+        var request = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+            "CN=deployment-specific", rsa,
+            System.Security.Cryptography.HashAlgorithmName.SHA256,
+            System.Security.Cryptography.RSASignaturePadding.Pkcs1);
+
+        var now = DateTimeOffset.UtcNow;
+        using var cert = request.CreateSelfSigned(now.AddDays(-1), now.AddYears(1));
+
+        var bytes = cert.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Pfx, password);
+
+        return (Convert.ToBase64String(bytes), password);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid repo working tree");
+    }
+}

--- a/tests/Squid.UnitTests/Settings/SelfCertValidatorTests.cs
+++ b/tests/Squid.UnitTests/Settings/SelfCertValidatorTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Shouldly;
 using Squid.Core.Settings.SelfCert;
 using Squid.Message.Hardening;
+using Squid.UnitTests.Support;
 using Xunit;
 
 namespace Squid.UnitTests.Settings;
@@ -20,6 +21,7 @@ namespace Squid.UnitTests.Settings;
 /// deploy that forgot silently served the public identity — and anyone with repository read
 /// access could impersonate the server to every agent pinning that thumbprint.</para>
 /// </summary>
+[Collection(GlobalStateSerialisedCollection.Name)]
 public sealed class SelfCertValidatorTests
 {
     [Fact]
@@ -37,8 +39,21 @@ public sealed class SelfCertValidatorTests
         // identity is easy to miss and the consequence is fleet-wide impersonation, so this guard
         // deliberately opts into the stricter posture — same call the master-key guard made.
         SelfCertValidator.DefaultMode.ShouldBe(EnforcementMode.Strict);
-        SelfCertValidator.ResolveMode().ShouldBe(EnforcementMode.Strict,
-            customMessage: "With the env var unset the guard must resolve Strict, not the shared Warn default.");
+
+        // ResolveMode reads the environment, and this guard's own rejection message tells a
+        // developer to export that variable — so the one test that asserts the UNSET default has
+        // to clear it explicitly, or it goes red on exactly the machines that followed the advice.
+        var restore = SetEnforcementEnvVar(null);
+
+        try
+        {
+            SelfCertValidator.ResolveMode().ShouldBe(EnforcementMode.Strict,
+                customMessage: "With the env var unset the guard must resolve Strict, not the shared Warn default.");
+        }
+        finally
+        {
+            restore();
+        }
     }
 
     // ── The committed certificate ────────────────────────────────────────
@@ -63,14 +78,23 @@ public sealed class SelfCertValidatorTests
     {
         // The end-to-end statement of intent: with no configuration at all, the identity in the
         // repository must not be usable.
-        var committed = LoadCommittedCertificate();
+        var restore = SetEnforcementEnvVar(null);
 
-        var ex = Should.Throw<InvalidOperationException>(
-            () => SelfCertValidator.EnsureNotPublishedIdentity(committed, SelfCertValidator.ResolveMode()));
+        try
+        {
+            var committed = LoadCommittedCertificate();
 
-        ex.Message.ShouldContain(committed.Thumbprint);
-        ex.Message.ShouldContain(SelfCertValidator.EnforcementEnvVar,
-            customMessage: "The rejection must name its own escape hatch, or an operator who needs to proceed is stuck.");
+            var ex = Should.Throw<InvalidOperationException>(
+                () => SelfCertValidator.EnsureNotPublishedIdentity(committed, SelfCertValidator.ResolveMode()));
+
+            ex.Message.ShouldContain(committed.Thumbprint);
+            ex.Message.ShouldContain(SelfCertValidator.EnforcementEnvVar,
+                customMessage: "The rejection must name its own escape hatch, or an operator who needs to proceed is stuck.");
+        }
+        finally
+        {
+            restore();
+        }
     }
 
     [Theory]
@@ -126,6 +150,16 @@ public sealed class SelfCertValidatorTests
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static Action SetEnforcementEnvVar(string value)
+    {
+        var name = SelfCertValidator.EnforcementEnvVar;
+        var prior = Environment.GetEnvironmentVariable(name);
+
+        Environment.SetEnvironmentVariable(name, value);
+
+        return () => Environment.SetEnvironmentVariable(name, prior);
+    }
 
     /// <summary>Loads the certificate exactly as HalibutModule would, from the real appsettings.json.</summary>
     private static X509Certificate2 LoadCommittedCertificate()

--- a/tests/Squid.UnitTests/Settings/SelfCertValidatorTests.cs
+++ b/tests/Squid.UnitTests/Settings/SelfCertValidatorTests.cs
@@ -152,10 +152,15 @@ public sealed class SelfCertValidatorTests
         return request.CreateSelfSigned(now.AddDays(-1), now.AddYears(1));
     }
 
+    /// <summary>
+    /// Walks up to the repository root. Accepts <c>.git</c> as either a directory (normal clone)
+    /// or a file (linked worktree, which is how review/agent tooling checks the branch out) —
+    /// a directory-only probe walks straight past a worktree root and fails spuriously there.
+    /// </summary>
     private static string RepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")) && !File.Exists(Path.Combine(dir.FullName, ".git")))
             dir = dir.Parent;
 
         return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid repo working tree");

--- a/tests/Squid.UnitTests/Settings/SelfCertValidatorTests.cs
+++ b/tests/Squid.UnitTests/Settings/SelfCertValidatorTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using Shouldly;
+using Squid.Core.Settings.SelfCert;
+using Squid.Message.Hardening;
+using Xunit;
+
+namespace Squid.UnitTests.Settings;
+
+/// <summary>
+/// Pins the guard that stops the repository's own Halibut server identity being served to a
+/// production fleet.
+///
+/// <para><c>appsettings.json</c> ships a working PKCS#12 under <c>SelfCert:Base64</c> with its
+/// password beside it. Deployments are expected to override both, but nothing enforced it, so a
+/// deploy that forgot silently served the public identity — and anyone with repository read
+/// access could impersonate the server to every agent pinning that thumbprint.</para>
+/// </summary>
+public sealed class SelfCertValidatorTests
+{
+    [Fact]
+    public void EnforcementEnvVar_ConstantNamePinned()
+    {
+        // Rule 8: renaming this silently re-arms the rejection for every operator who set it by
+        // its documented name — turning a working deploy into a hard startup failure.
+        SelfCertValidator.EnforcementEnvVar.ShouldBe("SQUID_SELFCERT_ENFORCEMENT");
+    }
+
+    [Fact]
+    public void DefaultMode_IsStrict_NotTheSharedWarnDefault()
+    {
+        // The shared EnforcementModeReader default is Warn. A warning about a published server
+        // identity is easy to miss and the consequence is fleet-wide impersonation, so this guard
+        // deliberately opts into the stricter posture — same call the master-key guard made.
+        SelfCertValidator.DefaultMode.ShouldBe(EnforcementMode.Strict);
+        SelfCertValidator.ResolveMode().ShouldBe(EnforcementMode.Strict,
+            customMessage: "With the env var unset the guard must resolve Strict, not the shared Warn default.");
+    }
+
+    // ── The committed certificate ────────────────────────────────────────
+
+    [Fact]
+    public void KnownPublishedThumbprints_MatchesTheCertificateActuallyCommitted()
+    {
+        // Drift guard: the pinned thumbprint is a hand-copied constant, so it can silently stop
+        // matching the file it describes — leaving the guard permanently inert while still
+        // looking correct. Recompute it from the real appsettings.json instead of trusting it.
+        var committed = LoadCommittedCertificate();
+
+        SelfCertValidator.KnownPublishedThumbprints.ShouldContain(committed.Thumbprint,
+            customMessage: $"The certificate committed to appsettings.json has thumbprint {committed.Thumbprint}, " +
+                           "which is NOT in KnownPublishedThumbprints — the guard would let it through. If the " +
+                           "committed certificate was rotated, ADD the new thumbprint (keep the old one so operators " +
+                           "still running it are told).");
+    }
+
+    [Fact]
+    public void CommittedCertificate_IsRejectedUnderTheDefaultMode()
+    {
+        // The end-to-end statement of intent: with no configuration at all, the identity in the
+        // repository must not be usable.
+        var committed = LoadCommittedCertificate();
+
+        var ex = Should.Throw<InvalidOperationException>(
+            () => SelfCertValidator.EnsureNotPublishedIdentity(committed, SelfCertValidator.ResolveMode()));
+
+        ex.Message.ShouldContain(committed.Thumbprint);
+        ex.Message.ShouldContain(SelfCertValidator.EnforcementEnvVar,
+            customMessage: "The rejection must name its own escape hatch, or an operator who needs to proceed is stuck.");
+    }
+
+    [Theory]
+    [InlineData(EnforcementMode.Off)]
+    [InlineData(EnforcementMode.Warn)]
+    public void CommittedCertificate_IsAllowedUnderTheEscapeHatchModes(EnforcementMode mode)
+    {
+        var committed = LoadCommittedCertificate();
+
+        Should.NotThrow(() => SelfCertValidator.EnsureNotPublishedIdentity(committed, mode),
+            customMessage: $"{mode} is the documented opt-out; local development depends on it.");
+    }
+
+    [Theory]
+    [InlineData(EnforcementMode.Off)]
+    [InlineData(EnforcementMode.Warn)]
+    [InlineData(EnforcementMode.Strict)]
+    public void ADeploymentSpecificCertificate_IsAllowedInEveryMode(EnforcementMode mode)
+    {
+        // Guards against 'fix by rejecting everything': the guard must be inert for the
+        // overwhelmingly common case of a properly-configured deployment.
+        using var ownCert = CreateSelfSignedCertificate();
+
+        Should.NotThrow(() => SelfCertValidator.EnsureNotPublishedIdentity(ownCert, mode));
+    }
+
+    // ── Missing configuration ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EnsureConfigured_MissingBase64_ThrowsRegardlessOfMode(string rawBase64)
+    {
+        // Unconditional by design: no mode can substitute for an absent identity, and failing
+        // here beats an opaque FormatException from deep inside the PKCS#12 loader.
+        var ex = Should.Throw<InvalidOperationException>(() => SelfCertValidator.EnsureConfigured(rawBase64));
+
+        ex.Message.ShouldContain(SelfCertValidator.SettingPath,
+            customMessage: "The message must name the setting the operator has to populate.");
+    }
+
+    [Fact]
+    public void EnsureConfigured_PresentBase64_DoesNotThrow()
+    {
+        Should.NotThrow(() => SelfCertValidator.EnsureConfigured("AAEC"));
+    }
+
+    [Fact]
+    public void EnsureNotPublishedIdentity_NullCertificate_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => SelfCertValidator.EnsureNotPublishedIdentity(null, EnforcementMode.Strict));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>Loads the certificate exactly as HalibutModule would, from the real appsettings.json.</summary>
+    private static X509Certificate2 LoadCommittedCertificate()
+    {
+        var path = Path.Combine(RepoRoot(), "src", "Squid.Api", "appsettings.json");
+        File.Exists(path).ShouldBeTrue($"expected appsettings.json at {path}");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var selfCert = doc.RootElement.GetProperty("SelfCert");
+        var base64 = selfCert.GetProperty("Base64").GetString();
+        var password = selfCert.GetProperty("Password").GetString();
+
+        base64.ShouldNotBeNullOrWhiteSpace("the committed appsettings.json is expected to still carry a SelfCert");
+
+        return X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(base64), password);
+    }
+
+    private static X509Certificate2 CreateSelfSignedCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=deployment-specific", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var now = DateTimeOffset.UtcNow;
+
+        return request.CreateSelfSigned(now.AddDays(-1), now.AddYears(1));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate .git — test must run inside the Squid repo working tree");
+    }
+}


### PR DESCRIPTION
## Summary

- `appsettings.json` ships a real, working PKCS#12 under `SelfCert:Base64` with its password beside it. That certificate is the Halibut server identity — the thumbprint every Tentacle pins for mTLS. A deployment is expected to override it, but nothing enforced that, so a deploy that forgot silently served the public identity: anyone with repository read access could impersonate the server to every agent trusting that thumbprint and dispatch scripts across the fleet.
- `SelfCertValidator` rejects it at startup. An absent identity is refused unconditionally (no mode substitutes for a missing one, and this beats an opaque `FormatException` from inside the loader). A known-published thumbprint follows `SQUID_SELFCERT_ENFORCEMENT`: `off` allows silently, `warn` allows and logs, `strict` refuses. Any other certificate is allowed in every mode.
- The default is `strict`, not the shared `warn` — a warning about a published server identity is easy to miss and the consequence is fleet-wide impersonation. Same call the master-key guard made.

### Operational consequence

A server whose config still carries the committed certificate will now refuse to start, naming the thumbprint and the env var that overrides the decision. Deployments that template their own `appsettings` are unaffected. Rotating the committed certificate must **add** its old thumbprint to `KnownPublishedThumbprints`, never replace it, so operators still running the previous one keep being told.

## Test plan

- [x] Unit: full (certificate × mode) matrix, including that a deployment-specific certificate is allowed in every mode
- [x] Unit: drift guard recomputes the thumbprint from the real `appsettings.json` rather than trusting the pinned constant
- [x] Unit: wiring tests resolve `HalibutRuntime` from a real Autofac container, so the guard being on the identity path is pinned, not just the guard itself
- [x] Mutation: deleting either call site from `HalibutModule` left the whole suite green before those wiring tests; each of the three mutants now fails
- [x] Hermetic under `SQUID_SELFCERT_ENFORCEMENT` unset, `off` and `warn` — 17/17 in all three
- [x] Full unit suite green
