### PR TITLE
Accept --version as an alias for the version subcommand

### DIFF
--- a/src/Squid.Tentacle/Commands/CommandResolver.cs
+++ b/src/Squid.Tentacle/Commands/CommandResolver.cs
@@ -27,6 +27,20 @@ public static class CommandResolver
         if (IsHelpFlag(first))
             return CommandRoute.ForHelp();
 
+        // Same for --version, and for the same reason: without this it falls into the
+        // `-` → run default below and STARTS THE AGENT instead of reporting a version.
+        // That cost a production hang in 1.4.1/1.4.2 (see deploy/packaging/after-install.sh)
+        // and every caller since has had to remember to spell it as the bare `version` verb.
+        // Falls through when no VersionCommand is registered, so behaviour is unchanged for
+        // a command set that does not offer one.
+        if (IsVersionFlag(first))
+        {
+            var versionCommand = commands.OfType<VersionCommand>().FirstOrDefault();
+
+            if (versionCommand != null)
+                return CommandRoute.ForCommand(versionCommand, args[1..]);
+        }
+
         // Leading `-` or `--` is a configuration flag, not a verb → default to run.
         if (first.StartsWith('-'))
             return CommandRoute.ForCommand(commands.OfType<RunCommand>().FirstOrDefault() ?? commands[0], args);
