### PR TITLE
Preview action planner for Octopus import

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewDiagnosticCodes.cs
@@ -1,0 +1,12 @@
+namespace Squid.Core.Services.OctopusImport;
+
+public static class OctopusImportPreviewDiagnosticCodes
+{
+    public const string DependencyPlanBlocker = "octopus.preview.dependency_plan_blocker";
+    public const string ResourceOutOfScope = "octopus.preview.resource_out_of_scope";
+    public const string ResourceUnsupported = "octopus.preview.resource_unsupported";
+    public const string ReuseExistingResource = "octopus.preview.resource_reuse_existing";
+    public const string RenameRequiredForProject = "octopus.preview.project_rename_required";
+    public const string RenameRequiredForAmbiguousConflict = "octopus.preview.resource_rename_required_ambiguous";
+    public const string ResourceBlockedByDependencyPlan = "octopus.preview.resource_blocked_by_dependency_plan";
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
@@ -1,0 +1,213 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public interface IOctopusImportPreviewPlanner : IScopedDependency
+{
+    OctopusImportPreviewPlanDto BuildPreviewPlan(
+        OctopusImportDependencyPlan dependencyPlan,
+        OctopusImportConflictDiscoveryResult conflicts);
+}
+
+public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
+{
+    public OctopusImportPreviewPlanDto BuildPreviewPlan(
+        OctopusImportDependencyPlan dependencyPlan,
+        OctopusImportConflictDiscoveryResult conflicts)
+    {
+        ArgumentNullException.ThrowIfNull(dependencyPlan);
+        ArgumentNullException.ThrowIfNull(conflicts);
+
+        var conflictsBySourceId = conflicts.Conflicts
+            .GroupBy(c => c.Source.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        var blockedSourceIds = dependencyPlan.Diagnostics
+            .Where(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker && !string.IsNullOrWhiteSpace(d.SourceId))
+            .Select(d => d.SourceId)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var resources = dependencyPlan.OrderedResources
+            .OrderBy(r => Rank(r.Kind))
+            .ThenBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(resource => BuildResourcePreview(resource, conflictsBySourceId, blockedSourceIds))
+            .ToList();
+
+        var diagnostics = dependencyPlan.Diagnostics
+            .Select(MapDependencyDiagnostic)
+            .ToList();
+
+        return new OctopusImportPreviewPlanDto
+        {
+            Resources = resources,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private static OctopusImportResourceResultDto BuildResourcePreview(
+        OctopusResourceNode resource,
+        IReadOnlyDictionary<string, OctopusImportResourceConflict> conflictsBySourceId,
+        IReadOnlySet<string> blockedSourceIds)
+    {
+        var result = new OctopusImportResourceResultDto
+        {
+            SourceId = resource.SourceId,
+            SourceType = resource.Kind.ToString(),
+            SourceName = resource.Name,
+            OutcomeState = OctopusImportResourceOutcomeState.Pending
+        };
+
+        if (blockedSourceIds.Contains(resource.SourceId))
+        {
+            result.PreviewAction = OctopusImportPreviewAction.Blocked;
+            result.OutcomeState = OctopusImportResourceOutcomeState.Blocked;
+            result.Diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                OctopusImportPreviewDiagnosticCodes.ResourceBlockedByDependencyPlan,
+                "This Octopus resource is blocked by a dependency-plan diagnostic.",
+                resource));
+            return result;
+        }
+
+        if (resource.IsHistorical || IsOutOfScope(resource.Kind))
+        {
+            result.PreviewAction = OctopusImportPreviewAction.Skip;
+            result.OutcomeState = OctopusImportResourceOutcomeState.Skipped;
+            result.Diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Info,
+                OctopusImportPreviewDiagnosticCodes.ResourceOutOfScope,
+                $"Octopus {resource.Kind} resource is outside the initial current-configuration import scope.",
+                resource));
+            return result;
+        }
+
+        if (IsUnsupported(resource.Kind))
+        {
+            result.PreviewAction = OctopusImportPreviewAction.Unsupported;
+            result.OutcomeState = OctopusImportResourceOutcomeState.Unsupported;
+            result.Diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportPreviewDiagnosticCodes.ResourceUnsupported,
+                $"Octopus {resource.Kind} resources are detected but are not imported by the current preview planner.",
+                resource));
+            return result;
+        }
+
+        if (!conflictsBySourceId.TryGetValue(resource.SourceId, out var conflict))
+        {
+            result.PreviewAction = OctopusImportPreviewAction.Create;
+            return result;
+        }
+
+        ApplyConflictAction(result, resource, conflict);
+        return result;
+    }
+
+    private static void ApplyConflictAction(
+        OctopusImportResourceResultDto result,
+        OctopusResourceNode resource,
+        OctopusImportResourceConflict conflict)
+    {
+        if (resource.Kind == OctopusResourceKind.Project)
+        {
+            result.PreviewAction = OctopusImportPreviewAction.RenameRequired;
+            result.Diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                OctopusImportPreviewDiagnosticCodes.RenameRequiredForProject,
+                "A project with the same name or slug already exists in the destination space. Project imports are never silently merged.",
+                resource));
+            return;
+        }
+
+        if (conflict.Matches.Count != 1)
+        {
+            result.PreviewAction = OctopusImportPreviewAction.RenameRequired;
+            result.Diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                OctopusImportPreviewDiagnosticCodes.RenameRequiredForAmbiguousConflict,
+                $"Found {conflict.Matches.Count} destination resources with matching identity. Select a destination resource or rename the Octopus resource before importing.",
+                resource));
+            return;
+        }
+
+        var match = conflict.Matches[0];
+        result.PreviewAction = OctopusImportPreviewAction.ReuseExisting;
+        result.DestinationId = match.Destination.Id;
+        result.Diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Info,
+            OctopusImportPreviewDiagnosticCodes.ReuseExistingResource,
+            $"A compatible destination {resource.Kind} identity was found by {match.MatchKind}.",
+            resource));
+    }
+
+    private static OctopusImportDiagnosticDto MapDependencyDiagnostic(OctopusInputExtractionDiagnostic diagnostic)
+        => new()
+        {
+            Severity = diagnostic.Severity,
+            Code = string.IsNullOrWhiteSpace(diagnostic.Code)
+                ? OctopusImportPreviewDiagnosticCodes.DependencyPlanBlocker
+                : diagnostic.Code,
+            Message = diagnostic.Message,
+            SourceId = diagnostic.SourceId,
+            ResourceType = diagnostic.DocumentKind?.ToString()
+        };
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = resource.Kind.ToString(),
+            SourceId = resource.SourceId,
+            ResourceName = resource.Name
+        };
+
+    private static bool IsOutOfScope(OctopusResourceKind kind)
+        => kind is OctopusResourceKind.Release
+            or OctopusResourceKind.Deployment
+            or OctopusResourceKind.ServerTask
+            or OctopusResourceKind.DeploymentProcessSnapshot
+            or OctopusResourceKind.VariableSetSnapshot;
+
+    private static bool IsUnsupported(OctopusResourceKind kind)
+        => kind is OctopusResourceKind.Unknown
+            or OctopusResourceKind.ActionTemplate
+            or OctopusResourceKind.Certificate;
+
+    private static int Rank(OctopusResourceKind kind)
+    {
+        return kind switch
+        {
+            OctopusResourceKind.ProjectGroup => 10,
+            OctopusResourceKind.Environment => 20,
+            OctopusResourceKind.Lifecycle => 30,
+            OctopusResourceKind.LifecyclePhase => 40,
+            OctopusResourceKind.Feed => 50,
+            OctopusResourceKind.Team => 60,
+            OctopusResourceKind.Machine => 70,
+            OctopusResourceKind.Account => 80,
+            OctopusResourceKind.Certificate => 90,
+            OctopusResourceKind.Project => 100,
+            OctopusResourceKind.Channel => 110,
+            OctopusResourceKind.DeploymentSettings => 120,
+            OctopusResourceKind.VariableSet => 130,
+            OctopusResourceKind.Variable => 140,
+            OctopusResourceKind.DeploymentProcess => 150,
+            OctopusResourceKind.DeploymentStep => 160,
+            OctopusResourceKind.DeploymentAction => 170,
+            OctopusResourceKind.DeploymentProcessSnapshot => 900,
+            OctopusResourceKind.VariableSetSnapshot => 910,
+            OctopusResourceKind.Release => 920,
+            OctopusResourceKind.Deployment => 930,
+            OctopusResourceKind.ServerTask => 940,
+            _ => 1000
+        };
+    }
+}

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportPreviewPlanDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportPreviewPlanDto.cs
@@ -1,0 +1,13 @@
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Message.Models.OctopusImport;
+
+public class OctopusImportPreviewPlanDto
+{
+    public List<OctopusImportResourceResultDto> Resources { get; set; } = [];
+
+    public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];
+
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker)
+        || Resources.Any(r => r.Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker));
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
@@ -1,0 +1,190 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportPreviewPlannerTests
+{
+    private readonly OctopusImportPreviewPlanner _planner = new();
+
+    [Fact]
+    public void BuildPreviewPlan_WhenResourceHasNoConflict_ProposesCreate()
+    {
+        var resource = Node("Environments-1", OctopusResourceKind.Environment, "Development");
+
+        var preview = _planner.BuildPreviewPlan(Plan([resource]), NoConflicts());
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.Create);
+        result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Pending);
+        result.DestinationId.ShouldBeNull();
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenSharedResourceHasOneConflict_ProposesReuseExisting()
+    {
+        var resource = Node("Feeds-1", OctopusResourceKind.Feed, "Docker");
+        var conflicts = new OctopusImportConflictDiscoveryResult(
+        [
+            Conflict(resource, Match(200, OctopusResourceKind.Feed, "Docker", "docker"))
+        ]);
+
+        var preview = _planner.BuildPreviewPlan(Plan([resource]), conflicts);
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.ReuseExisting);
+        result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Pending);
+        result.DestinationId.ShouldBe(200);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.ReuseExistingResource);
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenProjectConflicts_RequiresRenameAndAddsBlocker()
+    {
+        var resource = Node("Projects-1", OctopusResourceKind.Project, "My Project");
+        var conflicts = new OctopusImportConflictDiscoveryResult(
+        [
+            Conflict(resource, Match(300, OctopusResourceKind.Project, "My Project", "my-project"))
+        ]);
+
+        var preview = _planner.BuildPreviewPlan(Plan([resource]), conflicts);
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.RenameRequired);
+        result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Pending);
+        result.DestinationId.ShouldBeNull();
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.RenameRequiredForProject);
+        preview.HasBlockers.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenSharedResourceHasAmbiguousConflicts_RequiresRename()
+    {
+        var resource = Node("ProjectGroups-1", OctopusResourceKind.ProjectGroup, "Default");
+        var conflicts = new OctopusImportConflictDiscoveryResult(
+        [
+            Conflict(
+                resource,
+                Match(400, OctopusResourceKind.ProjectGroup, "Default", "default-a"),
+                Match(401, OctopusResourceKind.ProjectGroup, "Default B", "default"))
+        ]);
+
+        var preview = _planner.BuildPreviewPlan(Plan([resource]), conflicts);
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.RenameRequired);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.RenameRequiredForAmbiguousConflict);
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenResourceIsHistoricalOrOutOfScope_ProposesSkip()
+    {
+        var release = Node("Releases-1", OctopusResourceKind.Release, "1.0.0", isHistorical: true);
+
+        var preview = _planner.BuildPreviewPlan(Plan([release]), NoConflicts());
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.Skip);
+        result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Skipped);
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Info);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.ResourceOutOfScope);
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenResourceKindIsUnsupported_ProposesUnsupported()
+    {
+        var certificate = Node("Certificates-1", OctopusResourceKind.Certificate, "TLS");
+
+        var preview = _planner.BuildPreviewPlan(Plan([certificate]), NoConflicts());
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.Unsupported);
+        result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Unsupported);
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Warning);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.ResourceUnsupported);
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenDependencyPlanHasResourceBlocker_ProposesBlocked()
+    {
+        var project = Node("Projects-1", OctopusResourceKind.Project, "Project");
+        var dependencyDiagnostic = new OctopusInputExtractionDiagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            "octopus.test.blocker",
+            "Dependency graph is blocked.",
+            SourceId: project.SourceId,
+            DocumentKind: OctopusDocumentKind.Project);
+
+        var preview = _planner.BuildPreviewPlan(Plan([project], [dependencyDiagnostic]), NoConflicts());
+
+        var result = preview.Resources.Single();
+        result.PreviewAction.ShouldBe(OctopusImportPreviewAction.Blocked);
+        result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Blocked);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.ResourceBlockedByDependencyPlan);
+        preview.Diagnostics.Single().Code.ShouldBe("octopus.test.blocker");
+        preview.HasBlockers.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_ReturnsResourcesInDependencyOrderRank()
+    {
+        var resources = new[]
+        {
+            Node("Actions-1", OctopusResourceKind.DeploymentAction, "Action"),
+            Node("Projects-1", OctopusResourceKind.Project, "Project"),
+            Node("Environments-1", OctopusResourceKind.Environment, "Development")
+        };
+
+        var preview = _planner.BuildPreviewPlan(Plan(resources), NoConflicts());
+
+        preview.Resources.Select(r => r.SourceId).ToList().ShouldBe(["Environments-1", "Projects-1", "Actions-1"]);
+    }
+
+    private static OctopusImportDependencyPlan Plan(
+        IReadOnlyList<OctopusResourceNode> resources,
+        IReadOnlyList<OctopusInputExtractionDiagnostic> diagnostics = null)
+        => new(resources, [], [], diagnostics ?? []);
+
+    private static OctopusImportConflictDiscoveryResult NoConflicts()
+        => new([]);
+
+    private static OctopusImportResourceConflict Conflict(
+        OctopusResourceNode resource,
+        params OctopusImportDestinationMatch[] matches)
+        => new(resource, matches);
+
+    private static OctopusImportDestinationMatch Match(
+        int destinationId,
+        OctopusResourceKind kind,
+        string name,
+        string slug)
+        => new(
+            new OctopusImportDestinationResource(
+                destinationId,
+                7,
+                kind,
+                name,
+                slug,
+                DateTimeOffset.UtcNow),
+            OctopusImportIdentityMatchKind.NameAndSlug);
+
+    private static OctopusResourceNode Node(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name,
+        bool isHistorical = false)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.Project,
+            $"{sourceId}.json",
+            "Projects-1",
+            null,
+            isHistorical,
+            new object());
+}


### PR DESCRIPTION
## Summary

- Implemented task 3.4 on `feature/octopus-import-preview-actions`.
- Added `OctopusImportPreviewPlanner` to produce preview resources with `Create`, `ReuseExisting`, `RenameRequired`, `Skip`, `Unsupported`, and `Blocked` actions.
- Added compatibility diagnostics for reuse, project collisions, ambiguous conflicts, out-of-scope resources, unsupported resources, and dependency-plan blockers.
- Added `OctopusImportPreviewPlanDto` for preview output using existing Octopus import resource/diagnostic DTOs.
- Kept scope limited to preview action planning; current-document selection remains 3.5, unresolved reference validation and stale-plan checks remain 3.6.
- Updated local OpenSpec progress: task 3.4 marked complete in excluded `tasks.md`.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore` passed: 127/127.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --no-restore` passed: 6349/6349.
- [x] Checked OpenSpec task status and local exclude behavior for `openspec/`.
- [x] Checked new files for trailing whitespace.
- [ ] No additional integration/API tests were added in this branch; those remain later OpenSpec tasks.