### PR TITLE
Add Octopus extraction DTOs and frozen-snapshot document classification

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentClassification.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentClassification.cs
@@ -1,0 +1,14 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public sealed record OctopusDocumentClassification(
+    OctopusDocumentKind Kind,
+    string SourcePath,
+    string SourceId,
+    string ManifestDocumentType,
+    bool IsHistoricalSnapshot,
+    bool IsOutOfScopeHistory)
+{
+    public bool IsKnown => Kind != OctopusDocumentKind.Unknown;
+
+    public bool IsCurrentConfiguration => IsKnown && !IsHistoricalSnapshot && !IsOutOfScopeHistory;
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentClassifier.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentClassifier.cs
@@ -1,0 +1,204 @@
+using System.Text.RegularExpressions;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public static partial class OctopusDocumentClassifier
+{
+    public static OctopusDocumentClassification Classify(OctopusManifestEntryDto manifestEntry)
+    {
+        ArgumentNullException.ThrowIfNull(manifestEntry);
+
+        var sourcePath = manifestEntry.DocumentSource;
+        var sourceId = manifestEntry.Id;
+        var kind = MapManifestDocumentType(manifestEntry.DocumentType);
+        var isSnapshot = IsSnapshotId(sourceId) || IsSnapshotFileName(sourcePath);
+
+        kind = ApplySnapshotKind(kind, isSnapshot);
+
+        return new OctopusDocumentClassification(
+            kind,
+            sourcePath,
+            sourceId,
+            manifestEntry.DocumentType,
+            IsSnapshotKind(kind),
+            IsOutOfScopeHistory(kind));
+    }
+
+    public static OctopusDocumentClassification ClassifyFileName(string sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+            return Unknown(sourcePath);
+
+        var fileName = Path.GetFileName(sourcePath);
+
+        if (string.Equals(fileName, "manifest.json", StringComparison.OrdinalIgnoreCase))
+            return Build(OctopusDocumentKind.Manifest, sourcePath);
+
+        var isSnapshot = IsSnapshotFileName(fileName);
+        var kind = MapFileName(fileName);
+        kind = ApplySnapshotKind(kind, isSnapshot);
+
+        return Build(kind, sourcePath);
+    }
+
+    public static OctopusDocumentClassification ClassifyJsonDocument(string sourcePath, string id, string documentType = null)
+    {
+        if (!string.IsNullOrWhiteSpace(documentType))
+        {
+            var kind = MapManifestDocumentType(documentType);
+            var isSnapshot = IsSnapshotId(id) || IsSnapshotFileName(sourcePath);
+            kind = ApplySnapshotKind(kind, isSnapshot);
+
+            return new OctopusDocumentClassification(
+                kind,
+                sourcePath,
+                id,
+                documentType,
+                IsSnapshotKind(kind),
+                IsOutOfScopeHistory(kind));
+        }
+
+        if (!string.IsNullOrWhiteSpace(id))
+        {
+            var isSnapshot = IsSnapshotId(id) || IsSnapshotFileName(sourcePath);
+            var kind = MapId(id);
+            kind = ApplySnapshotKind(kind, isSnapshot);
+
+            return new OctopusDocumentClassification(
+                kind,
+                sourcePath,
+                id,
+                null,
+                IsSnapshotKind(kind),
+                IsOutOfScopeHistory(kind));
+        }
+
+        return ClassifyFileName(sourcePath);
+    }
+
+    private static OctopusDocumentClassification Build(OctopusDocumentKind kind, string sourcePath)
+        => new(kind, sourcePath, null, null, IsSnapshotKind(kind), IsOutOfScopeHistory(kind));
+
+    private static OctopusDocumentClassification Unknown(string sourcePath)
+        => new(OctopusDocumentKind.Unknown, sourcePath, null, null, false, false);
+
+    private static OctopusDocumentKind MapManifestDocumentType(string documentType)
+    {
+        if (string.IsNullOrWhiteSpace(documentType))
+            return OctopusDocumentKind.Unknown;
+
+        return documentType.Trim() switch
+        {
+            "Project" => OctopusDocumentKind.Project,
+            "ProjectGroup" => OctopusDocumentKind.ProjectGroup,
+            "StaticDeploymentEnvironment" => OctopusDocumentKind.Environment,
+            "Environment" => OctopusDocumentKind.Environment,
+            "Lifecycle" => OctopusDocumentKind.Lifecycle,
+            "Channel" => OctopusDocumentKind.Channel,
+            "DeploymentSettings" => OctopusDocumentKind.DeploymentSettings,
+            "DeploymentProcess" => OctopusDocumentKind.DeploymentProcess,
+            "ProjectVariables" => OctopusDocumentKind.VariableSet,
+            "VariableSet" => OctopusDocumentKind.VariableSet,
+            "DockerFeed" => OctopusDocumentKind.Feed,
+            "NuGetFeed" => OctopusDocumentKind.Feed,
+            "HelmFeed" => OctopusDocumentKind.Feed,
+            "GitHubFeed" => OctopusDocumentKind.Feed,
+            "Feed" => OctopusDocumentKind.Feed,
+            "ConfigurableTeam" => OctopusDocumentKind.Team,
+            "Team" => OctopusDocumentKind.Team,
+            "Machine" => OctopusDocumentKind.Machine,
+            "Account" => OctopusDocumentKind.Account,
+            "Certificate" => OctopusDocumentKind.Certificate,
+            "Release" => OctopusDocumentKind.Release,
+            "Deployment" => OctopusDocumentKind.Deployment,
+            "ServerTask" => OctopusDocumentKind.ServerTask,
+            "ActionTemplate" => OctopusDocumentKind.ActionTemplate,
+            _ => OctopusDocumentKind.Unknown
+        };
+    }
+
+    private static OctopusDocumentKind MapFileName(string fileName)
+    {
+        var lower = fileName.ToLowerInvariant();
+
+        if (lower.StartsWith("deploymentprocess-", StringComparison.Ordinal))
+            return OctopusDocumentKind.DeploymentProcess;
+
+        if (lower.StartsWith("variableset-", StringComparison.Ordinal))
+            return OctopusDocumentKind.VariableSet;
+
+        return MapId(fileName);
+    }
+
+    private static OctopusDocumentKind MapId(string idOrFileName)
+    {
+        if (string.IsNullOrWhiteSpace(idOrFileName))
+            return OctopusDocumentKind.Unknown;
+
+        var value = idOrFileName.Trim();
+
+        if (value.StartsWith("Projects-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Project;
+        if (value.StartsWith("ProjectGroups-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.ProjectGroup;
+        if (value.StartsWith("Environments-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Environment;
+        if (value.StartsWith("Lifecycles-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Lifecycle;
+        if (value.StartsWith("Channels-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Channel;
+        if (value.StartsWith("deploymentsettings-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.DeploymentSettings;
+        if (value.StartsWith("Feeds-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Feed;
+        if (value.StartsWith("Teams-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Team;
+        if (value.StartsWith("Machines-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Machine;
+        if (value.StartsWith("Accounts-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Account;
+        if (value.StartsWith("Certificates-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Certificate;
+        if (value.StartsWith("Releases-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Release;
+        if (value.StartsWith("Deployments-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.Deployment;
+        if (value.StartsWith("ServerTasks-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.ServerTask;
+        if (value.StartsWith("ActionTemplates-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.ActionTemplate;
+
+        return OctopusDocumentKind.Unknown;
+    }
+
+    private static OctopusDocumentKind ApplySnapshotKind(OctopusDocumentKind kind, bool isSnapshot)
+    {
+        if (!isSnapshot)
+            return kind;
+
+        return kind switch
+        {
+            OctopusDocumentKind.DeploymentProcess => OctopusDocumentKind.DeploymentProcessSnapshot,
+            OctopusDocumentKind.VariableSet => OctopusDocumentKind.VariableSetSnapshot,
+            _ => kind
+        };
+    }
+
+    private static bool IsSnapshotKind(OctopusDocumentKind kind)
+        => kind is OctopusDocumentKind.DeploymentProcessSnapshot or OctopusDocumentKind.VariableSetSnapshot;
+
+    private static bool IsOutOfScopeHistory(OctopusDocumentKind kind)
+        => IsSnapshotKind(kind) || kind is OctopusDocumentKind.Release or OctopusDocumentKind.Deployment or OctopusDocumentKind.ServerTask;
+
+    private static bool IsSnapshotId(string id)
+        => !string.IsNullOrWhiteSpace(id) && SnapshotIdPattern().IsMatch(id);
+
+    private static bool IsSnapshotFileName(string sourcePath)
+        => !string.IsNullOrWhiteSpace(sourcePath) && SnapshotFileNamePattern().IsMatch(Path.GetFileName(sourcePath));
+
+    [GeneratedRegex(@"-(s)-\d+-", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SnapshotIdPattern();
+
+    [GeneratedRegex(@"^(deploymentprocess|variableset)-.+-s-\d+-", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SnapshotFileNamePattern();
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentKind.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentKind.cs
@@ -1,0 +1,26 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public enum OctopusDocumentKind
+{
+    Unknown,
+    Manifest,
+    Project,
+    ProjectGroup,
+    Environment,
+    Lifecycle,
+    Channel,
+    DeploymentSettings,
+    DeploymentProcess,
+    DeploymentProcessSnapshot,
+    VariableSet,
+    VariableSetSnapshot,
+    Feed,
+    Team,
+    Machine,
+    Account,
+    Certificate,
+    Release,
+    Deployment,
+    ServerTask,
+    ActionTemplate
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusTransportDtos.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusTransportDtos.cs
@@ -1,0 +1,464 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public class OctopusExportManifestDto
+{
+    public List<string> SchemaVersions { get; set; } = [];
+
+    public List<OctopusManifestEntryDto> Entries { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusManifestEntryDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string DocumentType { get; set; }
+
+    public string ExportType { get; set; }
+
+    public string DocumentSource { get; set; }
+
+    public string ParentId { get; set; }
+
+    public string Hash { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public abstract class OctopusDocumentDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string Slug { get; set; }
+
+    public string SpaceId { get; set; }
+
+    public DateTimeOffset? LastModified { get; set; }
+
+    public string DataVersion { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusProjectDto : OctopusDocumentDto
+{
+    public string Description { get; set; }
+
+    public bool IsDisabled { get; set; }
+
+    public string VariableSetId { get; set; }
+
+    public string DeploymentProcessId { get; set; }
+
+    public string DeploymentSettingsId { get; set; }
+
+    public string ProjectGroupId { get; set; }
+
+    public string LifecycleId { get; set; }
+
+    public bool AutoCreateRelease { get; set; }
+
+    public bool DiscreteChannelRelease { get; set; }
+
+    public List<string> IncludedLibraryVariableSetIds { get; set; } = [];
+
+    public List<JsonElement> Templates { get; set; } = [];
+
+    public List<JsonElement> ExtensionSettings { get; set; } = [];
+
+    public string TenantedDeploymentMode { get; set; }
+}
+
+public class OctopusProjectGroupDto : OctopusDocumentDto
+{
+    public string Description { get; set; }
+}
+
+public class OctopusEnvironmentDto : OctopusDocumentDto
+{
+    public string Description { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public bool? UseGuidedFailure { get; set; }
+
+    public bool? AllowDynamicInfrastructure { get; set; }
+}
+
+public class OctopusLifecycleDto : OctopusDocumentDto
+{
+    public string Type { get; set; }
+
+    public string Description { get; set; }
+
+    public List<OctopusLifecyclePhaseDto> Phases { get; set; } = [];
+
+    public JsonElement? ReleaseRetentionPolicy { get; set; }
+
+    public JsonElement? TentacleRetentionPolicy { get; set; }
+}
+
+public class OctopusLifecyclePhaseDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public List<string> AutomaticDeploymentTargets { get; set; } = [];
+
+    public List<string> OptionalDeploymentTargets { get; set; } = [];
+
+    public int MinimumEnvironmentsBeforePromotion { get; set; }
+
+    public bool IsOptionalPhase { get; set; }
+
+    public bool IsPriorityPhase { get; set; }
+
+    public JsonElement? ReleaseRetentionPolicy { get; set; }
+
+    public JsonElement? TentacleRetentionPolicy { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusChannelDto : OctopusDocumentDto
+{
+    public string ProjectId { get; set; }
+
+    public string LifecycleId { get; set; }
+
+    public bool IsDefault { get; set; }
+
+    public List<JsonElement> Rules { get; set; } = [];
+}
+
+public class OctopusDeploymentSettingsDto : OctopusDocumentDto
+{
+    public string ProjectId { get; set; }
+
+    public bool DefaultToSkipIfAlreadyInstalled { get; set; }
+
+    public JsonElement? ConnectivityPolicy { get; set; }
+
+    public string DefaultGuidedFailureMode { get; set; }
+
+    public JsonElement? VersioningStrategy { get; set; }
+
+    public bool ForcePackageDownload { get; set; }
+
+    public bool FailTargetDiscovery { get; set; }
+}
+
+public class OctopusDeploymentProcessDto
+{
+    public string Id { get; set; }
+
+    public string OwnerId { get; set; }
+
+    public int Version { get; set; }
+
+    public string SpaceId { get; set; }
+
+    public List<OctopusDeploymentStepDto> Steps { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusDeploymentStepDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string Slug { get; set; }
+
+    public string Condition { get; set; }
+
+    public string StartTrigger { get; set; }
+
+    public string PackageRequirement { get; set; }
+
+    public List<OctopusDeploymentActionDto> Actions { get; set; } = [];
+
+    public Dictionary<string, string> Properties { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusDeploymentActionDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string Slug { get; set; }
+
+    public string ActionType { get; set; }
+
+    public string Notes { get; set; }
+
+    public string WorkerPoolId { get; set; }
+
+    public string WorkerPoolVariable { get; set; }
+
+    public OctopusActionContainerDto Container { get; set; }
+
+    public bool IsDisabled { get; set; }
+
+    public bool IsRequired { get; set; }
+
+    public List<string> Environments { get; set; } = [];
+
+    public string EnvironmentsVariable { get; set; }
+
+    public List<string> ExcludedEnvironments { get; set; } = [];
+
+    public string ExcludedEnvironmentsVariable { get; set; }
+
+    public List<string> Channels { get; set; } = [];
+
+    public string ChannelsVariable { get; set; }
+
+    public List<string> TenantTags { get; set; } = [];
+
+    public string TenantTagsVariable { get; set; }
+
+    public List<OctopusActionPackageDto> Packages { get; set; } = [];
+
+    public List<JsonElement> GitDependencies { get; set; } = [];
+
+    public string Condition { get; set; }
+
+    public Dictionary<string, string> Properties { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusActionContainerDto
+{
+    public string Image { get; set; }
+
+    public string FeedId { get; set; }
+
+    public string GitUrl { get; set; }
+
+    public string Dockerfile { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusActionPackageDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string PackageId { get; set; }
+
+    public string FeedId { get; set; }
+
+    public string AcquisitionLocation { get; set; }
+
+    public string Version { get; set; }
+
+    public Dictionary<string, string> Properties { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusVariableSetDto
+{
+    public string Id { get; set; }
+
+    public string OwnerId { get; set; }
+
+    public string OwnerType { get; set; }
+
+    public int Version { get; set; }
+
+    public List<OctopusVariableDto> Variables { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusVariableDto
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public string Description { get; set; }
+
+    public string Value { get; set; }
+
+    public string Type { get; set; }
+
+    public bool IsSensitive { get; set; }
+
+    public bool IsEditable { get; set; }
+
+    public OctopusVariablePromptDto Prompt { get; set; }
+
+    public Dictionary<string, List<string>> Scope { get; set; } = [];
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusVariablePromptDto
+{
+    public string Label { get; set; }
+
+    public string Description { get; set; }
+
+    public bool Required { get; set; }
+
+    public string DisplaySettings { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusFeedDto : OctopusDocumentDto
+{
+    public string FeedType { get; set; }
+
+    public string FeedUri { get; set; }
+
+    public string RegistryPath { get; set; }
+
+    public string ApiVersion { get; set; }
+
+    public string Username { get; set; }
+
+    public string Password { get; set; }
+
+    public int DownloadAttempts { get; set; }
+
+    public int DownloadRetryBackoffSeconds { get; set; }
+}
+
+public class OctopusTeamDto : OctopusDocumentDto
+{
+    public List<string> MemberUserIds { get; set; } = [];
+
+    public List<string> ExternalSecurityGroups { get; set; } = [];
+}
+
+public class OctopusMachineDto : OctopusDocumentDto
+{
+    public string MachinePolicyId { get; set; }
+
+    public List<string> Roles { get; set; } = [];
+
+    public List<string> EnvironmentIds { get; set; } = [];
+
+    public bool IsDisabled { get; set; }
+
+    public JsonElement? Endpoint { get; set; }
+}
+
+public class OctopusAccountDto : OctopusDocumentDto
+{
+    public string AccountType { get; set; }
+
+    public string Description { get; set; }
+
+    public List<string> EnvironmentIds { get; set; } = [];
+
+    public JsonElement? Credentials { get; set; }
+}
+
+public class OctopusCertificateDto : OctopusDocumentDto
+{
+    public string Notes { get; set; }
+
+    public bool HasPrivateKey { get; set; }
+
+    public DateTimeOffset? NotAfter { get; set; }
+
+    public DateTimeOffset? NotBefore { get; set; }
+
+    public JsonElement? CertificateData { get; set; }
+}
+
+public class OctopusReleaseDto : OctopusDocumentDto
+{
+    public string ProjectId { get; set; }
+
+    public string ChannelId { get; set; }
+
+    public string Version { get; set; }
+
+    public string ReleaseNotes { get; set; }
+
+    public DateTimeOffset? Assembled { get; set; }
+
+    public string ProjectVariableSetSnapshotId { get; set; }
+
+    public string ProjectDeploymentProcessSnapshotId { get; set; }
+
+    public List<OctopusSelectedPackageDto> SelectedPackages { get; set; } = [];
+}
+
+public class OctopusSelectedPackageDto
+{
+    public string ActionName { get; set; }
+
+    public string PackageReferenceName { get; set; }
+
+    public string Version { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtensionData { get; set; } = [];
+}
+
+public class OctopusDeploymentDto : OctopusDocumentDto
+{
+    public string ProjectId { get; set; }
+
+    public string EnvironmentId { get; set; }
+
+    public string ReleaseId { get; set; }
+
+    public string TaskId { get; set; }
+
+    public string DeployedBy { get; set; }
+
+    public DateTimeOffset? Created { get; set; }
+}
+
+public class OctopusServerTaskDto : OctopusDocumentDto
+{
+    public string Description { get; set; }
+
+    public string State { get; set; }
+
+    public DateTimeOffset? QueueTime { get; set; }
+
+    public DateTimeOffset? StartTime { get; set; }
+
+    public DateTimeOffset? CompletedTime { get; set; }
+
+    public string ProjectId { get; set; }
+
+    public string EnvironmentId { get; set; }
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusDocumentClassifierTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusDocumentClassifierTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.UnitTests.Services.OctopusImport.Octopus;
+
+public class OctopusDocumentClassifierTests
+{
+    [Fact]
+    public void Classify_UsesManifestDocumentTypeBeforeFileName()
+    {
+        var entry = new OctopusManifestEntryDto
+        {
+            Id = "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+            Name = "Next Chat",
+            DocumentType = "DeploymentProcess",
+            DocumentSource = "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43.json"
+        };
+
+        var classification = OctopusDocumentClassifier.Classify(entry);
+
+        classification.Kind.ShouldBe(OctopusDocumentKind.DeploymentProcess);
+        classification.SourceId.ShouldBe(entry.Id);
+        classification.ManifestDocumentType.ShouldBe("DeploymentProcess");
+        classification.IsCurrentConfiguration.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Classify_ManifestProjectVariablesSnapshot_AsVariableSetSnapshot()
+    {
+        var entry = new OctopusManifestEntryDto
+        {
+            Id = "variableset-Projects-1323-s-55-N6739-D4C63A85E7894C5D8C20D9297FEA1A43",
+            Name = "Variables",
+            DocumentType = "ProjectVariables",
+            DocumentSource = "variableset-Projects-1323-s-55-N6739-D4C63A85E7894C5D8C20D9297FEA1A43.json"
+        };
+
+        var classification = OctopusDocumentClassifier.Classify(entry);
+
+        classification.Kind.ShouldBe(OctopusDocumentKind.VariableSetSnapshot);
+        classification.IsHistoricalSnapshot.ShouldBeTrue();
+        classification.IsOutOfScopeHistory.ShouldBeTrue();
+        classification.IsCurrentConfiguration.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Classify_ManifestCurrentDeploymentProcess_AsCurrentConfiguration()
+    {
+        var entry = new OctopusManifestEntryDto
+        {
+            Id = "deploymentprocess-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+            DocumentType = "DeploymentProcess",
+            DocumentSource = "deploymentprocess-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43.json"
+        };
+
+        var classification = OctopusDocumentClassifier.Classify(entry);
+
+        classification.Kind.ShouldBe(OctopusDocumentKind.DeploymentProcess);
+        classification.IsHistoricalSnapshot.ShouldBeFalse();
+        classification.IsCurrentConfiguration.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("manifest.json", OctopusDocumentKind.Manifest, false)]
+    [InlineData("Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Project, false)]
+    [InlineData("ProjectGroups-210-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.ProjectGroup, false)]
+    [InlineData("Environments-3-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Environment, false)]
+    [InlineData("Lifecycles-302-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Lifecycle, false)]
+    [InlineData("Channels-1523-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Channel, false)]
+    [InlineData("Feeds-1083-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Feed, false)]
+    [InlineData("Teams-286-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Team, false)]
+    [InlineData("Releases-93056-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Release, true)]
+    [InlineData("Deployments-390384-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.Deployment, true)]
+    [InlineData("ServerTasks-2032665-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.ServerTask, true)]
+    [InlineData("deploymentprocess-Projects-1323-s-21-8DWSK-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.DeploymentProcessSnapshot, true)]
+    [InlineData("variableset-Projects-1323-s-55-N6739-D4C63A85E7894C5D8C20D9297FEA1A43.json", OctopusDocumentKind.VariableSetSnapshot, true)]
+    public void ClassifyFileName_MapsKnownExportFileNames(string fileName, OctopusDocumentKind expectedKind, bool outOfScope)
+    {
+        var classification = OctopusDocumentClassifier.ClassifyFileName(fileName);
+
+        classification.Kind.ShouldBe(expectedKind);
+        classification.IsOutOfScopeHistory.ShouldBe(outOfScope);
+    }
+
+    [Fact]
+    public void ClassifyJsonDocument_UsesDocumentTypeWhenAvailable()
+    {
+        var classification = OctopusDocumentClassifier.ClassifyJsonDocument(
+            "ambiguous.json",
+            "Feeds-1083-D4C63A85E7894C5D8C20D9297FEA1A43",
+            "DockerFeed");
+
+        classification.Kind.ShouldBe(OctopusDocumentKind.Feed);
+        classification.ManifestDocumentType.ShouldBe("DockerFeed");
+    }
+
+    [Fact]
+    public void ClassifyJsonDocument_UsesIdWhenDocumentTypeIsMissing()
+    {
+        var classification = OctopusDocumentClassifier.ClassifyJsonDocument(
+            "payload.json",
+            "Machines-1-D4C63A85E7894C5D8C20D9297FEA1A43");
+
+        classification.Kind.ShouldBe(OctopusDocumentKind.Machine);
+    }
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusTransportDtoTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusTransportDtoTests.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.UnitTests.Services.OctopusImport.Octopus;
+
+public class OctopusTransportDtoTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Fact]
+    public void ManifestDto_DeserializesEntriesAndPreservesUnknownFields()
+    {
+        const string json = """
+        {
+          "SchemaVersions": [ "Script0271InitialiseGuidedFailureEnumValue" ],
+          "Entries": [
+            {
+              "Id": "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+              "Name": "Next Chat",
+              "DocumentType": "Project",
+              "ExportType": "FullDocument",
+              "DocumentSource": "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43.json",
+              "ParentId": null,
+              "Hash": "cc80017a933e6da5e3f7d55d574d11e10c9877cf",
+              "FutureField": "kept"
+            }
+          ],
+          "OtherManifestField": true
+        }
+        """;
+
+        var manifest = JsonSerializer.Deserialize<OctopusExportManifestDto>(json, JsonOptions);
+
+        manifest.SchemaVersions.ShouldBe(["Script0271InitialiseGuidedFailureEnumValue"]);
+        manifest.Entries.Count.ShouldBe(1);
+        manifest.Entries[0].DocumentType.ShouldBe("Project");
+        manifest.Entries[0].ExtensionData.Keys.ShouldContain("FutureField");
+        manifest.ExtensionData.Keys.ShouldContain("OtherManifestField");
+    }
+
+    [Fact]
+    public void ProjectDto_DeserializesCoreProjectReferences()
+    {
+        const string json = """
+        {
+          "SpaceId": "Spaces-1-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "Id": "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "Name": "Next Chat",
+          "Slug": "next-chat",
+          "Description": "",
+          "IsDisabled": false,
+          "VariableSetId": "variableset-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "DeploymentProcessId": "deploymentprocess-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "DeploymentSettingsId": "deploymentsettings-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "ProjectGroupId": "ProjectGroups-210-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "LifecycleId": "Lifecycles-302-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "IncludedLibraryVariableSetIds": [],
+          "ExtensionSettings": [],
+          "DataVersion": "AAAAAAIhdD8="
+        }
+        """;
+
+        var project = JsonSerializer.Deserialize<OctopusProjectDto>(json, JsonOptions);
+
+        project.Id.ShouldBe("Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43");
+        project.Name.ShouldBe("Next Chat");
+        project.VariableSetId.ShouldStartWith("variableset-Projects-1323");
+        project.DeploymentProcessId.ShouldStartWith("deploymentprocess-Projects-1323");
+        project.ProjectGroupId.ShouldStartWith("ProjectGroups-210");
+        project.LifecycleId.ShouldStartWith("Lifecycles-302");
+    }
+
+    [Fact]
+    public void DeploymentProcessDto_DeserializesStepsActionsPackagesAndProperties()
+    {
+        const string json = """
+        {
+          "Id": "deploymentprocess-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "OwnerId": "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "Version": 21,
+          "SpaceId": "Spaces-1-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "Steps": [
+            {
+              "Id": "13149498-f8e1-436f-9110-288719b4dd80",
+              "Name": "Deploy Kubernetes resources",
+              "Condition": "Success",
+              "StartTrigger": "StartAfterPrevious",
+              "PackageRequirement": "LetOctopusDecide",
+              "Actions": [
+                {
+                  "Id": "b3823849-4b09-4ace-871b-fee35641a13c",
+                  "Name": "Deploy Kubernetes resources",
+                  "ActionType": "Octopus.KubernetesDeployContainers",
+                  "IsDisabled": false,
+                  "IsRequired": false,
+                  "Environments": [],
+                  "ExcludedEnvironments": [],
+                  "Channels": [],
+                  "TenantTags": [],
+                  "Packages": [
+                    {
+                      "Id": "95caadda-feaa-44aa-b67b-66646fc78336",
+                      "Name": "next-chat",
+                      "PackageId": "sjdistributor/next-chat",
+                      "FeedId": "Feeds-1083-D4C63A85E7894C5D8C20D9297FEA1A43",
+                      "AcquisitionLocation": "NotAcquired",
+                      "Properties": { "SelectionMode": "immediate" }
+                    }
+                  ],
+                  "GitDependencies": [],
+                  "Condition": "Success",
+                  "Properties": {
+                    "Octopus.Action.KubernetesContainers.Namespace": "#{K8SNameSpace}"
+                  }
+                }
+              ],
+              "Properties": {}
+            }
+          ]
+        }
+        """;
+
+        var process = JsonSerializer.Deserialize<OctopusDeploymentProcessDto>(json, JsonOptions);
+
+        process.Version.ShouldBe(21);
+        process.Steps.Count.ShouldBe(1);
+        process.Steps[0].Actions[0].ActionType.ShouldBe("Octopus.KubernetesDeployContainers");
+        process.Steps[0].Actions[0].Packages[0].FeedId.ShouldStartWith("Feeds-1083");
+        process.Steps[0].Actions[0].Properties["Octopus.Action.KubernetesContainers.Namespace"].ShouldBe("#{K8SNameSpace}");
+    }
+
+    [Fact]
+    public void VariableSetDto_DeserializesVariableScopes()
+    {
+        const string json = """
+        {
+          "Id": "variableset-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "OwnerId": "Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "OwnerType": "Project",
+          "Version": 55,
+          "Variables": [
+            {
+              "Id": "dc3df21e-8a46-737c-7d98-4abae6378e2f",
+              "Name": "K8SNameSpace",
+              "Value": "next-chat-prd",
+              "Scope": {
+                "Environment": [ "Environments-3-D4C63A85E7894C5D8C20D9297FEA1A43" ]
+              }
+            }
+          ]
+        }
+        """;
+
+        var variableSet = JsonSerializer.Deserialize<OctopusVariableSetDto>(json, JsonOptions);
+
+        variableSet.OwnerType.ShouldBe("Project");
+        variableSet.Version.ShouldBe(55);
+        variableSet.Variables[0].Name.ShouldBe("K8SNameSpace");
+        variableSet.Variables[0].Scope["Environment"].ShouldBe(["Environments-3-D4C63A85E7894C5D8C20D9297FEA1A43"]);
+    }
+
+    [Fact]
+    public void FeedDto_DeserializesCredentialsForLaterRedaction()
+    {
+        const string json = """
+        {
+          "FeedType": "Docker",
+          "Username": "sjdistributor",
+          "Password": "encrypted-value",
+          "FeedUri": "https://index.docker.io",
+          "Id": "Feeds-1083-D4C63A85E7894C5D8C20D9297FEA1A43",
+          "Name": "Docker Hub Registry",
+          "SpaceId": "Spaces-1-D4C63A85E7894C5D8C20D9297FEA1A43"
+        }
+        """;
+
+        var feed = JsonSerializer.Deserialize<OctopusFeedDto>(json, JsonOptions);
+
+        feed.FeedType.ShouldBe("Docker");
+        feed.Username.ShouldBe("sjdistributor");
+        feed.Password.ShouldBe("encrypted-value");
+        feed.FeedUri.ShouldBe("https://index.docker.io");
+    }
+}


### PR DESCRIPTION
## Summary

- Added Octopus transport DTOs for manifest entries, projects, project groups, environments, lifecycles/phases, channels, deployment settings, deployment processes, steps, actions, variables/scopes, feeds, teams, machines, accounts, certificates, releases, deployments, server tasks, and snapshot-related documents.
- Added Octopus document classification for known export document types, with manifest metadata taking precedence over filename fallback.
- Added current-versus-historical classification for deployment process and variable set `-s-` snapshots, and marked releases, deployments, server tasks, and frozen snapshots as out of scope for the initial current-configuration import.
- Added focused unit tests for DTO deserialization, extension-data preservation, manifest-driven classification, filename fallback classification, and snapshot handling.
- Updated local OpenSpec progress tracking for `add-octopus-import` by marking tasks `2.1` and `2.2` complete.
- Scope intentionally stops at the extract model/classification layer; safe ZIP extraction, manifest inventory, parse diagnostics, and normalized graph construction remain for later branches.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport.Octopus"`
- [x] Result: passed, `47` tests total, `0` failed, `0` skipped.
- [ ] Full unit/integration suites were not run for this branch; this branch only covers Octopus import DTO and classifier behavior.