### PR TITLE
Add safe Octopus archive extraction with configurable limits

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionErrorCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionErrorCodes.cs
@@ -1,0 +1,12 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public static class OctopusArchiveExtractionErrorCodes
+{
+    public const string InvalidArchive = "octopus.archive.invalid";
+    public const string EntryCountLimitExceeded = "octopus.archive.entry_count_limit_exceeded";
+    public const string EntryPathUnsafe = "octopus.archive.entry_path_unsafe";
+    public const string DuplicateEntryPath = "octopus.archive.duplicate_entry_path";
+    public const string NestedArchiveRejected = "octopus.archive.nested_archive_rejected";
+    public const string EntrySizeLimitExceeded = "octopus.archive.entry_size_limit_exceeded";
+    public const string TotalSizeLimitExceeded = "octopus.archive.total_size_limit_exceeded";
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionException.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionException.cs
@@ -1,0 +1,15 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public class OctopusArchiveExtractionException : Exception
+{
+    public OctopusArchiveExtractionException(string code, string message, string sourcePath = null, Exception innerException = null)
+        : base(message, innerException)
+    {
+        Code = code;
+        SourcePath = sourcePath;
+    }
+
+    public string Code { get; }
+
+    public string SourcePath { get; }
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionOptions.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionOptions.cs
@@ -1,0 +1,28 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public sealed class OctopusArchiveExtractionOptions
+{
+    public const int DefaultMaxEntryCount = 5_000;
+    public const long DefaultMaxEntrySizeBytes = 10 * 1024 * 1024;
+    public const long DefaultMaxTotalUncompressedSizeBytes = 100 * 1024 * 1024;
+
+    public int MaxEntryCount { get; init; } = DefaultMaxEntryCount;
+
+    public long MaxEntrySizeBytes { get; init; } = DefaultMaxEntrySizeBytes;
+
+    public long MaxTotalUncompressedSizeBytes { get; init; } = DefaultMaxTotalUncompressedSizeBytes;
+
+    public static OctopusArchiveExtractionOptions Default { get; } = new();
+
+    public void EnsureValid()
+    {
+        if (MaxEntryCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxEntryCount), MaxEntryCount, "Entry count limit must be greater than zero.");
+
+        if (MaxEntrySizeBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxEntrySizeBytes), MaxEntrySizeBytes, "Entry size limit must be greater than zero.");
+
+        if (MaxTotalUncompressedSizeBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxTotalUncompressedSizeBytes), MaxTotalUncompressedSizeBytes, "Total uncompressed size limit must be greater than zero.");
+    }
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionResult.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractionResult.cs
@@ -1,0 +1,13 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public sealed record OctopusArchiveExtractionResult(IReadOnlyList<OctopusExtractedArchiveEntry> Entries)
+{
+    public int EntryCount => Entries.Count;
+
+    public long TotalUncompressedSizeBytes => Entries.Sum(e => e.SizeBytes);
+}
+
+public sealed record OctopusExtractedArchiveEntry(string RelativePath, byte[] Content)
+{
+    public long SizeBytes => Content.LongLength;
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractor.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusArchiveExtractor.cs
@@ -1,0 +1,226 @@
+using System.IO.Compression;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public interface IOctopusArchiveExtractor : IScopedDependency
+{
+    Task<OctopusArchiveExtractionResult> ExtractZipAsync(
+        Stream archiveStream,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default);
+}
+
+public class OctopusArchiveExtractor : IOctopusArchiveExtractor
+{
+    private const int CopyBufferSize = 81920;
+    private static readonly string PathSafetyRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "squid-octopus-import-archive-root"));
+    private static readonly byte[] ZipMagic = [0x50, 0x4B, 0x03, 0x04];
+    private static readonly byte[] GzipMagic = [0x1F, 0x8B];
+    private static readonly HashSet<string> NestedArchiveExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".zip",
+        ".tar",
+        ".gz",
+        ".tgz",
+        ".rar",
+        ".7z"
+    };
+
+    public async Task<OctopusArchiveExtractionResult> ExtractZipAsync(
+        Stream archiveStream,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(archiveStream);
+
+        options ??= OctopusArchiveExtractionOptions.Default;
+        options.EnsureValid();
+
+        try
+        {
+            using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Read, leaveOpen: true);
+
+            if (archive.Entries.Count > options.MaxEntryCount)
+                throw BuildLimitException(
+                    OctopusArchiveExtractionErrorCodes.EntryCountLimitExceeded,
+                    $"Octopus import archive contains {archive.Entries.Count} entries, exceeding the configured limit of {options.MaxEntryCount}.");
+
+            var entries = new List<OctopusExtractedArchiveEntry>();
+            var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            long totalUncompressedSizeBytes = 0;
+
+            foreach (var entry in archive.Entries)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var isDirectory = IsDirectoryEntry(entry);
+                var relativePath = NormalizeAndValidateEntryPath(entry.FullName, isDirectory);
+
+                if (IsDirectoryEntry(entry))
+                    continue;
+
+                if (!seenPaths.Add(relativePath))
+                    throw BuildEntryException(
+                        OctopusArchiveExtractionErrorCodes.DuplicateEntryPath,
+                        $"Octopus import archive contains duplicate entry path '{relativePath}'.",
+                        relativePath);
+
+                RejectNestedArchiveByPath(relativePath);
+                EnsureEntryLengthWithinLimit(entry, relativePath, options.MaxEntrySizeBytes);
+
+                var content = await ReadEntryContentAsync(entry, relativePath, options.MaxEntrySizeBytes, ct).ConfigureAwait(false);
+
+                RejectNestedArchiveByContent(relativePath, content);
+
+                totalUncompressedSizeBytes = checked(totalUncompressedSizeBytes + content.LongLength);
+
+                if (totalUncompressedSizeBytes > options.MaxTotalUncompressedSizeBytes)
+                    throw BuildLimitException(
+                        OctopusArchiveExtractionErrorCodes.TotalSizeLimitExceeded,
+                        $"Octopus import archive uncompressed size exceeds the configured limit of {options.MaxTotalUncompressedSizeBytes} bytes.",
+                        relativePath);
+
+                entries.Add(new OctopusExtractedArchiveEntry(relativePath, content));
+            }
+
+            return new OctopusArchiveExtractionResult(entries);
+        }
+        catch (OctopusArchiveExtractionException)
+        {
+            throw;
+        }
+        catch (InvalidDataException ex)
+        {
+            throw new OctopusArchiveExtractionException(
+                OctopusArchiveExtractionErrorCodes.InvalidArchive,
+                "Octopus import archive could not be opened as a ZIP archive.",
+                innerException: ex);
+        }
+    }
+
+    private static bool IsDirectoryEntry(ZipArchiveEntry entry)
+        => string.IsNullOrEmpty(entry.Name);
+
+    private static string NormalizeAndValidateEntryPath(string entryPath, bool isDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(entryPath))
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.EntryPathUnsafe,
+                "Octopus import archive contains an entry with an empty path.",
+                entryPath);
+
+        if (entryPath.StartsWith('/') || entryPath.StartsWith('\\') || HasDriveLetter(entryPath))
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.EntryPathUnsafe,
+                $"Octopus import archive entry path '{entryPath}' is not relative.",
+                entryPath);
+
+        var normalized = entryPath.Replace('\\', '/');
+
+        if (isDirectory)
+            normalized = normalized.TrimEnd('/');
+
+        var segments = normalized.Split('/');
+
+        if (segments.Any(segment => segment.Length == 0 || segment == "." || segment == ".."))
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.EntryPathUnsafe,
+                $"Octopus import archive entry path '{entryPath}' contains an unsafe segment.",
+                entryPath);
+
+        var resolvedPath = Path.GetFullPath(Path.Combine(PathSafetyRoot, normalized.Replace('/', Path.DirectorySeparatorChar)));
+        var expectedRoot = PathSafetyRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? PathSafetyRoot
+            : PathSafetyRoot + Path.DirectorySeparatorChar;
+
+        if (!resolvedPath.StartsWith(expectedRoot, StringComparison.Ordinal))
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.EntryPathUnsafe,
+                $"Octopus import archive entry path '{entryPath}' resolves outside the extraction root.",
+                entryPath);
+
+        return normalized;
+    }
+
+    private static bool HasDriveLetter(string entryPath)
+        => entryPath.Length >= 2 && entryPath[1] == ':';
+
+    private static void RejectNestedArchiveByPath(string relativePath)
+    {
+        if (NestedArchiveExtensions.Contains(Path.GetExtension(relativePath)) ||
+            relativePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.NestedArchiveRejected,
+                $"Octopus import archive entry '{relativePath}' appears to be a nested archive.",
+                relativePath);
+    }
+
+    private static void EnsureEntryLengthWithinLimit(ZipArchiveEntry entry, string relativePath, long maxEntrySizeBytes)
+    {
+        if (entry.Length > maxEntrySizeBytes)
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.EntrySizeLimitExceeded,
+                $"Octopus import archive entry '{relativePath}' exceeds the configured per-entry size limit of {maxEntrySizeBytes} bytes.",
+                relativePath);
+    }
+
+    private static async Task<byte[]> ReadEntryContentAsync(
+        ZipArchiveEntry entry,
+        string relativePath,
+        long maxEntrySizeBytes,
+        CancellationToken ct)
+    {
+        await using var entryStream = entry.Open();
+        await using var memoryStream = new MemoryStream();
+        var buffer = new byte[CopyBufferSize];
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var read = await entryStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+
+            if (read == 0)
+                break;
+
+            if (memoryStream.Length + read > maxEntrySizeBytes)
+                throw BuildEntryException(
+                    OctopusArchiveExtractionErrorCodes.EntrySizeLimitExceeded,
+                    $"Octopus import archive entry '{relativePath}' exceeds the configured per-entry size limit of {maxEntrySizeBytes} bytes.",
+                    relativePath);
+
+            await memoryStream.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+        }
+
+        return memoryStream.ToArray();
+    }
+
+    private static void RejectNestedArchiveByContent(string relativePath, byte[] content)
+    {
+        if (StartsWith(content, ZipMagic) || StartsWith(content, GzipMagic))
+            throw BuildEntryException(
+                OctopusArchiveExtractionErrorCodes.NestedArchiveRejected,
+                $"Octopus import archive entry '{relativePath}' contains nested archive content.",
+                relativePath);
+    }
+
+    private static bool StartsWith(byte[] content, byte[] prefix)
+    {
+        if (content.Length < prefix.Length)
+            return false;
+
+        for (var i = 0; i < prefix.Length; i++)
+        {
+            if (content[i] != prefix[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    private static OctopusArchiveExtractionException BuildLimitException(string code, string message, string sourcePath = null)
+        => new(code, message, sourcePath);
+
+    private static OctopusArchiveExtractionException BuildEntryException(string code, string message, string sourcePath)
+        => new(code, message, sourcePath);
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusArchiveExtractorTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusArchiveExtractorTests.cs
@@ -1,0 +1,214 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.UnitTests.Services.OctopusImport.Octopus;
+
+public class OctopusArchiveExtractorTests
+{
+    private readonly OctopusArchiveExtractor _extractor = new();
+
+    [Fact]
+    public async Task ExtractZipAsync_ValidZip_ReturnsNormalizedEntries()
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["manifest.json"] = JsonBytes("""{"Entries":[]}"""),
+            ["Projects-1.json"] = JsonBytes("""{"Id":"Projects-1","Name":"Project"}""")
+        });
+
+        var result = await ExtractAsync(bytes);
+
+        result.EntryCount.ShouldBe(2);
+        result.Entries[0].RelativePath.ShouldBe("manifest.json");
+        result.Entries[1].RelativePath.ShouldBe("Projects-1.json");
+        Encoding.UTF8.GetString(result.Entries[1].Content).ShouldContain("Projects-1");
+    }
+
+    [Theory]
+    [InlineData("../manifest.json")]
+    [InlineData("folder/../../manifest.json")]
+    [InlineData("/manifest.json")]
+    [InlineData("C:/manifest.json")]
+    [InlineData("folder//manifest.json")]
+    [InlineData("folder/./manifest.json")]
+    public async Task ExtractZipAsync_UnsafeEntryPath_RejectsArchive(string entryPath)
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            [entryPath] = JsonBytes("""{"Entries":[]}""")
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(() => ExtractAsync(bytes));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.EntryPathUnsafe);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_UnsafeDirectoryEntry_RejectsArchive()
+    {
+        var bytes = CreateZipArchiveWithDirectory("../");
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(() => ExtractAsync(bytes));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.EntryPathUnsafe);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_DuplicateNormalizedPath_RejectsArchive()
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["manifest.json"] = JsonBytes("""{"Entries":[]}"""),
+            ["MANIFEST.json"] = JsonBytes("""{"Entries":[]}""")
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(() => ExtractAsync(bytes));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.DuplicateEntryPath);
+    }
+
+    [Theory]
+    [InlineData("nested.zip")]
+    [InlineData("nested.tar.gz")]
+    [InlineData("nested.tgz")]
+    public async Task ExtractZipAsync_NestedArchiveExtension_RejectsArchive(string entryPath)
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            [entryPath] = Encoding.UTF8.GetBytes("not even opened as an archive")
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(() => ExtractAsync(bytes));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.NestedArchiveRejected);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_NestedArchiveMagic_RejectsArchive()
+    {
+        var nestedZipBytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["inner.json"] = JsonBytes("""{"Id":"Projects-1"}""")
+        });
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["looks-like-json.json"] = nestedZipBytes
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(() => ExtractAsync(bytes));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.NestedArchiveRejected);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_EntryCountLimitExceeded_RejectsArchive()
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["one.json"] = JsonBytes("{}"),
+            ["two.json"] = JsonBytes("{}")
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(
+            () => ExtractAsync(bytes, new OctopusArchiveExtractionOptions { MaxEntryCount = 1 }));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.EntryCountLimitExceeded);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_PerEntryLimitExceeded_RejectsArchive()
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["large.json"] = JsonBytes("""{"value":"1234567890"}""")
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(
+            () => ExtractAsync(bytes, new OctopusArchiveExtractionOptions { MaxEntrySizeBytes = 8 }));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.EntrySizeLimitExceeded);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_TotalUncompressedLimitExceeded_RejectsArchive()
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["one.json"] = JsonBytes("""{"value":"12345"}"""),
+            ["two.json"] = JsonBytes("""{"value":"67890"}""")
+        });
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(
+            () => ExtractAsync(bytes, new OctopusArchiveExtractionOptions
+            {
+                MaxEntrySizeBytes = 100,
+                MaxTotalUncompressedSizeBytes = 20
+            }));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.TotalSizeLimitExceeded);
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_CancellationRequested_StopsExtraction()
+    {
+        var bytes = CreateZipArchive(new Dictionary<string, byte[]>
+        {
+            ["manifest.json"] = JsonBytes("""{"Entries":[]}""")
+        });
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => ExtractAsync(bytes, ct: cts.Token));
+    }
+
+    [Fact]
+    public async Task ExtractZipAsync_InvalidZip_RejectsArchive()
+    {
+        var bytes = Encoding.UTF8.GetBytes("not a zip");
+
+        var ex = await Should.ThrowAsync<OctopusArchiveExtractionException>(() => ExtractAsync(bytes));
+
+        ex.Code.ShouldBe(OctopusArchiveExtractionErrorCodes.InvalidArchive);
+    }
+
+    private Task<OctopusArchiveExtractionResult> ExtractAsync(
+        byte[] bytes,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default)
+    {
+        return _extractor.ExtractZipAsync(new MemoryStream(bytes), options, ct);
+    }
+
+    private static byte[] CreateZipArchive(Dictionary<string, byte[]> entries)
+    {
+        using var stream = new MemoryStream();
+
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (path, content) in entries)
+            {
+                var entry = archive.CreateEntry(path);
+                using var entryStream = entry.Open();
+                entryStream.Write(content);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateZipArchiveWithDirectory(string directoryPath)
+    {
+        using var stream = new MemoryStream();
+
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            archive.CreateEntry(directoryPath);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] JsonBytes(string json) => Encoding.UTF8.GetBytes(json);
+}


