### PR TITLE
Current resource selection with out-of-scope skipping

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlan.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlan.cs
@@ -7,7 +7,17 @@ public sealed record OctopusImportDependencyPlan(
     IReadOnlyList<OctopusResourceNode> OrderedResources,
     IReadOnlyList<OctopusResourceDependency> AppliedDependencies,
     IReadOnlyList<OctopusResourceReference> OptionalReferences,
-    IReadOnlyList<OctopusInputExtractionDiagnostic> Diagnostics)
+    IReadOnlyList<OctopusInputExtractionDiagnostic> Diagnostics,
+    IReadOnlyList<OctopusResourceNode> OutOfScopeResources)
 {
+    public OctopusImportDependencyPlan(
+        IReadOnlyList<OctopusResourceNode> orderedResources,
+        IReadOnlyList<OctopusResourceDependency> appliedDependencies,
+        IReadOnlyList<OctopusResourceReference> optionalReferences,
+        IReadOnlyList<OctopusInputExtractionDiagnostic> diagnostics)
+        : this(orderedResources, appliedDependencies, optionalReferences, diagnostics, [])
+    {
+    }
+
     public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
 }

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportDependencyPlanner.cs
@@ -15,6 +15,13 @@ public class OctopusImportDependencyPlanner : IOctopusImportDependencyPlanner
         ArgumentNullException.ThrowIfNull(graph);
 
         var diagnostics = new List<OctopusInputExtractionDiagnostic>(graph.Diagnostics);
+        var outOfScopeResources = graph.Resources
+            .Where(IsOutOfScopeReportResource)
+            .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderBy(r => Rank(r.Kind))
+            .ThenBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
         var resources = graph.Resources
             .Where(r => !r.IsHistorical && IsOrderable(r.Kind))
             .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
@@ -35,7 +42,7 @@ public class OctopusImportDependencyPlanner : IOctopusImportDependencyPlanner
             .ThenBy(r => r.ToSourceId, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        return new OctopusImportDependencyPlan(orderedResources, appliedDependencies, optionalReferences, diagnostics);
+        return new OctopusImportDependencyPlan(orderedResources, appliedDependencies, optionalReferences, diagnostics, outOfScopeResources);
     }
 
     private static IReadOnlyList<OrderingEdge> BuildOrderingEdges(OctopusResourceGraph graph, Dictionary<string, OctopusResourceNode> resources)
@@ -127,6 +134,13 @@ public class OctopusImportDependencyPlanner : IOctopusImportDependencyPlanner
 
     private static bool IsOrderable(OctopusResourceKind kind)
         => kind is not (OctopusResourceKind.Unknown or OctopusResourceKind.ActionTemplate);
+
+    private static bool IsOutOfScopeReportResource(OctopusResourceNode resource)
+        => resource.Kind is OctopusResourceKind.Release
+            or OctopusResourceKind.Deployment
+            or OctopusResourceKind.ServerTask
+            or OctopusResourceKind.DeploymentProcessSnapshot
+            or OctopusResourceKind.VariableSetSnapshot;
 
     private static int Rank(OctopusResourceKind kind)
     {

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
@@ -30,6 +30,9 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var resources = dependencyPlan.OrderedResources
+            .Concat(dependencyPlan.OutOfScopeResources)
+            .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
             .OrderBy(r => Rank(r.Kind))
             .ThenBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
             .Select(resource => BuildResourcePreview(resource, conflictsBySourceId, blockedSourceIds))

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportDependencyPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportDependencyPlannerTests.cs
@@ -42,6 +42,7 @@ public class OctopusImportDependencyPlannerTests
 
         plan.Diagnostics.ShouldBeEmpty();
         plan.OrderedResources.Select(r => r.SourceId).ShouldNotContain("Releases-1");
+        plan.OutOfScopeResources.Select(r => r.SourceId).ShouldBe(["Releases-1"]);
         plan.OrderedResources.ShouldRespectOrder("ProjectGroups-1", "Projects-1");
         plan.OrderedResources.ShouldRespectOrder("Lifecycles-1", "Projects-1");
         plan.OrderedResources.ShouldRespectOrder("Environments-1", "Phase-1");
@@ -56,6 +57,45 @@ public class OctopusImportDependencyPlannerTests
             d.SourceId == "Variables-1" &&
             d.DependsOnSourceId == "variableset-Projects-1" &&
             d.ReferenceKind == OctopusResourceReferenceKind.Parent);
