### PR TITLE
Integrate registered action mappers into deployment process mapping

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
@@ -6,4 +6,8 @@ public static class OctopusImportActionMappingDiagnosticCodes
     public const string UnsupportedActionType = "OctopusImport.Action.UnsupportedActionType";
     public const string InvalidActionMapperConfiguration = "OctopusImport.Action.InvalidActionMapperConfiguration";
     public const string DuplicateActionMapperRegistration = "OctopusImport.Action.DuplicateActionMapperRegistration";
+    public const string UnsupportedScriptSyntax = "OctopusImport.Action.Script.UnsupportedSyntax";
+    public const string MissingPackageFeedMapping = "OctopusImport.Action.Script.MissingPackageFeedMapping";
+    public const string MultiplePackageReferencesUnsupported = "OctopusImport.Action.Script.MultiplePackageReferencesUnsupported";
+    public const string MissingResponsibleTeamMapping = "OctopusImport.Action.Manual.MissingResponsibleTeamMapping";
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusManualActionMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusManualActionMapper.cs
@@ -1,0 +1,134 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Constants;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
+
+public sealed class OctopusManualActionMapper : IOctopusImportActionMapper
+{
+    private const string OctopusActionTypeName = "Octopus.Manual";
+    private const string OctopusInstructionsPropertyName = "Octopus.Action.Manual.Instructions";
+    private const string OctopusResponsibleTeamIdsPropertyName = "Octopus.Action.Manual.ResponsibleTeamIds";
+
+    public string OctopusActionType => OctopusActionTypeName;
+
+    public string SquidActionType => SpecialVariables.ActionTypes.Manual;
+
+    public OctopusImportActionMappingResult Map(
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var properties = new List<ActionPropertyModel>();
+
+        AddMappedProperty(properties, action.Properties, OctopusInstructionsPropertyName, SpecialVariables.Action.ManualInstructions);
+        AddResponsibleTeams(properties, action, context, diagnostics);
+
+        var model = new CreateOrUpdateDeploymentActionModel
+        {
+            Name = action.Name,
+            ActionType = SquidActionType,
+            IsDisabled = action.IsDisabled,
+            IsRequired = action.IsRequired,
+            CanBeUsedForProjectVersioning = false,
+            Properties = properties
+        };
+
+        return new OctopusImportActionMappingResult(model, diagnostics);
+    }
+
+    private static void AddResponsibleTeams(
+        List<ActionPropertyModel> properties,
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var sourceTeamIds = SplitReferenceList(GetProperty(action.Properties, OctopusResponsibleTeamIdsPropertyName)).ToList();
+
+        if (sourceTeamIds.Count == 0)
+            return;
+
+        var destinationTeamIds = new List<int>();
+
+        foreach (var sourceTeamId in sourceTeamIds)
+        {
+            if (context.IdMap.TryGetDestinationId(sourceTeamId, OctopusResourceKind.Team.ToString(), out var destinationTeamId))
+            {
+                destinationTeamIds.Add(destinationTeamId);
+                continue;
+            }
+
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                OctopusImportActionMappingDiagnosticCodes.MissingResponsibleTeamMapping,
+                $"Octopus manual action '{action.Name}' references responsible team '{sourceTeamId}', which has not been mapped to a destination Squid team.",
+                action));
+        }
+
+        if (destinationTeamIds.Count > 0)
+        {
+            properties.Add(Property(
+                SpecialVariables.Action.ManualResponsibleTeamIds,
+                string.Join(",", destinationTeamIds.Distinct())));
+        }
+    }
+
+    private static void AddMappedProperty(
+        List<ActionPropertyModel> properties,
+        Dictionary<string, string> source,
+        string sourceName,
+        string destinationName)
+    {
+        var value = GetProperty(source, sourceName);
+
+        if (!string.IsNullOrWhiteSpace(value))
+            properties.Add(Property(destinationName, value));
+    }
+
+    private static string GetProperty(Dictionary<string, string> source, string name)
+    {
+        if (source == null)
+            return null;
+
+        return source.TryGetValue(name, out var value)
+            ? value
+            : source.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase)).Value;
+    }
+
+    private static IEnumerable<string> SplitReferenceList(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return [];
+
+        return value
+            .Split([',', ';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(v => !string.IsNullOrWhiteSpace(v));
+    }
+
+    private static ActionPropertyModel Property(string name, string value)
+        => new()
+        {
+            PropertyName = name,
+            PropertyValue = value
+        };
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusDeploymentActionDto action)
+        => new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
+            SourceId = action.Id,
+            ResourceName = action.Name
+        };
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusScriptActionMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusScriptActionMapper.cs
@@ -1,0 +1,191 @@
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Constants;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Execution;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
+
+public sealed class OctopusScriptActionMapper : IOctopusImportActionMapper
+{
+    private const string OctopusActionTypeName = "Octopus.Script";
+    private const string OctopusScriptBodyPropertyName = "Octopus.Action.Script.ScriptBody";
+    private const string OctopusScriptSyntaxPropertyName = "Octopus.Action.Script.Syntax";
+    private const string OctopusScriptSourcePropertyName = "Octopus.Action.Script.ScriptSource";
+    private const string OctopusPackageFeedIdPropertyName = "Octopus.Action.Package.FeedId";
+    private const string OctopusPackageIdPropertyName = "Octopus.Action.Package.PackageId";
+    private const string OctopusPackageVersionPropertyName = "Octopus.Action.Package.PackageVersion";
+
+    private static readonly IReadOnlySet<string> SupportedSyntaxes =
+        Enum.GetNames<ScriptSyntax>().ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    public string OctopusActionType => OctopusActionTypeName;
+
+    public string SquidActionType => SpecialVariables.ActionTypes.Script;
+
+    public OctopusImportActionMappingResult Map(
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var properties = new List<ActionPropertyModel>();
+
+        AddMappedProperty(properties, action.Properties, OctopusScriptSourcePropertyName, SpecialVariables.Action.ScriptSource);
+        AddMappedSyntax(properties, action, diagnostics);
+        AddMappedProperty(properties, action.Properties, OctopusScriptBodyPropertyName, SpecialVariables.Action.ScriptBody);
+        AddPackageReferenceProperties(properties, action, context, diagnostics);
+
+        var model = new CreateOrUpdateDeploymentActionModel
+        {
+            Name = action.Name,
+            ActionType = SquidActionType,
+            IsDisabled = action.IsDisabled,
+            IsRequired = action.IsRequired,
+            CanBeUsedForProjectVersioning = false,
+            Properties = properties
+        };
+
+        return new OctopusImportActionMappingResult(model, diagnostics);
+    }
+
+    private static void AddMappedSyntax(
+        List<ActionPropertyModel> properties,
+        OctopusDeploymentActionDto action,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var syntax = GetProperty(action.Properties, OctopusScriptSyntaxPropertyName);
+
+        if (string.IsNullOrWhiteSpace(syntax))
+            return;
+
+        if (!SupportedSyntaxes.Contains(syntax.Trim()))
+        {
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                OctopusImportActionMappingDiagnosticCodes.UnsupportedScriptSyntax,
+                $"Octopus script action '{action.Name}' uses syntax '{syntax}', which is not supported by Squid script actions.",
+                action));
+            return;
+        }
+
+        properties.Add(Property(SpecialVariables.Action.ScriptSyntax, syntax.Trim()));
+    }
+
+    private static void AddPackageReferenceProperties(
+        List<ActionPropertyModel> properties,
+        OctopusDeploymentActionDto action,
+        OctopusImportActionMappingContext context,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var packageReference = ResolvePackageReference(action);
+
+        if (packageReference == null)
+            return;
+
+        if ((action.Packages?.Count ?? 0) > 1)
+        {
+            diagnostics.Add(Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                OctopusImportActionMappingDiagnosticCodes.MultiplePackageReferencesUnsupported,
+                $"Octopus script action '{action.Name}' contains multiple package references. Squid script action import currently supports one action-level package reference.",
+                action));
+        }
+
+        if (!string.IsNullOrWhiteSpace(packageReference.PackageId))
+            properties.Add(Property(SpecialVariables.Action.PackageId, packageReference.PackageId));
+
+        if (!string.IsNullOrWhiteSpace(packageReference.Version))
+            properties.Add(Property(SpecialVariables.Action.PackageVersion, packageReference.Version));
+
+        if (string.IsNullOrWhiteSpace(packageReference.FeedId))
+            return;
+
+        if (context.IdMap.TryGetDestinationId(packageReference.FeedId, OctopusResourceKind.Feed.ToString(), out var destinationFeedId))
+        {
+            properties.Add(Property(SpecialVariables.Action.PackageFeedId, destinationFeedId.ToString()));
+            return;
+        }
+
+        diagnostics.Add(Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            OctopusImportActionMappingDiagnosticCodes.MissingPackageFeedMapping,
+            $"Octopus script action '{action.Name}' references package feed '{packageReference.FeedId}', which has not been mapped to a destination Squid feed.",
+            action));
+    }
+
+    private static PackageReference ResolvePackageReference(OctopusDeploymentActionDto action)
+    {
+        var firstPackage = action.Packages?.FirstOrDefault();
+
+        if (firstPackage != null)
+        {
+            return new PackageReference(
+                firstPackage.PackageId,
+                firstPackage.FeedId,
+                firstPackage.Version);
+        }
+
+        var packageId = GetProperty(action.Properties, OctopusPackageIdPropertyName);
+        var feedId = GetProperty(action.Properties, OctopusPackageFeedIdPropertyName);
+        var version = GetProperty(action.Properties, OctopusPackageVersionPropertyName);
+
+        if (string.IsNullOrWhiteSpace(packageId)
+            && string.IsNullOrWhiteSpace(feedId)
+            && string.IsNullOrWhiteSpace(version))
+        {
+            return null;
+        }
+
+        return new PackageReference(packageId, feedId, version);
+    }
+
+    private static void AddMappedProperty(
+        List<ActionPropertyModel> properties,
+        Dictionary<string, string> source,
+        string sourceName,
+        string destinationName)
+    {
+        var value = GetProperty(source, sourceName);
+
+        if (!string.IsNullOrWhiteSpace(value))
+            properties.Add(Property(destinationName, value));
+    }
+
+    private static string GetProperty(Dictionary<string, string> source, string name)
+    {
+        if (source == null)
+            return null;
+
+        return source.TryGetValue(name, out var value)
+            ? value
+            : source.FirstOrDefault(p => string.Equals(p.Key, name, StringComparison.OrdinalIgnoreCase)).Value;
+    }
+
+    private static ActionPropertyModel Property(string name, string value)
+        => new()
+        {
+            PropertyName = name,
+            PropertyValue = value
+        };
+
+    private static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusDeploymentActionDto action)
+        => new()
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
+            SourceId = action.Id,
+            ResourceName = action.Name
+        };
+
+    private sealed record PackageReference(string PackageId, string FeedId, string Version);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs
@@ -1,4 +1,5 @@
 using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Core.Services.OctopusImport.Mapping.Actions;
 using Squid.Message.Commands.Deployments.Process.Step;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -24,6 +25,13 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
     private const string OctopusStepConditionExpressionPropertyName = "Octopus.Step.ConditionExpression";
     private const string OctopusMaxParallelismPropertyName = "Octopus.Action.MaxParallelism";
     private const string OctopusTimeoutPropertyName = "Octopus.Action.Timeout";
