### PR TITLE
Project mapper for Octopus import with reference validation

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportProjectMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportProjectMapper.cs
@@ -1,0 +1,231 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Project;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public interface IOctopusImportProjectMapper : IScopedDependency
+{
+    OctopusImportProjectMappingResult MapToCreateOrUpdateModel(
+        OctopusResourceNode projectResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId,
+        OctopusDeploymentSettingsDto deploymentSettings = null,
+        OctopusChannelDto defaultChannel = null);
+}
+
+public class OctopusImportProjectMapper : IOctopusImportProjectMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public OctopusImportProjectMappingResult MapToCreateOrUpdateModel(
+        OctopusResourceNode projectResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId,
+        OctopusDeploymentSettingsDto deploymentSettings = null,
+        OctopusChannelDto defaultChannel = null)
+    {
+        ArgumentNullException.ThrowIfNull(projectResource);
+        ArgumentNullException.ThrowIfNull(idMap);
+
+        if (projectResource.Kind != OctopusResourceKind.Project)
+            throw new ArgumentException("Octopus project mapper requires a project resource.", nameof(projectResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var project = projectResource.GetSource<OctopusProjectDto>()
+            ?? throw new ArgumentException("Octopus project resource does not contain an OctopusProjectDto source.", nameof(projectResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var model = new CreateOrUpdateProjectModel
+        {
+            Name = project.Name,
+            Slug = project.Slug,
+            IsDisabled = project.IsDisabled,
+            AutoCreateRelease = project.AutoCreateRelease,
+            DiscreteChannelRelease = project.DiscreteChannelRelease,
+            SpaceId = destinationSpaceId,
+            IncludedLibraryVariableSetIds = []
+        };
+
+        if (idMap.TryGetDestinationId(project.ProjectGroupId, OctopusResourceKind.ProjectGroup.ToString(), out var projectGroupId))
+            model.ProjectGroupId = projectGroupId;
+        else
+            diagnostics.Add(Blocker(
+                OctopusImportProjectMappingDiagnosticCodes.MissingProjectGroupMapping,
+                $"Octopus project group '{project.ProjectGroupId}' has not been mapped to a destination project group.",
+                projectResource));
+
+        if (idMap.TryGetDestinationId(project.LifecycleId, OctopusResourceKind.Lifecycle.ToString(), out var lifecycleId))
+            model.LifecycleId = lifecycleId;
+        else
+            diagnostics.Add(Blocker(
+                OctopusImportProjectMappingDiagnosticCodes.MissingLifecycleMapping,
+                $"Octopus lifecycle '{project.LifecycleId}' has not been mapped to a destination lifecycle.",
+                projectResource));
+
+        AddDeferredReferenceDiagnostics(project, diagnostics, projectResource);
+        model.Json = BuildMetadataJson(project, deploymentSettings, defaultChannel, diagnostics, projectResource);
+
+        return new OctopusImportProjectMappingResult(model, diagnostics);
+    }
+
+    private static void AddDeferredReferenceDiagnostics(
+        OctopusProjectDto project,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        OctopusResourceNode projectResource)
+    {
+        if (project.IncludedLibraryVariableSetIds?.Count > 0)
+        {
+            diagnostics.Add(Warning(
+                OctopusImportProjectMappingDiagnosticCodes.IncludedLibraryVariableSetsDeferred,
+                "Octopus included library variable sets are preserved as source metadata and are not mapped to Squid project library variable set ids in this step.",
+                projectResource));
+        }
+
+        if (!string.IsNullOrWhiteSpace(project.TenantedDeploymentMode))
+        {
+            diagnostics.Add(Warning(
+                OctopusImportProjectMappingDiagnosticCodes.UnsupportedTenantedDeploymentMode,
+                $"Octopus tenanted deployment mode '{project.TenantedDeploymentMode}' is preserved as metadata and is not mapped to a Squid project setting.",
+                projectResource));
+        }
+    }
+
+    private static string BuildMetadataJson(
+        OctopusProjectDto project,
+        OctopusDeploymentSettingsDto deploymentSettings,
+        OctopusChannelDto defaultChannel,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        OctopusResourceNode projectResource)
+    {
+        var metadata = new OctopusProjectImportMetadata
+        {
+            SourceId = project.Id,
+            Description = project.Description,
+            DeploymentSettingsId = project.DeploymentSettingsId,
+            VariableSetId = project.VariableSetId,
+            DeploymentProcessId = project.DeploymentProcessId,
+            IncludedLibraryVariableSetIds = project.IncludedLibraryVariableSetIds ?? [],
+            TenantedDeploymentMode = project.TenantedDeploymentMode,
+            ExtensionSettingsCount = project.ExtensionSettings?.Count ?? 0,
+            TemplatesCount = project.Templates?.Count ?? 0,
+            DeploymentSettings = deploymentSettings == null
+                ? null
+                : new OctopusProjectDeploymentSettingsMetadata
+                {
+                    SourceId = deploymentSettings.Id,
+                    DefaultToSkipIfAlreadyInstalled = deploymentSettings.DefaultToSkipIfAlreadyInstalled,
+                    DefaultGuidedFailureMode = deploymentSettings.DefaultGuidedFailureMode,
+                    ForcePackageDownload = deploymentSettings.ForcePackageDownload,
+                    FailTargetDiscovery = deploymentSettings.FailTargetDiscovery,
+                    HasConnectivityPolicy = deploymentSettings.ConnectivityPolicy.HasValue,
+                    HasVersioningStrategy = deploymentSettings.VersioningStrategy.HasValue
+                },
+            DefaultChannel = defaultChannel == null
+                ? null
+                : new OctopusProjectDefaultChannelMetadata
+                {
+                    SourceId = defaultChannel.Id,
+                    Name = defaultChannel.Name,
+                    LifecycleId = defaultChannel.LifecycleId,
+                    RuleCount = defaultChannel.Rules.Count
+                }
+        };
+
+        if (deploymentSettings != null)
+        {
+            diagnostics.Add(Warning(
+                OctopusImportProjectMappingDiagnosticCodes.DeploymentSettingsStoredAsMetadata,
+                "Octopus deployment settings are preserved as non-sensitive import metadata; behavior-specific settings are handled by later mapping tasks.",
+                projectResource));
+        }
+
+        if (defaultChannel != null)
+        {
+            diagnostics.Add(Warning(
+                OctopusImportProjectMappingDiagnosticCodes.ChannelDefaultsStoredAsMetadata,
+                "Octopus default channel details are preserved as non-sensitive import metadata; channel creation is handled by later mapping tasks.",
+                projectResource));
+        }
+
+        return JsonSerializer.Serialize(metadata, JsonOptions);
+    }
+
+    private static OctopusImportDiagnosticDto Warning(
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => Diagnostic(OctopusImportCompatibilitySeverity.Warning, code, message, resource);
+
+    private static OctopusImportDiagnosticDto Blocker(
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => Diagnostic(OctopusImportCompatibilitySeverity.Blocker, code, message, resource);
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = resource.Kind.ToString(),
+            SourceId = resource.SourceId,
+            ResourceName = resource.Name
+        };
+
+    private sealed class OctopusProjectImportMetadata
+    {
+        public string SourceId { get; set; }
+        public string Description { get; set; }
+        public string DeploymentSettingsId { get; set; }
+        public string VariableSetId { get; set; }
+        public string DeploymentProcessId { get; set; }
+        public List<string> IncludedLibraryVariableSetIds { get; set; } = [];
+        public string TenantedDeploymentMode { get; set; }
+        public int ExtensionSettingsCount { get; set; }
+        public int TemplatesCount { get; set; }
+        public OctopusProjectDeploymentSettingsMetadata DeploymentSettings { get; set; }
+        public OctopusProjectDefaultChannelMetadata DefaultChannel { get; set; }
+    }
+
+    private sealed class OctopusProjectDeploymentSettingsMetadata
+    {
+        public string SourceId { get; set; }
+        public bool DefaultToSkipIfAlreadyInstalled { get; set; }
+        public string DefaultGuidedFailureMode { get; set; }
+        public bool ForcePackageDownload { get; set; }
+        public bool FailTargetDiscovery { get; set; }
+        public bool HasConnectivityPolicy { get; set; }
+        public bool HasVersioningStrategy { get; set; }
+    }
+
+    private sealed class OctopusProjectDefaultChannelMetadata
+    {
+        public string SourceId { get; set; }
+        public string Name { get; set; }
+        public string LifecycleId { get; set; }
+        public int RuleCount { get; set; }
+    }
+}
+
+public sealed record OctopusImportProjectMappingResult(
+    CreateOrUpdateProjectModel Project,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportProjectMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportProjectMappingDiagnosticCodes.cs
@@ -1,0 +1,11 @@
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public static class OctopusImportProjectMappingDiagnosticCodes
+{
+    public const string MissingProjectGroupMapping = "octopus.mapping.project.missing_project_group_mapping";
+    public const string MissingLifecycleMapping = "octopus.mapping.project.missing_lifecycle_mapping";
+    public const string IncludedLibraryVariableSetsDeferred = "octopus.mapping.project.included_library_variable_sets_deferred";
+    public const string ChannelDefaultsStoredAsMetadata = "octopus.mapping.project.channel_defaults_stored_as_metadata";
+    public const string DeploymentSettingsStoredAsMetadata = "octopus.mapping.project.deployment_settings_stored_as_metadata";
+    public const string UnsupportedTenantedDeploymentMode = "octopus.mapping.project.unsupported_tenanted_deployment_mode";
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportProjectMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportProjectMapperTests.cs
@@ -1,0 +1,156 @@
+using System.Linq;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping;
+
+public class OctopusImportProjectMapperTests
+{
+    private readonly OctopusImportProjectMapper _mapper = new();
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_MapsProjectFieldsAndDestinationReferences()
+    {
+        var project = Project();
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("ProjectGroups-1", OctopusResourceKind.ProjectGroup, "Default", new OctopusProjectGroupDto()), 10);
+        idMap.AddReused(Resource("Lifecycles-1", OctopusResourceKind.Lifecycle, "Default", new OctopusLifecycleDto()), 20);
+
+        var result = _mapper.MapToCreateOrUpdateModel(
+            Resource(project.Id, OctopusResourceKind.Project, project.Name, project),
+            idMap,
+            7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Project.Name.ShouldBe("Octopus Project");
+        result.Project.Slug.ShouldBe("octopus-project");
+        result.Project.IsDisabled.ShouldBeTrue();
+        result.Project.AutoCreateRelease.ShouldBeTrue();
+        result.Project.DiscreteChannelRelease.ShouldBeTrue();
+        result.Project.ProjectGroupId.ShouldBe(10);
+        result.Project.LifecycleId.ShouldBe(20);
+        result.Project.SpaceId.ShouldBe(7);
+        result.Project.IncludedLibraryVariableSetIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_WhenRequiredReferencesAreMissing_AddsBlockers()
+    {
+        var project = Project();
+
+        var result = _mapper.MapToCreateOrUpdateModel(
+            Resource(project.Id, OctopusResourceKind.Project, project.Name, project),
+            new OctopusImportIdMap(),
+            7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Count(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker).ShouldBe(2);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportProjectMappingDiagnosticCodes.MissingProjectGroupMapping);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportProjectMappingDiagnosticCodes.MissingLifecycleMapping);
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_PreservesDeploymentSettingsAndDefaultChannelAsMetadata()
+    {
+        var project = Project();
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("ProjectGroups-1", OctopusResourceKind.ProjectGroup, "Default", new OctopusProjectGroupDto()), 10);
+        idMap.AddReused(Resource("Lifecycles-1", OctopusResourceKind.Lifecycle, "Default", new OctopusLifecycleDto()), 20);
+        var deploymentSettings = new OctopusDeploymentSettingsDto
+        {
+            Id = "deploymentsettings-Projects-1",
+            DefaultGuidedFailureMode = "EnvironmentDefault",
+            DefaultToSkipIfAlreadyInstalled = true,
+            ForcePackageDownload = true,
+            FailTargetDiscovery = true
+        };
+        var defaultChannel = new OctopusChannelDto
+        {
+            Id = "Channels-1",
+            Name = "Default",
+            LifecycleId = "Lifecycles-1",
+            Rules = [JsonDocument.Parse("""{"tag":"latest"}""").RootElement.Clone()]
+        };
+
+        var result = _mapper.MapToCreateOrUpdateModel(
+            Resource(project.Id, OctopusResourceKind.Project, project.Name, project),
+            idMap,
+            7,
+            deploymentSettings,
+            defaultChannel);
+
+        using var metadata = JsonDocument.Parse(result.Project.Json);
+        metadata.RootElement.GetProperty("sourceId").GetString().ShouldBe("Projects-1");
+        metadata.RootElement.GetProperty("deploymentSettings").GetProperty("sourceId").GetString().ShouldBe("deploymentsettings-Projects-1");
+        metadata.RootElement.GetProperty("deploymentSettings").GetProperty("forcePackageDownload").GetBoolean().ShouldBeTrue();
+        metadata.RootElement.GetProperty("defaultChannel").GetProperty("sourceId").GetString().ShouldBe("Channels-1");
+        metadata.RootElement.GetProperty("defaultChannel").GetProperty("ruleCount").GetInt32().ShouldBe(1);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportProjectMappingDiagnosticCodes.DeploymentSettingsStoredAsMetadata);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportProjectMappingDiagnosticCodes.ChannelDefaultsStoredAsMetadata);
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_WhenDeferredProjectFeaturesExist_AddsWarnings()
+    {
+        var project = Project();
+        project.IncludedLibraryVariableSetIds.Add("LibraryVariableSets-1");
+        project.TenantedDeploymentMode = "TenantedOrUntenanted";
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("ProjectGroups-1", OctopusResourceKind.ProjectGroup, "Default", new OctopusProjectGroupDto()), 10);
+        idMap.AddReused(Resource("Lifecycles-1", OctopusResourceKind.Lifecycle, "Default", new OctopusLifecycleDto()), 20);
+
+        var result = _mapper.MapToCreateOrUpdateModel(
+            Resource(project.Id, OctopusResourceKind.Project, project.Name, project),
+            idMap,
+            7);
+
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportProjectMappingDiagnosticCodes.IncludedLibraryVariableSetsDeferred);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportProjectMappingDiagnosticCodes.UnsupportedTenantedDeploymentMode);
+        result.Diagnostics.All(d => d.Severity == OctopusImportCompatibilitySeverity.Warning).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_WhenResourceIsNotProject_Throws()
+    {
+        Should.Throw<ArgumentException>(() => _mapper.MapToCreateOrUpdateModel(
+            Resource("Feeds-1", OctopusResourceKind.Feed, "Feed", new OctopusFeedDto()),
+            new OctopusImportIdMap(),
+            7));
+    }
+
+    private static OctopusProjectDto Project()
+        => new()
+        {
+            Id = "Projects-1",
+            Name = "Octopus Project",
+            Slug = "octopus-project",
+            Description = "Imported from Octopus.",
+            IsDisabled = true,
+            ProjectGroupId = "ProjectGroups-1",
+            LifecycleId = "Lifecycles-1",
+            VariableSetId = "variableset-Projects-1",
+            DeploymentProcessId = "deploymentprocess-Projects-1",
+            DeploymentSettingsId = "deploymentsettings-Projects-1",
+            AutoCreateRelease = true,
+            DiscreteChannelRelease = true
+        };
+
+    private static OctopusResourceNode Resource(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name,
+        object source)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.Project,
+            $"{sourceId}.json",
+            sourceId.StartsWith("Projects-", StringComparison.OrdinalIgnoreCase) ? sourceId : null,
+            null,
+            false,
+            source);
+}


### PR DESCRIPTION
## Summary

- Added `OctopusImportProjectMapper` for mapping `OctopusProjectDto` into existing `CreateOrUpdateProjectModel`.
- Added project mapping diagnostics for missing project group/lifecycle ID mappings and deferred Octopus-only project features.
- Preserved deployment settings, default channel details, and source project metadata as non-sensitive `Json` metadata.
- Added unit tests for successful mapping, missing reference blockers, metadata preservation, deferred feature warnings, and invalid resource type handling.
- Updated local OpenSpec progress tracking to mark task 4.1 complete; `openspec/` is ignored locally via `.git/info/exclude`.
- Scope intentionally excludes environment, lifecycle, feed, variable, deployment process, and action mapping tasks.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers` passed: 143/143 before the final null-safe metadata guard.
- [x] `git diff --check` passed after the final code adjustment.
- [ ] Full unit suite rerun was blocked because the required sandbox escalation was rejected by automatic approval review.