### PR TITLE
Import ID mapping DTO and session-tracked mapping store

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/OctopusImportIdMap.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportIdMap.cs
@@ -1,0 +1,124 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public sealed class OctopusImportIdMap
+{
+    private readonly Dictionary<OctopusImportIdMapKey, OctopusImportIdMappingDto> _mappings;
+
+    public OctopusImportIdMap()
+        : this([])
+    {
+    }
+
+    private OctopusImportIdMap(IEnumerable<OctopusImportIdMappingDto> mappings)
+    {
+        _mappings = new Dictionary<OctopusImportIdMapKey, OctopusImportIdMappingDto>();
+
+        foreach (var mapping in mappings)
+            Add(mapping);
+    }
+
+    public IReadOnlyCollection<OctopusImportIdMappingDto> Mappings => _mappings.Values;
+
+    public static OctopusImportIdMap FromSessionResult(OctopusImportSessionResultDto result)
+        => new(result?.IdMappings ?? []);
+
+    public OctopusImportIdMappingDto AddCreated(OctopusResourceNode source, int destinationId, string destinationType = null)
+        => Add(source, destinationId, OctopusImportResourceOutcomeState.Created, destinationType);
+
+    public OctopusImportIdMappingDto AddReused(OctopusResourceNode source, int destinationId, string destinationType = null)
+        => Add(source, destinationId, OctopusImportResourceOutcomeState.Reused, destinationType);
+
+    public bool TryGetDestinationId(OctopusResourceNode source, out int destinationId)
+        => TryGetDestinationId(source?.SourceId, source?.Kind.ToString(), out destinationId);
+
+    public bool TryGetDestinationId(OctopusResourceReference reference, out int destinationId)
+        => TryGetDestinationId(reference?.ToSourceId, reference?.ToKind?.ToString(), out destinationId);
+
+    public bool TryGetDestinationId(string sourceId, string sourceType, out int destinationId)
+    {
+        if (_mappings.TryGetValue(OctopusImportIdMapKey.Create(sourceId, sourceType), out var mapping))
+        {
+            destinationId = mapping.DestinationId;
+            return true;
+        }
+
+        destinationId = default;
+        return false;
+    }
+
+    public IReadOnlyList<OctopusImportIdMappingDto> ToDto()
+    {
+        return _mappings.Values
+            .OrderBy(m => m.SourceType, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public void CopyTo(OctopusImportSessionResultDto result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        result.IdMappings = ToDto().ToList();
+    }
+
+    private OctopusImportIdMappingDto Add(OctopusResourceNode source, int destinationId, OctopusImportResourceOutcomeState outcomeState, string destinationType)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var mapping = new OctopusImportIdMappingDto
+        {
+            SourceId = source.SourceId,
+            SourceType = source.Kind.ToString(),
+            SourceName = source.Name,
+            DestinationType = destinationType ?? source.Kind.ToString(),
+            DestinationId = destinationId,
+            OutcomeState = outcomeState
+        };
+
+        Add(mapping);
+        return mapping;
+    }
+
+    private void Add(OctopusImportIdMappingDto mapping)
+    {
+        ArgumentNullException.ThrowIfNull(mapping);
+        Validate(mapping);
+
+        var key = OctopusImportIdMapKey.Create(mapping.SourceId, mapping.SourceType);
+
+        if (_mappings.ContainsKey(key))
+            throw new InvalidOperationException($"Octopus import source '{mapping.SourceType}:{mapping.SourceId}' has already been mapped.");
+
+        _mappings.Add(key, mapping);
+    }
+
+    private static void Validate(OctopusImportIdMappingDto mapping)
+    {
+        if (string.IsNullOrWhiteSpace(mapping.SourceId))
+            throw new ArgumentException("Octopus import ID mappings require a source id.", nameof(mapping));
+
+        if (string.IsNullOrWhiteSpace(mapping.SourceType))
+            throw new ArgumentException("Octopus import ID mappings require a source type.", nameof(mapping));
+
+        if (string.IsNullOrWhiteSpace(mapping.DestinationType))
+            throw new ArgumentException("Octopus import ID mappings require a destination type.", nameof(mapping));
+
+        if (mapping.DestinationId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(mapping), mapping.DestinationId, "Octopus import ID mappings require a positive destination id.");
+
+        if (mapping.OutcomeState is not (OctopusImportResourceOutcomeState.Created or OctopusImportResourceOutcomeState.Reused))
+            throw new ArgumentOutOfRangeException(nameof(mapping), mapping.OutcomeState, "Octopus import ID mappings only support created or reused destination resources.");
+    }
+
+    private readonly record struct OctopusImportIdMapKey(string SourceId, string SourceType)
+    {
+        public static OctopusImportIdMapKey Create(string sourceId, string sourceType)
+            => new(Normalize(sourceId), Normalize(sourceType));
+
+        private static string Normalize(string value) => value?.Trim().ToUpperInvariant() ?? string.Empty;
+    }
+}

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportIdMappingDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportIdMappingDto.cs
@@ -1,0 +1,18 @@
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Message.Models.OctopusImport;
+
+public class OctopusImportIdMappingDto
+{
+    public string SourceId { get; set; }
+
+    public string SourceType { get; set; }
+
+    public string SourceName { get; set; }
+
+    public string DestinationType { get; set; }
+
+    public int DestinationId { get; set; }
+
+    public OctopusImportResourceOutcomeState OutcomeState { get; set; }
+}

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportSessionResultDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportSessionResultDto.cs
@@ -8,5 +8,7 @@ public class OctopusImportSessionResultDto
 
     public List<OctopusImportResourceResultDto> Resources { get; set; } = [];
 
+    public List<OctopusImportIdMappingDto> IdMappings { get; set; } = [];
+
     public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];
 }

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportIdMapTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportIdMapTests.cs
@@ -1,0 +1,176 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportIdMapTests
+{
+    [Fact]
+    public void AddCreated_RecordsSourceAndDestinationIdentifiers()
+    {
+        var map = new OctopusImportIdMap();
+        var source = Resource("Projects-1", OctopusResourceKind.Project, "Project");
+
+        var mapping = map.AddCreated(source, 101);
+
+        mapping.SourceId.ShouldBe("Projects-1");
+        mapping.SourceType.ShouldBe("Project");
+        mapping.SourceName.ShouldBe("Project");
+        mapping.DestinationType.ShouldBe("Project");
+        mapping.DestinationId.ShouldBe(101);
+        mapping.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Created);
+    }
+
+    [Fact]
+    public void AddReused_AllowsExplicitDestinationType()
+    {
+        var map = new OctopusImportIdMap();
+        var source = Resource("Feeds-1", OctopusResourceKind.Feed, "Docker feed");
+
+        var mapping = map.AddReused(source, 202, "ExternalFeed");
+
+        mapping.DestinationType.ShouldBe("ExternalFeed");
+        mapping.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Reused);
+    }
+
+    [Fact]
+    public void TryGetDestinationId_LooksUpSourceCaseInsensitively()
+    {
+        var map = new OctopusImportIdMap();
+        map.AddCreated(Resource("Environments-1", OctopusResourceKind.Environment, "Production"), 303);
+
+        var found = map.TryGetDestinationId(" environments-1 ", " environment ", out var destinationId);
+
+        found.ShouldBeTrue();
+        destinationId.ShouldBe(303);
+    }
+
+    [Fact]
+    public void TryGetDestinationId_ResolvesGraphReferences()
+    {
+        var map = new OctopusImportIdMap();
+        map.AddCreated(Resource("Feeds-1", OctopusResourceKind.Feed, "Docker feed"), 404);
+        var reference = new OctopusResourceReference(
+            "Actions-1",
+            OctopusResourceKind.DeploymentAction,
+            OctopusResourceReferenceKind.Feed,
+            "Feeds-1",
+            OctopusResourceKind.Feed,
+            "Projects-1",
+            true,
+            true);
+
+        var found = map.TryGetDestinationId(reference, out var destinationId);
+
+        found.ShouldBeTrue();
+        destinationId.ShouldBe(404);
+    }
+
+    [Fact]
+    public void FromSessionResult_RestoresMappingsForLookup()
+    {
+        var result = new OctopusImportSessionResultDto
+        {
+            IdMappings =
+            [
+                new OctopusImportIdMappingDto
+                {
+                    SourceId = "Lifecycles-1",
+                    SourceType = "Lifecycle",
+                    DestinationType = "Lifecycle",
+                    DestinationId = 505,
+                    OutcomeState = OctopusImportResourceOutcomeState.Reused
+                }
+            ]
+        };
+
+        var map = OctopusImportIdMap.FromSessionResult(result);
+
+        map.TryGetDestinationId("Lifecycles-1", "Lifecycle", out var destinationId).ShouldBeTrue();
+        destinationId.ShouldBe(505);
+    }
+
+    [Fact]
+    public void CopyTo_WritesDeterministicallyOrderedSessionMappings()
+    {
+        var map = new OctopusImportIdMap();
+        map.AddCreated(Resource("Projects-1", OctopusResourceKind.Project, "Project"), 2);
+        map.AddCreated(Resource("Environments-1", OctopusResourceKind.Environment, "Production"), 1);
+        var result = new OctopusImportSessionResultDto();
+
+        map.CopyTo(result);
+
+        result.IdMappings.Select(m => m.SourceId).ToList().ShouldBe(["Environments-1", "Projects-1"]);
+    }
+
+    [Fact]
+    public void AddCreated_WhenSourceAlreadyMapped_Throws()
+    {
+        var map = new OctopusImportIdMap();
+        var source = Resource("Projects-1", OctopusResourceKind.Project, "Project");
+        map.AddCreated(source, 101);
+
+        Should.Throw<InvalidOperationException>(() => map.AddReused(source, 102));
+    }
+
+    [Theory]
+    [InlineData(OctopusImportResourceOutcomeState.Pending)]
+    [InlineData(OctopusImportResourceOutcomeState.Skipped)]
+    [InlineData(OctopusImportResourceOutcomeState.Unsupported)]
+    [InlineData(OctopusImportResourceOutcomeState.Blocked)]
+    [InlineData(OctopusImportResourceOutcomeState.Failed)]
+    public void FromSessionResult_WhenOutcomeCannotMapDestination_Throws(OctopusImportResourceOutcomeState outcomeState)
+    {
+        var result = new OctopusImportSessionResultDto
+        {
+            IdMappings =
+            [
+                new OctopusImportIdMappingDto
+                {
+                    SourceId = "Projects-1",
+                    SourceType = "Project",
+                    DestinationType = "Project",
+                    DestinationId = 101,
+                    OutcomeState = outcomeState
+                }
+            ]
+        };
+
+        Should.Throw<ArgumentOutOfRangeException>(() => OctopusImportIdMap.FromSessionResult(result));
+    }
+
+    [Fact]
+    public void FromSessionResult_WhenDestinationIdIsMissing_Throws()
+    {
+        var result = new OctopusImportSessionResultDto
+        {
+            IdMappings =
+            [
+                new OctopusImportIdMappingDto
+                {
+                    SourceId = "Projects-1",
+                    SourceType = "Project",
+                    DestinationType = "Project",
+                    OutcomeState = OctopusImportResourceOutcomeState.Created
+                }
+            ]
+        };
+
+        Should.Throw<ArgumentOutOfRangeException>(() => OctopusImportIdMap.FromSessionResult(result));
+    }
+
+    private static OctopusResourceNode Resource(string sourceId, OctopusResourceKind kind, string name)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.Project,
+            $"{sourceId}.json",
+            "Projects-1",
+            null,
+            false,
+            new object());
+}


### PR DESCRIPTION
## Summary

- Created `feature/octopus-import-id-mapping` from `feature/squid-import-project`.
- Added `OctopusImportIdMappingDto` and included `IdMappings` in `OctopusImportSessionResultDto`.
- Added `OctopusImportIdMap` for created/reused source-to-destination ID mappings, deterministic DTO export, session-result restore, duplicate mapping protection, and graph reference lookup.
- Added unit tests for created/reused mappings, case-insensitive lookup, reference resolution, session round-trip, duplicate protection, and invalid mapping states.
- Marked OpenSpec task `3.1` complete locally; `openspec/` remains ignored and is not part of the branch diff.
- Scope stops before dependency ordering, conflict discovery, preview planning, and validation.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport"` passed: 109 passed, 0 failed.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj` passed: 6331 passed, 0 failed.
- [x] `git diff --check` passed.
- [ ] No integration tests were added for this branch; current scope is DTO/Core ID mapping plus unit coverage.