+
+    private readonly IOctopusImportActionMapperRegistry _actionMapperRegistry;
+
+    public OctopusImportDeploymentProcessMapper(IOctopusImportActionMapperRegistry actionMapperRegistry = null)
+    {
+        _actionMapperRegistry = actionMapperRegistry;
+    }
 
     public OctopusImportDeploymentProcessMappingResult MapToCreateStepCommands(
         OctopusResourceNode deploymentProcessResource,
@@ -69,7 +77,7 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         return default;
     }
 
-    private static OctopusImportDeploymentStepCommandMapping MapStep(
+    private OctopusImportDeploymentStepCommandMapping MapStep(
         OctopusDeploymentStepDto step,
         int stepIndex,
         int destinationProcessId,
@@ -78,7 +86,7 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         List<OctopusImportDiagnosticDto> diagnostics)
     {
         var actions = (step.Actions ?? [])
-            .Select((action, actionIndex) => MapAction(action, actionIndex, idMap, diagnostics))
+            .Select((action, actionIndex) => MapAction(action, actionIndex, destinationSpaceId, idMap, diagnostics))
             .ToList();
 
         var stepProperties = MapStepProperties(step, diagnostics);
@@ -117,13 +125,15 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
             actions.Select(a => new OctopusImportDeploymentActionModelMapping(a.SourceAction.Id, a.SourceAction.Name, a.SourceIndex, a.Action)).ToList());
     }
 
