### PR TITLE
Add manifest-driven inventory with SHA1 validation and diagnostics

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
@@ -11,4 +11,14 @@ public static class OctopusInputExtractionDiagnosticCodes
     public const string EntryCountLimitExceeded = "octopus.input.entry_count_limit_exceeded";
     public const string EntrySizeLimitExceeded = "octopus.input.entry_size_limit_exceeded";
     public const string TotalSizeLimitExceeded = "octopus.input.total_size_limit_exceeded";
+    public const string ManifestMissing = "octopus.manifest.missing";
+    public const string MultipleManifests = "octopus.manifest.multiple";
+    public const string ManifestMalformed = "octopus.manifest.malformed";
+    public const string ManifestEntryMissingSource = "octopus.manifest.entry_missing_source";
+    public const string ManifestDuplicateSource = "octopus.manifest.duplicate_source";
+    public const string ManifestDocumentMissing = "octopus.manifest.document_missing";
+    public const string ManifestHashMismatch = "octopus.manifest.hash_mismatch";
+    public const string ManifestSourceIdMismatch = "octopus.manifest.source_id_mismatch";
+    public const string ManifestDocumentTypeMismatch = "octopus.manifest.document_type_mismatch";
+    public const string DocumentNotInManifest = "octopus.manifest.document_not_listed";
 }

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionResult.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionResult.cs
@@ -14,7 +14,8 @@ public sealed record OctopusExtractedJsonDocument(
     string SourcePath,
     OctopusDocumentClassification Classification,
     JsonElement Root,
-    long SizeBytes);
+    long SizeBytes,
+    string Sha1);
 
 public sealed record OctopusInputExtractionDiagnostic(
     OctopusImportCompatibilitySeverity Severity,

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractor.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractor.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text.Json;
 using Squid.Message.Enums.OctopusImport;
 
@@ -277,7 +278,7 @@ public class OctopusInputExtractor : IOctopusInputExtractor
                 return;
             }
 