### PR DESCRIPTION
## Summary

- Created local branch `feature/octopus-import-safe-archive-extraction` from `feature/squid-import-project`.
- Added `IOctopusArchiveExtractor` / `OctopusArchiveExtractor` for safe ZIP extraction under `Squid.Core.Services.OctopusImport.Octopus`.
- Added configurable extraction limits for entry count, per-entry uncompressed size, and total uncompressed size.
- Added explicit extraction error codes and `OctopusArchiveExtractionException` for unsafe archive rejection.
- Implemented traversal prevention, duplicate normalized path rejection, nested archive rejection by extension and content magic, invalid ZIP handling, and cancellation checks.
- Added focused unit coverage in `OctopusArchiveExtractorTests` for valid ZIP extraction, unsafe paths, unsafe directory entries, nested archives, entry-count limits, size limits, cancellation, and invalid ZIP input.
- Scope intentionally stops at task 2.3; JSON/folder fallback, manifest inventory/hash checks, and normalized resource graph construction remain for later branches.
- Local ignored OpenSpec task file now shows task 2.3 complete, but `openspec/` is ignored by `.git/info/exclude` and is not part of tracked branch changes.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport"` passed: `65` passed, `0` failed, `0` skipped.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj` passed: `6287` passed, `0` failed, `0` skipped.
- [ ] OpenSpec CLI validation was not run because `openspec` is not available in this environment.
- [ ] Integration tests were not run; this branch only adds the safe ZIP extraction service and unit tests.