### PR TITLE
Variable-set mapper for Octopus import

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMapper.cs
@@ -1,0 +1,382 @@
+using System.Globalization;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Commands.Deployments.Variable;
+using Squid.Message.Enums;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Variable;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public interface IOctopusImportVariableMapper : IScopedDependency
+{
+    OctopusImportVariableMappingResult MapToCreateCommand(
+        OctopusResourceNode variableSetResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId,
+        string name = null,
+        string description = null);
+
+    OctopusImportVariableMappingResult MapToUpdateCommand(
+        OctopusResourceNode variableSetResource,
+        OctopusImportIdMap idMap,
+        int destinationVariableSetId,
+        int destinationSpaceId,
+        string name = null,
+        string description = null);
+}
+
+public class OctopusImportVariableMapper : IOctopusImportVariableMapper
+{
+    public OctopusImportVariableMappingResult MapToCreateCommand(
+        OctopusResourceNode variableSetResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId,
+        string name = null,
+        string description = null)
+    {
+        var mapping = Map(variableSetResource, idMap, destinationSpaceId, name, description);
+
+        return new OctopusImportVariableMappingResult(
+            new CreateVariableSetCommand
+            {
+                Name = mapping.Name,
+                Description = mapping.Description,
+                OwnerId = mapping.OwnerId,
+                OwnerType = mapping.OwnerType,
+                SpaceId = destinationSpaceId,
+                Variables = mapping.Variables
+            },
+            null,
+            mapping.Diagnostics);
+    }
+
+    public OctopusImportVariableMappingResult MapToUpdateCommand(
+        OctopusResourceNode variableSetResource,
+        OctopusImportIdMap idMap,
+        int destinationVariableSetId,
+        int destinationSpaceId,
+        string name = null,
+        string description = null)
+    {
+        if (destinationVariableSetId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationVariableSetId), destinationVariableSetId, "Destination variable set id must be positive.");
+
+        var mapping = Map(variableSetResource, idMap, destinationSpaceId, name, description);
+
+        return new OctopusImportVariableMappingResult(
+            null,
+            new UpdateVariableSetCommand
+            {
+                Id = destinationVariableSetId,
+                Name = mapping.Name,
+                Description = mapping.Description,
+                OwnerId = mapping.OwnerId,
+                OwnerType = mapping.OwnerType,
+                SpaceId = destinationSpaceId,
+                Variables = mapping.Variables
+            },
+            mapping.Diagnostics);
+    }
+
+    private static VariableSetCommandMapping Map(
+        OctopusResourceNode variableSetResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId,
+        string name,
+        string description)
+    {
+        ArgumentNullException.ThrowIfNull(variableSetResource);
+        ArgumentNullException.ThrowIfNull(idMap);
+
+        if (variableSetResource.Kind != OctopusResourceKind.VariableSet)
+            throw new ArgumentException("Octopus variable mapper requires a current variable set resource.", nameof(variableSetResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var variableSet = variableSetResource.GetSource<OctopusVariableSetDto>()
+            ?? throw new ArgumentException("Octopus variable set resource does not contain an OctopusVariableSetDto source.", nameof(variableSetResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var ownerType = MapOwnerType(variableSet, variableSetResource, diagnostics);
+        var ownerId = MapOwnerId(variableSet, idMap, variableSetResource, diagnostics);
+        var variables = variableSet.Variables
+            .Select((variable, index) => MapVariable(variable, index, idMap, diagnostics))
+            .ToList();
+
+        return new VariableSetCommandMapping(
+            name,
+            description,
+            ownerId,
+            ownerType,
+            variables,
+            diagnostics);
+    }
+
+    private static VariableSetOwnerType MapOwnerType(
+        OctopusVariableSetDto variableSet,
+        OctopusResourceNode variableSetResource,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        if (string.Equals(variableSet.OwnerType, "Project", StringComparison.OrdinalIgnoreCase))
+            return VariableSetOwnerType.Project;
+
+        diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusImportVariableMappingDiagnosticCodes.UnsupportedVariableSetOwnerType,
+            $"Octopus variable set owner type '{variableSet.OwnerType}' is not supported by the current Squid import variable mapper.",
+            variableSetResource));
+
+        return VariableSetOwnerType.Project;
+    }
+
+    private static int MapOwnerId(
+        OctopusVariableSetDto variableSet,
+        OctopusImportIdMap idMap,
+        OctopusResourceNode variableSetResource,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        if (idMap.TryGetDestinationId(variableSet.OwnerId, OctopusResourceKind.Project.ToString(), out var ownerId))
+            return ownerId;
+
+        diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusImportVariableMappingDiagnosticCodes.MissingProjectMapping,
+            $"Octopus variable set owner project '{variableSet.OwnerId}' has not been mapped to a destination project.",
+            variableSetResource));
+
+        return default;
+    }
+
+    private static VariableModel MapVariable(
+        OctopusVariableDto variable,
+        int index,
+        OctopusImportIdMap idMap,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var variableType = MapVariableType(variable, diagnostics);
+        var isSensitive = variable.IsSensitive || IsType(variable.Type, "Sensitive");
+
+        if (isSensitive)
+        {
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportVariableMappingDiagnosticCodes.SensitiveValueOmitted,
+                $"Sensitive Octopus variable '{variable.Name}' was mapped without its source value and must be supplied manually after import.",
+                OctopusResourceKind.Variable,
+                variable.Id,
+                variable.Name));
+        }
+
+        if (!string.IsNullOrWhiteSpace(variable.Prompt?.DisplaySettings))
+        {
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportVariableMappingDiagnosticCodes.PromptDisplaySettingsOmitted,
+                $"Octopus prompt display settings for variable '{variable.Name}' are not represented in Squid variable commands and were omitted.",
+                OctopusResourceKind.Variable,
+                variable.Id,
+                variable.Name));
+        }
+
+        return new VariableModel
+        {
+            Name = variable.Name,
+            Description = variable.Description,
+            Value = isSensitive ? string.Empty : variable.Value,
+            Type = variableType,
+            IsSensitive = isSensitive,
+            SortOrder = index,
+            PromptLabel = variable.Prompt?.Label,
+            PromptDescription = variable.Prompt?.Description,
+            PromptRequired = variable.Prompt?.Required ?? false,
+            Scopes = MapScopes(variable, idMap, diagnostics)
+        };
+    }
+
+    private static VariableType MapVariableType(
+        OctopusVariableDto variable,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        if (variable.IsSensitive || IsType(variable.Type, "Sensitive"))
+            return VariableType.Password;
+
+        var type = variable.Type?.Trim();
+
+        if (string.IsNullOrWhiteSpace(type) || IsType(type, "String"))
+            return VariableType.String;
+
+        if (IsType(type, "Certificate"))
+            return VariableType.Certificate;
+
+        if (IsType(type, "Boolean"))
+            return VariableType.Boolean;
+
+        if (IsType(type, "Integer") || IsType(type, "Number"))
+            return VariableType.Number;
+
+        if (IsType(type, "MultiLineText"))
+            return VariableType.MultiLineText;
+
+        if (IsType(type, "SelectList") || IsType(type, "Select"))
+            return VariableType.SelectList;
+
+        diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusImportVariableMappingDiagnosticCodes.UnsupportedVariableType,
+            $"Octopus variable type '{variable.Type}' for variable '{variable.Name}' is not supported by the current Squid import variable mapper.",
+            OctopusResourceKind.Variable,
+            variable.Id,
+            variable.Name));
+
+        return VariableType.String;
+    }
+
+    private static List<VariableScopeModel> MapScopes(
+        OctopusVariableDto variable,
+        OctopusImportIdMap idMap,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var scopes = new List<VariableScopeModel>();
+
+        foreach (var scope in variable.Scope ?? [])
+        {
+            var scopeType = MapScopeType(scope.Key);
+
+            if (scopeType == null)
+            {
+                diagnostics.Add(Diagnostic(
+                    OctopusImportCompatibilitySeverity.Blocker,
+                    OctopusImportVariableMappingDiagnosticCodes.UnsupportedScopeType,
+                    $"Octopus variable scope type '{scope.Key}' for variable '{variable.Name}' is not supported by Squid variable commands.",
+                    OctopusResourceKind.Variable,
+                    variable.Id,
+                    variable.Name));
+                continue;
+            }
+
+            foreach (var sourceScopeValue in scope.Value ?? [])
+                AddScope(variable, scope.Key, scopeType.Value, sourceScopeValue, idMap, diagnostics, scopes);
+        }
+
+        return scopes;
+    }
+
+    private static void AddScope(
+        OctopusVariableDto variable,
+        string octopusScopeType,
+        VariableScopeType scopeType,
+        string sourceScopeValue,
+        OctopusImportIdMap idMap,
+        List<OctopusImportDiagnosticDto> diagnostics,
+        List<VariableScopeModel> scopes)
+    {
+        if (string.IsNullOrWhiteSpace(sourceScopeValue))
+        {
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportVariableMappingDiagnosticCodes.EmptyScopeValue,
+                $"Octopus variable '{variable.Name}' contains an empty '{octopusScopeType}' scope value that was omitted.",
+                OctopusResourceKind.Variable,
+                variable.Id,
+                variable.Name));
+            return;
+        }
+
+        if (scopeType == VariableScopeType.Role)
+        {
+            scopes.Add(new VariableScopeModel
+            {
+                ScopeType = scopeType,
+                ScopeValue = sourceScopeValue
+            });
+            return;
+        }
+
+        var sourceKind = ScopeSourceKind(scopeType);
+        if (sourceKind != null && idMap.TryGetDestinationId(sourceScopeValue, sourceKind.Value.ToString(), out var destinationId))
+        {
+            scopes.Add(new VariableScopeModel
+            {
+                ScopeType = scopeType,
+                ScopeValue = destinationId.ToString(CultureInfo.InvariantCulture)
+            });
+            return;
+        }
+
+        diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusImportVariableMappingDiagnosticCodes.MissingScopeMapping,
+            $"Octopus variable scope '{octopusScopeType}:{sourceScopeValue}' for variable '{variable.Name}' has not been mapped to a destination Squid scope value.",
+            OctopusResourceKind.Variable,
+            variable.Id,
+            variable.Name));
+    }
+
+    private static VariableScopeType? MapScopeType(string octopusScopeType)
+        => octopusScopeType?.Trim() switch
+        {
+            "Environment" => VariableScopeType.Environment,
+            "Machine" => VariableScopeType.Machine,
+            "Role" => VariableScopeType.Role,
+            "Channel" => VariableScopeType.Channel,
+            "Action" => VariableScopeType.Action,
+            "Process" => VariableScopeType.Process,
+            _ => null
+        };
+
+    private static OctopusResourceKind? ScopeSourceKind(VariableScopeType scopeType)
+        => scopeType switch
+        {
+            VariableScopeType.Environment => OctopusResourceKind.Environment,
+            VariableScopeType.Machine => OctopusResourceKind.Machine,
+            VariableScopeType.Channel => OctopusResourceKind.Channel,
+            VariableScopeType.Action => OctopusResourceKind.DeploymentAction,
+            VariableScopeType.Process => OctopusResourceKind.DeploymentProcess,
+            _ => null
+        };
+
+    private static bool IsType(string value, string expected)
+        => string.Equals(value?.Trim(), expected, StringComparison.OrdinalIgnoreCase);
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => Diagnostic(severity, code, message, resource.Kind, resource.SourceId, resource.Name);
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusResourceKind resourceKind,
+        string sourceId,
+        string resourceName)
+        => new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = resourceKind.ToString(),
+            SourceId = sourceId,
+            ResourceName = resourceName
+        };
+
+    private sealed record VariableSetCommandMapping(
+        string Name,
+        string Description,
+        int OwnerId,
+        VariableSetOwnerType OwnerType,
+        List<VariableModel> Variables,
+        IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics);
+}
+
+public sealed record OctopusImportVariableMappingResult(
+    CreateVariableSetCommand CreateCommand,
+    UpdateVariableSetCommand UpdateCommand,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMappingDiagnosticCodes.cs
@@ -1,0 +1,13 @@
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public static class OctopusImportVariableMappingDiagnosticCodes
+{
+    public const string MissingProjectMapping = "OctopusImport.Variable.MissingProjectMapping";
+    public const string UnsupportedVariableSetOwnerType = "OctopusImport.Variable.UnsupportedVariableSetOwnerType";
+    public const string SensitiveValueOmitted = "OctopusImport.Variable.SensitiveValueOmitted";
+    public const string UnsupportedVariableType = "OctopusImport.Variable.UnsupportedVariableType";
+    public const string PromptDisplaySettingsOmitted = "OctopusImport.Variable.PromptDisplaySettingsOmitted";
+    public const string MissingScopeMapping = "OctopusImport.Variable.MissingScopeMapping";
+    public const string UnsupportedScopeType = "OctopusImport.Variable.UnsupportedScopeType";
+    public const string EmptyScopeValue = "OctopusImport.Variable.EmptyScopeValue";
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportVariableMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportVariableMapperTests.cs
@@ -1,0 +1,305 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping;
+
+public class OctopusImportVariableMapperTests
+{
+    private readonly OctopusImportVariableMapper _mapper = new();
+
+    [Fact]
+    public void MapToCreateCommand_MapsProjectVariableSetVariablesPromptMetadataOrderingAndScopes()
+    {
+        var variableSet = VariableSet(
+            new OctopusVariableDto
+            {
+                Id = "Variables-1",
+                Name = "Namespace",
+                Description = "Kubernetes namespace",
+                Value = "next-chat",
+                Type = "String",
+                Prompt = new OctopusVariablePromptDto
+                {
+                    Label = "Namespace",
+                    Description = "Enter a namespace",
+                    Required = true
+                },
+                Scope =
+                {
+                    ["Environment"] = ["Environments-1"],
+                    ["Channel"] = ["Channels-1"],
+                    ["Action"] = ["Actions-1"],
+                    ["Process"] = ["deploymentprocess-Projects-1"],
+                    ["Role"] = ["aws-eks-us"]
+                }
+            },
+            new OctopusVariableDto
+            {
+                Id = "Variables-2",
+                Name = "ReplicaCount",
+                Value = "3",
+                Type = "Integer"
+            });
+        var idMap = IdMap();
+
+        var result = _mapper.MapToCreateCommand(
+            Resource(variableSet),
+            idMap,
+            7,
+            "Project variables",
+            "Imported from Octopus");
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.ShouldNotBeNull();
+        result.UpdateCommand.ShouldBeNull();
+        result.CreateCommand.Name.ShouldBe("Project variables");
+        result.CreateCommand.Description.ShouldBe("Imported from Octopus");
+        result.CreateCommand.OwnerId.ShouldBe(100);
+        result.CreateCommand.OwnerType.ShouldBe(VariableSetOwnerType.Project);
+        result.CreateCommand.SpaceId.ShouldBe(7);
+        result.CreateCommand.Variables.Count.ShouldBe(2);
+
+        var namespaceVariable = result.CreateCommand.Variables[0];
+        namespaceVariable.Name.ShouldBe("Namespace");
+        namespaceVariable.Value.ShouldBe("next-chat");
+        namespaceVariable.Description.ShouldBe("Kubernetes namespace");
+        namespaceVariable.Type.ShouldBe(VariableType.String);
+        namespaceVariable.IsSensitive.ShouldBeFalse();
+        namespaceVariable.SortOrder.ShouldBe(0);
+        namespaceVariable.PromptLabel.ShouldBe("Namespace");
+        namespaceVariable.PromptDescription.ShouldBe("Enter a namespace");
+        namespaceVariable.PromptRequired.ShouldBeTrue();
+        namespaceVariable.Scopes.Select(s => (s.ScopeType, s.ScopeValue)).ShouldBe([
+            (VariableScopeType.Environment, "101"),
+            (VariableScopeType.Channel, "201"),
+            (VariableScopeType.Action, "301"),
+            (VariableScopeType.Process, "401"),
+            (VariableScopeType.Role, "aws-eks-us")
+        ]);
+
+        result.CreateCommand.Variables[1].Name.ShouldBe("ReplicaCount");
+        result.CreateCommand.Variables[1].Type.ShouldBe(VariableType.Number);
+        result.CreateCommand.Variables[1].SortOrder.ShouldBe(1);
+    }
+
+    [Fact]
+    public void MapToUpdateCommand_TargetsDestinationVariableSet()
+    {
+        var result = _mapper.MapToUpdateCommand(
+            Resource(VariableSet()),
+            IdMap(),
+            42,
+            7);
+
+        result.CreateCommand.ShouldBeNull();
+        result.UpdateCommand.ShouldNotBeNull();
+        result.UpdateCommand.Id.ShouldBe(42);
+        result.UpdateCommand.OwnerId.ShouldBe(100);
+        result.UpdateCommand.OwnerType.ShouldBe(VariableSetOwnerType.Project);
+        result.UpdateCommand.SpaceId.ShouldBe(7);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenVariableIsSensitive_OmitsSourceValueAndAddsWarning()
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = "Variables-Secret",
+            Name = "ApiKey",
+            Value = "encrypted-source-secret",
+            Type = "Sensitive",
+            IsSensitive = true
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.Variables[0].Type.ShouldBe(VariableType.Password);
+        result.CreateCommand.Variables[0].IsSensitive.ShouldBeTrue();
+        result.CreateCommand.Variables[0].Value.ShouldBe(string.Empty);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.SensitiveValueOmitted);
+        result.Diagnostics.All(d => d.Message.Contains("encrypted-source-secret", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Certificate", VariableType.Certificate)]
+    [InlineData("Boolean", VariableType.Boolean)]
+    [InlineData("MultiLineText", VariableType.MultiLineText)]
+    [InlineData("SelectList", VariableType.SelectList)]
+    public void MapToCreateCommand_MapsSupportedVariableTypes(string octopusType, VariableType expectedType)
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = $"Variables-{octopusType}",
+            Name = octopusType,
+            Type = octopusType
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.Variables.Single().Type.ShouldBe(expectedType);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenScopeMappingIsMissing_AddsBlockerAndDropsScope()
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = "Variables-Scoped",
+            Name = "Scoped",
+            Scope =
+            {
+                ["Environment"] = ["Environments-Missing"]
+            }
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.CreateCommand.Variables.Single().Scopes.ShouldBeEmpty();
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.MissingScopeMapping);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenScopeTypeIsUnsupported_AddsBlockerAndDropsScope()
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = "Variables-Tenant",
+            Name = "TenantScoped",
+            Scope =
+            {
+                ["TenantTag"] = ["TenantTags/VIP"]
+            }
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.CreateCommand.Variables.Single().Scopes.ShouldBeEmpty();
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.UnsupportedScopeType);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenVariableTypeIsUnsupported_AddsBlocker()
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = "Variables-Account",
+            Name = "AwsAccount",
+            Type = "AmazonWebServicesAccount"
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.CreateCommand.Variables.Single().Type.ShouldBe(VariableType.String);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.UnsupportedVariableType);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenPromptDisplaySettingsArePresent_AddsWarning()
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = "Variables-Prompt",
+            Name = "Prompted",
+            Prompt = new OctopusVariablePromptDto
+            {
+                Label = "Choose",
+                DisplaySettings = """{"Octopus.ControlType":"Select"}"""
+            }
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.Variables.Single().PromptLabel.ShouldBe("Choose");
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.PromptDisplaySettingsOmitted);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenProjectMappingIsMissing_AddsBlocker()
+    {
+        var result = _mapper.MapToCreateCommand(
+            Resource(VariableSet()),
+            new OctopusImportIdMap(),
+            7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.CreateCommand.OwnerId.ShouldBe(0);
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.MissingProjectMapping);
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenResourceIsNotVariableSet_Throws()
+    {
+        Should.Throw<ArgumentException>(() => _mapper.MapToCreateCommand(
+            new OctopusResourceNode(
+                "Projects-1",
+                "Project",
+                OctopusResourceKind.Project,
+                OctopusDocumentKind.Project,
+                "Projects-1.json",
+                null,
+                null,
+                false,
+                new OctopusProjectDto()),
+            IdMap(),
+            7));
+    }
+
+    private static OctopusVariableSetDto VariableSet(params OctopusVariableDto[] variables)
+        => new()
+        {
+            Id = "variableset-Projects-1",
+            OwnerId = "Projects-1",
+            OwnerType = "Project",
+            Version = 5,
+            Variables = variables.ToList()
+        };
+
+    private static OctopusResourceNode Resource(OctopusVariableSetDto variableSet)
+        => new(
+            variableSet.Id,
+            null,
+            OctopusResourceKind.VariableSet,
+            OctopusDocumentKind.VariableSet,
+            $"{variableSet.Id}.json",
+            variableSet.OwnerId,
+            null,
+            false,
+            variableSet);
+
+    private static OctopusImportIdMap IdMap()
+    {
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("Projects-1", OctopusResourceKind.Project, "Project", new OctopusProjectDto()), 100);
+        idMap.AddReused(Resource("Environments-1", OctopusResourceKind.Environment, "Production", new OctopusEnvironmentDto()), 101);
+        idMap.AddReused(Resource("Channels-1", OctopusResourceKind.Channel, "Default", new OctopusChannelDto()), 201);
+        idMap.AddReused(Resource("Actions-1", OctopusResourceKind.DeploymentAction, "Deploy", new OctopusDeploymentActionDto()), 301);
+        idMap.AddReused(Resource("deploymentprocess-Projects-1", OctopusResourceKind.DeploymentProcess, "Process", new OctopusDeploymentProcessDto()), 401);
+        return idMap;
+    }
+
+    private static OctopusResourceNode Resource(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name,
+        object source)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.VariableSet,
+            $"{sourceId}.json",
+            null,
+            null,
+            false,
+            source);
+}


### PR DESCRIPTION
## Summary

- Implemented Octopus variable-set mapping into existing Squid `CreateVariableSetCommand` and `UpdateVariableSetCommand`.
- Added variable mapping for prompt metadata, variable types, sort order, sensitive value omission, and scoped ID remapping through `OctopusImportIdMap`.
- Added diagnostics for missing project/scope mappings, unsupported owner types, unsupported variable types, omitted prompt display settings, and omitted sensitive values.
- Added focused unit tests in `OctopusImportVariableMapperTests`.
- Marked OpenSpec task `4.4` complete in local progress tracking.
- Scope intentionally excludes `4.5` deployment-process/step mapping and `4.6` variable-reference validation.

## Test plan

- [x] Ran `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport.Mapping" --no-restore --disable-build-servers`: passed 33/33.
- [x] Ran `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers`: passed 171/171.
- [x] Ran `git diff --check`: passed.