+    }
+
+    [Fact]
+    public void BuildCurrentConfigurationPlan_SelectsCurrentProcessAndVariablesAndReportsHistoricalDocuments()
+    {
+        var resources = new[]
+        {
+            Node("variableset-Projects-1", OctopusResourceKind.VariableSet, ownerProjectId: "Projects-1"),
+            Node("Variables-1", OctopusResourceKind.Variable, ownerProjectId: "Projects-1", parentSourceId: "variableset-Projects-1"),
+            Node("variableset-Projects-1-s-1-ABC", OctopusResourceKind.VariableSetSnapshot, ownerProjectId: "Projects-1", isHistorical: true),
+            Node("SnapshotVariable-1", OctopusResourceKind.Variable, ownerProjectId: "Projects-1", parentSourceId: "variableset-Projects-1-s-1-ABC", isHistorical: true),
+            Node("deploymentprocess-Projects-1", OctopusResourceKind.DeploymentProcess, ownerProjectId: "Projects-1"),
+            Node("Steps-1", OctopusResourceKind.DeploymentStep, ownerProjectId: "Projects-1", parentSourceId: "deploymentprocess-Projects-1"),
+            Node("deploymentprocess-Projects-1-s-1-ABC", OctopusResourceKind.DeploymentProcessSnapshot, ownerProjectId: "Projects-1", isHistorical: true),
+            Node("SnapshotSteps-1", OctopusResourceKind.DeploymentStep, ownerProjectId: "Projects-1", parentSourceId: "deploymentprocess-Projects-1-s-1-ABC", isHistorical: true),
+            Node("Releases-1", OctopusResourceKind.Release, ownerProjectId: "Projects-1", isHistorical: true),
+            Node("Deployments-1", OctopusResourceKind.Deployment, ownerProjectId: "Projects-1", isHistorical: true),
+            Node("ServerTasks-1", OctopusResourceKind.ServerTask, ownerProjectId: "Projects-1", isHistorical: true)
+        };
+        var graph = new OctopusResourceGraph(resources, [], [], []);
+
+        var plan = _planner.BuildCurrentConfigurationPlan(graph);
+
+        plan.OrderedResources.Select(r => r.SourceId).ShouldBe([
+            "variableset-Projects-1",
+            "Variables-1",
+            "deploymentprocess-Projects-1",
+            "Steps-1"
+        ], ignoreOrder: true);
+        plan.OrderedResources.ShouldNotContain(r => r.SourceId.Contains("-s-", StringComparison.OrdinalIgnoreCase));
+        plan.OutOfScopeResources.Select(r => r.SourceId).ShouldBe([
+            "variableset-Projects-1-s-1-ABC",
+            "deploymentprocess-Projects-1-s-1-ABC",
+            "Releases-1",
+            "Deployments-1",
+            "ServerTasks-1"
+        ], ignoreOrder: true);
+        plan.OutOfScopeResources.Select(r => r.SourceId).ShouldNotContain("SnapshotVariable-1");
+        plan.OutOfScopeResources.Select(r => r.SourceId).ShouldNotContain("SnapshotSteps-1");
     }
 
     [Fact]

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
@@ -85,13 +85,31 @@ public class OctopusImportPreviewPlannerTests
     {
         var release = Node("Releases-1", OctopusResourceKind.Release, "1.0.0", isHistorical: true);
 
-        var preview = _planner.BuildPreviewPlan(Plan([release]), NoConflicts());
+        var preview = _planner.BuildPreviewPlan(Plan([], outOfScopeResources: [release]), NoConflicts());
 
         var result = preview.Resources.Single();
         result.PreviewAction.ShouldBe(OctopusImportPreviewAction.Skip);
         result.OutcomeState.ShouldBe(OctopusImportResourceOutcomeState.Skipped);
         result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Info);
         result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.ResourceOutOfScope);
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_IncludesOutOfScopeResourcesAsSkippedPreviewResults()
+    {
+        var currentProcess = Node("deploymentprocess-Projects-1", OctopusResourceKind.DeploymentProcess, "Current process");
+        var frozenProcess = Node("deploymentprocess-Projects-1-s-1-ABC", OctopusResourceKind.DeploymentProcessSnapshot, "Frozen process", isHistorical: true);
+        var release = Node("Releases-1", OctopusResourceKind.Release, "1.0.0", isHistorical: true);
+
+        var preview = _planner.BuildPreviewPlan(Plan([currentProcess], outOfScopeResources: [frozenProcess, release]), NoConflicts());
+
+        preview.Resources.Single(r => r.SourceId == currentProcess.SourceId).PreviewAction.ShouldBe(OctopusImportPreviewAction.Create);
+        preview.Resources.Single(r => r.SourceId == frozenProcess.SourceId).PreviewAction.ShouldBe(OctopusImportPreviewAction.Skip);
+        preview.Resources.Single(r => r.SourceId == release.SourceId).PreviewAction.ShouldBe(OctopusImportPreviewAction.Skip);
+        preview.Resources.Where(r => r.PreviewAction == OctopusImportPreviewAction.Skip)
+            .SelectMany(r => r.Diagnostics)
+            .All(d => d.Code == OctopusImportPreviewDiagnosticCodes.ResourceOutOfScope)
+            .ShouldBeTrue();
     }
 
     [Fact]
@@ -146,8 +164,9 @@ public class OctopusImportPreviewPlannerTests
 
     private static OctopusImportDependencyPlan Plan(
         IReadOnlyList<OctopusResourceNode> resources,
-        IReadOnlyList<OctopusInputExtractionDiagnostic> diagnostics = null)
-        => new(resources, [], [], diagnostics ?? []);
+        IReadOnlyList<OctopusInputExtractionDiagnostic> diagnostics = null,
+        IReadOnlyList<OctopusResourceNode> outOfScopeResources = null)
+        => new(resources, [], [], diagnostics ?? [], outOfScopeResources ?? []);
 
     private static OctopusImportConflictDiscoveryResult NoConflicts()
         => new([]);


### PR DESCRIPTION
## Summary

- Implemented branch `feature/octopus-import-current-selection` for OpenSpec task 3.5.
- Added `OutOfScopeResources` to `OctopusImportDependencyPlan` so current configuration planning selects only current variable sets/deployment processes while retaining releases, deployments, server tasks, and frozen process/variable snapshots for preview reporting.
- Updated `OctopusImportPreviewPlanner` to include out-of-scope resources as `Skip` preview results with `ResourceOutOfScope` diagnostics.
- Added unit coverage in `OctopusImportDependencyPlannerTests` and `OctopusImportPreviewPlannerTests`.
- Updated local OpenSpec progress tracking to mark task 3.5 complete; `openspec/` is ignored locally via `.git/info/exclude`.
- Scope intentionally excludes task 3.6 validation work and any API/persistence changes.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers` passed: 129/129.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --no-restore --disable-build-servers` passed: 6351/6351.
- [x] `git diff --check` passed.