-            documents.Add(new OctopusExtractedJsonDocument(sourcePath, classification, root.Clone(), content.LongLength));
+            documents.Add(new OctopusExtractedJsonDocument(sourcePath, classification, root.Clone(), content.LongLength, ComputeSha1(content)));
         }
         catch (JsonException ex)
         {
@@ -348,6 +349,9 @@ public class OctopusInputExtractor : IOctopusInputExtractor
 
     private static bool HasJsonExtension(string sourcePath)
         => string.Equals(Path.GetExtension(sourcePath), ".json", StringComparison.OrdinalIgnoreCase);
+
+    private static string ComputeSha1(byte[] content)
+        => Convert.ToHexString(SHA1.HashData(content)).ToLowerInvariant();
 
     private static OctopusInputExtractionDiagnostic Warning(
         string code,

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusManifestInventoryBuilder.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusManifestInventoryBuilder.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public interface IOctopusManifestInventoryBuilder : IScopedDependency
+{
+    OctopusManifestInventoryResult Build(OctopusInputExtractionResult extractionResult);
+}
+
+public class OctopusManifestInventoryBuilder : IOctopusManifestInventoryBuilder
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public OctopusManifestInventoryResult Build(OctopusInputExtractionResult extractionResult)
+    {
+        ArgumentNullException.ThrowIfNull(extractionResult);
+
+        var diagnostics = new List<OctopusInputExtractionDiagnostic>(extractionResult.Diagnostics);
+        var manifestDocuments = extractionResult.Documents
+            .Where(d => d.Classification.Kind == OctopusDocumentKind.Manifest)
+            .ToList();
+
+        if (manifestDocuments.Count == 0)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.ManifestMissing,
+                "Octopus import input does not contain manifest.json."));
+
+            return new OctopusManifestInventoryResult(null, [], [], diagnostics);
+        }
+
+        if (manifestDocuments.Count > 1)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.MultipleManifests,
+                "Octopus import input contains multiple manifest documents.",
+                manifestDocuments[1].SourcePath));
+        }
+
+        var manifestDocument = SelectManifest(manifestDocuments);
+        var manifest = DeserializeManifest(manifestDocument, diagnostics);
+
+        if (manifest == null)
+            return new OctopusManifestInventoryResult(null, [], [], diagnostics);
+
+        var documentsByPath = extractionResult.Documents
+            .Where(d => d.Classification.Kind != OctopusDocumentKind.Manifest)
+            .GroupBy(d => NormalizePath(d.SourcePath), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        var entriesBySource = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var items = new List<OctopusManifestInventoryItem>();
+
+        foreach (var entry in manifest.Entries)
+        {
+            var manifestClassification = OctopusDocumentClassifier.Classify(entry);
+            var sourcePath = NormalizePath(entry.DocumentSource);
+
+            if (string.IsNullOrWhiteSpace(sourcePath))
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.ManifestEntryMissingSource,
+                    "Octopus import manifest entry is missing DocumentSource.",
+                    sourceId: entry.Id,
+                    documentKind: manifestClassification.Kind));
+
+                items.Add(new OctopusManifestInventoryItem(entry, null, manifestClassification, false));
+                continue;
+            }
+
+            if (!entriesBySource.Add(sourcePath))
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.ManifestDuplicateSource,
+                    $"Octopus import manifest lists document '{sourcePath}' more than once.",
+                    sourcePath,
+                    entry.Id,
+                    manifestClassification.Kind));
+            }
+
+            if (!documentsByPath.TryGetValue(sourcePath, out var document))
+            {
+                diagnostics.Add(Blocker(
+                    OctopusInputExtractionDiagnosticCodes.ManifestDocumentMissing,
+                    $"Octopus import manifest references missing document '{sourcePath}'.",
+                    sourcePath,
+                    entry.Id,
+                    manifestClassification.Kind));
+
+                items.Add(new OctopusManifestInventoryItem(entry, null, manifestClassification, false));
+                continue;
+            }
+
+            ValidateManifestEntryAgainstDocument(entry, manifestClassification, document, diagnostics);
+
+            var hashMatches = ValidateHash(entry, document, diagnostics);
+            items.Add(new OctopusManifestInventoryItem(entry, document, manifestClassification, hashMatches));
+        }
+
+        AddUnlistedDocumentDiagnostics(documentsByPath.Values, entriesBySource, diagnostics);
+
+        var counts = items
+            .GroupBy(i => i.Classification.Kind)
+            .OrderBy(g => g.Key)
+            .Select(g => new OctopusManifestInventoryCount(g.Key, g.Count()))
+            .ToList();
+
+        return new OctopusManifestInventoryResult(manifest, items, counts, diagnostics);
+    }
+
+    private static OctopusExtractedJsonDocument SelectManifest(List<OctopusExtractedJsonDocument> manifestDocuments)
+    {
+        return manifestDocuments.FirstOrDefault(d => string.Equals(Path.GetFileName(d.SourcePath), "manifest.json", StringComparison.OrdinalIgnoreCase))
+               ?? manifestDocuments[0];
+    }
+
+    private static OctopusExportManifestDto DeserializeManifest(
+        OctopusExtractedJsonDocument manifestDocument,
+        List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        try
+        {
+            return manifestDocument.Root.Deserialize<OctopusExportManifestDto>(JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.ManifestMalformed,
+                $"Octopus import manifest '{manifestDocument.SourcePath}' could not be deserialized ({ex.GetType().Name}).",
+                manifestDocument.SourcePath));
+
+            return null;
+        }
+    }
+
+    private static void ValidateManifestEntryAgainstDocument(
+        OctopusManifestEntryDto entry,
+        OctopusDocumentClassification manifestClassification,
+        OctopusExtractedJsonDocument document,
+        List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.Id) &&
+            !string.IsNullOrWhiteSpace(document.Classification.SourceId) &&
+            !string.Equals(entry.Id, document.Classification.SourceId, StringComparison.OrdinalIgnoreCase))
+        {
+            diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.ManifestSourceIdMismatch,
+                $"Octopus import manifest entry for '{NormalizePath(entry.DocumentSource)}' does not match the parsed document id.",
+                NormalizePath(entry.DocumentSource),
+                entry.Id,
+                manifestClassification.Kind));
+        }
+
+        if (manifestClassification.Kind != document.Classification.Kind)
+        {
+            diagnostics.Add(Warning(
+                OctopusInputExtractionDiagnosticCodes.ManifestDocumentTypeMismatch,
+                $"Octopus import manifest entry for '{NormalizePath(entry.DocumentSource)}' has a document type that differs from parsed document classification.",
+                NormalizePath(entry.DocumentSource),
+                entry.Id,
+                manifestClassification.Kind));
+        }
+    }
+
+    private static bool ValidateHash(
+        OctopusManifestEntryDto entry,
+        OctopusExtractedJsonDocument document,
+        List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        if (string.IsNullOrWhiteSpace(entry.Hash))
+            return false;
+
+        if (string.Equals(entry.Hash, document.Sha1, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        diagnostics.Add(Blocker(
+            OctopusInputExtractionDiagnosticCodes.ManifestHashMismatch,
+            $"Octopus import manifest hash does not match document '{NormalizePath(entry.DocumentSource)}'.",
+            NormalizePath(entry.DocumentSource),
+            entry.Id,
+            document.Classification.Kind));
+
+        return false;
+    }
+
+    private static void AddUnlistedDocumentDiagnostics(
+        IEnumerable<OctopusExtractedJsonDocument> documents,
+        HashSet<string> listedPaths,
+        List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        foreach (var document in documents.OrderBy(d => d.SourcePath, StringComparer.OrdinalIgnoreCase))
+        {
+            var sourcePath = NormalizePath(document.SourcePath);
+
+            if (listedPaths.Contains(sourcePath))
+                continue;
+
+            diagnostics.Add(Warning(
+                OctopusInputExtractionDiagnosticCodes.DocumentNotInManifest,
+                $"Octopus import input contains JSON document '{sourcePath}' that is not listed in the manifest.",
+                sourcePath,
+                document.Classification.SourceId,
+                document.Classification.Kind));
+        }
+    }
+
+    private static string NormalizePath(string path)
+        => string.IsNullOrWhiteSpace(path) ? path : path.Replace('\\', '/').TrimStart('/');
+
+    private static OctopusInputExtractionDiagnostic Warning(
+        string code,
+        string message,
+        string sourcePath = null,
+        string sourceId = null,
+        OctopusDocumentKind? documentKind = null)
+        => new(OctopusImportCompatibilitySeverity.Warning, code, message, sourcePath, sourceId, documentKind);
+
+    private static OctopusInputExtractionDiagnostic Blocker(
+        string code,
+        string message,
+        string sourcePath = null,
+        string sourceId = null,
+        OctopusDocumentKind? documentKind = null)
+        => new(OctopusImportCompatibilitySeverity.Blocker, code, message, sourcePath, sourceId, documentKind);
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusManifestInventoryResult.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusManifestInventoryResult.cs
@@ -1,0 +1,21 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public sealed record OctopusManifestInventoryResult(
+    OctopusExportManifestDto Manifest,
+    IReadOnlyList<OctopusManifestInventoryItem> Items,
+    IReadOnlyList<OctopusManifestInventoryCount> Counts,
+    IReadOnlyList<OctopusInputExtractionDiagnostic> Diagnostics)
+{
+    public bool HasManifest => Manifest != null;
+}
+
+public sealed record OctopusManifestInventoryItem(
+    OctopusManifestEntryDto ManifestEntry,
+    OctopusExtractedJsonDocument Document,
+    OctopusDocumentClassification Classification,
+    bool HashMatches)
+{
+    public bool HasDocument => Document != null;
+}
+
+public sealed record OctopusManifestInventoryCount(OctopusDocumentKind Kind, int Count);

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusManifestInventoryBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusManifestInventoryBuilderTests.cs
@@ -1,0 +1,203 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Octopus;
+
+public class OctopusManifestInventoryBuilderTests
+{
+    private readonly OctopusInputExtractor _inputExtractor = new();
+    private readonly OctopusManifestInventoryBuilder _builder = new();
+
+    [Fact]
+    public async Task Build_WithManifest_MatchesDocumentsAndCountsKinds()
+    {
+        var projectJson = """{"Id":"Projects-1","Name":"Project"}""";
+        var environmentJson = """{"Id":"Environments-1","Name":"Production"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Project", "Projects-1.json", Sha1(projectJson)),
+                ("Environments-1", "StaticDeploymentEnvironment", "Environments-1.json", Sha1(environmentJson)))),
+            ("Projects-1.json", projectJson),
+            ("Environments-1.json", environmentJson));
+
+        var inventory = _builder.Build(result);
+
+        inventory.HasManifest.ShouldBeTrue();
+        inventory.Items.Count.ShouldBe(2);
+        inventory.Items.All(i => i.HasDocument).ShouldBeTrue();
+        inventory.Items.All(i => i.HashMatches).ShouldBeTrue();
+        inventory.Counts.Single(c => c.Kind == OctopusDocumentKind.Project).Count.ShouldBe(1);
+        inventory.Counts.Single(c => c.Kind == OctopusDocumentKind.Environment).Count.ShouldBe(1);
+        inventory.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Build_MissingManifest_ReturnsBlocker()
+    {
+        var result = await ExtractEntriesAsync(("Projects-1.json", """{"Id":"Projects-1"}"""));
+
+        var inventory = _builder.Build(result);
+
+        inventory.HasManifest.ShouldBeFalse();
+        inventory.Diagnostics.Single().Code.ShouldBe(OctopusInputExtractionDiagnosticCodes.ManifestMissing);
+    }
+
+    [Fact]
+    public async Task Build_MissingManifestDocument_ReturnsBlockerWithoutSourceValues()
+    {
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Project", "Projects-1.json", "0123456789012345678901234567890123456789"))));
+
+        var inventory = _builder.Build(result);
+
+        var diagnostic = inventory.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.ManifestDocumentMissing);
+        diagnostic.Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        diagnostic.SourcePath.ShouldBe("Projects-1.json");
+        diagnostic.SourceId.ShouldBe("Projects-1");
+        diagnostic.Message.ShouldNotContain("0123456789012345678901234567890123456789");
+    }
+
+    [Fact]
+    public async Task Build_HashMismatch_ReturnsBlockerWithoutJsonContentOrHashValues()
+    {
+        var secretValue = "super-secret-source-value";
+        var projectJson = $$"""{"Id":"Projects-1","Name":"Project","Value":"{{secretValue}}"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Project", "Projects-1.json", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))),
+            ("Projects-1.json", projectJson));
+
+        var inventory = _builder.Build(result);
+
+        var diagnostic = inventory.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.ManifestHashMismatch);
+        diagnostic.Message.ShouldContain("Projects-1.json");
+        diagnostic.Message.ShouldNotContain(secretValue);
+        diagnostic.Message.ShouldNotContain("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        diagnostic.Message.ShouldNotContain(Sha1(projectJson));
+    }
+
+    [Fact]
+    public async Task Build_SourceIdMismatch_ReturnsBlocker()
+    {
+        var projectJson = """{"Id":"Projects-2","Name":"Project"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Project", "Projects-1.json", Sha1(projectJson)))),
+            ("Projects-1.json", projectJson));
+
+        var inventory = _builder.Build(result);
+
+        var diagnostic = inventory.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.ManifestSourceIdMismatch);
+        diagnostic.SourceId.ShouldBe("Projects-1");
+        diagnostic.SourcePath.ShouldBe("Projects-1.json");
+    }
+
+    [Fact]
+    public async Task Build_DocumentTypeMismatch_ReturnsWarning()
+    {
+        var projectJson = """{"Id":"Projects-1","Name":"Project"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Lifecycle", "Projects-1.json", Sha1(projectJson)))),
+            ("Projects-1.json", projectJson));
+
+        var inventory = _builder.Build(result);
+
+        var diagnostic = inventory.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.ManifestDocumentTypeMismatch);
+        diagnostic.Severity.ShouldBe(OctopusImportCompatibilitySeverity.Warning);
+        diagnostic.DocumentKind.ShouldBe(OctopusDocumentKind.Lifecycle);
+    }
+
+    [Fact]
+    public async Task Build_DuplicateManifestSource_ReturnsBlocker()
+    {
+        var projectJson = """{"Id":"Projects-1","Name":"Project"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Project", "Projects-1.json", Sha1(projectJson)),
+                ("Projects-1", "Project", "Projects-1.json", Sha1(projectJson)))),
+            ("Projects-1.json", projectJson));
+
+        var inventory = _builder.Build(result);
+
+        inventory.Diagnostics.Any(d => d.Code == OctopusInputExtractionDiagnosticCodes.ManifestDuplicateSource).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Build_UnlistedDocument_ReturnsWarning()
+    {
+        var projectJson = """{"Id":"Projects-1","Name":"Project"}""";
+        var environmentJson = """{"Id":"Environments-1","Name":"Production"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("Projects-1", "Project", "Projects-1.json", Sha1(projectJson)))),
+            ("Projects-1.json", projectJson),
+            ("Environments-1.json", environmentJson));
+
+        var inventory = _builder.Build(result);
+
+        var diagnostic = inventory.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.DocumentNotInManifest);
+        diagnostic.Severity.ShouldBe(OctopusImportCompatibilitySeverity.Warning);
+        diagnostic.SourcePath.ShouldBe("Environments-1.json");
+        diagnostic.SourceId.ShouldBe("Environments-1");
+    }
+
+    [Fact]
+    public async Task Build_ManifestSnapshotsAndHistory_AreCountedByClassification()
+    {
+        var snapshotJson = """{"Id":"variableset-Projects-1-s-3-ABC","OwnerId":"Projects-1"}""";
+        var releaseJson = """{"Id":"Releases-1","ProjectId":"Projects-1"}""";
+        var result = await ExtractEntriesAsync(
+            ("manifest.json", BuildManifestJson(
+                ("variableset-Projects-1-s-3-ABC", "ProjectVariables", "variableset-Projects-1-s-3-ABC.json", Sha1(snapshotJson)),
+                ("Releases-1", "Release", "Releases-1.json", Sha1(releaseJson)))),
+            ("variableset-Projects-1-s-3-ABC.json", snapshotJson),
+            ("Releases-1.json", releaseJson));
+
+        var inventory = _builder.Build(result);
+
+        inventory.Counts.Single(c => c.Kind == OctopusDocumentKind.VariableSetSnapshot).Count.ShouldBe(1);
+        inventory.Counts.Single(c => c.Kind == OctopusDocumentKind.Release).Count.ShouldBe(1);
+        inventory.Items.All(i => i.Classification.IsOutOfScopeHistory).ShouldBeTrue();
+    }
+
+    private async Task<OctopusInputExtractionResult> ExtractEntriesAsync(params (string Path, string Json)[] entries)
+    {
+        var archiveEntries = entries
+            .Select(e => new OctopusExtractedArchiveEntry(e.Path, Encoding.UTF8.GetBytes(e.Json)))
+            .ToList();
+
+        return await _inputExtractor.ExtractJsonEntriesAsync(archiveEntries);
+    }
+
+    private static string BuildManifestJson(params (string Id, string DocumentType, string DocumentSource, string Hash)[] entries)
+    {
+        var manifest = new
+        {
+            SchemaVersions = Array.Empty<string>(),
+            Entries = entries.Select(e => new
+            {
+                e.Id,
+                Name = e.Id,
+                e.DocumentType,
+                ExportType = "FullDocument",
+                e.DocumentSource,
+                ParentId = (string)null,
+                e.Hash
+            })
+        };
+
+        return JsonSerializer.Serialize(manifest);
+    }
+
+    private static string Sha1(string value)
+    {
+        var bytes = System.Security.Cryptography.SHA1.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
## Summary

- Implemented manifest-driven Octopus import inventory on `feature/octopus-import-manifest-inventory`.
- Added `OctopusManifestInventoryBuilder` and result models for manifest lookup, manifest entry matching, per-kind counts, SHA1 validation, source ID/type consistency checks, duplicate/missing document diagnostics, and unlisted document warnings.
- Extended extracted JSON documents with SHA1 hashes from `OctopusInputExtractor`.
- Added manifest diagnostic codes without logging raw JSON content, source values, or expected/actual hash values in diagnostic messages.
- Added focused unit coverage in `OctopusManifestInventoryBuilderTests`.
- Updated local OpenSpec progress tracking for task `2.5`; `openspec/` is ignored locally and is not part of the branch diff.
- Scope intentionally stops before task `2.6`; normalized Octopus resource graph construction remains unfinished.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport"` passed: 87 passed, 0 failed.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj` passed: 6309 passed, 0 failed.
- [x] Observed existing dependency vulnerability warnings for `KubernetesClient` and `AutoMapper`; no test failures.
- [ ] No integration tests were added for this branch; current scope is Core inventory logic plus unit coverage.