### PR TITLE
Action mapper registry foundation for Octopus import

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperContracts.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperContracts.cs
@@ -1,0 +1,50 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
+
+public sealed class OctopusImportActionMappingContext
+{
+    public OctopusImportActionMappingContext(OctopusImportIdMap idMap, int destinationSpaceId)
+    {
+        IdMap = idMap ?? throw new ArgumentNullException(nameof(idMap));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        DestinationSpaceId = destinationSpaceId;
+    }
+
+    public OctopusImportIdMap IdMap { get; }
+
+    public int DestinationSpaceId { get; }
+}
+
+public interface IOctopusImportActionMapper : IScopedDependency
+{
+    string OctopusActionType { get; }
+
+    string SquidActionType { get; }
+
+    OctopusImportActionMappingResult Map(
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context);
+}
+
+public interface IOctopusImportActionMapperRegistry : IScopedDependency
+{
+    IReadOnlyCollection<string> SupportedActionTypes { get; }
+
+    OctopusImportActionMappingResult Map(
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context);
+}
+
+public sealed record OctopusImportActionMappingResult(
+    CreateOrUpdateDeploymentActionModel Action,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperRegistry.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperRegistry.cs
@@ -1,0 +1,102 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
+
+public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegistry
+{
+    private readonly IReadOnlyDictionary<string, IOctopusImportActionMapper> _mappers;
+
+    public OctopusImportActionMapperRegistry(IEnumerable<IOctopusImportActionMapper> mappers)
+    {
+        ArgumentNullException.ThrowIfNull(mappers);
+        _mappers = BuildMapperIndex(mappers);
+    }
+
+    public IReadOnlyCollection<string> SupportedActionTypes => _mappers.Keys.ToArray();
+
+    public OctopusImportActionMappingResult Map(
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var actionType = action.ActionType?.Trim();
+        if (string.IsNullOrWhiteSpace(actionType))
+            return Unsupported(
+                action,
+                OctopusImportActionMappingDiagnosticCodes.MissingActionType,
+                $"[{OctopusImportActionMappingDiagnosticCodes.MissingActionType}] Octopus action type is missing.");
+
+        if (!_mappers.TryGetValue(actionType, out var mapper))
+        {
+            return Unsupported(
+                action,
+                OctopusImportActionMappingDiagnosticCodes.UnsupportedActionType,
+                $"[{OctopusImportActionMappingDiagnosticCodes.UnsupportedActionType}] Octopus action type '{action.ActionType}' is not registered for import action mapping.");
+        }
+
+        var result = mapper.Map(action, context);
+
+        if (result == null)
+            throw new InvalidOperationException($"Mapper '{mapper.GetType().Name}' returned null for action type '{mapper.OctopusActionType}'.");
+
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, IOctopusImportActionMapper> BuildMapperIndex(IEnumerable<IOctopusImportActionMapper> mappers)
+    {
+        var mapperList = mappers.ToList();
+        var index = new Dictionary<string, IOctopusImportActionMapper>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var mapper in mapperList)
+        {
+            if (mapper == null)
+                throw new ArgumentException("Import action mappers cannot contain null entries.", nameof(mappers));
+
+            if (string.IsNullOrWhiteSpace(mapper.OctopusActionType))
+            {
+                throw new InvalidOperationException(
+                    $"[{OctopusImportActionMappingDiagnosticCodes.InvalidActionMapperConfiguration}] Import action mapper '{mapper.GetType().Name}' must declare a non-empty Octopus action type.");
+            }
+
+            if (string.IsNullOrWhiteSpace(mapper.SquidActionType))
+            {
+                throw new InvalidOperationException(
+                    $"[{OctopusImportActionMappingDiagnosticCodes.InvalidActionMapperConfiguration}] Import action mapper '{mapper.GetType().Name}' must declare a non-empty Squid action type.");
+            }
+
+            if (!index.TryAdd(mapper.OctopusActionType.Trim(), mapper))
+            {
+                throw new InvalidOperationException(
+                    $"[{OctopusImportActionMappingDiagnosticCodes.DuplicateActionMapperRegistration}] Duplicate import action mapper registration detected for Octopus action type '{mapper.OctopusActionType}'.");
+            }
+        }
+
+        return index;
+    }
+
+    private static OctopusImportActionMappingResult Unsupported(
+        OctopusDeploymentActionDto action,
+        string code,
+        string message)
+    {
+        var diagnostics = new List<OctopusImportDiagnosticDto>
+        {
+            new()
+            {
+                Severity = OctopusImportCompatibilitySeverity.Blocker,
+                Code = code,
+                Message = message,
+                ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
+                SourceId = action.Id,
+                ResourceName = action.Name
+            }
+        };
+
+        return new OctopusImportActionMappingResult(null, diagnostics);
+    }
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
@@ -1,0 +1,9 @@
+namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
+
+public static class OctopusImportActionMappingDiagnosticCodes
+{
+    public const string MissingActionType = "OctopusImport.Action.MissingActionType";
+    public const string UnsupportedActionType = "OctopusImport.Action.UnsupportedActionType";
+    public const string InvalidActionMapperConfiguration = "OctopusImport.Action.InvalidActionMapperConfiguration";
+    public const string DuplicateActionMapperRegistration = "OctopusImport.Action.DuplicateActionMapperRegistration";
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperRegistryTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperRegistryTests.cs
@@ -1,0 +1,114 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping.Actions;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Constants;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping.Actions;
+
+public class OctopusImportActionMapperRegistryTests
+{
+    [Fact]
+    public void Map_ReturnsUnsupportedDiagnostic_WhenMapperIsMissing()
+    {
+        var registry = new OctopusImportActionMapperRegistry([]);
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "a-1",
+            Name = "Deploy app",
+            ActionType = "Octopus.Unknown"
+        };
+        var context = new OctopusImportActionMappingContext(new OctopusImportIdMap(), 42);
+
+        var result = registry.Map(action, context);
+
+        result.Action.ShouldBeNull();
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.ShouldContain(d => d.Code == OctopusImportActionMappingDiagnosticCodes.UnsupportedActionType);
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+    }
+
+    [Fact]
+    public void Map_DelegatesToRegisteredMapper_CaseInsensitively()
+    {
+        var mapper = new RecordingMapper();
+        var registry = new OctopusImportActionMapperRegistry([mapper]);
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "a-2",
+            Name = "Manual step",
+            ActionType = "octopus.manual"
+        };
+        var context = new OctopusImportActionMappingContext(new OctopusImportIdMap(), 7);
+
+        var result = registry.Map(action, context);
+
+        mapper.Invocations.ShouldBe(1);
+        mapper.LastAction.ShouldBe(action);
+        mapper.LastContext.ShouldBe(context);
+        result.Action.ActionType.ShouldBe(SpecialVariables.ActionTypes.Manual);
+        result.Action.Name.ShouldBe("Manual step");
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SupportedActionTypes_ExposesRegisteredActionTypes()
+    {
+        var registry = new OctopusImportActionMapperRegistry([new RecordingMapper()]);
+
+        registry.SupportedActionTypes.ShouldContain("Octopus.Manual");
+    }
+
+    [Fact]
+    public void Constructor_Throws_WhenDuplicateActionTypeIsRegistered()
+    {
+        var mapper1 = new RecordingMapper("Octopus.Manual", SpecialVariables.ActionTypes.Manual);
+        var mapper2 = new RecordingMapper("octopus.manual", SpecialVariables.ActionTypes.Manual);
+
+        Should.Throw<InvalidOperationException>(() => new OctopusImportActionMapperRegistry([mapper1, mapper2]))
+            .Message.ShouldContain(OctopusImportActionMappingDiagnosticCodes.DuplicateActionMapperRegistration);
+    }
+
+    private sealed class RecordingMapper : IOctopusImportActionMapper
+    {
+        public RecordingMapper()
+            : this("Octopus.Manual", SpecialVariables.ActionTypes.Manual)
+        {
+        }
+
+        public RecordingMapper(string octopusActionType, string squidActionType)
+        {
+            OctopusActionType = octopusActionType;
+            SquidActionType = squidActionType;
+        }
+
+        public int Invocations { get; private set; }
+
+        public OctopusDeploymentActionDto LastAction { get; private set; }
+
+        public OctopusImportActionMappingContext LastContext { get; private set; }
+
+        public string OctopusActionType { get; }
+
+        public string SquidActionType { get; }
+
+        public OctopusImportActionMappingResult Map(
+            OctopusDeploymentActionDto action,
+            OctopusImportActionMappingContext context)
+        {
+            Invocations++;
+            LastAction = action;
+            LastContext = context;
+
+            return new OctopusImportActionMappingResult(
+                new CreateOrUpdateDeploymentActionModel
+                {
+                    Name = action.Name,
+                    ActionType = SquidActionType
+                },
+                []);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implemented the OpenSpec 5.1 foundation for Octopus import action mapping in `src/Squid.Core/Services/OctopusImport/Mapping/Actions/`.
- Added `IOctopusImportActionMapper`, `IOctopusImportActionMapperRegistry`, `OctopusImportActionMappingContext`, `OctopusImportActionMappingResult`, and shared diagnostic codes.
- Added `OctopusImportActionMapperRegistry` to resolve import mappers separately from runtime `ActionHandlerRegistry`, with duplicate-registration and unsupported-action diagnostics.
- Added unit tests for missing mapper fallback, case-insensitive resolution, supported type exposure, and duplicate registration handling in `tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/`.
- Updated `openspec/changes/add-octopus-import/tasks.md` to mark 5.1 complete and refreshed `SESSION_MEMORY.md` with the new durable branch state.
- Scope stayed limited to the contract/registry foundation; no Octopus.Kubernetes, Script, Manual, or other concrete action mappers were implemented.

## Test plan

- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport.Mapping.Actions" --no-restore --disable-build-servers`
- [x] `/usr/local/share/dotnet/dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~Services.OctopusImport" --no-restore --disable-build-servers`
- [x] `git diff --check`