### PR TITLE
Dependency ordering planner with cycle detection for resource graph

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusInputExtractionDiagnosticCodes.cs
@@ -24,4 +24,5 @@ public static class OctopusInputExtractionDiagnosticCodes
     public const string GraphDocumentMalformed = "octopus.graph.document_malformed";
     public const string GraphResourceMissingSourceId = "octopus.graph.resource_missing_source_id";
     public const string GraphDuplicateSourceId = "octopus.graph.duplicate_source_id";
+    public const string DependencyCycle = "octopus.dependency.cycle";
 }

--- a/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceReferenceKind.cs
+++ b/src/Squid.Core/Services/OctopusImport/Octopus/OctopusResourceReferenceKind.cs
@@ -21,6 +21,7 @@ public enum OctopusResourceReferenceKind
     Release,
     ServerTask,
     DeploymentAction,
+    Parent,
     TargetRole,
     WorkerPool,
     TenantTag

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlan.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlan.cs
@@ -1,0 +1,13 @@
+using Squid.Message.Enums.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public sealed record OctopusImportDependencyPlan(
+    IReadOnlyList<OctopusResourceNode> OrderedResources,
+    IReadOnlyList<OctopusResourceDependency> AppliedDependencies,
+    IReadOnlyList<OctopusResourceReference> OptionalReferences,
+    IReadOnlyList<OctopusInputExtractionDiagnostic> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlanner.cs
@@ -1,0 +1,161 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public interface IOctopusImportDependencyPlanner : IScopedDependency
+{
+    OctopusImportDependencyPlan BuildCurrentConfigurationPlan(OctopusResourceGraph graph);
+}
+
+public class OctopusImportDependencyPlanner : IOctopusImportDependencyPlanner
+{
+    public OctopusImportDependencyPlan BuildCurrentConfigurationPlan(OctopusResourceGraph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var diagnostics = new List<OctopusInputExtractionDiagnostic>(graph.Diagnostics);
+        var resources = graph.Resources
+            .Where(r => !r.IsHistorical && IsOrderable(r.Kind))
+            .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToDictionary(r => r.SourceId, StringComparer.OrdinalIgnoreCase);
+
+        var orderingEdges = BuildOrderingEdges(graph, resources);
+        var orderedResources = OrderResources(resources, orderingEdges, diagnostics);
+        var appliedDependencies = orderingEdges
+            .Select(e => new OctopusResourceDependency(e.SourceId, e.DependsOnSourceId, e.ReferenceKind, e.DependsOnKind))
+            .Distinct()
+            .ToList();
+        var optionalReferences = graph.References
+            .Where(r => !r.IsRequired && resources.ContainsKey(r.FromSourceId))
+            .OrderBy(r => Rank(r.FromKind))
+            .ThenBy(r => r.FromSourceId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(r => r.ReferenceKind)
+            .ThenBy(r => r.ToSourceId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new OctopusImportDependencyPlan(orderedResources, appliedDependencies, optionalReferences, diagnostics);
+    }
+
+    private static IReadOnlyList<OrderingEdge> BuildOrderingEdges(OctopusResourceGraph graph, Dictionary<string, OctopusResourceNode> resources)
+    {
+        var edges = new List<OrderingEdge>();
+
+        foreach (var dependency in graph.Dependencies)
+        {
+            if (!resources.ContainsKey(dependency.SourceId) || !resources.ContainsKey(dependency.DependsOnSourceId))
+                continue;
+
+            edges.Add(new OrderingEdge(dependency.SourceId, dependency.DependsOnSourceId, dependency.ReferenceKind, dependency.DependsOnKind));
+        }
+
+        foreach (var resource in resources.Values)
+        {
+            if (string.IsNullOrWhiteSpace(resource.ParentSourceId) || !resources.TryGetValue(resource.ParentSourceId, out var parent))
+                continue;
+
+            edges.Add(new OrderingEdge(resource.SourceId, parent.SourceId, OctopusResourceReferenceKind.Parent, parent.Kind));
+        }
+
+        return edges.Distinct().ToList();
+    }
+
+    private static IReadOnlyList<OctopusResourceNode> OrderResources(
+        Dictionary<string, OctopusResourceNode> resources,
+        IReadOnlyList<OrderingEdge> orderingEdges,
+        List<OctopusInputExtractionDiagnostic> diagnostics)
+    {
+        var incoming = resources.Keys.ToDictionary(id => id, _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+        var outgoing = resources.Keys.ToDictionary(id => id, _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var edge in orderingEdges)
+        {
+            incoming[edge.SourceId].Add(edge.DependsOnSourceId);
+            outgoing[edge.DependsOnSourceId].Add(edge.SourceId);
+        }
+
+        var ordered = new List<OctopusResourceNode>();
+        var ready = resources.Values
+            .Where(r => incoming[r.SourceId].Count == 0)
+            .ToList();
+
+        while (ready.Count > 0)
+        {
+            ready.Sort(CompareResources);
+            var next = ready[0];
+            ready.RemoveAt(0);
+            ordered.Add(next);
+
+            foreach (var dependentId in outgoing[next.SourceId].OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList())
+            {
+                incoming[dependentId].Remove(next.SourceId);
+
+                if (incoming[dependentId].Count == 0)
+                    ready.Add(resources[dependentId]);
+            }
+        }
+
+        if (ordered.Count == resources.Count)
+            return ordered;
+
+        var remaining = resources.Values
+            .Where(r => incoming[r.SourceId].Count > 0)
+            .OrderBy(r => Rank(r.Kind))
+            .ThenBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        diagnostics.Add(new OctopusInputExtractionDiagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusInputExtractionDiagnosticCodes.DependencyCycle,
+            "Octopus import current-configuration dependency graph contains a cycle.",
+            SourceId: remaining.FirstOrDefault()?.SourceId,
+            DocumentKind: remaining.FirstOrDefault()?.DocumentKind));
+
+        ordered.AddRange(remaining);
+        return ordered;
+    }
+
+    private static int CompareResources(OctopusResourceNode left, OctopusResourceNode right)
+    {
+        var rankComparison = Rank(left.Kind).CompareTo(Rank(right.Kind));
+        if (rankComparison != 0)
+            return rankComparison;
+
+        return string.Compare(left.SourceId, right.SourceId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsOrderable(OctopusResourceKind kind)
+        => kind is not (OctopusResourceKind.Unknown or OctopusResourceKind.ActionTemplate);
+
+    private static int Rank(OctopusResourceKind kind)
+    {
+        return kind switch
+        {
+            OctopusResourceKind.ProjectGroup => 10,
+            OctopusResourceKind.Environment => 20,
+            OctopusResourceKind.Lifecycle => 30,
+            OctopusResourceKind.LifecyclePhase => 40,
+            OctopusResourceKind.Feed => 50,
+            OctopusResourceKind.Team => 60,
+            OctopusResourceKind.Machine => 70,
+            OctopusResourceKind.Account => 80,
+            OctopusResourceKind.Certificate => 90,
+            OctopusResourceKind.Project => 100,
+            OctopusResourceKind.Channel => 110,
+            OctopusResourceKind.DeploymentSettings => 120,
+            OctopusResourceKind.VariableSet => 130,
+            OctopusResourceKind.Variable => 140,
+            OctopusResourceKind.DeploymentProcess => 150,
+            OctopusResourceKind.DeploymentStep => 160,
+            OctopusResourceKind.DeploymentAction => 170,
+            _ => 1000
+        };
+    }
+
+    private sealed record OrderingEdge(
+        string SourceId,
+        string DependsOnSourceId,
+        OctopusResourceReferenceKind ReferenceKind,
+        OctopusResourceKind? DependsOnKind);
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportDependencyPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportDependencyPlannerTests.cs
@@ -1,0 +1,167 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportDependencyPlannerTests
+{
+    private readonly OctopusImportDependencyPlanner _planner = new();
+
+    [Fact]
+    public void BuildCurrentConfigurationPlan_OrdersResourcesAfterDependenciesAndParents()
+    {
+        var resources = new[]
+        {
+            Node("Actions-1", OctopusResourceKind.DeploymentAction, parentSourceId: "Steps-1"),
+            Node("variableset-Projects-1", OctopusResourceKind.VariableSet, ownerProjectId: "Projects-1"),
+            Node("Variables-1", OctopusResourceKind.Variable, ownerProjectId: "Projects-1", parentSourceId: "variableset-Projects-1"),
+            Node("deploymentprocess-Projects-1", OctopusResourceKind.DeploymentProcess, ownerProjectId: "Projects-1"),
+            Node("Steps-1", OctopusResourceKind.DeploymentStep, ownerProjectId: "Projects-1", parentSourceId: "deploymentprocess-Projects-1"),
+            Node("Projects-1", OctopusResourceKind.Project, ownerProjectId: "Projects-1"),
+            Node("ProjectGroups-1", OctopusResourceKind.ProjectGroup),
+            Node("Lifecycles-1", OctopusResourceKind.Lifecycle),
+            Node("Phase-1", OctopusResourceKind.LifecyclePhase, parentSourceId: "Lifecycles-1"),
+            Node("Environments-1", OctopusResourceKind.Environment),
+            Node("Feeds-1", OctopusResourceKind.Feed),
+            Node("Releases-1", OctopusResourceKind.Release, isHistorical: true)
+        };
+        var dependencies = new[]
+        {
+            Dependency("Projects-1", "ProjectGroups-1", OctopusResourceReferenceKind.ProjectGroup, OctopusResourceKind.ProjectGroup),
+            Dependency("Projects-1", "Lifecycles-1", OctopusResourceReferenceKind.Lifecycle, OctopusResourceKind.Lifecycle),
+            Dependency("Phase-1", "Environments-1", OctopusResourceReferenceKind.Environment, OctopusResourceKind.Environment),
+            Dependency("variableset-Projects-1", "Projects-1", OctopusResourceReferenceKind.Project, OctopusResourceKind.Project),
+            Dependency("deploymentprocess-Projects-1", "Projects-1", OctopusResourceReferenceKind.Project, OctopusResourceKind.Project),
+            Dependency("Actions-1", "Feeds-1", OctopusResourceReferenceKind.Feed, OctopusResourceKind.Feed)
+        };
+        var graph = new OctopusResourceGraph(resources, [], dependencies, []);
+
+        var plan = _planner.BuildCurrentConfigurationPlan(graph);
+
+        plan.Diagnostics.ShouldBeEmpty();
+        plan.OrderedResources.Select(r => r.SourceId).ShouldNotContain("Releases-1");
+        plan.OrderedResources.ShouldRespectOrder("ProjectGroups-1", "Projects-1");
+        plan.OrderedResources.ShouldRespectOrder("Lifecycles-1", "Projects-1");
+        plan.OrderedResources.ShouldRespectOrder("Environments-1", "Phase-1");
+        plan.OrderedResources.ShouldRespectOrder("Lifecycles-1", "Phase-1");
+        plan.OrderedResources.ShouldRespectOrder("Projects-1", "variableset-Projects-1");
+        plan.OrderedResources.ShouldRespectOrder("variableset-Projects-1", "Variables-1");
+        plan.OrderedResources.ShouldRespectOrder("Projects-1", "deploymentprocess-Projects-1");
+        plan.OrderedResources.ShouldRespectOrder("deploymentprocess-Projects-1", "Steps-1");
+        plan.OrderedResources.ShouldRespectOrder("Steps-1", "Actions-1");
+        plan.OrderedResources.ShouldRespectOrder("Feeds-1", "Actions-1");
+        plan.AppliedDependencies.ShouldContain(d =>
+            d.SourceId == "Variables-1" &&
+            d.DependsOnSourceId == "variableset-Projects-1" &&
+            d.ReferenceKind == OctopusResourceReferenceKind.Parent);
+    }
+
+    [Fact]
+    public void BuildCurrentConfigurationPlan_KeepsOptionalReferencesOutOfOrderingDependencies()
+    {
+        var resources = new[]
+        {
+            Node("Actions-1", OctopusResourceKind.DeploymentAction)
+        };
+        var references = new[]
+        {
+            new OctopusResourceReference(
+                "Actions-1",
+                OctopusResourceKind.DeploymentAction,
+                OctopusResourceReferenceKind.TargetRole,
+                "aws-eks-us",
+                null,
+                "Projects-1",
+                false,
+                false)
+        };
+        var graph = new OctopusResourceGraph(resources, references, [], []);
+
+        var plan = _planner.BuildCurrentConfigurationPlan(graph);
+
+        plan.OrderedResources.Single().SourceId.ShouldBe("Actions-1");
+        plan.AppliedDependencies.ShouldBeEmpty();
+        plan.OptionalReferences.Single().ReferenceKind.ShouldBe(OctopusResourceReferenceKind.TargetRole);
+    }
+
+    [Fact]
+    public void BuildCurrentConfigurationPlan_IgnoresMissingDependencyTargetsUntilValidation()
+    {
+        var resources = new[]
+        {
+            Node("Actions-1", OctopusResourceKind.DeploymentAction)
+        };
+        var dependencies = new[]
+        {
+            Dependency("Actions-1", "Feeds-Missing", OctopusResourceReferenceKind.Feed, OctopusResourceKind.Feed)
+        };
+        var graph = new OctopusResourceGraph(resources, [], dependencies, []);
+
+        var plan = _planner.BuildCurrentConfigurationPlan(graph);
+
+        plan.Diagnostics.ShouldBeEmpty();
+        plan.OrderedResources.Single().SourceId.ShouldBe("Actions-1");
+        plan.AppliedDependencies.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildCurrentConfigurationPlan_WhenCycleExists_AddsBlockerAndReturnsRemainingResources()
+    {
+        var resources = new[]
+        {
+            Node("Projects-1", OctopusResourceKind.Project),
+            Node("variableset-Projects-1", OctopusResourceKind.VariableSet)
+        };
+        var dependencies = new[]
+        {
+            Dependency("Projects-1", "variableset-Projects-1", OctopusResourceReferenceKind.VariableSet, OctopusResourceKind.VariableSet),
+            Dependency("variableset-Projects-1", "Projects-1", OctopusResourceReferenceKind.Project, OctopusResourceKind.Project)
+        };
+        var graph = new OctopusResourceGraph(resources, [], dependencies, []);
+
+        var plan = _planner.BuildCurrentConfigurationPlan(graph);
+
+        var diagnostic = plan.Diagnostics.Single(d => d.Code == OctopusInputExtractionDiagnosticCodes.DependencyCycle);
+        diagnostic.Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        plan.OrderedResources.Select(r => r.SourceId).ShouldBe(["Projects-1", "variableset-Projects-1"]);
+        plan.HasBlockers.ShouldBeTrue();
+    }
+
+    private static OctopusResourceNode Node(
+        string sourceId,
+        OctopusResourceKind kind,
+        string ownerProjectId = null,
+        string parentSourceId = null,
+        bool isHistorical = false)
+        => new(
+            sourceId,
+            sourceId,
+            kind,
+            OctopusDocumentKind.Project,
+            $"{sourceId}.json",
+            ownerProjectId,
+            parentSourceId,
+            isHistorical,
+            new object());
+
+    private static OctopusResourceDependency Dependency(
+        string sourceId,
+        string dependsOnSourceId,
+        OctopusResourceReferenceKind referenceKind,
+        OctopusResourceKind dependsOnKind)
+        => new(sourceId, dependsOnSourceId, referenceKind, dependsOnKind);
+}
+
+public static class OctopusImportDependencyPlannerTestExtensions
+{
+    public static void ShouldRespectOrder(this IReadOnlyList<OctopusResourceNode> resources, string firstSourceId, string laterSourceId)
+    {
+        var orderedIds = resources.Select(r => r.SourceId).ToList();
+
+        orderedIds.IndexOf(firstSourceId).ShouldBeGreaterThanOrEqualTo(0);
+        orderedIds.IndexOf(laterSourceId).ShouldBeGreaterThanOrEqualTo(0);
+        orderedIds.IndexOf(firstSourceId).ShouldBeLessThan(orderedIds.IndexOf(laterSourceId));
+    }
+}


### PR DESCRIPTION
## Summary

- Created `feature/octopus-import-dependency-ordering` from `feature/squid-import-project`.
- Added `OctopusImportDependencyPlanner` and `OctopusImportDependencyPlan` for current-configuration dependency ordering.
- Planner now orders graph resources using dependency edges plus parent-child edges, excludes historical resources, tracks optional references, and reports dependency cycles as blockers.
- Added `Parent` reference kind and `DependencyCycle` diagnostic code.
- Added unit tests for dependency ordering, parent ordering, optional target references, missing dependency deferral, and cycle detection.
- Marked OpenSpec task `3.2` complete locally; `openspec/` remains ignored and is not part of the branch diff.
- Scope stops before conflict discovery, preview actions, current-document selection policy, and missing-reference validation.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport"` passed: 113 passed, 0 failed.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj` passed: 6335 passed, 0 failed.
- [x] `git diff --check` passed.
- [ ] No integration tests were added for this branch; current scope is Core dependency ordering plus unit coverage.