### PR TITLE
Conflict discovery with read-only destination provider

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/OctopusImportConflictDiscoveryResult.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportConflictDiscoveryResult.cs
@@ -1,0 +1,24 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public enum OctopusImportIdentityMatchKind
+{
+    Name,
+    Slug,
+    NameAndSlug
+}
+
+public sealed record OctopusImportDestinationMatch(
+    OctopusImportDestinationResource Destination,
+    OctopusImportIdentityMatchKind MatchKind);
+
+public sealed record OctopusImportResourceConflict(
+    OctopusResourceNode Source,
+    IReadOnlyList<OctopusImportDestinationMatch> Matches);
+
+public sealed record OctopusImportConflictDiscoveryResult(
+    IReadOnlyList<OctopusImportResourceConflict> Conflicts)
+{
+    public bool HasConflicts => Conflicts.Count > 0;
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportConflictDiscoveryService.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportConflictDiscoveryService.cs
@@ -1,0 +1,102 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public interface IOctopusImportConflictDiscoveryService : IScopedDependency
+{
+    Task<OctopusImportConflictDiscoveryResult> DiscoverAsync(
+        int destinationSpaceId,
+        OctopusResourceGraph graph,
+        CancellationToken cancellationToken = default);
+}
+
+public class OctopusImportConflictDiscoveryService(
+    IOctopusImportDestinationDataProvider destinationDataProvider)
+    : IOctopusImportConflictDiscoveryService
+{
+    public async Task<OctopusImportConflictDiscoveryResult> DiscoverAsync(
+        int destinationSpaceId,
+        OctopusResourceGraph graph,
+        CancellationToken cancellationToken = default)
+    {
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var destinationResources = await destinationDataProvider
+            .GetResourcesAsync(destinationSpaceId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var destinationsByKind = destinationResources
+            .GroupBy(x => x.Kind)
+            .ToDictionary(x => x.Key, x => x.OrderBy(resource => resource.Id).ToList());
+
+        var conflicts = graph.Resources
+            .Where(x => !x.IsHistorical && IsDiscoverable(x.Kind))
+            .OrderBy(x => x.Kind)
+            .ThenBy(x => x.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(source => BuildConflict(source, destinationsByKind))
+            .Where(conflict => conflict != null)
+            .ToList();
+
+        return new OctopusImportConflictDiscoveryResult(conflicts);
+    }
+
+    private static OctopusImportResourceConflict BuildConflict(
+        OctopusResourceNode source,
+        IReadOnlyDictionary<OctopusResourceKind, List<OctopusImportDestinationResource>> destinationsByKind)
+    {
+        if (!destinationsByKind.TryGetValue(source.Kind, out var destinations))
+            return null;
+
+        var sourceSlug = source.GetSource<OctopusDocumentDto>()?.Slug;
+        var matches = destinations
+            .Select(destination => BuildMatch(source.Name, sourceSlug, destination))
+            .Where(match => match != null)
+            .ToList();
+
+        return matches.Count == 0
+            ? null
+            : new OctopusImportResourceConflict(source, matches);
+    }
+
+    private static OctopusImportDestinationMatch BuildMatch(
+        string sourceName,
+        string sourceSlug,
+        OctopusImportDestinationResource destination)
+    {
+        var nameMatches = IdentityEquals(sourceName, destination.Name);
+        var slugMatches = IdentityEquals(sourceSlug, destination.Slug);
+
+        if (!nameMatches && !slugMatches)
+            return null;
+
+        var matchKind = (nameMatches, slugMatches) switch
+        {
+            (true, true) => OctopusImportIdentityMatchKind.NameAndSlug,
+            (true, false) => OctopusImportIdentityMatchKind.Name,
+            _ => OctopusImportIdentityMatchKind.Slug
+        };
+
+        return new OctopusImportDestinationMatch(destination, matchKind);
+    }
+
+    private static bool IdentityEquals(string left, string right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            return false;
+
+        return string.Equals(left.Trim(), right.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDiscoverable(OctopusResourceKind kind)
+        => kind is OctopusResourceKind.Project
+            or OctopusResourceKind.ProjectGroup
+            or OctopusResourceKind.Environment
+            or OctopusResourceKind.Lifecycle
+            or OctopusResourceKind.Feed
+            or OctopusResourceKind.Team
+            or OctopusResourceKind.Machine
+            or OctopusResourceKind.Account;
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportDestinationDataProvider.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportDestinationDataProvider.cs
@@ -1,0 +1,77 @@
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Account;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.OctopusImport.Octopus;
+using DeploymentEnvironment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public interface IOctopusImportDestinationDataProvider : IScopedDependency
+{
+    Task<IReadOnlyList<OctopusImportDestinationResource>> GetResourcesAsync(
+        int destinationSpaceId,
+        CancellationToken cancellationToken = default);
+}
+
+public class OctopusImportDestinationDataProvider(IRepository repository) : IOctopusImportDestinationDataProvider
+{
+    public async Task<IReadOnlyList<OctopusImportDestinationResource>> GetResourcesAsync(
+        int destinationSpaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var resources = new List<OctopusImportDestinationResource>();
+
+        resources.AddRange(await repository.QueryNoTracking<Project>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Project, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<ProjectGroup>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.ProjectGroup, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<DeploymentEnvironment>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Environment, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<Lifecycle>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Lifecycle, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<ExternalFeed>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Feed, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<Team>(x => x.SpaceId == destinationSpaceId || x.SpaceId == 0)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Team, x.Name, null, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<Machine>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Machine, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        resources.AddRange(await repository.QueryNoTracking<DeploymentAccount>(x => x.SpaceId == destinationSpaceId)
+            .Select(x => new OctopusImportDestinationResource(
+                x.Id, x.SpaceId, OctopusResourceKind.Account, x.Name, x.Slug, x.LastModifiedDate))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false));
+
+        return resources
+            .OrderBy(x => x.Kind)
+            .ThenBy(x => x.Id)
+            .ToList();
+    }
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportDestinationResource.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportDestinationResource.cs
@@ -1,0 +1,11 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public sealed record OctopusImportDestinationResource(
+    int Id,
+    int SpaceId,
+    OctopusResourceKind Kind,
+    string Name,
+    string Slug,
+    DateTimeOffset LastModifiedDate);

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportConflictDiscoveryServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportConflictDiscoveryServiceTests.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportConflictDiscoveryServiceTests
+{
+    private readonly Mock<IOctopusImportDestinationDataProvider> _dataProvider = new();
+
+    [Fact]
+    public async Task DiscoverAsync_FindsNormalizedIdentityConflictsForAllSupportedResourceKinds()
+    {
+        var sourceResources = DiscoverableKinds
+            .Select((kind, index) => Node(
+                $"Source-{index}",
+                kind,
+                $" Source {index} ",
+                $" source-{index} "))
+            .ToList();
+        var destinations = DiscoverableKinds
+            .Select((kind, index) => Destination(
+                index + 1,
+                kind,
+                $"source {index}",
+                $"SOURCE-{index}"))
+            .ToList();
+        SetupDestinations(destinations);
+        var service = new OctopusImportConflictDiscoveryService(_dataProvider.Object);
+
+        var result = await service.DiscoverAsync(7, Graph(sourceResources));
+
+        result.HasConflicts.ShouldBeTrue();
+        result.Conflicts.Count.ShouldBe(DiscoverableKinds.Count);
+        foreach (var conflict in result.Conflicts)
+        {
+            conflict.Matches.Count.ShouldBe(1);
+            conflict.Matches[0].MatchKind.ShouldBe(OctopusImportIdentityMatchKind.NameAndSlug);
+            conflict.Matches[0].Destination.Kind.ShouldBe(conflict.Source.Kind);
+        }
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_PreservesSeparateNameAndSlugMatches()
+    {
+        SetupDestinations(
+        [
+            Destination(10, OctopusResourceKind.Project, "My Project", "different-slug"),
+            Destination(11, OctopusResourceKind.Project, "Different Project", "my-project")
+        ]);
+        var service = new OctopusImportConflictDiscoveryService(_dataProvider.Object);
+        var graph = Graph([Node("Projects-1", OctopusResourceKind.Project, "My Project", "my-project")]);
+
+        var result = await service.DiscoverAsync(7, graph);
+
+        var conflict = result.Conflicts.Single();
+        conflict.Matches.Select(x => (x.Destination.Id, x.MatchKind)).ShouldBe(
+        [
+            (10, OctopusImportIdentityMatchKind.Name),
+            (11, OctopusImportIdentityMatchKind.Slug)
+        ]);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_IgnoresHistoricalUnsupportedAndUnmatchedResources()
+    {
+        SetupDestinations(
+        [
+            Destination(10, OctopusResourceKind.Project, "Historical", "historical"),
+            Destination(11, OctopusResourceKind.Project, "Different", "different")
+        ]);
+        var service = new OctopusImportConflictDiscoveryService(_dataProvider.Object);
+        var graph = Graph(
+        [
+            Node("Projects-Historical", OctopusResourceKind.Project, "Historical", "historical", isHistorical: true),
+            Node("Channels-1", OctopusResourceKind.Channel, "Channel", "channel"),
+            Node("Projects-New", OctopusResourceKind.Project, "New Project", "new-project")
+        ]);
+
+        var result = await service.DiscoverAsync(7, graph);
+
+        result.HasConflicts.ShouldBeFalse();
+        result.Conflicts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_RejectsInvalidDestinationSpaceBeforeQuerying()
+    {
+        var service = new OctopusImportConflictDiscoveryService(_dataProvider.Object);
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() => service.DiscoverAsync(0, Graph([])));
+
+        _dataProvider.Verify(
+            x => x.GetResourcesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_PassesCancellationTokenToDataProvider()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        SetupDestinations([]);
+        var service = new OctopusImportConflictDiscoveryService(_dataProvider.Object);
+
+        await service.DiscoverAsync(7, Graph([]), cancellationTokenSource.Token);
+
+        _dataProvider.Verify(
+            x => x.GetResourcesAsync(7, cancellationTokenSource.Token),
+            Times.Once);
+    }
+
+    private void SetupDestinations(IReadOnlyList<OctopusImportDestinationResource> destinations)
+    {
+        _dataProvider
+            .Setup(x => x.GetResourcesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(destinations);
+    }
+
+    private static OctopusImportDestinationResource Destination(
+        int id,
+        OctopusResourceKind kind,
+        string name,
+        string slug)
+        => new(id, 7, kind, name, slug, DateTimeOffset.UtcNow);
+
+    private static OctopusResourceGraph Graph(IReadOnlyList<OctopusResourceNode> resources)
+        => new(resources, [], [], []);
+
+    private static OctopusResourceNode Node(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name,
+        string slug,
+        bool isHistorical = false)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.Project,
+            $"{sourceId}.json",
+            null,
+            null,
+            isHistorical,
+            Source(kind, sourceId, name, slug));
+
+    private static OctopusDocumentDto Source(
+        OctopusResourceKind kind,
+        string sourceId,
+        string name,
+        string slug)
+    {
+        OctopusDocumentDto source = kind switch
+        {
+            OctopusResourceKind.Project => new OctopusProjectDto(),
+            OctopusResourceKind.ProjectGroup => new OctopusProjectGroupDto(),
+            OctopusResourceKind.Environment => new OctopusEnvironmentDto(),
+            OctopusResourceKind.Lifecycle => new OctopusLifecycleDto(),
+            OctopusResourceKind.Feed => new OctopusFeedDto(),
+            OctopusResourceKind.Team => new OctopusTeamDto(),
+            OctopusResourceKind.Machine => new OctopusMachineDto(),
+            OctopusResourceKind.Account => new OctopusAccountDto(),
+            _ => new OctopusProjectDto()
+        };
+
+        source.Id = sourceId;
+        source.Name = name;
+        source.Slug = slug;
+        return source;
+    }
+
+    private static readonly IReadOnlyList<OctopusResourceKind> DiscoverableKinds =
+    [
+        OctopusResourceKind.Project,
+        OctopusResourceKind.ProjectGroup,
+        OctopusResourceKind.Environment,
+        OctopusResourceKind.Lifecycle,
+        OctopusResourceKind.Feed,
+        OctopusResourceKind.Team,
+        OctopusResourceKind.Machine,
+        OctopusResourceKind.Account
+    ];
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportDestinationDataProviderTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportDestinationDataProviderTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using Squid.Core.Persistence;
+using Squid.Core.Persistence.Db;
+using Squid.Core.Persistence.Entities.Account;
+using Squid.Core.Persistence.Entities.Deployments;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+using DeploymentEnvironment = Squid.Core.Persistence.Entities.Deployments.Environment;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportDestinationDataProviderTests
+{
+    [Fact]
+    public async Task GetResourcesAsync_ReturnsSupportedResourcesFromDestinationSpaceAndGlobalTeams()
+    {
+        await using var db = CreateDbContext();
+        var provider = new OctopusImportDestinationDataProvider(new EfRepository(db));
+
+        db.Set<Project>().AddRange(
+            new Project { Id = 1, SpaceId = 7, Name = "Project", Slug = "project" },
+            new Project { Id = 2, SpaceId = 8, Name = "Other Project", Slug = "other-project" });
+        db.Set<ProjectGroup>().Add(new ProjectGroup { Id = 3, SpaceId = 7, Name = "Group", Slug = "group" });
+        db.Set<DeploymentEnvironment>().Add(new DeploymentEnvironment { Id = 4, SpaceId = 7, Name = "Development", Slug = "development" });
+        db.Set<Lifecycle>().Add(new Lifecycle { Id = 5, SpaceId = 7, Name = "Default Lifecycle", Slug = "default-lifecycle" });
+        db.Set<ExternalFeed>().Add(new ExternalFeed
+        {
+            Id = 6,
+            SpaceId = 7,
+            Name = "Docker",
+            Slug = "docker",
+            Password = "must-not-be-read"
+        });
+        db.Set<Team>().AddRange(
+            new Team { Id = 7, SpaceId = 7, Name = "Operators" },
+            new Team { Id = 8, SpaceId = 0, Name = "Administrators", IsBuiltIn = true },
+            new Team { Id = 9, SpaceId = 8, Name = "Other Team" });
+        db.Set<Machine>().Add(new Machine
+        {
+            Id = 10,
+            SpaceId = 7,
+            Name = "Worker",
+            Slug = "worker",
+            Endpoint = """{"Password":"must-not-be-read"}"""
+        });
+        db.Set<DeploymentAccount>().Add(new DeploymentAccount
+        {
+            Id = 11,
+            SpaceId = 7,
+            Name = "AWS",
+            Slug = "aws",
+            Credentials = """{"SecretKey":"must-not-be-read"}"""
+        });
+        await db.SaveChangesAsync();
+
+        var resources = await provider.GetResourcesAsync(7);
+
+        resources.Count.ShouldBe(9);
+        resources.Select(x => (x.Kind, x.Id)).ShouldBe(
+        [
+            (OctopusResourceKind.Project, 1),
+            (OctopusResourceKind.ProjectGroup, 3),
+            (OctopusResourceKind.Environment, 4),
+            (OctopusResourceKind.Lifecycle, 5),
+            (OctopusResourceKind.Feed, 6),
+            (OctopusResourceKind.Team, 7),
+            (OctopusResourceKind.Team, 8),
+            (OctopusResourceKind.Machine, 10),
+            (OctopusResourceKind.Account, 11)
+        ]);
+        resources.All(x => x.SpaceId == 0 || x.SpaceId == 7).ShouldBeTrue();
+    }
+
+    private static SquidDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<SquidDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new SquidDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary

- Created `feature/octopus-import-conflict-discovery` from `feature/squid-import-project`.
- Implemented OpenSpec task 3.3 for projects, environments, project groups, lifecycles, feeds, teams, machines, and accounts.
- Added a read-only destination provider that projects only identity/version fields, excluding credentials, passwords, and endpoint data.
- Added normalized Name/Slug matching with deterministic ordering and preservation of ambiguous matches.
- Global built-in teams remain discoverable according to existing Squid team semantics.
- Compatibility diagnostics and preview actions remain scoped to task 3.4.
- Marked task 3.3 complete in the locally excluded `tasks.md`.

## Test plan

- OctopusImport focused tests: **119 passed, 0 failed**.
- Complete `Squid.UnitTests`: **6341 passed, 0 failed, 0 skipped**.
- Final whitespace and workspace checks passed.