-    private static ActionMapping MapAction(
+    private ActionMapping MapAction(
         OctopusDeploymentActionDto action,
         int actionIndex,
+        int destinationSpaceId,
         OctopusImportIdMap idMap,
         List<OctopusImportDiagnosticDto> diagnostics)
     {
-        var actionType = MapActionType(action, diagnostics);
+        var mappedAction = MapActionSpecifics(action, destinationSpaceId, idMap, diagnostics);
+        var actionType = mappedAction.ActionType;
         var isUnsupportedActionType = string.Equals(actionType, action.ActionType, StringComparison.OrdinalIgnoreCase)
             && !SpecialVariables.ActionTypes.All.Contains(actionType);
 
@@ -135,7 +145,7 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
             IsRequired = action.IsRequired,
             WorkerPoolId = MapWorkerPool(action, diagnostics),
             CanBeUsedForProjectVersioning = false,
-            Properties = MapActionProperties(action, diagnostics),
+            Properties = mappedAction.Properties,
             Environments = MapScopedIds(action, action.Environments, OctopusResourceKind.Environment, OctopusImportDeploymentProcessMappingDiagnosticCodes.MissingEnvironmentMapping, "environment", idMap, diagnostics),
             ExcludedEnvironments = MapScopedIds(action, action.ExcludedEnvironments, OctopusResourceKind.Environment, OctopusImportDeploymentProcessMappingDiagnosticCodes.MissingExcludedEnvironmentMapping, "excluded environment", idMap, diagnostics),
             Channels = MapScopedIds(action, action.Channels, OctopusResourceKind.Channel, OctopusImportDeploymentProcessMappingDiagnosticCodes.MissingChannelMapping, "channel", idMap, diagnostics)
@@ -146,6 +156,30 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         AddUnsupportedActionConditionDiagnostic(action, diagnostics);
 
         return new ActionMapping(action, actionIndex, model);
+    }
+
+    private ActionSpecificMapping MapActionSpecifics(
+        OctopusDeploymentActionDto action,
+        int destinationSpaceId,
+        OctopusImportIdMap idMap,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        if (_actionMapperRegistry != null
+            && !string.IsNullOrWhiteSpace(action.ActionType)
+            && _actionMapperRegistry.SupportedActionTypes.Contains(action.ActionType.Trim(), StringComparer.OrdinalIgnoreCase))
+        {
+            var context = new OctopusImportActionMappingContext(idMap, destinationSpaceId);
+            var result = _actionMapperRegistry.Map(action, context);
+
+            diagnostics.AddRange(result.Diagnostics);
+
+            if (result.Action != null)
+                return new ActionSpecificMapping(result.Action.ActionType, result.Action.Properties ?? []);
+        }
+
+        return new ActionSpecificMapping(
+            MapActionType(action, diagnostics),
+            MapActionProperties(action, diagnostics));
     }
 
     private static string MapActionType(
@@ -446,6 +480,10 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         OctopusDeploymentActionDto SourceAction,
         int SourceIndex,
         CreateOrUpdateDeploymentActionModel Action);
+
+    private sealed record ActionSpecificMapping(
+        string ActionType,
+        List<ActionPropertyModel> Properties);
 }
 
 public sealed record OctopusImportDeploymentProcessMappingResult(

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusManualActionMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusManualActionMapperTests.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping.Actions;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Constants;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping.Actions;
+
+public class OctopusManualActionMapperTests
+{
+    private readonly OctopusManualActionMapper _mapper = new();
+
+    [Fact]
+    public void Map_MapsInstructionsAndResponsibleTeams()
+    {
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "Actions-Manual",
+            Name = "Approval",
+            ActionType = "Octopus.Manual",
+            Properties =
+            {
+                ["Octopus.Action.Manual.Instructions"] = "Check #{Environment.Name}",
+                ["Octopus.Action.Manual.ResponsibleTeamIds"] = "Teams-1, Teams-2"
+            }
+        };
+
+        var result = _mapper.Map(action, Context(includeSecondTeam: true));
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Action.ActionType.ShouldBe(SpecialVariables.ActionTypes.Manual);
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ManualInstructions).PropertyValue.ShouldBe("Check #{Environment.Name}");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ManualResponsibleTeamIds).PropertyValue.ShouldBe("401,402");
+    }
+
+    [Fact]
+    public void Map_WhenResponsibleTeamMappingIsMissing_AddsBlockerAndKeepsResolvedTeams()
+    {
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "Actions-Manual",
+            Name = "Approval",
+            ActionType = "Octopus.Manual",
+            Properties =
+            {
+                ["Octopus.Action.Manual.ResponsibleTeamIds"] = "Teams-1, Teams-Missing"
+            }
+        };
+
+        var result = _mapper.Map(action, Context(includeSecondTeam: false));
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportActionMappingDiagnosticCodes.MissingResponsibleTeamMapping);
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ManualResponsibleTeamIds).PropertyValue.ShouldBe("401");
+    }
+
+    private static OctopusImportActionMappingContext Context(bool includeSecondTeam)
+    {
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("Teams-1", "Release approvers"), 401);
+
+        if (includeSecondTeam)
+            idMap.AddReused(Resource("Teams-2", "SRE"), 402);
+
+        return new OctopusImportActionMappingContext(idMap, 7);
+    }
+
+    private static OctopusResourceNode Resource(string sourceId, string name)
+        => new(
+            sourceId,
+            name,
+            OctopusResourceKind.Team,
+            OctopusDocumentKind.Team,
+            $"{sourceId}.json",
+            null,
+            null,
+            false,
+            new OctopusTeamDto());
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusScriptActionMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusScriptActionMapperTests.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping.Actions;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Constants;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping.Actions;
+
+public class OctopusScriptActionMapperTests
+{
+    private readonly OctopusScriptActionMapper _mapper = new();
+
+    [Fact]
+    public void Map_MapsSyntaxSourceBodyAndPackageReference()
+    {
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "Actions-1",
+            Name = "Run script",
+            ActionType = "Octopus.Script",
+            Properties =
+            {
+                ["Octopus.Action.Script.ScriptSource"] = "Inline",
+                ["Octopus.Action.Script.Syntax"] = "PowerShell",
+                ["Octopus.Action.Script.ScriptBody"] = "Write-Host #{Greeting}",
+                ["Octopus.Action.Package.FeedId"] = "Feeds-1",
+                ["Octopus.Action.Package.PackageId"] = "#{PackageId}",
+                ["Octopus.Action.Package.PackageVersion"] = "#{PackageVersion}"
+            }
+        };
+
+        var result = _mapper.Map(action, Context());
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Action.ActionType.ShouldBe(SpecialVariables.ActionTypes.Script);
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ScriptSource).PropertyValue.ShouldBe("Inline");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ScriptSyntax).PropertyValue.ShouldBe("PowerShell");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ScriptBody).PropertyValue.ShouldBe("Write-Host #{Greeting}");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageFeedId).PropertyValue.ShouldBe("301");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageId).PropertyValue.ShouldBe("#{PackageId}");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageVersion).PropertyValue.ShouldBe("#{PackageVersion}");
+    }
+
+    [Fact]
+    public void Map_MapsPackageReferenceFromActionPackages()
+    {
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "Actions-2",
+            Name = "Run packaged script",
+            ActionType = "Octopus.Script",
+            Packages =
+            [
+                new OctopusActionPackageDto
+                {
+                    FeedId = "Feeds-1",
+                    PackageId = "Acme.Tools",
+                    Version = "1.2.3"
+                }
+            ]
+        };
+
+        var result = _mapper.Map(action, Context());
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageFeedId).PropertyValue.ShouldBe("301");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageId).PropertyValue.ShouldBe("Acme.Tools");
+        result.Action.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageVersion).PropertyValue.ShouldBe("1.2.3");
+    }
+
+    [Fact]
+    public void Map_WhenPackageFeedMappingIsMissing_AddsBlocker()
+    {
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "Actions-3",
+            Name = "Run script",
+            ActionType = "Octopus.Script",
+            Properties =
+            {
+                ["Octopus.Action.Package.FeedId"] = "Feeds-Missing",
+                ["Octopus.Action.Package.PackageId"] = "Acme.Tools"
+            }
+        };
+
+        var result = _mapper.Map(action, Context());
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportActionMappingDiagnosticCodes.MissingPackageFeedMapping);
+        result.Diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        result.Action.Properties.ShouldNotContain(p => p.PropertyName == SpecialVariables.Action.PackageFeedId);
+    }
+
+    [Fact]
+    public void Map_WhenSyntaxIsUnsupported_AddsBlocker()
+    {
+        var action = new OctopusDeploymentActionDto
+        {
+            Id = "Actions-4",
+            Name = "Run script",
+            ActionType = "Octopus.Script",
+            Properties =
+            {
+                ["Octopus.Action.Script.Syntax"] = "Ruby"
+            }
+        };
+
+        var result = _mapper.Map(action, Context());
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportActionMappingDiagnosticCodes.UnsupportedScriptSyntax);
+        result.Action.Properties.ShouldNotContain(p => p.PropertyName == SpecialVariables.Action.ScriptSyntax);
+    }
+
+    private static OctopusImportActionMappingContext Context()
+    {
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource("Feeds-1", OctopusResourceKind.Feed, "Built-in feed", new OctopusFeedDto()), 301);
+        return new OctopusImportActionMappingContext(idMap, 7);
+    }
+
+    private static OctopusResourceNode Resource(
+        string sourceId,
+        OctopusResourceKind kind,
+        string name,
+        object source)
+        => new(
+            sourceId,
+            name,
+            kind,
+            OctopusDocumentKind.DeploymentProcess,
+            $"{sourceId}.json",
+            null,
+            null,
+            false,
+            source);
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapperTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Mapping;
+using Squid.Core.Services.OctopusImport.Mapping.Actions;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -125,6 +126,67 @@ public class OctopusImportDeploymentProcessMapperTests
         result.HasBlockers.ShouldBeFalse();
         result.Steps.Single().CreateCommand.Step.Actions.Single().ActionType.ShouldBe(SpecialVariables.ActionTypes.Script);
         result.Steps.Single().CreateCommand.Step.Properties.Single(p => p.PropertyName == SpecialVariables.Step.RunOnServer).PropertyValue.ShouldBe("true");
