### PR TITLE
Add JSON and folder fallback extraction for Octopus import

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
@@ -1,0 +1,14 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public static class OctopusInputExtractionDiagnosticCodes
+{
+    public const string FolderNotFound = "octopus.input.folder_not_found";
+    public const string NoJsonDocuments = "octopus.input.no_json_documents";
+    public const string FileReadFailed = "octopus.input.file_read_failed";
+    public const string MalformedJson = "octopus.input.malformed_json";
+    public const string UnsupportedJsonRoot = "octopus.input.unsupported_json_root";
+    public const string UnrecognizedDocument = "octopus.input.unrecognized_document";
+    public const string EntryCountLimitExceeded = "octopus.input.entry_count_limit_exceeded";
+    public const string EntrySizeLimitExceeded = "octopus.input.entry_size_limit_exceeded";
+    public const string TotalSizeLimitExceeded = "octopus.input.total_size_limit_exceeded";
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionResult.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionResult.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public sealed record OctopusInputExtractionResult(
+    IReadOnlyList<OctopusExtractedJsonDocument> Documents,
+    IReadOnlyList<OctopusInputExtractionDiagnostic> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}
+
+public sealed record OctopusExtractedJsonDocument(
+    string SourcePath,
+    OctopusDocumentClassification Classification,
+    JsonElement Root,
+    long SizeBytes);
+
+public sealed record OctopusInputExtractionDiagnostic(
+    OctopusImportCompatibilitySeverity Severity,
+    string Code,
+    string Message,
+    string SourcePath = null,
+    string SourceId = null,
+    OctopusDocumentKind? DocumentKind = null);

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractor.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractor.cs
@@ -1,0 +1,362 @@
+using System.Text.Json;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public interface IOctopusInputExtractor : IScopedDependency
+{
+    Task<OctopusInputExtractionResult> ExtractStandaloneJsonAsync(
+        Stream jsonStream,
+        string sourcePath,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default);
+
+    Task<OctopusInputExtractionResult> ExtractFolderAsync(
+        string folderPath,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default);
+
+    Task<OctopusInputExtractionResult> ExtractJsonEntriesAsync(
+        IReadOnlyList<OctopusExtractedArchiveEntry> entries,
+        CancellationToken ct = default);
+}
+
+public class OctopusInputExtractor : IOctopusInputExtractor
+{
+    private const int CopyBufferSize = 81920;
+
+    public async Task<OctopusInputExtractionResult> ExtractStandaloneJsonAsync(
+        Stream jsonStream,
+        string sourcePath,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(jsonStream);
+
+        options ??= OctopusArchiveExtractionOptions.Default;
+        options.EnsureValid();
+
+        var diagnostics = new List<OctopusInputExtractionDiagnostic>();
+        var documents = new List<OctopusExtractedJsonDocument>();
+        var safeSourcePath = NormalizeDisplayPath(sourcePath);
+        var content = await ReadStreamWithLimitAsync(jsonStream, safeSourcePath, options.MaxEntrySizeBytes, diagnostics, ct).ConfigureAwait(false);
+
+        if (content != null)
+            AddParsedDocument(safeSourcePath, content, documents, diagnostics);
+
+        return new OctopusInputExtractionResult(documents, diagnostics);
+    }
+
+    public async Task<OctopusInputExtractionResult> ExtractFolderAsync(
+        string folderPath,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default)
+    {
+        options ??= OctopusArchiveExtractionOptions.Default;
+        options.EnsureValid();
+
+        var diagnostics = new List<OctopusInputExtractionDiagnostic>();
+        var documents = new List<OctopusExtractedJsonDocument>();
+
+        if (string.IsNullOrWhiteSpace(folderPath) || !Directory.Exists(folderPath))
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.FolderNotFound,
+                "Octopus import folder input was not found.",
+                NormalizeDisplayPath(folderPath)));
+
+            return new OctopusInputExtractionResult(documents, diagnostics);
+        }
+
+        var root = Path.GetFullPath(folderPath);
+        var jsonFiles = EnumerateJsonFiles(root, diagnostics);
+
+        if (jsonFiles.Count == 0)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.NoJsonDocuments,
+                "Octopus import folder input does not contain JSON documents.",
+                NormalizeDisplayPath(folderPath)));
+
+            return new OctopusInputExtractionResult(documents, diagnostics);
+        }
+
+        if (jsonFiles.Count > options.MaxEntryCount)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.EntryCountLimitExceeded,
+                $"Octopus import folder contains {jsonFiles.Count} JSON documents, exceeding the configured limit of {options.MaxEntryCount}.",
+                NormalizeDisplayPath(folderPath)));
+
+            return new OctopusInputExtractionResult(documents, diagnostics);
+        }
+
+        long totalSizeBytes = 0;
+
+        foreach (var filePath in jsonFiles)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var relativePath = NormalizeFolderRelativePath(root, filePath);
+            var content = await ReadFileWithLimitsAsync(filePath, relativePath, options.MaxEntrySizeBytes, diagnostics, ct).ConfigureAwait(false);
+
+            if (content == null)
+                continue;
+
+            totalSizeBytes = checked(totalSizeBytes + content.LongLength);
+
+            if (totalSizeBytes > options.MaxTotalUncompressedSizeBytes)
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.TotalSizeLimitExceeded,
+                    $"Octopus import folder JSON content exceeds the configured total size limit of {options.MaxTotalUncompressedSizeBytes} bytes.",
+                    relativePath));
+
+                break;
+            }
+
+            AddParsedDocument(relativePath, content, documents, diagnostics);
+        }
+
+        return new OctopusInputExtractionResult(documents, diagnostics);
+    }
+
+    public Task<OctopusInputExtractionResult> ExtractJsonEntriesAsync(
+        IReadOnlyList<OctopusExtractedArchiveEntry> entries,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var diagnostics = new List<OctopusInputExtractionDiagnostic>();
+        var documents = new List<OctopusExtractedJsonDocument>();
+
+        foreach (var entry in entries)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (!HasJsonExtension(entry.RelativePath))
+                continue;
+
+            AddParsedDocument(entry.RelativePath, entry.Content, documents, diagnostics);
+        }
+
+        return Task.FromResult(new OctopusInputExtractionResult(documents, diagnostics));
+    }
+
+    private static List<string> EnumerateJsonFiles(string root, List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(root, "*.json", SearchOption.AllDirectories)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.FileReadFailed,
+                $"Octopus import folder JSON documents could not be enumerated ({ex.GetType().Name}).",
+                NormalizeDisplayPath(root)));
+
+            return [];
+        }
+    }
+
+    private static async Task<byte[]> ReadFileWithLimitsAsync(
+        string filePath,
+        string sourcePath,
+        long maxEntrySizeBytes,
+        List<OctopusInputExtractionDiagnostic> diagnostics,
+        CancellationToken ct)
+    {
+        try
+        {
+            var fileInfo = new FileInfo(filePath);
+
+            if (fileInfo.Length > maxEntrySizeBytes)
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.EntrySizeLimitExceeded,
+                    $"Octopus import JSON document '{sourcePath}' exceeds the configured per-entry size limit of {maxEntrySizeBytes} bytes.",
+                    sourcePath));
+
+                return null;
+            }
+
+            await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, CopyBufferSize, useAsync: true);
+            return await ReadStreamWithLimitAsync(stream, sourcePath, maxEntrySizeBytes, diagnostics, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.FileReadFailed,
+                $"Octopus import JSON document '{sourcePath}' could not be read ({ex.GetType().Name}).",
+                sourcePath));
+
+            return null;
+        }
+    }
+
+    private static async Task<byte[]> ReadStreamWithLimitAsync(
+        Stream stream,
+        string sourcePath,
+        long maxEntrySizeBytes,
+        List<OctopusInputExtractionDiagnostic> diagnostics,
+        CancellationToken ct)
+    {
+        if (stream.CanSeek && stream.Length > maxEntrySizeBytes)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.EntrySizeLimitExceeded,
+                $"Octopus import JSON document '{sourcePath}' exceeds the configured per-entry size limit of {maxEntrySizeBytes} bytes.",
+                sourcePath));
+
+            return null;
+        }
+
+        await using var memoryStream = new MemoryStream();
+        var buffer = new byte[CopyBufferSize];
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+
+            if (read == 0)
+                break;
+
+            if (memoryStream.Length + read > maxEntrySizeBytes)
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.EntrySizeLimitExceeded,
+                    $"Octopus import JSON document '{sourcePath}' exceeds the configured per-entry size limit of {maxEntrySizeBytes} bytes.",
+                    sourcePath));
+
+                return null;
+            }
+
+            await memoryStream.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+        }
+
+        return memoryStream.ToArray();
+    }
+
+    private static void AddParsedDocument(
+        string sourcePath,
+        byte[] content,
+        List<OctopusExtractedJsonDocument> documents,
+        List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        try
+        {
+            using var jsonDocument = JsonDocument.Parse(content);
+            var root = jsonDocument.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.UnsupportedJsonRoot,
+                    $"Octopus import JSON document '{sourcePath}' must contain a JSON object at the root.",
+                    sourcePath));
+
+                return;
+            }
+
+            var classification = ClassifyJson(sourcePath, root);
+
+            if (!classification.IsKnown)
+            {
+                diagnostics.Add(Warning(
+                    OctopusInputExtractionDiagnosticCodes.UnrecognizedDocument,
+                    $"Octopus import JSON document '{sourcePath}' is not a recognized Octopus export document.",
+                    sourcePath,
+                    classification.SourceId,
+                    classification.Kind));
+
+                return;
+            }
+
+            documents.Add(new OctopusExtractedJsonDocument(sourcePath, classification, root.Clone(), content.LongLength));
+        }
+        catch (JsonException ex)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.MalformedJson,
+                BuildMalformedJsonMessage(sourcePath, ex),
+                sourcePath));
+        }
+    }
+
+    private static OctopusDocumentClassification ClassifyJson(string sourcePath, JsonElement root)
+    {
+        if (TryGetProperty(root, "Entries", out var entries) && entries.ValueKind == JsonValueKind.Array)
+        {
+            return new OctopusDocumentClassification(
+                OctopusDocumentKind.Manifest,
+                sourcePath,
+                null,
+                null,
+                false,
+                false);
+        }
+
+        var id = TryGetStringProperty(root, "Id");
+        var documentType = TryGetStringProperty(root, "DocumentType");
+
+        return OctopusDocumentClassifier.ClassifyJsonDocument(sourcePath, id, documentType);
+    }
+
+    private static bool TryGetProperty(JsonElement root, string propertyName, out JsonElement value)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static string TryGetStringProperty(JsonElement root, string propertyName)
+    {
+        return TryGetProperty(root, propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+
+    private static string BuildMalformedJsonMessage(string sourcePath, JsonException ex)
+    {
+        if (ex.LineNumber.HasValue && ex.BytePositionInLine.HasValue)
+            return $"Octopus import JSON document '{sourcePath}' is malformed at line {ex.LineNumber.Value}, byte {ex.BytePositionInLine.Value}.";
+
+        return $"Octopus import JSON document '{sourcePath}' is malformed.";
+    }
+
+    private static string NormalizeFolderRelativePath(string root, string filePath)
+    {
+        var relativePath = Path.GetRelativePath(root, filePath);
+        return NormalizeDisplayPath(relativePath);
+    }
+
+    private static string NormalizeDisplayPath(string path)
+        => string.IsNullOrWhiteSpace(path) ? path : path.Replace('\\', '/');
+
+    private static bool HasJsonExtension(string sourcePath)
+        => string.Equals(Path.GetExtension(sourcePath), ".json", StringComparison.OrdinalIgnoreCase);
+
+    private static OctopusInputExtractionDiagnostic Warning(
+        string code,
+        string message,
+        string sourcePath,
+        string sourceId = null,
+        OctopusDocumentKind? documentKind = null)
+        => new(OctopusImportCompatibilitySeverity.Warning, code, message, sourcePath, sourceId, documentKind);
+
+    private static OctopusInputExtractionDiagnostic Blocker(string code, string message, string sourcePath)
+        => new(OctopusImportCompatibilitySeverity.Blocker, code, message, sourcePath);
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusInputExtractorTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusInputExtractorTests.cs
@@ -1,0 +1,237 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Octopus;
+
+public class OctopusInputExtractorTests
+{
+    private readonly OctopusInputExtractor _extractor = new();
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_ProjectJson_ReturnsRecognizedDocument()
+    {
+        var result = await ExtractStandaloneAsync("""
+        {
+          "Id": "Projects-1",
+          "Name": "Project"
+        }
+        """, "project.json");
+
+        result.Documents.Count.ShouldBe(1);
+        result.Documents[0].Classification.Kind.ShouldBe(OctopusDocumentKind.Project);
+        result.Documents[0].Classification.SourceId.ShouldBe("Projects-1");
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_ManifestJson_ReturnsManifestDocument()
+    {
+        var result = await ExtractStandaloneAsync("""
+        {
+          "Entries": []
+        }
+        """, "export.json");
+
+        result.Documents.Count.ShouldBe(1);
+        result.Documents[0].Classification.Kind.ShouldBe(OctopusDocumentKind.Manifest);
+    }
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_MalformedJson_ReturnsStructuredDiagnostic()
+    {
+        var result = await ExtractStandaloneAsync("""{"Id":""", "bad.json");
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Count.ShouldBe(1);
+        result.Diagnostics[0].Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        result.Diagnostics[0].Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.MalformedJson);
+        result.Diagnostics[0].Message.ShouldContain("bad.json");
+        result.Diagnostics[0].Message.ShouldNotContain("""{"Id":""");
+    }
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_UnrecognizedJson_ReturnsDiagnostic()
+    {
+        var result = await ExtractStandaloneAsync("""
+        {
+          "Name": "not an Octopus resource"
+        }
+        """, "unknown.json");
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Count.ShouldBe(1);
+        result.Diagnostics[0].Severity.ShouldBe(OctopusImportCompatibilitySeverity.Warning);
+        result.Diagnostics[0].Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.UnrecognizedDocument);
+    }
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_ArrayRoot_ReturnsUnsupportedRootDiagnostic()
+    {
+        var result = await ExtractStandaloneAsync("""[]""", "array.json");
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.UnsupportedJsonRoot);
+    }
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_EntryLimitExceeded_ReturnsDiagnostic()
+    {
+        var result = await ExtractStandaloneAsync(
+            """{"Id":"Projects-1"}""",
+            "project.json",
+            new OctopusArchiveExtractionOptions { MaxEntrySizeBytes = 4 });
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.EntrySizeLimitExceeded);
+    }
+
+    [Fact]
+    public async Task ExtractFolderAsync_ReadsJsonFilesRecursivelyAndSkipsNonJson()
+    {
+        using var folder = TempFolder.Create();
+        folder.WriteText("manifest.json", """{"Entries":[]}""");
+        folder.WriteText("nested/Projects-1.json", """{"Id":"Projects-1"}""");
+        folder.WriteText("readme.txt", "ignored");
+
+        var result = await _extractor.ExtractFolderAsync(folder.Path);
+
+        result.Documents.Count.ShouldBe(2);
+        result.Documents.Select(d => d.SourcePath).ShouldBe(["manifest.json", "nested/Projects-1.json"]);
+        result.Documents.Select(d => d.Classification.Kind).ShouldBe([OctopusDocumentKind.Manifest, OctopusDocumentKind.Project]);
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractFolderAsync_MissingFolder_ReturnsDiagnostic()
+    {
+        var result = await _extractor.ExtractFolderAsync(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.FolderNotFound);
+    }
+
+    [Fact]
+    public async Task ExtractFolderAsync_NoJson_ReturnsDiagnostic()
+    {
+        using var folder = TempFolder.Create();
+        folder.WriteText("readme.txt", "ignored");
+
+        var result = await _extractor.ExtractFolderAsync(folder.Path);
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.NoJsonDocuments);
+    }
+
+    [Fact]
+    public async Task ExtractFolderAsync_EntryCountLimitExceeded_ReturnsDiagnostic()
+    {
+        using var folder = TempFolder.Create();
+        folder.WriteText("one.json", "{}");
+        folder.WriteText("two.json", "{}");
+
+        var result = await _extractor.ExtractFolderAsync(
+            folder.Path,
+            new OctopusArchiveExtractionOptions { MaxEntryCount = 1 });
+
+        result.Documents.ShouldBeEmpty();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.EntryCountLimitExceeded);
+    }
+
+    [Fact]
+    public async Task ExtractFolderAsync_TotalSizeLimitExceeded_ReturnsDiagnostic()
+    {
+        using var folder = TempFolder.Create();
+        folder.WriteText("one.json", """{"Id":"Projects-1"}""");
+        folder.WriteText("two.json", """{"Id":"ProjectGroups-1"}""");
+
+        var result = await _extractor.ExtractFolderAsync(
+            folder.Path,
+            new OctopusArchiveExtractionOptions
+            {
+                MaxEntrySizeBytes = 100,
+                MaxTotalUncompressedSizeBytes = 30
+            });
+
+        result.Documents.Count.ShouldBe(1);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.TotalSizeLimitExceeded);
+    }
+
+    [Fact]
+    public async Task ExtractJsonEntriesAsync_ParsesJsonEntriesAndSkipsNonJson()
+    {
+        var entries = new List<OctopusExtractedArchiveEntry>
+        {
+            new("manifest.json", JsonBytes("""{"Entries":[]}""")),
+            new("notes.txt", Encoding.UTF8.GetBytes("ignored")),
+            new("Projects-1.json", JsonBytes("""{"Id":"Projects-1"}"""))
+        };
+
+        var result = await _extractor.ExtractJsonEntriesAsync(entries);
+
+        result.Documents.Count.ShouldBe(2);
+        result.Documents.Select(d => d.Classification.Kind).ShouldBe([OctopusDocumentKind.Manifest, OctopusDocumentKind.Project]);
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractStandaloneJsonAsync_CancellationRequested_StopsExtraction()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => ExtractStandaloneAsync("""{"Id":"Projects-1"}""", "project.json", ct: cts.Token));
+    }
+
+    private Task<OctopusInputExtractionResult> ExtractStandaloneAsync(
+        string json,
+        string sourcePath,
+        OctopusArchiveExtractionOptions options = null,
+        CancellationToken ct = default)
+    {
+        return _extractor.ExtractStandaloneJsonAsync(
+            new MemoryStream(JsonBytes(json)),
+            sourcePath,
+            options,
+            ct);
+    }
+
+    private static byte[] JsonBytes(string json) => Encoding.UTF8.GetBytes(json);
+
+    private sealed class TempFolder : IDisposable
+    {
+        private TempFolder(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TempFolder Create()
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"squid-octopus-input-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(path);
+            return new TempFolder(path);
+        }
+
+        public void WriteText(string relativePath, string text)
+        {
+            var path = System.IO.Path.Combine(Path, relativePath);
+            var directory = System.IO.Path.GetDirectoryName(path);
+
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+
+            File.WriteAllText(path, text);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Created local branch `feature/octopus-import-input-fallback` from `feature/squid-import-project`.
- Added `IOctopusInputExtractor` / `OctopusInputExtractor` for supported non-ZIP Octopus import inputs.
- Added standalone JSON extraction and recursive folder JSON discovery with shared import size/count limits.
- Added structured diagnostics for missing folders, empty JSON folders, read failures, malformed JSON, unsupported JSON roots, unrecognized documents, and input size/count limit failures.
- Added parsed JSON document results carrying source path, classification, cloned JSON root, and size metadata.
- Added unit tests covering standalone JSON, manifest detection, malformed/unrecognized documents, folder fallback, archive-entry JSON parsing, limits, and cancellation.
- Scope intentionally stops at task 2.4; manifest hash/file consistency checks and normalized resource graph construction remain for later branches.
- Local ignored OpenSpec task file now shows task 2.4 complete, but `openspec/` is ignored by `.git/info/exclude` and is not part of tracked branch changes.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport"` passed: `78` passed, `0` failed, `0` skipped.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj` passed: `6300` passed, `0` failed, `0` skipped.