### PR TITLE
Preview validation for unresolved references and stale plans

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewDiagnosticCodes.cs
@@ -9,4 +9,10 @@ public static class OctopusImportPreviewDiagnosticCodes
     public const string RenameRequiredForProject = "octopus.preview.project_rename_required";
     public const string RenameRequiredForAmbiguousConflict = "octopus.preview.resource_rename_required_ambiguous";
     public const string ResourceBlockedByDependencyPlan = "octopus.preview.resource_blocked_by_dependency_plan";
+    public const string UnresolvedReference = "octopus.validation.unresolved_reference";
+    public const string MissingTargetRole = "octopus.validation.missing_target_role";
+    public const string MissingMachine = "octopus.validation.missing_machine";
+    public const string MissingAccount = "octopus.validation.missing_account";
+    public const string IncompatibleSharedResourceReuse = "octopus.validation.incompatible_shared_resource_reuse";
+    public const string StalePreviewPlan = "octopus.validation.stale_preview_plan";
 }

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
@@ -44,6 +44,7 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
 
         return new OctopusImportPreviewPlanDto
         {
+            GeneratedAt = DateTimeOffset.UtcNow,
             Resources = resources,
             Diagnostics = diagnostics
         };

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewValidator.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewValidator.cs
@@ -1,0 +1,211 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public interface IOctopusImportPreviewValidator : IScopedDependency
+{
+    OctopusImportValidationResultDto Validate(
+        OctopusResourceGraph graph,
+        OctopusImportDependencyPlan dependencyPlan,
+        OctopusImportConflictDiscoveryResult conflicts,
+        OctopusImportPreviewPlanDto previewPlan);
+}
+
+public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
+{
+    private static readonly HashSet<OctopusResourceKind> ReusableSharedResourceKinds =
+    [
+        OctopusResourceKind.ProjectGroup,
+        OctopusResourceKind.Environment,
+        OctopusResourceKind.Lifecycle,
+        OctopusResourceKind.Feed,
+        OctopusResourceKind.Team,
+        OctopusResourceKind.Machine,
+        OctopusResourceKind.Account
+    ];
+
+    public OctopusImportValidationResultDto Validate(
+        OctopusResourceGraph graph,
+        OctopusImportDependencyPlan dependencyPlan,
+        OctopusImportConflictDiscoveryResult conflicts,
+        OctopusImportPreviewPlanDto previewPlan)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        ArgumentNullException.ThrowIfNull(dependencyPlan);
+        ArgumentNullException.ThrowIfNull(conflicts);
+        ArgumentNullException.ThrowIfNull(previewPlan);
+
+        var result = new OctopusImportValidationResultDto();
+        var selectedResources = dependencyPlan.OrderedResources
+            .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToDictionary(r => r.SourceId, StringComparer.OrdinalIgnoreCase);
+        var allCurrentResources = graph.Resources
+            .Where(r => !r.IsHistorical)
+            .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToDictionary(r => r.SourceId, StringComparer.OrdinalIgnoreCase);
+        var previewResources = previewPlan.Resources
+            .GroupBy(r => r.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+        var conflictsBySourceId = conflicts.Conflicts
+            .GroupBy(c => c.Source.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        ValidateReferences(graph, selectedResources, allCurrentResources, result);
+        ValidateReuse(conflictsBySourceId, previewResources, previewPlan.GeneratedAt, result);
+
+        return result;
+    }
+
+    private static void ValidateReferences(
+        OctopusResourceGraph graph,
+        IReadOnlyDictionary<string, OctopusResourceNode> selectedResources,
+        IReadOnlyDictionary<string, OctopusResourceNode> allCurrentResources,
+        OctopusImportValidationResultDto result)
+    {
+        var machineRoles = graph.References
+            .Where(r => r.FromKind == OctopusResourceKind.Machine && r.ReferenceKind == OctopusResourceReferenceKind.TargetRole)
+            .Select(r => r.ToSourceId)
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var reference in graph.References.OrderBy(r => r.FromSourceId, StringComparer.OrdinalIgnoreCase).ThenBy(r => r.ReferenceKind).ThenBy(r => r.ToSourceId, StringComparer.OrdinalIgnoreCase))
+        {
+            if (!selectedResources.TryGetValue(reference.FromSourceId, out var source))
+                continue;
+
+            if (reference.ReferenceKind == OctopusResourceReferenceKind.TargetRole)
+            {
+                if (!machineRoles.Contains(reference.ToSourceId))
+                    AddReferenceDiagnostic(
+                        result,
+                        source,
+                        OctopusImportPreviewDiagnosticCodes.MissingTargetRole,
+                        $"Octopus target role '{reference.ToSourceId}' is referenced but no exported deployment target declares that role.");
+
+                continue;
+            }
+
+            if (reference.ReferenceKind == OctopusResourceReferenceKind.Machine)
+            {
+                if (!allCurrentResources.ContainsKey(reference.ToSourceId))
+                    AddReferenceDiagnostic(
+                        result,
+                        source,
+                        OctopusImportPreviewDiagnosticCodes.MissingMachine,
+                        $"Octopus machine '{reference.ToSourceId}' is referenced but is missing from the current import graph.");
+
+                continue;
+            }
+
+            if (reference.ReferenceKind == OctopusResourceReferenceKind.Account)
+            {
+                if (!allCurrentResources.ContainsKey(reference.ToSourceId))
+                    AddReferenceDiagnostic(
+                        result,
+                        source,
+                        OctopusImportPreviewDiagnosticCodes.MissingAccount,
+                        $"Octopus account '{reference.ToSourceId}' is referenced but is missing from the current import graph.");
+
+                continue;
+            }
+
+            if (reference.IsRequired && !selectedResources.ContainsKey(reference.ToSourceId))
+            {
+                AddReferenceDiagnostic(
+                    result,
+                    source,
+                    OctopusImportPreviewDiagnosticCodes.UnresolvedReference,
+                    $"Required Octopus {reference.ReferenceKind} reference '{reference.ToSourceId}' cannot be resolved in the selected current-configuration import plan.");
+            }
+        }
+    }
+
+    private static void ValidateReuse(
+        IReadOnlyDictionary<string, OctopusImportResourceConflict> conflictsBySourceId,
+        IReadOnlyDictionary<string, OctopusImportResourceResultDto> previewResources,
+        DateTimeOffset previewGeneratedAt,
+        OctopusImportValidationResultDto result)
+    {
+        foreach (var previewResource in previewResources.Values.Where(r => r.PreviewAction == OctopusImportPreviewAction.ReuseExisting))
+        {
+            if (!conflictsBySourceId.TryGetValue(previewResource.SourceId, out var conflict))
+            {
+                AddIncompatibleReuseDiagnostic(result, previewResource);
+                continue;
+            }
+
+            if (!IsValidReuse(previewResource, conflict, out var match))
+            {
+                AddIncompatibleReuseDiagnostic(result, previewResource);
+                continue;
+            }
+
+            if (previewGeneratedAt != default && match.Destination.LastModifiedDate > previewGeneratedAt)
+            {
+                result.Diagnostics.Add(new OctopusImportDiagnosticDto
+                {
+                    Severity = OctopusImportCompatibilitySeverity.Blocker,
+                    Code = OctopusImportPreviewDiagnosticCodes.StalePreviewPlan,
+                    Message = $"Destination {match.Destination.Kind} '{match.Destination.Name}' was modified after the Octopus import preview was generated.",
+                    SourceId = previewResource.SourceId,
+                    ResourceType = previewResource.SourceType,
+                    ResourceName = previewResource.SourceName
+                });
+            }
+        }
+    }
+
+    private static bool IsValidReuse(
+        OctopusImportResourceResultDto previewResource,
+        OctopusImportResourceConflict conflict,
+        out OctopusImportDestinationMatch match)
+    {
+        match = null;
+
+        if (previewResource.DestinationId == null || conflict.Matches.Count != 1)
+            return false;
+
+        match = conflict.Matches[0];
+
+        return match.Destination.Id == previewResource.DestinationId.Value
+            && string.Equals(conflict.Source.Kind.ToString(), previewResource.SourceType, StringComparison.OrdinalIgnoreCase)
+            && match.Destination.Kind == conflict.Source.Kind
+            && ReusableSharedResourceKinds.Contains(conflict.Source.Kind);
+    }
+
+    private static void AddIncompatibleReuseDiagnostic(
+        OctopusImportValidationResultDto result,
+        OctopusImportResourceResultDto previewResource)
+    {
+        result.Diagnostics.Add(new OctopusImportDiagnosticDto
+        {
+            Severity = OctopusImportCompatibilitySeverity.Blocker,
+            Code = OctopusImportPreviewDiagnosticCodes.IncompatibleSharedResourceReuse,
+            Message = "Preview selected reuse for a resource that no longer has exactly one compatible destination match.",
+            SourceId = previewResource.SourceId,
+            ResourceType = previewResource.SourceType,
+            ResourceName = previewResource.SourceName
+        });
+    }
+
+    private static void AddReferenceDiagnostic(
+        OctopusImportValidationResultDto result,
+        OctopusResourceNode source,
+        string code,
+        string message)
+    {
+        result.Diagnostics.Add(new OctopusImportDiagnosticDto
+        {
+            Severity = OctopusImportCompatibilitySeverity.Blocker,
+            Code = code,
+            Message = message,
+            SourceId = source.SourceId,
+            ResourceType = source.Kind.ToString(),
+            ResourceName = source.Name
+        });
+    }
+}

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportPreviewPlanDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportPreviewPlanDto.cs
@@ -4,6 +4,8 @@ namespace Squid.Message.Models.OctopusImport;
 
 public class OctopusImportPreviewPlanDto
 {
+    public DateTimeOffset GeneratedAt { get; set; }
+
     public List<OctopusImportResourceResultDto> Resources { get; set; } = [];
 
     public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportValidationResultDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportValidationResultDto.cs
@@ -1,0 +1,10 @@
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Message.Models.OctopusImport;
+
+public class OctopusImportValidationResultDto
+{
+    public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];
+
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewValidatorTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewValidatorTests.cs
@@ -1,0 +1,259 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportPreviewValidatorTests
+{
+    private readonly OctopusImportPreviewValidator _validator = new();
+
+    [Fact]
+    public void Validate_WhenRequiredReferenceIsMissing_AddsBlocker()
+    {
+        var project = Node("Projects-1", OctopusResourceKind.Project, "Project");
+        var graph = Graph(
+            [project],
+            [
+                Reference(
+                    project.SourceId,
+                    project.Kind,
+                    OctopusResourceReferenceKind.Lifecycle,
+                    "Lifecycles-Missing",
+                    OctopusResourceKind.Lifecycle,
+                    isRequired: true)
+            ]);
+
+        var result = _validator.Validate(graph, Plan([project]), NoConflicts(), Preview([project]));
+
+        var diagnostic = result.Diagnostics.Single();
+        diagnostic.Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        diagnostic.Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.UnresolvedReference);
+        diagnostic.SourceId.ShouldBe(project.SourceId);
+        result.HasBlockers.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_WhenTargetRoleHasNoExportedMachine_AddsBlocker()
+    {
+        var action = Node("Actions-1", OctopusResourceKind.DeploymentAction, "Deploy");
+        var graph = Graph(
+            [action],
+            [
+                Reference(
+                    action.SourceId,
+                    action.Kind,
+                    OctopusResourceReferenceKind.TargetRole,
+                    "aws-eks-us",
+                    null,
+                    isRequired: false)
+            ]);
+
+        var result = _validator.Validate(graph, Plan([action]), NoConflicts(), Preview([action]));
+
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.MissingTargetRole);
+    }
+
+    [Fact]
+    public void Validate_WhenTargetRoleHasExportedMachine_DoesNotAddBlocker()
+    {
+        var action = Node("Actions-1", OctopusResourceKind.DeploymentAction, "Deploy");
+        var machine = Node("Machines-1", OctopusResourceKind.Machine, "EKS target");
+        var graph = Graph(
+            [action, machine],
+            [
+                Reference(
+                    action.SourceId,
+                    action.Kind,
+                    OctopusResourceReferenceKind.TargetRole,
+                    "aws-eks-us",
+                    null,
+                    isRequired: false),
+                Reference(
+                    machine.SourceId,
+                    machine.Kind,
+                    OctopusResourceReferenceKind.TargetRole,
+                    "aws-eks-us",
+                    null,
+                    isRequired: false)
+            ]);
+
+        var result = _validator.Validate(graph, Plan([action, machine]), NoConflicts(), Preview([action, machine]));
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.HasBlockers.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(OctopusResourceReferenceKind.Machine, OctopusResourceKind.Machine, "Machines-Missing", OctopusImportPreviewDiagnosticCodes.MissingMachine)]
+    [InlineData(OctopusResourceReferenceKind.Account, OctopusResourceKind.Account, "Accounts-Missing", OctopusImportPreviewDiagnosticCodes.MissingAccount)]
+    public void Validate_WhenMachineOrAccountReferenceIsMissing_AddsSpecificBlocker(
+        OctopusResourceReferenceKind referenceKind,
+        OctopusResourceKind targetKind,
+        string targetSourceId,
+        string expectedCode)
+    {
+        var variable = Node("Variables-1", OctopusResourceKind.Variable, "Scoped variable");
+        var graph = Graph(
+            [variable],
+            [
+                Reference(
+                    variable.SourceId,
+                    variable.Kind,
+                    referenceKind,
+                    targetSourceId,
+                    targetKind,
+                    isRequired: false)
+            ]);
+
+        var result = _validator.Validate(graph, Plan([variable]), NoConflicts(), Preview([variable]));
+
+        result.Diagnostics.Single().Code.ShouldBe(expectedCode);
+    }
+
+    [Fact]
+    public void Validate_WhenReuseNoLongerHasSingleDestinationMatch_AddsBlocker()
+    {
+        var environment = Node("Environments-1", OctopusResourceKind.Environment, "Production");
+        var preview = Preview([environment]);
+        preview.Resources.Single().PreviewAction = OctopusImportPreviewAction.ReuseExisting;
+        preview.Resources.Single().DestinationId = 100;
+        var conflicts = new OctopusImportConflictDiscoveryResult(
+        [
+            Conflict(
+                environment,
+                Match(100, OctopusResourceKind.Environment, "Production"),
+                Match(101, OctopusResourceKind.Environment, "Production Copy"))
+        ]);
+
+        var result = _validator.Validate(Graph([environment]), Plan([environment]), conflicts, preview);
+
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.IncompatibleSharedResourceReuse);
+    }
+
+    [Fact]
+    public void Validate_WhenReusedResourceNoLongerHasConflictMatch_AddsBlocker()
+    {
+        var environment = Node("Environments-1", OctopusResourceKind.Environment, "Production");
+        var preview = Preview([environment]);
+        preview.Resources.Single().PreviewAction = OctopusImportPreviewAction.ReuseExisting;
+        preview.Resources.Single().DestinationId = 100;
+
+        var result = _validator.Validate(Graph([environment]), Plan([environment]), NoConflicts(), preview);
+
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.IncompatibleSharedResourceReuse);
+    }
+
+    [Fact]
+    public void Validate_WhenReusedDestinationWasModifiedAfterPreview_AddsStalePlanBlocker()
+    {
+        var generatedAt = DateTimeOffset.UtcNow;
+        var feed = Node("Feeds-1", OctopusResourceKind.Feed, "Docker");
+        var preview = Preview([feed], generatedAt);
+        preview.Resources.Single().PreviewAction = OctopusImportPreviewAction.ReuseExisting;
+        preview.Resources.Single().DestinationId = 200;
+        var conflicts = new OctopusImportConflictDiscoveryResult(
+        [
+            Conflict(
+                feed,
+                Match(200, OctopusResourceKind.Feed, "Docker", generatedAt.AddMinutes(1)))
+        ]);
+
+        var result = _validator.Validate(Graph([feed]), Plan([feed]), conflicts, preview);
+
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportPreviewDiagnosticCodes.StalePreviewPlan);
+    }
+
+    [Fact]
+    public void Validate_WhenReuseIsCurrentAndCompatible_DoesNotAddDiagnostics()
+    {
+        var generatedAt = DateTimeOffset.UtcNow;
+        var feed = Node("Feeds-1", OctopusResourceKind.Feed, "Docker");
+        var preview = Preview([feed], generatedAt);
+        preview.Resources.Single().PreviewAction = OctopusImportPreviewAction.ReuseExisting;
+        preview.Resources.Single().DestinationId = 200;
+        var conflicts = new OctopusImportConflictDiscoveryResult(
+        [
+            Conflict(
+                feed,
+                Match(200, OctopusResourceKind.Feed, "Docker", generatedAt.AddMinutes(-1)))
+        ]);
+
+        var result = _validator.Validate(Graph([feed]), Plan([feed]), conflicts, preview);
+
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    private static OctopusResourceGraph Graph(
+        IReadOnlyList<OctopusResourceNode> resources,
+        IReadOnlyList<OctopusResourceReference> references = null)
+        => new(resources, references ?? [], [], []);
+
+    private static OctopusImportDependencyPlan Plan(IReadOnlyList<OctopusResourceNode> resources)
+        => new(resources, [], [], []);
+
+    private static OctopusImportConflictDiscoveryResult NoConflicts()
+        => new([]);
+
+    private static OctopusImportPreviewPlanDto Preview(
+        IReadOnlyList<OctopusResourceNode> resources,
+        DateTimeOffset? generatedAt = null)
+        => new()
+        {
+            GeneratedAt = generatedAt ?? DateTimeOffset.UtcNow,
+            Resources = resources.Select(resource => new OctopusImportResourceResultDto
+            {
+                SourceId = resource.SourceId,
+                SourceType = resource.Kind.ToString(),
+                SourceName = resource.Name,
+                PreviewAction = OctopusImportPreviewAction.Create,
+                OutcomeState = OctopusImportResourceOutcomeState.Pending
+            }).ToList()
+        };
+
+    private static OctopusImportResourceConflict Conflict(
+        OctopusResourceNode source,
+        params OctopusImportDestinationMatch[] matches)
+        => new(source, matches);
+
+    private static OctopusImportDestinationMatch Match(
+        int destinationId,
+        OctopusResourceKind kind,
+        string name,
+        DateTimeOffset? lastModifiedDate = null)
+        => new(
+            new OctopusImportDestinationResource(
+                destinationId,
+                7,
+                kind,
+                name,
+                null,
+                lastModifiedDate ?? DateTimeOffset.UtcNow),
+            OctopusImportIdentityMatchKind.Name);
+
+    private static OctopusResourceReference Reference(
+        string fromSourceId,
+        OctopusResourceKind fromKind,
+        OctopusResourceReferenceKind referenceKind,
+        string toSourceId,
+        OctopusResourceKind? toKind,
+        bool isRequired)
+        => new(fromSourceId, fromKind, referenceKind, toSourceId, toKind, "Projects-1", isRequired, isRequired);
+
+    private static OctopusResourceNode Node(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.Project,
+            $"{sourceId}.json",
+            "Projects-1",
+            null,
+            false,
+            new object());
+}


### PR DESCRIPTION
## Summary

- Implemented branch `feature/octopus-import-preview-validation` for OpenSpec task 3.6.
- Added `OctopusImportPreviewValidator` to validate unresolved required references, missing target roles, missing machine/account references, incompatible shared-resource reuse, and stale preview plans.
- Added `OctopusImportValidationResultDto` and preview `GeneratedAt` timestamp support for stale-plan checks.
- Added validation diagnostic codes for the new blocker cases.
- Added unit coverage for validation success and blocker scenarios.
- Updated local OpenSpec progress tracking to mark task 3.6 complete; `openspec/` is ignored locally via `.git/info/exclude`.
- Scope intentionally excludes API endpoint wiring, confirmation orchestration, and 4.x/5.x resource/action mapping validation.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers` passed: 138/138.
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --no-restore --disable-build-servers` passed: 6360/6360.
- [x] `git diff --check` passed.