+    }
+
+    [Fact]
+    public void MapToCreateStepCommands_UsesRegisteredActionMappersForScriptAndManualActions()
+    {
+        var mapper = new OctopusImportDeploymentProcessMapper(
+            new OctopusImportActionMapperRegistry([
+                new OctopusScriptActionMapper(),
+                new OctopusManualActionMapper()
+            ]));
+        var process = Process(new OctopusDeploymentStepDto
+        {
+            Id = "Steps-1",
+            Name = "Script and approval",
+            Actions =
+            [
+                new OctopusDeploymentActionDto
+                {
+                    Id = "Actions-Script",
+                    Name = "Run script",
+                    ActionType = "Octopus.Script",
+                    IsRequired = true,
+                    Properties =
+                    {
+                        ["Octopus.Action.Script.Syntax"] = "Bash",
+                        ["Octopus.Action.Script.ScriptBody"] = "echo #{Greeting}",
+                        ["Octopus.Action.Package.FeedId"] = "Feeds-1",
+                        ["Octopus.Action.Package.PackageId"] = "Acme.Tools"
+                    }
+                },
+                new OctopusDeploymentActionDto
+                {
+                    Id = "Actions-Manual",
+                    Name = "Approval",
+                    ActionType = "Octopus.Manual",
+                    IsRequired = true,
+                    Properties =
+                    {
+                        ["Octopus.Action.Manual.Instructions"] = "Approve #{Release.Number}",
+                        ["Octopus.Action.Manual.ResponsibleTeamIds"] = "Teams-1"
+                    }
+                }
+            ]
+        });
+
+        var result = mapper.MapToCreateStepCommands(Resource(process), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        var actions = result.Steps.Single().CreateCommand.Step.Actions;
+
+        var scriptAction = actions.Single(a => a.Name == "Run script");
+        scriptAction.ActionType.ShouldBe(SpecialVariables.ActionTypes.Script);
+        scriptAction.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ScriptSyntax).PropertyValue.ShouldBe("Bash");
+        scriptAction.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ScriptBody).PropertyValue.ShouldBe("echo #{Greeting}");
+        scriptAction.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageFeedId).PropertyValue.ShouldBe("301");
+        scriptAction.Properties.Single(p => p.PropertyName == SpecialVariables.Action.PackageId).PropertyValue.ShouldBe("Acme.Tools");
+
+        var manualAction = actions.Single(a => a.Name == "Approval");
+        manualAction.ActionType.ShouldBe(SpecialVariables.ActionTypes.Manual);
+        manualAction.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ManualInstructions).PropertyValue.ShouldBe("Approve #{Release.Number}");
+        manualAction.Properties.Single(p => p.PropertyName == SpecialVariables.Action.ManualResponsibleTeamIds).PropertyValue.ShouldBe("401");
     }
 
     [Fact]