@@ -49,6 +63,20 @@ public static class CommandResolver
             || arg.Equals("-h", StringComparison.OrdinalIgnoreCase)
             || arg.Equals("-?", StringComparison.Ordinal)
             || arg.Equals("/?", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Recognises the conventional long form of the version flag. Deliberately narrower than
+    /// <see cref="IsHelpFlag"/>: <c>-v</c> is NOT included, because a leading <c>-v</c> is
+    /// already pinned as an ordinary configuration flag that routes to run, and <c>-v</c>
+    /// means "verbose" in most CLIs. The bare <c>version</c> verb is matched by the normal
+    /// verb lookup and needs no entry here.
+    /// </summary>
+    public static bool IsVersionFlag(string arg)
+    {
+        if (string.IsNullOrEmpty(arg)) return false;
+
+        return arg.Equals("--version", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/Squid.Tentacle/Commands/VersionCommand.cs
+++ b/src/Squid.Tentacle/Commands/VersionCommand.cs
@@ -7,11 +7,18 @@ namespace Squid.Tentacle.Commands;
 /// Prints the binary's assembly version to stdout and exits 0.
 /// </summary>
 /// <remarks>
-/// <para>Added to close a CLI gap: <c>--version</c> falls into the default
-/// <see cref="RunCommand"/> (anything starting with <c>-</c> is treated as
-/// a config flag by <see cref="CommandResolver"/>), which starts the agent
-/// instead of reporting version — unexpected for anyone running it from
-/// the shell to check "did the upgrade land?".</para>
+/// <para>Added to close a CLI gap: <c>--version</c> used to fall into the default
+/// <see cref="RunCommand"/> (anything starting with <c>-</c> is treated as a config flag
+/// by <see cref="CommandResolver"/>), which started the agent instead of reporting a
+/// version — unexpected for anyone running it from the shell to check "did the upgrade
+/// land?", and a hang for anyone piping the output. <c>--version</c> is now routed here
+/// too, via <see cref="CommandResolver.IsVersionFlag"/>.</para>
+///
+/// <para>Callers that must also work against OLDER binaries — notably
+/// <c>deploy/packaging/after-install.sh</c>, which may probe a not-yet-replaced tentacle
+/// mid-upgrade — should keep using the bare <c>version</c> verb, which has always worked.
+/// The alias helps humans and new tooling, it does not make old binaries safe to probe
+/// with a flag.</para>
 ///
 /// <para>Called by the upgrade script's post-restart version verify step
 /// AND available to operators for ad-hoc checks:

--- a/tests/Squid.Tentacle.Tests/Commands/CommandResolverTests.cs
+++ b/tests/Squid.Tentacle.Tests/Commands/CommandResolverTests.cs
@@ -13,7 +13,8 @@ public class CommandResolverTests
         new ShowConfigCommand(),
         new NewCertificateCommand(),
         new RegisterCommand(),
-        new ServiceCommand()
+        new ServiceCommand(),
+        new VersionCommand()
     ];
 
     // ========================================================================
@@ -42,6 +43,65 @@ public class CommandResolverTests
     {
         CommandResolver.IsHelpFlag("").ShouldBeFalse();
         CommandResolver.IsHelpFlag(null).ShouldBeFalse();
+    }
+
+    // ========================================================================
+    // Version flag — must route to VersionCommand, never RunCommand
+    // ========================================================================
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("--VERSION")]   // case-insensitive, like the help flags
+    public void Resolve_VersionFlag_RoutesToVersionCommand(string flag)
+    {
+        // Without this route --version falls into the `-` → run default and STARTS THE AGENT:
+        // the probe captures no version, and a caller piping the output hangs on a process
+        // that never exits. That cost a production hang in 1.4.1/1.4.2, and is why
+        // deploy/packaging/after-install.sh spells it as the bare `version` verb with a
+        // timeout and </dev/null.
+        var route = CommandResolver.Resolve(Commands, [flag]);
+
+        route.Command.ShouldBeOfType<VersionCommand>(
+            customMessage: "--version must report the version, not start the agent.");
+        route.HelpRequested.ShouldBeFalse();
+        route.UnknownCommand.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_VersionVerb_StillRoutesToVersionCommand()
+    {
+        // The bare verb is what every existing caller uses (postinst, install scripts, CI).
+        // The alias must not disturb it.
+        var route = CommandResolver.Resolve(Commands, ["version"]);
+
+        route.Command.ShouldBeOfType<VersionCommand>();
+        route.RemainingArgs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_VersionFlag_NoVersionCommandRegistered_FallsBackToRun()
+    {
+        // A command set without a VersionCommand keeps today's behaviour rather than
+        // throwing — the alias is additive, never a new failure mode.
+        ITentacleCommand[] withoutVersion = [new RunCommand(), new ServiceCommand()];
+
+        var route = CommandResolver.Resolve(withoutVersion, ["--version"]);
+
+        route.Command.ShouldBeOfType<RunCommand>();
+        route.RemainingArgs.ShouldBe(["--version"]);
+    }
+
+    [Fact]
+    public void IsVersionFlag_ShortFormAndEmpty_ReturnFalse()
+    {
+        // -v stays an ordinary config flag: it is already pinned as one by
+        // Resolve_LeadingConfigFlag_DefaultsToRun_AndPassesAllArgsThrough, and it means
+        // "verbose" in most CLIs. Claiming it for version would be a breaking change.
+        CommandResolver.IsVersionFlag("-v").ShouldBeFalse();
+        CommandResolver.IsVersionFlag("-V").ShouldBeFalse();
+        CommandResolver.IsVersionFlag("version").ShouldBeFalse();  // the verb, not a flag
+        CommandResolver.IsVersionFlag("").ShouldBeFalse();
+        CommandResolver.IsVersionFlag(null).ShouldBeFalse();
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- `CommandResolver` treats any leading dash as a configuration flag and routes it to `RunCommand`, so `squid-tentacle --version` **started the agent** instead of reporting a version. A caller that pipes the output then waits on a process that never exits — that cost a production hang in 1.4.1/1.4.2, `deploy/packaging/after-install.sh` carries three layers of defence about it, and the one workflow that forgot had been failing daily on `main` (#481).
- Route `--version` the way help flags are already routed: checked *before* the dash-means-config rule, via a new `CommandResolver.IsVersionFlag`.
- **`-v` is deliberately not claimed.** It is already pinned as an ordinary config flag by the existing `Resolve_LeadingConfigFlag_DefaultsToRun_AndPassesAllArgsThrough` theory, and it means "verbose" in most CLIs — taking it would be exactly the breaking change this PR avoids.
- A command set with no `VersionCommand` registered falls through to today's behaviour, so the alias is additive and can never introduce a new failure mode.

Nothing depends on the old behaviour: the only reference to `squid-tentacle --version` anywhere in the repo was the (already corrected) assertion in `verify-linux-packages.yml`.

## Test plan

- [x] Unit: `--version` / `--VERSION` route to `VersionCommand`; the bare `version` verb still routes there; unregistered-`VersionCommand` falls back to run; `IsVersionFlag` rejects `-v`, `-V`, `version`, empty and null — 30/30 in `CommandResolverTests`
- [x] Mutation, three directions, each fails tests: drop the route (2 fail), also claim `-v` (2 fail), route to `RunCommand` instead of `VersionCommand` (3 fail)
- [x] Real binary: `version`, `--version` and `--VERSION` all print the version and exit immediately; `-v` still starts the agent, confirming the config-flag contract is untouched
- [x] Full `Squid.Tentacle.Tests` suite — remaining local failures are all `StartScript_*` tripping `DiskSpaceChecker` on a host below its 10% free-space floor, unrelated to this change
- [ ] CI confirmation

## Notes

`after-install.sh` keeps the bare `version` verb on purpose and this PR does not change it: mid-upgrade it can probe a not-yet-replaced older binary, for which only the verb has ever worked. Recorded in `VersionCommand`'s remarks.
