### PR TITLE
 Add Octopus resource graph with dependency edges and reference handling

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentClassifier.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusDocumentClassifier.cs
@@ -137,6 +137,10 @@ public static partial class OctopusDocumentClassifier
 
         var value = idOrFileName.Trim();
 
+        if (value.StartsWith("deploymentprocess-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.DeploymentProcess;
+        if (value.StartsWith("variableset-", StringComparison.OrdinalIgnoreCase))
+            return OctopusDocumentKind.VariableSet;
         if (value.StartsWith("Projects-", StringComparison.OrdinalIgnoreCase))
             return OctopusDocumentKind.Project;
         if (value.StartsWith("ProjectGroups-", StringComparison.OrdinalIgnoreCase))

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
@@ -21,4 +21,7 @@ public static class OctopusInputExtractionDiagnosticCodes
     public const string ManifestSourceIdMismatch = "octopus.manifest.source_id_mismatch";
     public const string ManifestDocumentTypeMismatch = "octopus.manifest.document_type_mismatch";
     public const string DocumentNotInManifest = "octopus.manifest.document_not_listed";
+    public const string GraphDocumentMalformed = "octopus.graph.document_malformed";
+    public const string GraphResourceMissingSourceId = "octopus.graph.resource_missing_source_id";
+    public const string GraphDuplicateSourceId = "octopus.graph.duplicate_source_id";
 }

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceGraphBuilder.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceGraphBuilder.cs
@@ -1,0 +1,527 @@
+using System.Text.Json;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public interface IOctopusResourceGraphBuilder : IScopedDependency
+{
+    OctopusResourceGraph Build(OctopusManifestInventoryResult inventory);
+}
+
+public class OctopusResourceGraphBuilder : IOctopusResourceGraphBuilder
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public OctopusResourceGraph Build(OctopusManifestInventoryResult inventory)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+
+        var diagnostics = new List<OctopusInputExtractionDiagnostic>(inventory.Diagnostics);
+        var resources = new List<OctopusResourceNode>();
+        var references = new List<OctopusResourceReference>();
+        var resourceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in inventory.Items.Where(i => i.HasDocument))
+        {
+            var context = new GraphBuildContext(item, diagnostics, resources, references, resourceIds);
+            AddDocumentResource(context);
+        }
+
+        var dependencies = references
+            .Where(r => r.CreatesDependency && !string.IsNullOrWhiteSpace(r.ToSourceId))
+            .Select(r => new OctopusResourceDependency(r.FromSourceId, r.ToSourceId, r.ReferenceKind, r.ToKind))
+            .Distinct()
+            .ToList();
+
+        return new OctopusResourceGraph(resources, references, dependencies, diagnostics);
+    }
+
+    private static void AddDocumentResource(GraphBuildContext context)
+    {
+        switch (context.Classification.Kind)
+        {
+            case OctopusDocumentKind.Project:
+                AddProject(context);
+                break;
+            case OctopusDocumentKind.ProjectGroup:
+                AddDocument<OctopusProjectGroupDto>(context, OctopusResourceKind.ProjectGroup);
+                break;
+            case OctopusDocumentKind.Environment:
+                AddDocument<OctopusEnvironmentDto>(context, OctopusResourceKind.Environment);
+                break;
+            case OctopusDocumentKind.Lifecycle:
+                AddLifecycle(context);
+                break;
+            case OctopusDocumentKind.Channel:
+                AddChannel(context);
+                break;
+            case OctopusDocumentKind.DeploymentSettings:
+                AddDeploymentSettings(context);
+                break;
+            case OctopusDocumentKind.DeploymentProcess:
+            case OctopusDocumentKind.DeploymentProcessSnapshot:
+                AddDeploymentProcess(context);
+                break;
+            case OctopusDocumentKind.VariableSet:
+            case OctopusDocumentKind.VariableSetSnapshot:
+                AddVariableSet(context);
+                break;
+            case OctopusDocumentKind.Feed:
+                AddDocument<OctopusFeedDto>(context, OctopusResourceKind.Feed);
+                break;
+            case OctopusDocumentKind.Team:
+                AddDocument<OctopusTeamDto>(context, OctopusResourceKind.Team);
+                break;
+            case OctopusDocumentKind.Machine:
+                AddMachine(context);
+                break;
+            case OctopusDocumentKind.Account:
+                AddAccount(context);
+                break;
+            case OctopusDocumentKind.Certificate:
+                AddDocument<OctopusCertificateDto>(context, OctopusResourceKind.Certificate);
+                break;
+            case OctopusDocumentKind.Release:
+                AddRelease(context);
+                break;
+            case OctopusDocumentKind.Deployment:
+                AddDeployment(context);
+                break;
+            case OctopusDocumentKind.ServerTask:
+                AddServerTask(context);
+                break;
+            case OctopusDocumentKind.ActionTemplate:
+                AddJsonDocument(context, OctopusResourceKind.ActionTemplate);
+                break;
+            default:
+                AddJsonDocument(context, OctopusResourceKind.Unknown);
+                break;
+        }
+    }
+
+    private static void AddProject(GraphBuildContext context)
+    {
+        var project = Deserialize<OctopusProjectDto>(context);
+        if (project == null)
+            return;
+
+        if (!AddDocumentNode(context, project, OctopusResourceKind.Project, project.Id, project.Name, project.Id))
+            return;
+
+        AddReference(context, project.Id, OctopusResourceKind.Project, OctopusResourceReferenceKind.ProjectGroup, project.ProjectGroupId, OctopusResourceKind.ProjectGroup, project.Id, true);
+        AddReference(context, project.Id, OctopusResourceKind.Project, OctopusResourceReferenceKind.Lifecycle, project.LifecycleId, OctopusResourceKind.Lifecycle, project.Id, true);
+        AddReference(context, project.Id, OctopusResourceKind.Project, OctopusResourceReferenceKind.VariableSet, project.VariableSetId, OctopusResourceKind.VariableSet, project.Id, true, false);
+        AddReference(context, project.Id, OctopusResourceKind.Project, OctopusResourceReferenceKind.DeploymentProcess, project.DeploymentProcessId, OctopusResourceKind.DeploymentProcess, project.Id, true, false);
+        AddReference(context, project.Id, OctopusResourceKind.Project, OctopusResourceReferenceKind.DeploymentSettings, project.DeploymentSettingsId, OctopusResourceKind.DeploymentSettings, project.Id, true, false);
+
+        foreach (var variableSetId in project.IncludedLibraryVariableSetIds)
+            AddReference(context, project.Id, OctopusResourceKind.Project, OctopusResourceReferenceKind.VariableSet, variableSetId, OctopusResourceKind.VariableSet, project.Id, true);
+    }
+
+    private static void AddLifecycle(GraphBuildContext context)
+    {
+        var lifecycle = Deserialize<OctopusLifecycleDto>(context);
+        if (lifecycle == null)
+            return;
+
+        if (!AddDocumentNode(context, lifecycle, OctopusResourceKind.Lifecycle, lifecycle.Id, lifecycle.Name, null))
+            return;
+
+        foreach (var phase in lifecycle.Phases.Select((value, index) => (value, index)))
+        {
+            var sourceId = BuildChildSourceId(lifecycle.Id, "phase", phase.value.Id, phase.index);
+            if (!AddNode(context, sourceId, phase.value.Name, OctopusResourceKind.LifecyclePhase, OctopusDocumentKind.Lifecycle, context.Document.SourcePath, null, lifecycle.Id, false, phase.value))
+                continue;
+
+            AddReference(context, lifecycle.Id, OctopusResourceKind.Lifecycle, OctopusResourceReferenceKind.LifecyclePhase, sourceId, OctopusResourceKind.LifecyclePhase, null, false);
+
+            foreach (var environmentId in phase.value.AutomaticDeploymentTargets)
+                AddReference(context, sourceId, OctopusResourceKind.LifecyclePhase, OctopusResourceReferenceKind.Environment, environmentId, OctopusResourceKind.Environment, null, true);
+
+            foreach (var environmentId in phase.value.OptionalDeploymentTargets)
+                AddReference(context, sourceId, OctopusResourceKind.LifecyclePhase, OctopusResourceReferenceKind.Environment, environmentId, OctopusResourceKind.Environment, null, false);
+        }
+    }
+
+    private static void AddChannel(GraphBuildContext context)
+    {
+        var channel = Deserialize<OctopusChannelDto>(context);
+        if (channel == null)
+            return;
+
+        if (!AddDocumentNode(context, channel, OctopusResourceKind.Channel, channel.Id, channel.Name, channel.ProjectId))
+            return;
+
+        AddReference(context, channel.Id, OctopusResourceKind.Channel, OctopusResourceReferenceKind.Project, channel.ProjectId, OctopusResourceKind.Project, channel.ProjectId, true);
+        AddReference(context, channel.Id, OctopusResourceKind.Channel, OctopusResourceReferenceKind.Lifecycle, channel.LifecycleId, OctopusResourceKind.Lifecycle, channel.ProjectId, true);
+    }
+
+    private static void AddDeploymentSettings(GraphBuildContext context)
+    {
+        var settings = Deserialize<OctopusDeploymentSettingsDto>(context);
+        if (settings == null)
+            return;
+
+        if (!AddDocumentNode(context, settings, OctopusResourceKind.DeploymentSettings, settings.Id, settings.Name, settings.ProjectId))
+            return;
+
+        AddReference(context, settings.Id, OctopusResourceKind.DeploymentSettings, OctopusResourceReferenceKind.Project, settings.ProjectId, OctopusResourceKind.Project, settings.ProjectId, true);
+    }
+
+    private static void AddDeploymentProcess(GraphBuildContext context)
+    {
+        var process = Deserialize<OctopusDeploymentProcessDto>(context);
+        if (process == null)
+            return;
+
+        var kind = context.Classification.Kind == OctopusDocumentKind.DeploymentProcessSnapshot
+            ? OctopusResourceKind.DeploymentProcessSnapshot
+            : OctopusResourceKind.DeploymentProcess;
+
+        if (!AddDocumentNode(context, process, kind, process.Id, null, process.OwnerId))
+            return;
+
+        AddReference(context, process.Id, kind, OctopusResourceReferenceKind.Project, process.OwnerId, OctopusResourceKind.Project, process.OwnerId, true);
+
+        foreach (var step in process.Steps.Select((value, index) => (value, index)))
+            AddDeploymentStep(context, process, kind, step.value, step.index);
+    }
+
+    private static void AddDeploymentStep(GraphBuildContext context, OctopusDeploymentProcessDto process, OctopusResourceKind processKind, OctopusDeploymentStepDto step, int index)
+    {
+        var sourceId = BuildChildSourceId(process.Id, "step", step.Id, index);
+        if (!AddNode(context, sourceId, step.Name, OctopusResourceKind.DeploymentStep, context.Classification.Kind, context.Document.SourcePath, process.OwnerId, process.Id, context.Classification.IsOutOfScopeHistory, step))
+            return;
+
+        AddReference(context, sourceId, OctopusResourceKind.DeploymentStep, ProcessReferenceKind(processKind), process.Id, processKind, process.OwnerId, true);
+
+        foreach (var action in step.Actions.Select((value, actionIndex) => (value, actionIndex)))
+            AddDeploymentAction(context, process, sourceId, action.value, action.actionIndex);
+    }
+
+    private static void AddDeploymentAction(GraphBuildContext context, OctopusDeploymentProcessDto process, string stepId, OctopusDeploymentActionDto action, int index)
+    {
+        var sourceId = BuildChildSourceId(stepId, "action", action.Id, index);
+        if (!AddNode(context, sourceId, action.Name, OctopusResourceKind.DeploymentAction, context.Classification.Kind, context.Document.SourcePath, process.OwnerId, stepId, context.Classification.IsOutOfScopeHistory, action))
+            return;
+
+        AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.DeploymentAction, stepId, OctopusResourceKind.DeploymentStep, process.OwnerId, true);
+
+        foreach (var environmentId in action.Environments)
+            AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.Environment, environmentId, OctopusResourceKind.Environment, process.OwnerId, false);
+
+        foreach (var environmentId in action.ExcludedEnvironments)
+            AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.Environment, environmentId, OctopusResourceKind.Environment, process.OwnerId, false);
+
+        foreach (var channelId in action.Channels)
+            AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.Channel, channelId, OctopusResourceKind.Channel, process.OwnerId, false);
+
+        AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.Feed, action.Container?.FeedId, OctopusResourceKind.Feed, process.OwnerId, true);
+
+        foreach (var package in action.Packages)
+            AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.Feed, package.FeedId, OctopusResourceKind.Feed, process.OwnerId, true);
+
+        foreach (var targetRole in SplitReferenceList(GetProperty(action.Properties, "Octopus.Action.TargetRoles")))
+            AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.TargetRole, targetRole, null, process.OwnerId, false);
+
+        foreach (var teamId in SplitReferenceList(GetProperty(action.Properties, "Octopus.Action.Manual.ResponsibleTeamIds")))
+            AddReference(context, sourceId, OctopusResourceKind.DeploymentAction, OctopusResourceReferenceKind.Team, teamId, OctopusResourceKind.Team, process.OwnerId, false);
+    }
+
+    private static void AddVariableSet(GraphBuildContext context)
+    {
+        var variableSet = Deserialize<OctopusVariableSetDto>(context);
+        if (variableSet == null)
+            return;
+
+        var kind = context.Classification.Kind == OctopusDocumentKind.VariableSetSnapshot
+            ? OctopusResourceKind.VariableSetSnapshot
+            : OctopusResourceKind.VariableSet;
+
+        if (!AddDocumentNode(context, variableSet, kind, variableSet.Id, null, variableSet.OwnerId))
+            return;
+
+        AddReference(context, variableSet.Id, kind, OctopusResourceReferenceKind.Project, variableSet.OwnerId, OctopusResourceKind.Project, variableSet.OwnerId, true);
+
+        foreach (var variable in variableSet.Variables.Select((value, index) => (value, index)))
+            AddVariable(context, variableSet, kind, variable.value, variable.index);
+    }
+
+    private static void AddVariable(GraphBuildContext context, OctopusVariableSetDto variableSet, OctopusResourceKind variableSetKind, OctopusVariableDto variable, int index)
+    {
+        var sourceId = BuildChildSourceId(variableSet.Id, "variable", variable.Id, index);
+        if (!AddNode(context, sourceId, variable.Name, OctopusResourceKind.Variable, context.Classification.Kind, context.Document.SourcePath, variableSet.OwnerId, variableSet.Id, context.Classification.IsOutOfScopeHistory, variable))
+            return;
+
+        AddReference(context, sourceId, OctopusResourceKind.Variable, VariableSetReferenceKind(variableSetKind), variableSet.Id, variableSetKind, variableSet.OwnerId, true);
+
+        foreach (var scope in variable.Scope)
+        {
+            foreach (var scopedValue in scope.Value)
+                AddVariableScopeReference(context, sourceId, variableSet.OwnerId, scope.Key, scopedValue);
+        }
+    }
+
+    private static void AddMachine(GraphBuildContext context)
+    {
+        var machine = Deserialize<OctopusMachineDto>(context);
+        if (machine == null)
+            return;
+
+        if (!AddDocumentNode(context, machine, OctopusResourceKind.Machine, machine.Id, machine.Name, null))
+            return;
+
+        foreach (var environmentId in machine.EnvironmentIds)
+            AddReference(context, machine.Id, OctopusResourceKind.Machine, OctopusResourceReferenceKind.Environment, environmentId, OctopusResourceKind.Environment, null, false);
+
+        foreach (var role in machine.Roles)
+            AddReference(context, machine.Id, OctopusResourceKind.Machine, OctopusResourceReferenceKind.TargetRole, role, null, null, false);
+    }
+
+    private static void AddAccount(GraphBuildContext context)
+    {
+        var account = Deserialize<OctopusAccountDto>(context);
+        if (account == null)
+            return;
+
+        if (!AddDocumentNode(context, account, OctopusResourceKind.Account, account.Id, account.Name, null))
+            return;
+
+        foreach (var environmentId in account.EnvironmentIds)
+            AddReference(context, account.Id, OctopusResourceKind.Account, OctopusResourceReferenceKind.Environment, environmentId, OctopusResourceKind.Environment, null, false);
+    }
+
+    private static void AddRelease(GraphBuildContext context)
+    {
+        var release = Deserialize<OctopusReleaseDto>(context);
+        if (release == null)
+            return;
+
+        if (!AddDocumentNode(context, release, OctopusResourceKind.Release, release.Id, release.Version ?? release.Name, release.ProjectId))
+            return;
+
+        AddReference(context, release.Id, OctopusResourceKind.Release, OctopusResourceReferenceKind.Project, release.ProjectId, OctopusResourceKind.Project, release.ProjectId, true);
+        AddReference(context, release.Id, OctopusResourceKind.Release, OctopusResourceReferenceKind.Channel, release.ChannelId, OctopusResourceKind.Channel, release.ProjectId, true);
+        AddReference(context, release.Id, OctopusResourceKind.Release, OctopusResourceReferenceKind.VariableSetSnapshot, release.ProjectVariableSetSnapshotId, OctopusResourceKind.VariableSetSnapshot, release.ProjectId, true);
+        AddReference(context, release.Id, OctopusResourceKind.Release, OctopusResourceReferenceKind.DeploymentProcessSnapshot, release.ProjectDeploymentProcessSnapshotId, OctopusResourceKind.DeploymentProcessSnapshot, release.ProjectId, true);
+    }
+
+    private static void AddDeployment(GraphBuildContext context)
+    {
+        var deployment = Deserialize<OctopusDeploymentDto>(context);
+        if (deployment == null)
+            return;
+
+        if (!AddDocumentNode(context, deployment, OctopusResourceKind.Deployment, deployment.Id, deployment.Name, deployment.ProjectId))
+            return;
+
+        AddReference(context, deployment.Id, OctopusResourceKind.Deployment, OctopusResourceReferenceKind.Project, deployment.ProjectId, OctopusResourceKind.Project, deployment.ProjectId, true);
+        AddReference(context, deployment.Id, OctopusResourceKind.Deployment, OctopusResourceReferenceKind.Environment, deployment.EnvironmentId, OctopusResourceKind.Environment, deployment.ProjectId, true);
+        AddReference(context, deployment.Id, OctopusResourceKind.Deployment, OctopusResourceReferenceKind.Release, deployment.ReleaseId, OctopusResourceKind.Release, deployment.ProjectId, true);
+        AddReference(context, deployment.Id, OctopusResourceKind.Deployment, OctopusResourceReferenceKind.ServerTask, deployment.TaskId, OctopusResourceKind.ServerTask, deployment.ProjectId, false);
+    }
+
+    private static void AddServerTask(GraphBuildContext context)
+    {
+        var task = Deserialize<OctopusServerTaskDto>(context);
+        if (task == null)
+            return;
+
+        if (!AddDocumentNode(context, task, OctopusResourceKind.ServerTask, task.Id, task.Name, task.ProjectId))
+            return;
+
+        AddReference(context, task.Id, OctopusResourceKind.ServerTask, OctopusResourceReferenceKind.Project, task.ProjectId, OctopusResourceKind.Project, task.ProjectId, false);
+        AddReference(context, task.Id, OctopusResourceKind.ServerTask, OctopusResourceReferenceKind.Environment, task.EnvironmentId, OctopusResourceKind.Environment, task.ProjectId, false);
+    }
+
+    private static void AddJsonDocument(GraphBuildContext context, OctopusResourceKind kind)
+    {
+        var sourceId = context.Classification.SourceId ?? context.Item.ManifestEntry.Id;
+        AddNode(context, sourceId, context.Item.ManifestEntry.Name, kind, context.Classification.Kind, context.Document.SourcePath, null, null, context.Classification.IsOutOfScopeHistory, context.Document.Root.Clone());
+    }
+
+    private static bool AddDocument<T>(GraphBuildContext context, OctopusResourceKind kind)
+        where T : OctopusDocumentDto
+    {
+        var document = Deserialize<T>(context);
+        return document != null && AddDocumentNode(context, document, kind, document.Id, document.Name, null);
+    }
+
+    private static bool AddDocumentNode(
+        GraphBuildContext context,
+        object source,
+        OctopusResourceKind kind,
+        string sourceId,
+        string name,
+        string ownerProjectId)
+        => AddNode(context, sourceId, name, kind, context.Classification.Kind, context.Document.SourcePath, ownerProjectId, null, context.Classification.IsOutOfScopeHistory, source);
+
+    private static bool AddNode(
+        GraphBuildContext context,
+        string sourceId,
+        string name,
+        OctopusResourceKind kind,
+        OctopusDocumentKind documentKind,
+        string sourcePath,
+        string ownerProjectId,
+        string parentSourceId,
+        bool isHistorical,
+        object source)
+    {
+        if (string.IsNullOrWhiteSpace(sourceId))
+        {
+            context.Diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.GraphResourceMissingSourceId,
+                $"Octopus import graph resource in '{sourcePath}' is missing a source id.",
+                sourcePath,
+                documentKind: documentKind));
+
+            return false;
+        }
+
+        if (!context.ResourceIds.Add(sourceId))
+        {
+            context.Diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.GraphDuplicateSourceId,
+                $"Octopus import graph contains duplicate source id '{sourceId}'.",
+                sourcePath,
+                sourceId,
+                documentKind));
+
+            return false;
+        }
+
+        context.Resources.Add(new OctopusResourceNode(sourceId, name, kind, documentKind, sourcePath, ownerProjectId, parentSourceId, isHistorical, source));
+        return true;
+    }
+
+    private static T Deserialize<T>(GraphBuildContext context)
+        where T : class
+    {
+        try
+        {
+            return context.Document.Root.Deserialize<T>(JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            context.Diagnostics.Add(Blocker(
+                OctopusInputExtractionDiagnosticCodes.GraphDocumentMalformed,
+                $"Octopus import document '{context.Document.SourcePath}' could not be deserialized for graph building ({ex.GetType().Name}).",
+                context.Document.SourcePath,
+                context.Classification.SourceId,
+                context.Classification.Kind));
+
+            return null;
+        }
+    }
+
+    private static void AddVariableScopeReference(GraphBuildContext context, string variableId, string ownerProjectId, string scopeKey, string scopedValue)
+    {
+        var referenceKind = scopeKey?.Trim() switch
+        {
+            "Environment" => OctopusResourceReferenceKind.Environment,
+            "Channel" => OctopusResourceReferenceKind.Channel,
+            "Action" => OctopusResourceReferenceKind.DeploymentAction,
+            "Machine" => OctopusResourceReferenceKind.Machine,
+            "Role" => OctopusResourceReferenceKind.TargetRole,
+            "TenantTag" => OctopusResourceReferenceKind.TenantTag,
+            _ => (OctopusResourceReferenceKind?)null
+        };
+
+        if (referenceKind == null)
+            return;
+
+        var toKind = referenceKind.Value switch
+        {
+            OctopusResourceReferenceKind.Environment => OctopusResourceKind.Environment,
+            OctopusResourceReferenceKind.Channel => OctopusResourceKind.Channel,
+            OctopusResourceReferenceKind.DeploymentAction => OctopusResourceKind.DeploymentAction,
+            OctopusResourceReferenceKind.Machine => OctopusResourceKind.Machine,
+            _ => (OctopusResourceKind?)null
+        };
+
+        AddReference(context, variableId, OctopusResourceKind.Variable, referenceKind.Value, scopedValue, toKind, ownerProjectId, false);
+    }
+
+    private static void AddReference(
+        GraphBuildContext context,
+        string fromSourceId,
+        OctopusResourceKind fromKind,
+        OctopusResourceReferenceKind referenceKind,
+        string toSourceId,
+        OctopusResourceKind? toKind,
+        string ownerProjectId,
+        bool isRequired,
+        bool? createsDependency = null)
+    {
+        if (string.IsNullOrWhiteSpace(fromSourceId) || string.IsNullOrWhiteSpace(toSourceId))
+            return;
+
+        var addsDependency = createsDependency ?? isRequired;
+
+        context.References.Add(new OctopusResourceReference(
+            fromSourceId,
+            fromKind,
+            referenceKind,
+            toSourceId,
+            toKind,
+            ownerProjectId,
+            isRequired,
+            addsDependency));
+    }
+
+    private static OctopusResourceReferenceKind ProcessReferenceKind(OctopusResourceKind processKind)
+        => processKind == OctopusResourceKind.DeploymentProcessSnapshot
+            ? OctopusResourceReferenceKind.DeploymentProcessSnapshot
+            : OctopusResourceReferenceKind.DeploymentProcess;
+
+    private static OctopusResourceReferenceKind VariableSetReferenceKind(OctopusResourceKind variableSetKind)
+        => variableSetKind == OctopusResourceKind.VariableSetSnapshot
+            ? OctopusResourceReferenceKind.VariableSetSnapshot
+            : OctopusResourceReferenceKind.VariableSet;
+
+    private static string BuildChildSourceId(string parentSourceId, string childKind, string sourceId, int index)
+        => string.IsNullOrWhiteSpace(sourceId)
+            ? $"{parentSourceId}/{childKind}-{index + 1}"
+            : sourceId;
+
+    private static string GetProperty(Dictionary<string, string> properties, string key)
+    {
+        return properties != null && properties.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
+
+    private static IEnumerable<string> SplitReferenceList(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return [];
+
+        return value
+            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(v => !string.IsNullOrWhiteSpace(v));
+    }
+
+    private static OctopusInputExtractionDiagnostic Blocker(
+        string code,
+        string message,
+        string sourcePath = null,
+        string sourceId = null,
+        OctopusDocumentKind? documentKind = null)
+        => new(OctopusImportCompatibilitySeverity.Blocker, code, message, sourcePath, sourceId, documentKind);
+
+    private sealed record GraphBuildContext(
+        OctopusManifestInventoryItem Item,
+        List<OctopusInputExtractionDiagnostic> Diagnostics,
+        List<OctopusResourceNode> Resources,
+        List<OctopusResourceReference> References,
+        HashSet<string> ResourceIds)
+    {
+        public OctopusExtractedJsonDocument Document => Item.Document;
+
+        public OctopusDocumentClassification Classification => Item.Classification;
+    }
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceGraphResult.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceGraphResult.cs
@@ -1,0 +1,42 @@
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public sealed record OctopusResourceGraph(
+    IReadOnlyList<OctopusResourceNode> Resources,
+    IReadOnlyList<OctopusResourceReference> References,
+    IReadOnlyList<OctopusResourceDependency> Dependencies,
+    IReadOnlyList<OctopusInputExtractionDiagnostic> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}
+
+public sealed record OctopusResourceNode(
+    string SourceId,
+    string Name,
+    OctopusResourceKind Kind,
+    OctopusDocumentKind DocumentKind,
+    string SourcePath,
+    string OwnerProjectId,
+    string ParentSourceId,
+    bool IsHistorical,
+    object Source)
+{
+    public T GetSource<T>() where T : class => Source as T;
+}
+
+public sealed record OctopusResourceReference(
+    string FromSourceId,
+    OctopusResourceKind FromKind,
+    OctopusResourceReferenceKind ReferenceKind,
+    string ToSourceId,
+    OctopusResourceKind? ToKind,
+    string OwnerProjectId,
+    bool IsRequired,
+    bool CreatesDependency);
+
+public sealed record OctopusResourceDependency(
+    string SourceId,
+    string DependsOnSourceId,
+    OctopusResourceReferenceKind ReferenceKind,
+    OctopusResourceKind? DependsOnKind);

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceKind.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceKind.cs
@@ -1,0 +1,29 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public enum OctopusResourceKind
+{
+    Unknown,
+    Project,
+    ProjectGroup,
+    Environment,
+    Lifecycle,
+    LifecyclePhase,
+    Channel,
+    DeploymentSettings,
+    DeploymentProcess,
+    DeploymentProcessSnapshot,
+    DeploymentStep,
+    DeploymentAction,
+    VariableSet,
+    VariableSetSnapshot,
+    Variable,
+    Feed,
+    Team,
+    Machine,
+    Account,
+    Certificate,
+    Release,
+    Deployment,
+    ServerTask,
+    ActionTemplate
+}

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceReferenceKind.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceReferenceKind.cs
@@ -1,0 +1,27 @@
+namespace Squid.Core.Services.OctopusImport.Octopus;
+
+public enum OctopusResourceReferenceKind
+{
+    Project,
+    ProjectGroup,
+    Lifecycle,
+    LifecyclePhase,
+    DeploymentSettings,
+    DeploymentProcess,
+    DeploymentProcessSnapshot,
+    VariableSet,
+    VariableSetSnapshot,
+    Channel,
+    Environment,
+    Feed,
+    Team,
+    Machine,
+    Account,
+    Certificate,
+    Release,
+    ServerTask,
+    DeploymentAction,
+    TargetRole,
+    WorkerPool,
+    TenantTag
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusDocumentClassifierTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusDocumentClassifierTests.cs
@@ -103,4 +103,17 @@ public class OctopusDocumentClassifierTests
 
         classification.Kind.ShouldBe(OctopusDocumentKind.Machine);
     }
+
+    [Theory]
+    [InlineData("deploymentprocess-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43", OctopusDocumentKind.DeploymentProcess, false)]
+    [InlineData("variableset-Projects-1323-D4C63A85E7894C5D8C20D9297FEA1A43", OctopusDocumentKind.VariableSet, false)]
+    [InlineData("deploymentprocess-Projects-1323-s-21-8DWSK-D4C63A85E7894C5D8C20D9297FEA1A43", OctopusDocumentKind.DeploymentProcessSnapshot, true)]
+    [InlineData("variableset-Projects-1323-s-55-N6739-D4C63A85E7894C5D8C20D9297FEA1A43", OctopusDocumentKind.VariableSetSnapshot, true)]
+    public void ClassifyJsonDocument_MapsCurrentAndSnapshotProcessAndVariableSetIds(string id, OctopusDocumentKind expectedKind, bool expectedHistory)
+    {
+        var classification = OctopusDocumentClassifier.ClassifyJsonDocument("payload.json", id);
+
+        classification.Kind.ShouldBe(expectedKind);
+        classification.IsOutOfScopeHistory.ShouldBe(expectedHistory);
+    }
 }

--- a/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusResourceGraphBuilderTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Octopus/OctopusResourceGraphBuilderTests.cs
@@ -1,0 +1,273 @@
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.UnitTests.Services.OctopusImport.Octopus;
+
+public class OctopusResourceGraphBuilderTests
+{
+    private readonly OctopusInputExtractor _inputExtractor = new();
+    private readonly OctopusManifestInventoryBuilder _inventoryBuilder = new();
+    private readonly OctopusResourceGraphBuilder _graphBuilder = new();
+
+    [Fact]
+    public async Task Build_CurrentProjectConfiguration_CreatesTypedResourcesReferencesAndDependencies()
+    {
+        var projectGroupJson = """{"Id":"ProjectGroups-1","Name":"Default"}""";
+        var environmentJson = """{"Id":"Environments-1","Name":"Production"}""";
+        var lifecycleJson = """
+                            {
+                                "Id":"Lifecycles-1",
+                                "Name":"Default",
+                                "Phases":[
+                                    {
+                                        "Id":"Phase-1",
+                                        "Name":"Deploy",
+                                        "AutomaticDeploymentTargets":["Environments-1"]
+                                    }
+                                ]
+                            }
+                            """;
+        var feedJson = """{"Id":"Feeds-1","Name":"Docker","FeedType":"Docker","FeedUri":"https://registry.example"}""";
+        var channelJson = """{"Id":"Channels-1","Name":"Default","ProjectId":"Projects-1","LifecycleId":"Lifecycles-1","IsDefault":true}""";
+        var settingsJson = """{"Id":"deploymentsettings-Projects-1","ProjectId":"Projects-1"}""";
+        var variablesJson = """
+                            {
+                                "Id":"variableset-Projects-1",
+                                "OwnerId":"Projects-1",
+                                "OwnerType":"Project",
+                                "Variables":[
+                                    {
+                                        "Id":"Variables-1",
+                                        "Name":"Namespace",
+                                        "Value":"#{Namespace}",
+                                        "Scope":{
+                                            "Environment":["Environments-1"],
+                                            "Channel":["Channels-1"],
+                                            "Action":["Actions-1"],
+                                            "Role":["aws-eks-us"]
+                                        }
+                                    }
+                                ]
+                            }
+                            """;
+        var processJson = """
+                          {
+                              "Id":"deploymentprocess-Projects-1",
+                              "OwnerId":"Projects-1",
+                              "Steps":[
+                                  {
+                                      "Id":"Steps-1",
+                                      "Name":"Deploy",
+                                      "Actions":[
+                                          {
+                                              "Id":"Actions-1",
+                                              "Name":"Deploy containers",
+                                              "ActionType":"Octopus.KubernetesDeployContainers",
+                                              "Environments":["Environments-1"],
+                                              "Channels":["Channels-1"],
+                                              "Container":{"FeedId":"Feeds-1"},
+                                              "Packages":[{"Id":"Packages-1","FeedId":"Feeds-1"}],
+                                              "Properties":{"Octopus.Action.TargetRoles":"aws-eks-us"}
+                                          }
+                                      ]
+                                  }
+                              ]
+                          }
+                          """;
+        var projectJson = """
+                          {
+                              "Id":"Projects-1",
+                              "Name":"Project",
+                              "VariableSetId":"variableset-Projects-1",
+                              "DeploymentProcessId":"deploymentprocess-Projects-1",
+                              "DeploymentSettingsId":"deploymentsettings-Projects-1",
+                              "ProjectGroupId":"ProjectGroups-1",
+                              "LifecycleId":"Lifecycles-1"
+                          }
+                          """;
+
+        var inventory = await BuildInventoryAsync(
+            ("ProjectGroups-1", "ProjectGroup", "ProjectGroups-1.json", projectGroupJson),
+            ("Environments-1", "StaticDeploymentEnvironment", "Environments-1.json", environmentJson),
+            ("Lifecycles-1", "Lifecycle", "Lifecycles-1.json", lifecycleJson),
+            ("Feeds-1", "DockerFeed", "Feeds-1.json", feedJson),
+            ("Channels-1", "Channel", "Channels-1.json", channelJson),
+            ("deploymentsettings-Projects-1", "DeploymentSettings", "deploymentsettings-Projects-1.json", settingsJson),
+            ("variableset-Projects-1", "ProjectVariables", "variableset-Projects-1.json", variablesJson),
+            ("deploymentprocess-Projects-1", "DeploymentProcess", "deploymentprocess-Projects-1.json", processJson),
+            ("Projects-1", "Project", "Projects-1.json", projectJson));
+
+        var graph = _graphBuilder.Build(inventory);
+
+        graph.Diagnostics.ShouldBeEmpty();
+        graph.Resources.Single(r => r.SourceId == "Projects-1").Kind.ShouldBe(OctopusResourceKind.Project);
+        graph.Resources.Single(r => r.SourceId == "deploymentprocess-Projects-1").OwnerProjectId.ShouldBe("Projects-1");
+        graph.Resources.Single(r => r.SourceId == "Steps-1").ParentSourceId.ShouldBe("deploymentprocess-Projects-1");
+        graph.Resources.Single(r => r.SourceId == "Actions-1").ParentSourceId.ShouldBe("Steps-1");
+        graph.Resources.Single(r => r.SourceId == "Variables-1").ParentSourceId.ShouldBe("variableset-Projects-1");
+
+        graph.References.ShouldContain(r =>
+            r.FromSourceId == "Projects-1" &&
+            r.ReferenceKind == OctopusResourceReferenceKind.ProjectGroup &&
+            r.ToSourceId == "ProjectGroups-1");
+        graph.References.ShouldContain(r =>
+            r.FromSourceId == "Actions-1" &&
+            r.ReferenceKind == OctopusResourceReferenceKind.Feed &&
+            r.ToSourceId == "Feeds-1");
+        graph.References.ShouldContain(r =>
+            r.FromSourceId == "Variables-1" &&
+            r.ReferenceKind == OctopusResourceReferenceKind.TargetRole &&
+            r.ToSourceId == "aws-eks-us");
+        graph.Dependencies.ShouldContain(d =>
+            d.SourceId == "Actions-1" &&
+            d.ReferenceKind == OctopusResourceReferenceKind.Feed &&
+            d.DependsOnSourceId == "Feeds-1");
+        graph.Dependencies.ShouldContain(d =>
+            d.SourceId == "deploymentprocess-Projects-1" &&
+            d.ReferenceKind == OctopusResourceReferenceKind.Project &&
+            d.DependsOnSourceId == "Projects-1");
+    }
+
+    [Fact]
+    public async Task Build_HistoricalDocuments_MarksDocumentAndChildResourcesHistorical()
+    {
+        var snapshotVariablesJson = """
+                                    {
+                                        "Id":"variableset-Projects-1-s-1-ABC",
+                                        "OwnerId":"Projects-1",
+                                        "Variables":[{"Id":"Variables-1","Name":"Snapshot"}]
+                                    }
+                                    """;
+        var snapshotProcessJson = """
+                                  {
+                                      "Id":"deploymentprocess-Projects-1-s-1-ABC",
+                                      "OwnerId":"Projects-1",
+                                      "Steps":[{"Id":"Steps-1","Actions":[{"Id":"Actions-1"}]}]
+                                  }
+                                  """;
+        var releaseJson = """
+                          {
+                              "Id":"Releases-1",
+                              "ProjectId":"Projects-1",
+                              "ChannelId":"Channels-1",
+                              "ProjectVariableSetSnapshotId":"variableset-Projects-1-s-1-ABC",
+                              "ProjectDeploymentProcessSnapshotId":"deploymentprocess-Projects-1-s-1-ABC"
+                          }
+                          """;
+        var deploymentJson = """{"Id":"Deployments-1","ProjectId":"Projects-1","EnvironmentId":"Environments-1","ReleaseId":"Releases-1","TaskId":"ServerTasks-1"}""";
+        var taskJson = """{"Id":"ServerTasks-1","ProjectId":"Projects-1","EnvironmentId":"Environments-1"}""";
+
+        var inventory = await BuildInventoryAsync(
+            ("variableset-Projects-1-s-1-ABC", "ProjectVariables", "variableset-Projects-1-s-1-ABC.json", snapshotVariablesJson),
+            ("deploymentprocess-Projects-1-s-1-ABC", "DeploymentProcess", "deploymentprocess-Projects-1-s-1-ABC.json", snapshotProcessJson),
+            ("Releases-1", "Release", "Releases-1.json", releaseJson),
+            ("Deployments-1", "Deployment", "Deployments-1.json", deploymentJson),
+            ("ServerTasks-1", "ServerTask", "ServerTasks-1.json", taskJson));
+
+        var graph = _graphBuilder.Build(inventory);
+
+        graph.Resources.Single(r => r.SourceId == "variableset-Projects-1-s-1-ABC").IsHistorical.ShouldBeTrue();
+        graph.Resources.Single(r => r.SourceId == "deploymentprocess-Projects-1-s-1-ABC").IsHistorical.ShouldBeTrue();
+        graph.Resources.Single(r => r.SourceId == "Variables-1").IsHistorical.ShouldBeTrue();
+        graph.Resources.Single(r => r.SourceId == "Actions-1").IsHistorical.ShouldBeTrue();
+        graph.Resources.Single(r => r.SourceId == "Releases-1").IsHistorical.ShouldBeTrue();
+        graph.Resources.Single(r => r.SourceId == "Deployments-1").IsHistorical.ShouldBeTrue();
+        graph.Resources.Single(r => r.SourceId == "ServerTasks-1").IsHistorical.ShouldBeTrue();
+        graph.References.ShouldContain(r =>
+            r.FromSourceId == "Releases-1" &&
+            r.ReferenceKind == OctopusResourceReferenceKind.VariableSetSnapshot &&
+            r.ToSourceId == "variableset-Projects-1-s-1-ABC");
+    }
+
+    [Fact]
+    public async Task Build_MalformedTypedDocument_AddsBlockerWithoutSourceValues()
+    {
+        var sourceValue = "source-value-that-must-not-leak";
+        var malformedProjectJson = "{\"Id\":\"Projects-1\",\"Name\":\"" + sourceValue + "\",\"IncludedLibraryVariableSetIds\":{}}";
+        var inventory = await BuildInventoryAsync(("Projects-1", "Project", "Projects-1.json", malformedProjectJson));
+
+        var graph = _graphBuilder.Build(inventory);
+
+        var diagnostic = graph.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.GraphDocumentMalformed);
+        diagnostic.SourcePath.ShouldBe("Projects-1.json");
+        diagnostic.SourceId.ShouldBe("Projects-1");
+        diagnostic.Message.ShouldNotContain(sourceValue);
+        graph.HasBlockers.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Build_DuplicateNestedSourceId_AddsBlocker()
+    {
+        var processJson = """
+                          {
+                              "Id":"deploymentprocess-Projects-1",
+                              "OwnerId":"Projects-1",
+                              "Steps":[
+                                  {"Id":"Steps-1","Actions":[{"Id":"Actions-1"}]},
+                                  {"Id":"Steps-1","Actions":[{"Id":"Actions-2"}]}
+                              ]
+                          }
+                          """;
+        var inventory = await BuildInventoryAsync(("deploymentprocess-Projects-1", "DeploymentProcess", "deploymentprocess-Projects-1.json", processJson));
+
+        var graph = _graphBuilder.Build(inventory);
+
+        var diagnostic = graph.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.GraphDuplicateSourceId);
+        diagnostic.SourceId.ShouldBe("Steps-1");
+        diagnostic.SourcePath.ShouldBe("deploymentprocess-Projects-1.json");
+        graph.HasBlockers.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Build_MissingReferenceTarget_KeepsTypedReferenceWithoutBlocker()
+    {
+        var projectJson = """{"Id":"Projects-1","Name":"Project","LifecycleId":"Lifecycles-Missing"}""";
+        var inventory = await BuildInventoryAsync(("Projects-1", "Project", "Projects-1.json", projectJson));
+
+        var graph = _graphBuilder.Build(inventory);
+
+        graph.Diagnostics.ShouldBeEmpty();
+        graph.References.Single(r => r.ReferenceKind == OctopusResourceReferenceKind.Lifecycle).ToSourceId.ShouldBe("Lifecycles-Missing");
+    }
+
+    private async Task<OctopusManifestInventoryResult> BuildInventoryAsync(params (string Id, string DocumentType, string DocumentSource, string Json)[] documents)
+    {
+        var archiveEntries = new List<OctopusExtractedArchiveEntry>
+        {
+            new("manifest.json", Encoding.UTF8.GetBytes(BuildManifestJson(documents)))
+        };
+
+        archiveEntries.AddRange(documents.Select(d => new OctopusExtractedArchiveEntry(d.DocumentSource, Encoding.UTF8.GetBytes(d.Json))));
+
+        var extractionResult = await _inputExtractor.ExtractJsonEntriesAsync(archiveEntries);
+        return _inventoryBuilder.Build(extractionResult);
+    }
+
+    private static string BuildManifestJson((string Id, string DocumentType, string DocumentSource, string Json)[] documents)
+    {
+        var manifest = new
+        {
+            SchemaVersions = Array.Empty<string>(),
+            Entries = documents.Select(d => new
+            {
+                d.Id,
+                Name = d.Id,
+                d.DocumentType,
+                ExportType = "FullDocument",
+                d.DocumentSource,
+                ParentId = (string)null,
+                Hash = Sha1(d.Json)
+            })
+        };
+
+        return JsonSerializer.Serialize(manifest);
+    }
+
+    private static string Sha1(string value)
+    {
+        var bytes = System.Security.Cryptography.SHA1.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
## Summary

- Created `feature/octopus-import-resource-graph` from `feature/squid-import-project`.
- Implemented normalized Octopus resource graph support with resource nodes, typed references, dependency edges, project ownership, and historical-resource classification.
- Added `OctopusResourceGraphBuilder`, graph result models, `OctopusResourceKind`, and `OctopusResourceReferenceKind`.
- Extended Octopus diagnostics for malformed graph documents, missing source IDs, and duplicate source IDs.
- Fixed JSON/folder classification for `deploymentprocess-*` and `variableset-*` IDs so current and snapshot process/variable-set documents can feed manifest inventory and graph building.
- Added unit coverage for graph construction, nested steps/actions/variables, historical resources, malformed typed documents, duplicate source IDs, missing-reference deferral, and classifier ID mapping.
- Marked OpenSpec task `2.6` complete locally; `openspec/` remains ignored and is not part of the branch diff.
- Scope stops before preview planning, Squid ID mapping, dependency ordering planner, and missing-reference validation.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport"` passed: 96 passed, 0 failed.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj` passed: 6318 passed, 0 failed.
- [x] `git diff --check` passed.
- [x] Observed existing dependency/security warnings for `KubernetesClient` and `AutoMapper`; no test failures.