@@ -276,6 +338,8 @@ public class OctopusImportDeploymentProcessMapperTests
         idMap.AddReused(Resource("Environments-1", OctopusResourceKind.Environment, "Production", new OctopusEnvironmentDto()), 101);
         idMap.AddReused(Resource("Environments-2", OctopusResourceKind.Environment, "Staging", new OctopusEnvironmentDto()), 102);
         idMap.AddReused(Resource("Channels-1", OctopusResourceKind.Channel, "Default", new OctopusChannelDto()), 201);
+        idMap.AddReused(Resource("Feeds-1", OctopusResourceKind.Feed, "Built-in feed", new OctopusFeedDto()), 301);
+        idMap.AddReused(Resource("Teams-1", OctopusResourceKind.Team, "Release approvers", new OctopusTeamDto()), 401);
         return idMap;
     }
 


### PR DESCRIPTION
## Summary

- Implemented `Octopus.Script` and `Octopus.Manual` action mappers and integrated them with the existing 5.1 registry/contract.

- `Script` mappings cover syntax/source/body, single package references, feed ID remaps, and variable expressions are preserved as is.

- `Manual` mappings cover instructions, responsible team remaps, and unresolved team blockers.

- Updated [OctopusImportDeploymentProcessMapper.cs](/Users/mindy/Documents/repo/Squid-script/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs), delegating only to registered action mappers; not extended to 5.2/5.3/5.6/5.7/5.8.

- Updated [SESSION_MEMORY.md](/Users/mindy/Documents/repo/Squid-script/SESSION_MEMORY.md); this file was ignored by git exclude but was actually written.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --no-restore --filter "FullyQualifiedName~OctopusImport"` passed: 195 passed, 0 failed.

- [x] Confirmed the current branch is still `codex/octopus-script-manual-action-mapping`.

- [x] Confirmed git status only contains changes related to Octopus import mapping/tests.

- [ ] OpenSpec artifacts not updated because `openspec/changes/add-octopus-import` does not exist in the current worktree, and the CLI also reports that this change does not exist.