### PR TITLE
Feature/fix deployment action id drift

### DIFF
--- a/src/Squid.Core/Services/Deployments/Process/Step/DeploymentStepService.cs
+++ b/src/Squid.Core/Services/Deployments/Process/Step/DeploymentStepService.cs
@@ -103,12 +103,7 @@ public class DeploymentStepService : IDeploymentStepService
             await _stepPropertyDataProvider.AddDeploymentStepPropertiesAsync(properties, cancellationToken).ConfigureAwait(false);
         }
 
-        await _actionDataProvider.DeleteDeploymentActionsByStepIdAsync(step.Id, cancellationToken).ConfigureAwait(false);
-
-        if (command.Step.Actions?.Any() == true)
-        {
-            await CreateActionsAsync(step.Id, command.Step.Actions, cancellationToken).ConfigureAwait(false);
-        }
+        await UpsertActionsAsync(step.Id, command.Step.Actions, cancellationToken).ConfigureAwait(false);
 
         var stepWithRelatedData = await GetStepWithRelatedDataAsync(step.Id, cancellationToken).ConfigureAwait(false);
 
@@ -285,19 +280,104 @@ public class DeploymentStepService : IDeploymentStepService
 
     private async Task CreateActionsAsync(int stepId, List<CreateOrUpdateDeploymentActionModel> actions, CancellationToken cancellationToken)
     {
-        foreach (var action in actions)
+        for (var i = 0; i < actions.Count; i++)
         {
-            var mappedAction = _mapper.Map<DeploymentAction>(action);
-
-            mappedAction.StepId = stepId;
-
-            await _actionDataProvider.AddDeploymentActionAsync(mappedAction, true, cancellationToken).ConfigureAwait(false);
-
-            await PersistActionPropertiesAsync(mappedAction.Id, action.Properties, cancellationToken).ConfigureAwait(false);
-            await PersistActionEnvironmentsAsync(mappedAction.Id, action.Environments, cancellationToken).ConfigureAwait(false);
-            await PersistActionExcludedEnvironmentsAsync(mappedAction.Id, action.ExcludedEnvironments, cancellationToken).ConfigureAwait(false);
-            await PersistActionChannelsAsync(mappedAction.Id, action.Channels, cancellationToken).ConfigureAwait(false);
+            await CreateActionAsync(stepId, actions[i], i + 1, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private async Task UpsertActionsAsync(int stepId, List<CreateOrUpdateDeploymentActionModel> actions, CancellationToken cancellationToken)
+    {
+        actions ??= new List<CreateOrUpdateDeploymentActionModel>();
+
+        var existingActions = await _actionDataProvider.GetDeploymentActionsByStepIdAsync(stepId, cancellationToken).ConfigureAwait(false);
+        var existingActionsById = existingActions.ToDictionary(a => a.Id);
+        var retainedActionIds = new HashSet<int>();
+
+        for (var i = 0; i < actions.Count; i++)
+        {
+            var action = actions[i];
+            var existingAction = ResolveExistingAction(stepId, action, existingActions, existingActionsById, retainedActionIds, i);
+
+            if (existingAction == null)
+            {
+                await CreateActionAsync(stepId, action, i + 1, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            _mapper.Map(action, existingAction);
+            existingAction.StepId = stepId;
+            existingAction.ActionOrder = i + 1;
+
+            await _actionDataProvider.UpdateDeploymentActionAsync(existingAction, true, cancellationToken).ConfigureAwait(false);
+            await ReplaceActionRelatedDataAsync(existingAction.Id, action, cancellationToken).ConfigureAwait(false);
+        }
+
+        var removedActions = existingActions.Where(a => !retainedActionIds.Contains(a.Id)).ToList();
+
+        foreach (var removedAction in removedActions)
+        {
+            await _actionDataProvider.DeleteDeploymentActionAsync(removedAction, true, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static DeploymentAction ResolveExistingAction(
+        int stepId,
+        CreateOrUpdateDeploymentActionModel action,
+        List<DeploymentAction> existingActions,
+        Dictionary<int, DeploymentAction> existingActionsById,
+        HashSet<int> retainedActionIds,
+        int actionIndex)
+    {
+        if (action.Id is > 0)
+        {
+            if (!existingActionsById.TryGetValue(action.Id.Value, out var existingAction))
+                throw new InvalidOperationException($"DeploymentAction {action.Id.Value} does not belong to DeploymentStep {stepId}.");
+
+            if (!retainedActionIds.Add(existingAction.Id))
+                throw new InvalidOperationException($"DeploymentAction {action.Id.Value} was submitted more than once.");
+
+            return existingAction;
+        }
+
+        if (actionIndex >= existingActions.Count) return null;
+
+        var fallbackAction = existingActions[actionIndex];
+
+        if (!retainedActionIds.Add(fallbackAction.Id)) return null;
+
+        return fallbackAction;
+    }
+
+    private async Task ReplaceActionRelatedDataAsync(int actionId, CreateOrUpdateDeploymentActionModel action, CancellationToken cancellationToken)
+    {
+        var properties = _mapper.Map<List<DeploymentActionProperty>>(action.Properties ?? new List<ActionPropertyModel>());
+        properties.ForEach(p => p.ActionId = actionId);
+        await _actionPropertyDataProvider.UpdateDeploymentActionPropertiesAsync(actionId, properties, cancellationToken).ConfigureAwait(false);
+
+        await _actionEnvironmentDataProvider.DeleteActionEnvironmentsByActionIdAsync(actionId, cancellationToken).ConfigureAwait(false);
+        await PersistActionEnvironmentsAsync(actionId, action.Environments, cancellationToken).ConfigureAwait(false);
+
+        await _actionExcludedEnvironmentDataProvider.DeleteActionExcludedEnvironmentsByActionIdAsync(actionId, cancellationToken).ConfigureAwait(false);
+        await PersistActionExcludedEnvironmentsAsync(actionId, action.ExcludedEnvironments, cancellationToken).ConfigureAwait(false);
+
+        await _actionChannelDataProvider.DeleteActionChannelsByActionIdAsync(actionId, cancellationToken).ConfigureAwait(false);
+        await PersistActionChannelsAsync(actionId, action.Channels, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task CreateActionAsync(int stepId, CreateOrUpdateDeploymentActionModel action, int actionOrder, CancellationToken cancellationToken)
+    {
+        var mappedAction = _mapper.Map<DeploymentAction>(action);
+
+        mappedAction.StepId = stepId;
+        mappedAction.ActionOrder = actionOrder;
+
+        await _actionDataProvider.AddDeploymentActionAsync(mappedAction, true, cancellationToken).ConfigureAwait(false);
+
+        await PersistActionPropertiesAsync(mappedAction.Id, action.Properties, cancellationToken).ConfigureAwait(false);
+        await PersistActionEnvironmentsAsync(mappedAction.Id, action.Environments, cancellationToken).ConfigureAwait(false);
+        await PersistActionExcludedEnvironmentsAsync(mappedAction.Id, action.ExcludedEnvironments, cancellationToken).ConfigureAwait(false);
+        await PersistActionChannelsAsync(mappedAction.Id, action.Channels, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task PersistActionPropertiesAsync(int actionId, List<ActionPropertyModel> properties, CancellationToken cancellationToken)
@@ -337,4 +417,3 @@ public class DeploymentStepService : IDeploymentStepService
         await _actionChannelDataProvider.AddActionChannelsAsync(entities, cancellationToken).ConfigureAwait(false);
     }
 }
-

--- a/src/Squid.Core/Services/Deployments/Process/Step/DeploymentStepService.cs
+++ b/src/Squid.Core/Services/Deployments/Process/Step/DeploymentStepService.cs
@@ -33,6 +33,7 @@ public class DeploymentStepService : IDeploymentStepService
     private readonly IActionEnvironmentDataProvider _actionEnvironmentDataProvider;
     private readonly IActionExcludedEnvironmentDataProvider _actionExcludedEnvironmentDataProvider;
     private readonly IActionChannelDataProvider _actionChannelDataProvider;
+    private readonly IActionMachineRoleDataProvider _actionMachineRoleDataProvider;
 
     public DeploymentStepService(
         IMapper mapper,
@@ -42,7 +43,8 @@ public class DeploymentStepService : IDeploymentStepService
         IDeploymentActionPropertyDataProvider actionPropertyDataProvider,
         IActionEnvironmentDataProvider actionEnvironmentDataProvider,
         IActionExcludedEnvironmentDataProvider actionExcludedEnvironmentDataProvider,
-        IActionChannelDataProvider actionChannelDataProvider)
+        IActionChannelDataProvider actionChannelDataProvider,
+        IActionMachineRoleDataProvider actionMachineRoleDataProvider)
     {
         _mapper = mapper;
         _stepDataProvider = stepDataProvider;
@@ -52,6 +54,7 @@ public class DeploymentStepService : IDeploymentStepService
         _actionEnvironmentDataProvider = actionEnvironmentDataProvider;
         _actionExcludedEnvironmentDataProvider = actionExcludedEnvironmentDataProvider;
         _actionChannelDataProvider = actionChannelDataProvider;
+        _actionMachineRoleDataProvider = actionMachineRoleDataProvider;
     }
 
     public async Task<DeploymentStepCreatedEvent> CreateDeploymentStepAsync(CreateDeploymentStepCommand command, CancellationToken cancellationToken)
@@ -292,12 +295,18 @@ public class DeploymentStepService : IDeploymentStepService
 
         var existingActions = await _actionDataProvider.GetDeploymentActionsByStepIdAsync(stepId, cancellationToken).ConfigureAwait(false);
         var existingActionsById = existingActions.ToDictionary(a => a.Id);
+        var hasExplicitActionIds = actions.Any(a => a.Id is > 0);
         var retainedActionIds = new HashSet<int>();
+
+        if (actions.Count > 0)
+        {
+            await AssignTemporaryActionOrdersAsync(existingActions, cancellationToken).ConfigureAwait(false);
+        }
 
         for (var i = 0; i < actions.Count; i++)
         {
             var action = actions[i];
-            var existingAction = ResolveExistingAction(stepId, action, existingActions, existingActionsById, retainedActionIds, i);
+            var existingAction = ResolveExistingAction(stepId, action, existingActions, existingActionsById, retainedActionIds, i, hasExplicitActionIds);
 
             if (existingAction == null)
             {
@@ -321,13 +330,24 @@ public class DeploymentStepService : IDeploymentStepService
         }
     }
 
+    private async Task AssignTemporaryActionOrdersAsync(List<DeploymentAction> existingActions, CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < existingActions.Count; i++)
+        {
+            existingActions[i].ActionOrder = -(i + 1);
+            var isLast = i == existingActions.Count - 1;
+            await _actionDataProvider.UpdateDeploymentActionAsync(existingActions[i], isLast, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     private static DeploymentAction ResolveExistingAction(
         int stepId,
         CreateOrUpdateDeploymentActionModel action,
         List<DeploymentAction> existingActions,
         Dictionary<int, DeploymentAction> existingActionsById,
         HashSet<int> retainedActionIds,
-        int actionIndex)
+        int actionIndex,
+        bool hasExplicitActionIds)
     {
         if (action.Id is > 0)
         {
@@ -340,7 +360,7 @@ public class DeploymentStepService : IDeploymentStepService
             return existingAction;
         }
 
-        if (actionIndex >= existingActions.Count) return null;
+        if (hasExplicitActionIds || actionIndex >= existingActions.Count) return null;
 
         var fallbackAction = existingActions[actionIndex];
 
@@ -363,6 +383,8 @@ public class DeploymentStepService : IDeploymentStepService
 
         await _actionChannelDataProvider.DeleteActionChannelsByActionIdAsync(actionId, cancellationToken).ConfigureAwait(false);
         await PersistActionChannelsAsync(actionId, action.Channels, cancellationToken).ConfigureAwait(false);
+
+        await _actionMachineRoleDataProvider.DeleteActionMachineRolesByActionIdAsync(actionId, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task CreateActionAsync(int stepId, CreateOrUpdateDeploymentActionModel action, int actionOrder, CancellationToken cancellationToken)

--- a/src/Squid.Message/Models/Deployments/Process/Action/CreateOrUpdateDeploymentActionModel.cs
+++ b/src/Squid.Message/Models/Deployments/Process/Action/CreateOrUpdateDeploymentActionModel.cs
@@ -2,6 +2,7 @@ namespace Squid.Message.Models.Deployments.Process;
 
 public class CreateOrUpdateDeploymentActionModel
 {
+    public int? Id { get; set; }
     public string Name { get; set; }
     public string ActionType { get; set; }
     public int? WorkerPoolId { get; set; }

--- a/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
@@ -222,6 +222,7 @@ public class DeploymentStepServiceTests : TestBase
             actions: [new CreateOrUpdateDeploymentActionModel { Name = "Old Action", ActionType = "Squid.Script" }]);
 
         var stepId = created.Id;
+        var actionId = created.Actions[0].Id;
 
         await Run<IDeploymentStepService>(async service =>
         {
@@ -264,6 +265,81 @@ public class DeploymentStepServiceTests : TestBase
 
             actions.Count.ShouldBe(1);
             actions[0].StepId.ShouldBe(stepId);
+            actions[0].Id.ShouldBe(actionId);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task UpdateStep_WithExistingActionId_PreservesActionId()
+    {
+        var processId = await SeedProcessAsync();
+
+        var created = await CreateStepAsync(processId, "Original Step",
+            actions:
+            [
+                new CreateOrUpdateDeploymentActionModel
+                {
+                    Name = "Original Action",
+                    ActionType = "Squid.Script",
+                    Properties =
+                    [
+                        new ActionPropertyModel { PropertyName = "OldProp", PropertyValue = "old" }
+                    ]
+                }
+            ]);
+
+        var stepId = created.Id;
+        var actionId = created.Actions[0].Id;
+
+        await Run<IDeploymentStepService>(async service =>
+        {
+            var command = new UpdateDeploymentStepCommand
+            {
+                Id = stepId,
+                Step = new CreateOrUpdateDeploymentStepModel
+                {
+                    Name = "Updated Step",
+                    StepType = "Action",
+                    Condition = "Success",
+                    StartTrigger = "",
+                    PackageRequirement = "",
+                    Actions =
+                    [
+                        new CreateOrUpdateDeploymentActionModel
+                        {
+                            Id = actionId,
+                            Name = "Updated Action",
+                            ActionType = "Squid.KubernetesDeployContainers",
+                            Properties =
+                            [
+                                new ActionPropertyModel { PropertyName = "NewProp", PropertyValue = "new" }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            await service.UpdateDeploymentStepAsync(command, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentActionDataProvider>(async provider =>
+        {
+            var actions = await provider.GetDeploymentActionsByStepIdAsync(stepId, CancellationToken.None).ConfigureAwait(false);
+
+            actions.Count.ShouldBe(1);
+            actions[0].Id.ShouldBe(actionId);
+            actions[0].Name.ShouldBe("Updated Action");
+            actions[0].ActionType.ShouldBe("Squid.KubernetesDeployContainers");
+            actions[0].ActionOrder.ShouldBe(1);
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentActionPropertyDataProvider>(async provider =>
+        {
+            var properties = await provider.GetDeploymentActionPropertiesByActionIdAsync(actionId, CancellationToken.None).ConfigureAwait(false);
+
+            properties.Count.ShouldBe(1);
+            properties[0].PropertyName.ShouldBe("NewProp");
+            properties[0].PropertyValue.ShouldBe("new");
         }).ConfigureAwait(false);
     }
 

--- a/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
+++ b/tests/Squid.IntegrationTests/Services/Deployments/Process/Step/DeploymentStepServiceTests.cs
@@ -344,6 +344,129 @@ public class DeploymentStepServiceTests : TestBase
     }
 
     [Fact]
+    public async Task UpdateStep_WithExistingActionIdAndInsertedAction_CreatesInsertedActionAndPreservesExistingAction()
+    {
+        var processId = await SeedProcessAsync();
+
+        var created = await CreateStepAsync(processId, "Original Step",
+            actions:
+            [
+                new CreateOrUpdateDeploymentActionModel
+                {
+                    Name = "Original Action",
+                    ActionType = "Squid.Script"
+                }
+            ]);
+
+        var stepId = created.Id;
+        var existingActionId = created.Actions[0].Id;
+
+        await Run<IDeploymentStepService>(async service =>
+        {
+            var command = new UpdateDeploymentStepCommand
+            {
+                Id = stepId,
+                Step = new CreateOrUpdateDeploymentStepModel
+                {
+                    Name = "Updated Step",
+                    StepType = "Action",
+                    Condition = "Success",
+                    StartTrigger = "",
+                    PackageRequirement = "",
+                    Actions =
+                    [
+                        new CreateOrUpdateDeploymentActionModel
+                        {
+                            Name = "Inserted Action",
+                            ActionType = "Squid.KubernetesDeployContainers"
+                        },
+                        new CreateOrUpdateDeploymentActionModel
+                        {
+                            Id = existingActionId,
+                            Name = "Existing Action",
+                            ActionType = "Squid.Script"
+                        }
+                    ]
+                }
+            };
+
+            await service.UpdateDeploymentStepAsync(command, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentActionDataProvider>(async provider =>
+        {
+            var actions = await provider.GetDeploymentActionsByStepIdAsync(stepId, CancellationToken.None).ConfigureAwait(false);
+
+            actions.Count.ShouldBe(2);
+            actions[0].Id.ShouldNotBe(existingActionId);
+            actions[0].Name.ShouldBe("Inserted Action");
+            actions[0].ActionOrder.ShouldBe(1);
+            actions[1].Id.ShouldBe(existingActionId);
+            actions[1].Name.ShouldBe("Existing Action");
+            actions[1].ActionOrder.ShouldBe(2);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task UpdateStep_WithExistingActionId_ClearsStaleActionMachineRoles()
+    {
+        var processId = await SeedProcessAsync();
+
+        var created = await CreateStepAsync(processId, "Original Step",
+            actions:
+            [
+                new CreateOrUpdateDeploymentActionModel
+                {
+                    Name = "Original Action",
+                    ActionType = "Squid.Script"
+                }
+            ]);
+
+        var stepId = created.Id;
+        var actionId = created.Actions[0].Id;
+
+        await Run<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var builder = new TestDataBuilder(repository, unitOfWork);
+            await builder.CreateActionMachineRolesAsync(actionId, "web-server").ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await Run<IDeploymentStepService>(async service =>
+        {
+            var command = new UpdateDeploymentStepCommand
+            {
+                Id = stepId,
+                Step = new CreateOrUpdateDeploymentStepModel
+                {
+                    Name = "Updated Step",
+                    StepType = "Action",
+                    Condition = "Success",
+                    StartTrigger = "",
+                    PackageRequirement = "",
+                    Actions =
+                    [
+                        new CreateOrUpdateDeploymentActionModel
+                        {
+                            Id = actionId,
+                            Name = "Updated Action",
+                            ActionType = "Squid.KubernetesDeployContainers"
+                        }
+                    ]
+                }
+            };
+
+            await service.UpdateDeploymentStepAsync(command, CancellationToken.None).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+
+        await Run<IActionMachineRoleDataProvider>(async provider =>
+        {
+            var roles = await provider.GetActionMachineRolesByActionIdAsync(actionId, CancellationToken.None).ConfigureAwait(false);
+
+            roles.Count.ShouldBe(0);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
     public async Task UpdateStep_PersistsNameChange()
     {
         var processId = await SeedProcessAsync();

--- a/tests/Squid.UnitTests/Services/Deployments/Process/DeploymentStepServiceActionAssociationTests.cs
+++ b/tests/Squid.UnitTests/Services/Deployments/Process/DeploymentStepServiceActionAssociationTests.cs
@@ -142,7 +142,8 @@ public class DeploymentStepServiceActionAssociationTests
         Mock<IDeploymentActionPropertyDataProvider> ActionProperty,
         Mock<IActionEnvironmentDataProvider> ActionEnvironment,
         Mock<IActionExcludedEnvironmentDataProvider> ActionExcludedEnvironment,
-        Mock<IActionChannelDataProvider> ActionChannel);
+        Mock<IActionChannelDataProvider> ActionChannel,
+        Mock<IActionMachineRoleDataProvider> ActionMachineRole);
 
     private static (DeploymentStepService Service, MockProviders Mocks) CreateServiceWithMocks()
     {
@@ -155,6 +156,7 @@ public class DeploymentStepServiceActionAssociationTests
         var actionEnvProvider = new Mock<IActionEnvironmentDataProvider>();
         var actionExEnvProvider = new Mock<IActionExcludedEnvironmentDataProvider>();
         var actionChannelProvider = new Mock<IActionChannelDataProvider>();
+        var actionMachineRoleProvider = new Mock<IActionMachineRoleDataProvider>();
 
         // Default: step insert assigns Id = 1
         stepProvider.Setup(p => p.AddDeploymentStepAsync(It.IsAny<DeploymentStep>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
@@ -186,8 +188,8 @@ public class DeploymentStepServiceActionAssociationTests
         actionChannelProvider.Setup(p => p.GetActionChannelsByActionIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ActionChannel>());
 
-        var service = new DeploymentStepService(mapper, stepProvider.Object, stepPropertyProvider.Object, actionProvider.Object, actionPropertyProvider.Object, actionEnvProvider.Object, actionExEnvProvider.Object, actionChannelProvider.Object);
-        var mocks = new MockProviders(stepProvider, stepPropertyProvider, actionProvider, actionPropertyProvider, actionEnvProvider, actionExEnvProvider, actionChannelProvider);
+        var service = new DeploymentStepService(mapper, stepProvider.Object, stepPropertyProvider.Object, actionProvider.Object, actionPropertyProvider.Object, actionEnvProvider.Object, actionExEnvProvider.Object, actionChannelProvider.Object, actionMachineRoleProvider.Object);
+        var mocks = new MockProviders(stepProvider, stepPropertyProvider, actionProvider, actionPropertyProvider, actionEnvProvider, actionExEnvProvider, actionChannelProvider, actionMachineRoleProvider);
 
         return (service, mocks);
     }


### PR DESCRIPTION
Close #487  

AI Review Summary

本分支主要改动是：更新部署 Step 时不再删除并重建 action，而是通过 action `Id` 做 upsert，从而避免 deployment action ID 漂移。

主要变化如下：

新增 `CreateOrUpdateDeploymentActionModel.Id`，允许更新请求携带已有 action ID。

`DeploymentStepService.UpdateDeploymentStepAsync` 改为调用 action upsert 逻辑：
- 显式传入 `Id` 的 action 会更新原 action，并保留原 ID。
- 没有传 `Id` 且请求中存在显式 ID 的 action 会按新 action 创建，不再错误按位置复用旧 action。
- 旧客户端完全不传 `Id` 时，仍保留按位置 fallback 的兼容逻辑。

修复插入新 action 时的 `ActionOrder` 唯一约束冲突：
- 更新前先把已有 actions 临时挪到负序号。
- 再按提交顺序写入最终 `ActionOrder`，支持在开头/中间插入新 action。

修复保留 action ID 后旧关联数据残留：
- 更新 retained action 时会继续替换 properties、environments、excluded environments、channels。
- 新增清理旧 `ActionMachineRole`，避免旧 machine roles 进入后续部署快照或造成数据不一致。

测试同步调整：
- 新增集成测试，验证“插入新 action + 保留已有 action ID”不会覆盖旧 action，也不会撞 `ActionOrder`。
- 新增集成测试，验证更新已有 action 时会清理旧 `ActionMachineRole`。
- 更新单测 mock，适配 `DeploymentStepService` 新增的 `IActionMachineRoleDataProvider` 依赖。

验证结果：
- 已通过：`DeploymentStepServiceActionAssociationTests`，9 passed，0 failed。
- 已通过：`DeploymentStepServiceTests`，15 passed，0 failed。
- 已通过：`git diff --check`。