### PR TITLE
Feed mapper for Octopus import with credential omission handling

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs
@@ -1,0 +1,195 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Commands.Deployments.ExternalFeed;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public interface IOctopusImportFeedMapper : IScopedDependency
+{
+    OctopusImportFeedMappingResult MapToCreateCommand(
+        OctopusResourceNode feedResource,
+        int destinationSpaceId);
+
+    OctopusImportFeedMappingResult MapToUpdateCommand(
+        OctopusResourceNode feedResource,
+        int destinationFeedId,
+        int destinationSpaceId);
+}
+
+public class OctopusImportFeedMapper : IOctopusImportFeedMapper
+{
+    public OctopusImportFeedMappingResult MapToCreateCommand(
+        OctopusResourceNode feedResource,
+        int destinationSpaceId)
+    {
+        var mapping = Map(feedResource, destinationSpaceId);
+
+        return new OctopusImportFeedMappingResult(
+            new CreateExternalFeedCommand
+            {
+                FeedType = mapping.FeedType,
+                Properties = mapping.Properties,
+                FeedUri = mapping.FeedUri,
+                Username = null,
+                Password = null,
+                Name = mapping.Name,
+                Slug = mapping.Slug,
+                PackageAcquisitionLocationOptions = [],
+                SpaceId = destinationSpaceId
+            },
+            null,
+            mapping.Diagnostics);
+    }
+
+    public OctopusImportFeedMappingResult MapToUpdateCommand(
+        OctopusResourceNode feedResource,
+        int destinationFeedId,
+        int destinationSpaceId)
+    {
+        if (destinationFeedId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationFeedId), destinationFeedId, "Destination feed id must be positive.");
+
+        var mapping = Map(feedResource, destinationSpaceId);
+
+        return new OctopusImportFeedMappingResult(
+            null,
+            new UpdateExternalFeedCommand
+            {
+                Id = destinationFeedId,
+                FeedType = mapping.FeedType,
+                Properties = mapping.Properties,
+                FeedUri = mapping.FeedUri,
+                Username = null,
+                PasswordNewValue = null,
+                Name = mapping.Name,
+                Slug = mapping.Slug,
+                PackageAcquisitionLocationOptions = [],
+                SpaceId = destinationSpaceId
+            },
+            mapping.Diagnostics);
+    }
+
+    private static FeedCommandMapping Map(OctopusResourceNode feedResource, int destinationSpaceId)
+    {
+        ArgumentNullException.ThrowIfNull(feedResource);
+
+        if (feedResource.Kind != OctopusResourceKind.Feed)
+            throw new ArgumentException("Octopus feed mapper requires a feed resource.", nameof(feedResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var feed = feedResource.GetSource<OctopusFeedDto>()
+            ?? throw new ArgumentException("Octopus feed resource does not contain an OctopusFeedDto source.", nameof(feedResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var mappedFeedType = MapFeedType(feed, feedResource, diagnostics);
+
+        if (!string.IsNullOrWhiteSpace(feed.Username) || !string.IsNullOrWhiteSpace(feed.Password))
+        {
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportFeedMappingDiagnosticCodes.CredentialsOmitted,
+                "Octopus feed credentials were omitted from the Squid ExternalFeed command and must be configured manually after import.",
+                feedResource));
+        }
+
+        return new FeedCommandMapping(
+            mappedFeedType,
+            feed.FeedUri,
+            feed.Name,
+            feed.Slug,
+            BuildProperties(feed),
+            diagnostics);
+    }
+
+    private static string MapFeedType(
+        OctopusFeedDto feed,
+        OctopusResourceNode feedResource,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var feedType = feed.FeedType ?? string.Empty;
+
+        if (ContainsAny(feedType, "Docker", "Container Registry", "OCI Registry", "ECR", "ACR", "GCR"))
+            return "Docker Registry";
+
+        if (ContainsAny(feedType, "NuGet"))
+            return "NuGet";
+
+        if (ContainsAny(feedType, "Helm"))
+            return "Helm";
+
+        if (ContainsAny(feedType, "GitHub") || IsGitHubUri(feed.FeedUri))
+            return "GitHub";
+
+        diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusImportFeedMappingDiagnosticCodes.UnsupportedFeedType,
+            $"Octopus feed type '{feed.FeedType}' is not supported by the current Squid import feed mapper.",
+            feedResource));
+
+        return feed.FeedType;
+    }
+
+    private static Dictionary<string, string> BuildProperties(OctopusFeedDto feed)
+    {
+        var properties = new Dictionary<string, string>();
+
+        AddIfPresent(properties, "RegistryPath", feed.RegistryPath);
+        AddIfPresent(properties, "ApiVersion", feed.ApiVersion);
+
+        if (feed.DownloadAttempts > 0)
+            properties["DownloadAttempts"] = feed.DownloadAttempts.ToString();
+
+        if (feed.DownloadRetryBackoffSeconds > 0)
+            properties["DownloadRetryBackoffSeconds"] = feed.DownloadRetryBackoffSeconds.ToString();
+
+        return properties;
+    }
+
+    private static void AddIfPresent(Dictionary<string, string> properties, string key, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            properties[key] = value;
+    }
+
+    private static bool ContainsAny(string value, params string[] candidates)
+        => !string.IsNullOrWhiteSpace(value) &&
+           candidates.Any(candidate => value.Contains(candidate, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsGitHubUri(string uri)
+        => Uri.TryCreate(uri, UriKind.Absolute, out var parsed) &&
+           parsed.Host.Contains("github", StringComparison.OrdinalIgnoreCase);
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = resource.Kind.ToString(),
+            SourceId = resource.SourceId,
+            ResourceName = resource.Name
+        };
+
+    private sealed record FeedCommandMapping(
+        string FeedType,
+        string FeedUri,
+        string Name,
+        string Slug,
+        Dictionary<string, string> Properties,
+        IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics);
+}
+
+public sealed record OctopusImportFeedMappingResult(
+    CreateExternalFeedCommand CreateCommand,
+    UpdateExternalFeedCommand UpdateCommand,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMappingDiagnosticCodes.cs
@@ -1,0 +1,7 @@
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public static class OctopusImportFeedMappingDiagnosticCodes
+{
+    public const string CredentialsOmitted = "octopus.mapping.feed.credentials_omitted";
+    public const string UnsupportedFeedType = "octopus.mapping.feed.unsupported_feed_type";
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportFeedMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportFeedMapperTests.cs
@@ -1,0 +1,150 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport.Mapping;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping;
+
+public class OctopusImportFeedMapperTests
+{
+    private readonly OctopusImportFeedMapper _mapper = new();
+
+    [Theory]
+    [InlineData("Docker", "Docker Registry")]
+    [InlineData("NuGet", "NuGet")]
+    [InlineData("Helm", "Helm")]
+    [InlineData("GitHub Repository", "GitHub")]
+    public void MapToCreateCommand_MapsSupportedFeedTypes(string octopusFeedType, string expectedSquidFeedType)
+    {
+        var feed = Feed(octopusFeedType);
+
+        var result = _mapper.MapToCreateCommand(
+            Resource(feed),
+            7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.ShouldNotBeNull();
+        result.UpdateCommand.ShouldBeNull();
+        result.CreateCommand.FeedType.ShouldBe(expectedSquidFeedType);
+        result.CreateCommand.FeedUri.ShouldBe("https://feed.example");
+        result.CreateCommand.Name.ShouldBe("Source Feed");
+        result.CreateCommand.Slug.ShouldBe("source-feed");
+        result.CreateCommand.SpaceId.ShouldBe(7);
+        result.CreateCommand.PackageAcquisitionLocationOptions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MapToCreateCommand_PreservesNonSensitiveFeedProperties()
+    {
+        var feed = Feed("Docker");
+        feed.RegistryPath = "library";
+        feed.ApiVersion = "v2";
+        feed.DownloadAttempts = 3;
+        feed.DownloadRetryBackoffSeconds = 15;
+
+        var result = _mapper.MapToCreateCommand(Resource(feed), 7);
+
+        result.CreateCommand.Properties["RegistryPath"].ShouldBe("library");
+        result.CreateCommand.Properties["ApiVersion"].ShouldBe("v2");
+        result.CreateCommand.Properties["DownloadAttempts"].ShouldBe("3");
+        result.CreateCommand.Properties["DownloadRetryBackoffSeconds"].ShouldBe("15");
+    }
+
+    [Fact]
+    public void MapToCreateCommand_OmitsCredentialsAndAddsWarning()
+    {
+        var feed = Feed("NuGet");
+        feed.Username = "octopus-user";
+        feed.Password = "encrypted-source-secret";
+
+        var result = _mapper.MapToCreateCommand(Resource(feed), 7);
+
+        result.CreateCommand.Username.ShouldBeNull();
+        result.CreateCommand.Password.ShouldBeNull();
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportFeedMappingDiagnosticCodes.CredentialsOmitted);
+        result.Diagnostics.All(d => d.Message.Contains("encrypted-source-secret", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MapToUpdateCommand_OmitsCredentialsAndTargetsDestinationFeed()
+    {
+        var feed = Feed("Helm");
+        feed.Username = "helm-user";
+        feed.Password = "helm-password";
+
+        var result = _mapper.MapToUpdateCommand(Resource(feed), 42, 7);
+
+        result.CreateCommand.ShouldBeNull();
+        result.UpdateCommand.ShouldNotBeNull();
+        result.UpdateCommand.Id.ShouldBe(42);
+        result.UpdateCommand.FeedType.ShouldBe("Helm");
+        result.UpdateCommand.Username.ShouldBeNull();
+        result.UpdateCommand.PasswordNewValue.ShouldBeNull();
+        result.UpdateCommand.SpaceId.ShouldBe(7);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportFeedMappingDiagnosticCodes.CredentialsOmitted);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_MapsGitHubCompatibleFeedByUri()
+    {
+        var feed = Feed("External");
+        feed.FeedUri = "https://api.github.com/repos/octopus/example/releases";
+
+        var result = _mapper.MapToCreateCommand(Resource(feed), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.FeedType.ShouldBe("GitHub");
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenFeedTypeIsUnsupported_AddsBlocker()
+    {
+        var feed = Feed("Maven");
+
+        var result = _mapper.MapToCreateCommand(Resource(feed), 7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportFeedMappingDiagnosticCodes.UnsupportedFeedType);
+        result.CreateCommand.FeedType.ShouldBe("Maven");
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenResourceIsNotFeed_Throws()
+    {
+        Should.Throw<ArgumentException>(() => _mapper.MapToCreateCommand(
+            new OctopusResourceNode(
+                "Projects-1",
+                "Project",
+                OctopusResourceKind.Project,
+                OctopusDocumentKind.Project,
+                "Projects-1.json",
+                "Projects-1",
+                null,
+                false,
+                new OctopusProjectDto()),
+            7));
+    }
+
+    private static OctopusFeedDto Feed(string feedType)
+        => new()
+        {
+            Id = "Feeds-1",
+            Name = "Source Feed",
+            Slug = "source-feed",
+            FeedType = feedType,
+            FeedUri = "https://feed.example"
+        };
+
+    private static OctopusResourceNode Resource(OctopusFeedDto feed)
+        => new(
+            feed.Id,
+            feed.Name,
+            OctopusResourceKind.Feed,
+            OctopusDocumentKind.Feed,
+            $"{feed.Id}.json",
+            null,
+            null,
+            false,
+            feed);
+}


### PR DESCRIPTION
## Summary

- Added Octopus feed mapping in [OctopusImportFeedMapper.cs](</Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs>) for Docker, NuGet, Helm, and GitHub-compatible feeds into Squid `CreateExternalFeedCommand` / `UpdateExternalFeedCommand`.
- Added feed mapping diagnostics in [OctopusImportFeedMappingDiagnosticCodes.cs](</Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMappingDiagnosticCodes.cs>) for omitted credentials and unsupported feed types.
- Added focused unit coverage in [OctopusImportFeedMapperTests.cs](</Users/mindy/Documents/repo/Squid/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportFeedMapperTests.cs>) covering supported feed types, non-sensitive properties, credential omission, GitHub-compatible URI detection, unsupported blockers, and invalid resource kind.
- Scope was kept to OpenSpec task 4.3; confirmation orchestration and later variable/process/action mapping tasks were not changed.
- Marked OpenSpec task 4.3 complete in local progress tracking; `openspec/` is ignored via `.git/info/exclude`.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport.Mapping" --no-restore --disable-build-servers` passed: 20/20.
- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers` passed: 158/158.
- [x] `git diff --check` passed.