### PR TITLE
Environment and lifecycle mappers for Octopus import

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportEnvironmentMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportEnvironmentMapper.cs
@@ -1,0 +1,52 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Commands.Deployments.Environment;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public interface IOctopusImportEnvironmentMapper : IScopedDependency
+{
+    OctopusImportEnvironmentMappingResult MapToCreateModel(
+        OctopusResourceNode environmentResource,
+        int destinationSpaceId);
+}
+
+public class OctopusImportEnvironmentMapper : IOctopusImportEnvironmentMapper
+{
+    public OctopusImportEnvironmentMappingResult MapToCreateModel(
+        OctopusResourceNode environmentResource,
+        int destinationSpaceId)
+    {
+        ArgumentNullException.ThrowIfNull(environmentResource);
+
+        if (environmentResource.Kind != OctopusResourceKind.Environment)
+            throw new ArgumentException("Octopus environment mapper requires an environment resource.", nameof(environmentResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var environment = environmentResource.GetSource<OctopusEnvironmentDto>()
+            ?? throw new ArgumentException("Octopus environment resource does not contain an OctopusEnvironmentDto source.", nameof(environmentResource));
+
+        return new OctopusImportEnvironmentMappingResult(
+            new CreateEnvironmentCommand
+            {
+                SpaceId = destinationSpaceId,
+                Slug = environment.Slug,
+                Name = environment.Name,
+                Description = environment.Description,
+                SortOrder = environment.SortOrder,
+                UseGuidedFailure = environment.UseGuidedFailure ?? false,
+                AllowDynamicInfrastructure = environment.AllowDynamicInfrastructure ?? false
+            },
+            []);
+    }
+}
+
+public sealed record OctopusImportEnvironmentMappingResult(
+    CreateEnvironmentCommand Environment,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMapper.cs
@@ -1,0 +1,352 @@
+using System.Globalization;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.Deployments;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.LifeCycle;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public interface IOctopusImportLifecycleMapper : IScopedDependency
+{
+    OctopusImportLifecycleMappingResult MapToCreateOrUpdateModel(
+        OctopusResourceNode lifecycleResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId);
+}
+
+public class OctopusImportLifecycleMapper : IOctopusImportLifecycleMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public OctopusImportLifecycleMappingResult MapToCreateOrUpdateModel(
+        OctopusResourceNode lifecycleResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId)
+    {
+        ArgumentNullException.ThrowIfNull(lifecycleResource);
+        ArgumentNullException.ThrowIfNull(idMap);
+
+        if (lifecycleResource.Kind != OctopusResourceKind.Lifecycle)
+            throw new ArgumentException("Octopus lifecycle mapper requires a lifecycle resource.", nameof(lifecycleResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var lifecycle = lifecycleResource.GetSource<OctopusLifecycleDto>()
+            ?? throw new ArgumentException("Octopus lifecycle resource does not contain an OctopusLifecycleDto source.", nameof(lifecycleResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var model = new CreateOrUpdateLifeCycleModel
+        {
+            Lifecycle = new LifeCycleModel
+            {
+                Name = lifecycle.Name,
+                Slug = lifecycle.Slug,
+                SpaceId = destinationSpaceId
+            }
+        };
+
+        var lifecycleRetention = MapLifecycleRetentionPolicy(lifecycle.ReleaseRetentionPolicy, lifecycle.TentacleRetentionPolicy, diagnostics, lifecycleResource);
+        model.Lifecycle.ReleaseRetentionUnit = lifecycleRetention.ReleaseUnit ?? RetentionPolicyUnit.Items;
+        model.Lifecycle.ReleaseRetentionQuantity = lifecycleRetention.ReleaseQuantity ?? 0;
+        model.Lifecycle.ReleaseRetentionKeepForever = lifecycleRetention.ReleaseKeepForever ?? true;
+        model.Lifecycle.TentacleRetentionUnit = lifecycleRetention.TentacleUnit ?? RetentionPolicyUnit.Items;
+        model.Lifecycle.TentacleRetentionQuantity = lifecycleRetention.TentacleQuantity ?? 0;
+        model.Lifecycle.TentacleRetentionKeepForever = lifecycleRetention.TentacleKeepForever ?? true;
+
+        foreach (var (phase, index) in lifecycle.Phases.Select((value, index) => (value, index)))
+        {
+            var mappedPhase = new LifecyclePhaseModel
+            {
+                Name = phase.Name,
+                SortOrder = index,
+                IsOptionalPhase = phase.IsOptionalPhase,
+                IsPriorityPhase = phase.IsPriorityPhase,
+                MinimumEnvironmentsBeforePromotion = phase.MinimumEnvironmentsBeforePromotion
+            };
+
+            mappedPhase.AutomaticDeploymentTargetIds.AddRange(MapEnvironmentTargetIds(
+                lifecycleResource,
+                phase.AutomaticDeploymentTargets,
+                idMap,
+                diagnostics,
+                OctopusImportLifecycleMappingDiagnosticCodes.MissingAutomaticDeploymentEnvironmentMapping,
+                "automatic deployment",
+                phase.Name));
+
+            mappedPhase.OptionalDeploymentTargetIds.AddRange(MapEnvironmentTargetIds(
+                lifecycleResource,
+                phase.OptionalDeploymentTargets,
+                idMap,
+                diagnostics,
+                OctopusImportLifecycleMappingDiagnosticCodes.MissingOptionalDeploymentEnvironmentMapping,
+                "optional deployment",
+                phase.Name));
+
+            var phaseRetention = MapPhaseRetentionPolicy(phase.ReleaseRetentionPolicy, phase.TentacleRetentionPolicy, diagnostics, lifecycleResource, phase.Name);
+            mappedPhase.ReleaseRetentionUnit = phaseRetention.ReleaseUnit;
+            mappedPhase.ReleaseRetentionQuantity = phaseRetention.ReleaseQuantity;
+            mappedPhase.ReleaseRetentionKeepForever = phaseRetention.ReleaseKeepForever;
+            mappedPhase.TentacleRetentionUnit = phaseRetention.TentacleUnit;
+            mappedPhase.TentacleRetentionQuantity = phaseRetention.TentacleQuantity;
+            mappedPhase.TentacleRetentionKeepForever = phaseRetention.TentacleKeepForever;
+
+            model.Phases.Add(mappedPhase);
+        }
+
+        return new OctopusImportLifecycleMappingResult(model, diagnostics);
+    }
+
+    private static IEnumerable<int> MapEnvironmentTargetIds(
+        OctopusResourceNode lifecycleResource,
+        IReadOnlyCollection<string> sourceEnvironmentIds,
+        OctopusImportIdMap idMap,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        string missingMappingCode,
+        string targetLabel,
+        string phaseName)
+    {
+        foreach (var sourceEnvironmentId in sourceEnvironmentIds ?? [])
+        {
+            if (idMap.TryGetDestinationId(sourceEnvironmentId, OctopusResourceKind.Environment.ToString(), out var destinationEnvironmentId))
+            {
+                yield return destinationEnvironmentId;
+                continue;
+            }
+
+            diagnostics.Add(new OctopusImportDiagnosticDto
+            {
+                Severity = OctopusImportCompatibilitySeverity.Blocker,
+                Code = missingMappingCode,
+                Message = $"Octopus lifecycle phase '{phaseName}' references {targetLabel} environment '{sourceEnvironmentId}', but no destination environment mapping exists.",
+                ResourceType = lifecycleResource.Kind.ToString(),
+                SourceId = lifecycleResource.SourceId,
+                ResourceName = lifecycleResource.Name
+            });
+        }
+    }
+
+    private static RetentionMappingResult MapLifecycleRetentionPolicy(
+        JsonElement? releaseRetentionPolicy,
+        JsonElement? tentacleRetentionPolicy,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        OctopusResourceNode resource)
+    {
+        var release = TryMapRetentionPolicy(
+            releaseRetentionPolicy,
+            resource,
+            OctopusImportLifecycleMappingDiagnosticCodes.UnsupportedLifecycleRetentionPolicy,
+            diagnostics,
+            preserveOnFailure: true);
+
+        var tentacle = TryMapRetentionPolicy(
+            tentacleRetentionPolicy,
+            resource,
+            OctopusImportLifecycleMappingDiagnosticCodes.UnsupportedLifecycleRetentionPolicy,
+            diagnostics,
+            preserveOnFailure: true);
+
+        return new RetentionMappingResult(
+            release.Unit,
+            release.Quantity,
+            release.KeepForever,
+            tentacle.Unit,
+            tentacle.Quantity,
+            tentacle.KeepForever);
+    }
+
+    private static RetentionMappingResult MapPhaseRetentionPolicy(
+        JsonElement? releaseRetentionPolicy,
+        JsonElement? tentacleRetentionPolicy,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        OctopusResourceNode resource,
+        string phaseName)
+    {
+        var release = TryMapRetentionPolicy(
+            releaseRetentionPolicy,
+            resource,
+            OctopusImportLifecycleMappingDiagnosticCodes.UnsupportedPhaseRetentionPolicy,
+            diagnostics,
+            preserveOnFailure: false,
+            phaseName);
+
+        var tentacle = TryMapRetentionPolicy(
+            tentacleRetentionPolicy,
+            resource,
+            OctopusImportLifecycleMappingDiagnosticCodes.UnsupportedPhaseRetentionPolicy,
+            diagnostics,
+            preserveOnFailure: false,
+            phaseName);
+
+        return new RetentionMappingResult(
+            release.Unit,
+            release.Quantity,
+            release.KeepForever,
+            tentacle.Unit,
+            tentacle.Quantity,
+            tentacle.KeepForever);
+    }
+
+    private static RetentionPolicyResult TryMapRetentionPolicy(
+        JsonElement? retentionPolicy,
+        OctopusResourceNode resource,
+        string diagnosticCode,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        bool preserveOnFailure,
+        string phaseName = null)
+    {
+        if (!retentionPolicy.HasValue || retentionPolicy.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return preserveOnFailure
+                ? new RetentionPolicyResult(null, null, null)
+                : new RetentionPolicyResult(RetentionPolicyUnit.Items, 0, true);
+        }
+
+        if (retentionPolicy.Value.ValueKind != JsonValueKind.Object)
+        {
+            AddRetentionDiagnostic(diagnostics, resource, diagnosticCode, phaseName, "Octopus retention policy is not an object.");
+            return preserveOnFailure
+                ? new RetentionPolicyResult(null, null, null)
+                : new RetentionPolicyResult(RetentionPolicyUnit.Items, 0, true);
+        }
+
+        var properties = retentionPolicy.Value.EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value, StringComparer.OrdinalIgnoreCase);
+
+        var keepForever = ReadBoolean(properties, "ShouldKeepForever", "KeepForever");
+        var quantity = ReadInt32(properties, "QuantityToKeep", "Quantity");
+        var unit = ReadRetentionUnit(properties, "Unit");
+
+        var hasRecognizedField = keepForever.HasValue || quantity.HasValue || unit.HasValue;
+        var hasUnsupportedField = properties.Keys.Except(new[]
+            {
+                "ShouldKeepForever",
+                "KeepForever",
+                "QuantityToKeep",
+                "Quantity",
+                "Unit"
+            }, StringComparer.OrdinalIgnoreCase).Any();
+
+        if (!hasRecognizedField)
+        {
+            AddRetentionDiagnostic(diagnostics, resource, diagnosticCode, phaseName, "Octopus retention policy does not use a supported shape.");
+            return preserveOnFailure
+                ? new RetentionPolicyResult(null, null, null)
+                : new RetentionPolicyResult(RetentionPolicyUnit.Items, 0, true);
+        }
+
+        if (hasUnsupportedField)
+        {
+            AddRetentionDiagnostic(diagnostics, resource, diagnosticCode, phaseName, "Octopus retention policy contains unsupported fields that were ignored.");
+        }
+
+        if (preserveOnFailure)
+        {
+            return new RetentionPolicyResult(
+                unit ?? RetentionPolicyUnit.Items,
+                quantity ?? 0,
+                keepForever ?? true);
+        }
+
+        return new RetentionPolicyResult(
+            unit,
+            quantity,
+            keepForever);
+    }
+
+    private static void AddRetentionDiagnostic(
+        List<OctopusImportDiagnosticDto> diagnostics,
+        OctopusResourceNode resource,
+        string diagnosticCode,
+        string phaseName,
+        string message)
+    {
+        diagnostics.Add(new OctopusImportDiagnosticDto
+        {
+            Severity = OctopusImportCompatibilitySeverity.Warning,
+            Code = diagnosticCode,
+            Message = phaseName == null
+                ? $"Octopus lifecycle '{resource.Name}' retention policy is not fully supported: {message}"
+                : $"Octopus lifecycle phase '{phaseName}' retention policy is not fully supported: {message}",
+            ResourceType = resource.Kind.ToString(),
+            SourceId = resource.SourceId,
+            ResourceName = resource.Name
+        });
+    }
+
+    private static bool? ReadBoolean(IReadOnlyDictionary<string, JsonElement> properties, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!properties.TryGetValue(name, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.True)
+                return true;
+
+            if (value.ValueKind == JsonValueKind.False)
+                return false;
+
+            if (value.ValueKind == JsonValueKind.String && bool.TryParse(value.GetString(), out var parsed))
+                return parsed;
+        }
+
+        return null;
+    }
+
+    private static int? ReadInt32(IReadOnlyDictionary<string, JsonElement> properties, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!properties.TryGetValue(name, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var parsed))
+                return parsed;
+
+            if (value.ValueKind == JsonValueKind.String && int.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed))
+                return parsed;
+        }
+
+        return null;
+    }
+
+    private static RetentionPolicyUnit? ReadRetentionUnit(IReadOnlyDictionary<string, JsonElement> properties, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!properties.TryGetValue(name, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String && Enum.TryParse<RetentionPolicyUnit>(value.GetString(), true, out var parsed))
+                return parsed;
+        }
+
+        return null;
+    }
+
+    private sealed record RetentionPolicyResult(
+        RetentionPolicyUnit? Unit,
+        int? Quantity,
+        bool? KeepForever);
+
+    private sealed record RetentionMappingResult(
+        RetentionPolicyUnit? ReleaseUnit,
+        int? ReleaseQuantity,
+        bool? ReleaseKeepForever,
+        RetentionPolicyUnit? TentacleUnit,
+        int? TentacleQuantity,
+        bool? TentacleKeepForever);
+}
+
+public sealed record OctopusImportLifecycleMappingResult(
+    CreateOrUpdateLifeCycleModel Lifecycle,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMappingDiagnosticCodes.cs
@@ -1,0 +1,9 @@
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public static class OctopusImportLifecycleMappingDiagnosticCodes
+{
+    public const string MissingAutomaticDeploymentEnvironmentMapping = "octopus.mapping.lifecycle.missing_automatic_deployment_environment_mapping";
+    public const string MissingOptionalDeploymentEnvironmentMapping = "octopus.mapping.lifecycle.missing_optional_deployment_environment_mapping";
+    public const string UnsupportedLifecycleRetentionPolicy = "octopus.mapping.lifecycle.unsupported_lifecycle_retention_policy";
+    public const string UnsupportedPhaseRetentionPolicy = "octopus.mapping.lifecycle.unsupported_phase_retention_policy";
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportEnvironmentLifecycleMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportEnvironmentLifecycleMapperTests.cs
@@ -1,0 +1,166 @@
+using System.Linq;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.Deployments;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping;
+
+public class OctopusImportEnvironmentLifecycleMapperTests
+{
+    private readonly OctopusImportEnvironmentMapper _environmentMapper = new();
+    private readonly OctopusImportLifecycleMapper _lifecycleMapper = new();
+
+    [Fact]
+    public void MapToCreateModel_MapsEnvironmentFieldsIntoCreateCommand()
+    {
+        var environment = new OctopusEnvironmentDto
+        {
+            Id = "Environments-1",
+            Name = "Production",
+            Slug = "production",
+            Description = "Live traffic",
+            SortOrder = 5,
+            UseGuidedFailure = true,
+            AllowDynamicInfrastructure = true
+        };
+
+        var result = _environmentMapper.MapToCreateModel(
+            Resource(environment.Id, OctopusResourceKind.Environment, environment.Name, environment),
+            7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Environment.SpaceId.ShouldBe(7);
+        result.Environment.Name.ShouldBe("Production");
+        result.Environment.Slug.ShouldBe("production");
+        result.Environment.Description.ShouldBe("Live traffic");
+        result.Environment.SortOrder.ShouldBe(5);
+        result.Environment.UseGuidedFailure.ShouldBeTrue();
+        result.Environment.AllowDynamicInfrastructure.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_MapsLifecyclePhasesAndRemapsEnvironmentIds()
+    {
+        var lifecycle = Lifecycle();
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("Environments-1", OctopusResourceKind.Environment, "Production", new OctopusEnvironmentDto()), 101);
+        idMap.AddReused(Resource("Environments-2", OctopusResourceKind.Environment, "Staging", new OctopusEnvironmentDto()), 102);
+
+        var result = _lifecycleMapper.MapToCreateOrUpdateModel(
+            Resource(lifecycle.Id, OctopusResourceKind.Lifecycle, lifecycle.Name, lifecycle),
+            idMap,
+            9);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Lifecycle.Lifecycle.Name.ShouldBe("Default");
+        result.Lifecycle.Lifecycle.Slug.ShouldBe("default");
+        result.Lifecycle.Lifecycle.SpaceId.ShouldBe(9);
+        result.Lifecycle.Lifecycle.ReleaseRetentionKeepForever.ShouldBeFalse();
+        result.Lifecycle.Lifecycle.ReleaseRetentionQuantity.ShouldBe(30);
+        result.Lifecycle.Lifecycle.ReleaseRetentionUnit.ShouldBe(RetentionPolicyUnit.Days);
+        result.Lifecycle.Lifecycle.TentacleRetentionKeepForever.ShouldBeTrue();
+        result.Lifecycle.Phases.Count.ShouldBe(2);
+        result.Lifecycle.Phases[0].SortOrder.ShouldBe(0);
+        result.Lifecycle.Phases[0].AutomaticDeploymentTargetIds.ShouldBe([101]);
+        result.Lifecycle.Phases[0].OptionalDeploymentTargetIds.ShouldBe([102]);
+        result.Lifecycle.Phases[0].ReleaseRetentionKeepForever.ShouldBe(false);
+        result.Lifecycle.Phases[0].ReleaseRetentionQuantity.ShouldBe(7);
+        result.Lifecycle.Phases[0].ReleaseRetentionUnit.ShouldBe(RetentionPolicyUnit.Weeks);
+        result.Lifecycle.Phases[1].SortOrder.ShouldBe(1);
+        result.Lifecycle.Phases[1].AutomaticDeploymentTargetIds.ShouldBe([102]);
+        result.Lifecycle.Phases[1].OptionalDeploymentTargetIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_WhenEnvironmentMappingIsMissing_AddsBlockerAndDropsMissingTarget()
+    {
+        var lifecycle = Lifecycle();
+        lifecycle.Phases[0].AutomaticDeploymentTargets.Add("Environments-999");
+
+        var result = _lifecycleMapper.MapToCreateOrUpdateModel(
+            Resource(lifecycle.Id, OctopusResourceKind.Lifecycle, lifecycle.Name, lifecycle),
+            new OctopusImportIdMap(),
+            9);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportLifecycleMappingDiagnosticCodes.MissingAutomaticDeploymentEnvironmentMapping);
+        result.Lifecycle.Phases[0].AutomaticDeploymentTargetIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_WhenRetentionPolicyShapeIsUnsupported_AddsWarningAndUsesSafeDefaults()
+    {
+        var lifecycle = Lifecycle();
+        lifecycle.ReleaseRetentionPolicy = JsonDocument.Parse("""{"Unsupported":"value"}""").RootElement.Clone();
+        lifecycle.Phases[0].ReleaseRetentionPolicy = JsonDocument.Parse("""{"Unsupported":"value"}""").RootElement.Clone();
+
+        var result = _lifecycleMapper.MapToCreateOrUpdateModel(
+            Resource(lifecycle.Id, OctopusResourceKind.Lifecycle, lifecycle.Name, lifecycle),
+            new OctopusImportIdMap(),
+            9);
+
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportLifecycleMappingDiagnosticCodes.UnsupportedLifecycleRetentionPolicy);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportLifecycleMappingDiagnosticCodes.UnsupportedPhaseRetentionPolicy);
+        result.Lifecycle.Lifecycle.ReleaseRetentionKeepForever.ShouldBeTrue();
+        result.Lifecycle.Phases[0].ReleaseRetentionUnit.ShouldBe(RetentionPolicyUnit.Items);
+        result.Lifecycle.Phases[0].ReleaseRetentionQuantity.ShouldBe(0);
+        result.Lifecycle.Phases[0].ReleaseRetentionKeepForever.ShouldBe(true);
+    }
+
+    [Fact]
+    public void MapToCreateOrUpdateModel_WhenResourceKindIsWrong_Throws()
+    {
+        Should.Throw<ArgumentException>(() => _lifecycleMapper.MapToCreateOrUpdateModel(
+            Resource("Environments-1", OctopusResourceKind.Environment, "Production", new OctopusEnvironmentDto()),
+            new OctopusImportIdMap(),
+            9));
+    }
+
+    private static OctopusLifecycleDto Lifecycle()
+        => new()
+        {
+            Id = "Lifecycles-1",
+            Name = "Default",
+            Slug = "default",
+            ReleaseRetentionPolicy = JsonDocument.Parse("""{"ShouldKeepForever":false,"QuantityToKeep":30,"Unit":"Days"}""").RootElement.Clone(),
+            TentacleRetentionPolicy = JsonDocument.Parse("""{"ShouldKeepForever":true,"QuantityToKeep":0,"Unit":"Items"}""").RootElement.Clone(),
+            Phases =
+            [
+                new OctopusLifecyclePhaseDto
+                {
+                    Id = "Phase-1",
+                    Name = "Deploy",
+                    MinimumEnvironmentsBeforePromotion = 1,
+                    AutomaticDeploymentTargets = ["Environments-1"],
+                    OptionalDeploymentTargets = ["Environments-2"],
+                    ReleaseRetentionPolicy = JsonDocument.Parse("""{"ShouldKeepForever":false,"QuantityToKeep":7,"Unit":"Weeks"}""").RootElement.Clone()
+                },
+                new OctopusLifecyclePhaseDto
+                {
+                    Id = "Phase-2",
+                    Name = "Production",
+                    MinimumEnvironmentsBeforePromotion = 0,
+                    AutomaticDeploymentTargets = ["Environments-2"]
+                }
+            ]
+        };
+
+    private static OctopusResourceNode Resource(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name,
+        object source)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.Lifecycle,
+            $"{sourceId}.json",
+            sourceId.StartsWith("Projects-", StringComparison.OrdinalIgnoreCase) ? sourceId : null,
+            null,
+            false,
+            source);
+}


### PR DESCRIPTION
## Summary
- Added Octopus environment and lifecycle import mappers in [OctopusImportEnvironmentMapper.cs](</Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportEnvironmentMapper.cs>) and [OctopusImportLifecycleMapper.cs](</Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMapper.cs>), plus lifecycle diagnostic codes in [OctopusImportLifecycleMappingDiagnosticCodes.cs](</Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMappingDiagnosticCodes.cs>).
- Mapped Octopus environment fields into Squid create commands, and mapped lifecycle phases with destination environment ID remapping, phase ordering, and retention-policy fallback/diagnostics.
- Added focused unit coverage in [OctopusImportEnvironmentLifecycleMapperTests.cs](</Users/mindy/Documents/repo/Squid/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportEnvironmentLifecycleMapperTests.cs>) and marked OpenSpec task 4.2 complete in [tasks.md](</Users/mindy/Documents/repo/Squid/openspec/changes/add-octopus-import/tasks.md>).
- No branch-local unfinished items remain; later OpenSpec tasks are untouched.

## Test plan
- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport.Mapping" --no-restore --disable-build-servers` (passed 10/10).
- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers` (passed 148/148).
- [x] `git diff --check` and a trailing-whitespace scan on the new files were clean.