### PR TITLE
Runtime handler validation for imported actions

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
@@ -8,6 +8,7 @@ public static class OctopusImportActionMappingDiagnosticCodes
     public const string DuplicateActionMapperRegistration = "OctopusImport.Action.DuplicateActionMapperRegistration";
     public const string UnsupportedActionSkipped = "OctopusImport.Action.UnsupportedActionSkipped";
     public const string UnsupportedActionPlaceholderCreated = "OctopusImport.Action.UnsupportedActionPlaceholderCreated";
+    public const string MissingRuntimeActionHandler = "OctopusImport.Action.MissingRuntimeActionHandler";
     public const string ActionPropertiesOmitted = "OctopusImport.Action.PropertiesOmitted";
     public const string SensitiveActionPropertyValueOmitted = "OctopusImport.Action.SensitivePropertyValueOmitted";
     public const string UnsupportedScriptSyntax = "OctopusImport.Action.Script.UnsupportedSyntax";

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportBuiltInActionMappers.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportBuiltInActionMappers.cs
@@ -8,22 +8,6 @@ using Squid.Message.Models.OctopusImport;
 
 namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
 
-public sealed class OctopusImportScriptActionMapper : OctopusImportTypeOnlyActionMapper
-{
-    public OctopusImportScriptActionMapper()
-        : base("Octopus.Script", SpecialVariables.ActionTypes.Script)
-    {
-    }
-}
-
-public sealed class OctopusImportManualActionMapper : OctopusImportTypeOnlyActionMapper
-{
-    public OctopusImportManualActionMapper()
-        : base("Octopus.Manual", SpecialVariables.ActionTypes.Manual)
-    {
-    }
-}
-
 public sealed class OctopusImportIisActionMapper : IOctopusImportActionMapper
 {
     private static readonly IReadOnlySet<string> AllowedProperties =

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportRuntimeActionHandlerValidator.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportRuntimeActionHandlerValidator.cs
@@ -1,0 +1,73 @@
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
+
+public interface IOctopusImportRuntimeActionHandlerValidator : IScopedDependency
+{
+    IReadOnlyList<OctopusImportDiagnosticDto> Validate(
+        OctopusDeploymentActionDto sourceAction,
+        CreateOrUpdateDeploymentActionModel mappedAction);
+}
+
+public sealed class OctopusImportRuntimeActionHandlerValidator : IOctopusImportRuntimeActionHandlerValidator
+{
+    private readonly IActionHandlerRegistry _runtimeActionHandlerRegistry;
+
+    public OctopusImportRuntimeActionHandlerValidator(IActionHandlerRegistry runtimeActionHandlerRegistry)
+    {
+        _runtimeActionHandlerRegistry = runtimeActionHandlerRegistry
+            ?? throw new ArgumentNullException(nameof(runtimeActionHandlerRegistry));
+    }
+
+    public IReadOnlyList<OctopusImportDiagnosticDto> Validate(
+        OctopusDeploymentActionDto sourceAction,
+        CreateOrUpdateDeploymentActionModel mappedAction)
+    {
+        ArgumentNullException.ThrowIfNull(sourceAction);
+
+        if (mappedAction == null || mappedAction.IsDisabled)
+            return [];
+
+        var runtimeAction = ToRuntimeAction(mappedAction);
+        if (_runtimeActionHandlerRegistry.Resolve(runtimeAction) != null)
+            return [];
+
+        return
+        [
+            new OctopusImportDiagnosticDto
+            {
+                Severity = OctopusImportCompatibilitySeverity.Blocker,
+                Code = OctopusImportActionMappingDiagnosticCodes.MissingRuntimeActionHandler,
+                Message = $"Mapped Octopus action '{sourceAction.Name}' produces enabled Squid action type '{mappedAction.ActionType}', but no registered Squid runtime action handler can handle it.",
+                ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
+                SourceId = sourceAction.Id,
+                ResourceName = sourceAction.Name
+            }
+        ];
+    }
+
+    private static DeploymentActionDto ToRuntimeAction(CreateOrUpdateDeploymentActionModel action)
+        => new()
+        {
+            Name = action.Name,
+            ActionType = action.ActionType,
+            WorkerPoolId = action.WorkerPoolId,
+            IsDisabled = action.IsDisabled,
+            IsRequired = action.IsRequired,
+            CanBeUsedForProjectVersioning = action.CanBeUsedForProjectVersioning,
+            Properties = (action.Properties ?? [])
+                .Select(p => new DeploymentActionPropertyDto
+                {
+                    PropertyName = p.PropertyName,
+                    PropertyValue = p.PropertyValue
+                })
+                .ToList(),
+            Environments = action.Environments?.ToList() ?? [],
+            ExcludedEnvironments = action.ExcludedEnvironments?.ToList() ?? [],
+            Channels = action.Channels?.ToList() ?? []
+        };
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs
@@ -26,15 +26,19 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
     private const string OctopusMaxParallelismPropertyName = "Octopus.Action.MaxParallelism";
     private const string OctopusTimeoutPropertyName = "Octopus.Action.Timeout";
     private readonly IOctopusImportActionMapperRegistry _actionMapperRegistry;
+    private readonly IOctopusImportRuntimeActionHandlerValidator _runtimeActionHandlerValidator;
 
     public OctopusImportDeploymentProcessMapper()
         : this(new OctopusImportActionMapperRegistry([]))
     {
     }
     
-    public OctopusImportDeploymentProcessMapper(IOctopusImportActionMapperRegistry actionMapperRegistry = null)
+    public OctopusImportDeploymentProcessMapper(
+        IOctopusImportActionMapperRegistry actionMapperRegistry = null,
+        IOctopusImportRuntimeActionHandlerValidator runtimeActionHandlerValidator = null)
     {
         _actionMapperRegistry = actionMapperRegistry ?? throw new ArgumentNullException(nameof(actionMapperRegistry));
+        _runtimeActionHandlerValidator = runtimeActionHandlerValidator;
     }
 
     public OctopusImportDeploymentProcessMappingResult MapToCreateStepCommands(
@@ -57,7 +61,15 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         var diagnostics = new List<OctopusImportDiagnosticDto>();
         var destinationProcessId = MapDestinationProcessId(process, idMap, deploymentProcessResource, diagnostics);
         var steps = (process.Steps ?? [])
-            .Select((step, index) => MapStep(step, index, destinationProcessId, destinationSpaceId, idMap, diagnostics, _actionMapperRegistry))
+            .Select((step, index) => MapStep(
+                step,
+                index,
+                destinationProcessId,
+                destinationSpaceId,
+                idMap,
+                diagnostics,
+                _actionMapperRegistry,
+                _runtimeActionHandlerValidator))
             .ToList();
 
         return new OctopusImportDeploymentProcessMappingResult(steps, diagnostics);
@@ -88,7 +100,8 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         int destinationSpaceId,
         OctopusImportIdMap idMap,
         List<OctopusImportDiagnosticDto> diagnostics,
-        IOctopusImportActionMapperRegistry actionMapperRegistry)
+        IOctopusImportActionMapperRegistry actionMapperRegistry,
+        IOctopusImportRuntimeActionHandlerValidator runtimeActionHandlerValidator)
     {
         var actionMappingContext = new OctopusImportActionMappingContext(
             idMap,
@@ -98,7 +111,14 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         var actions = new List<ActionMapping>();
         foreach (var (action, actionIndex) in (step.Actions ?? []).Select((action, actionIndex) => (action, actionIndex)))
         {
-            var mappedAction = MapAction(action, actionIndex, idMap, diagnostics, actionMappingContext, actionMapperRegistry);
+            var mappedAction = MapAction(
+                action,
+                actionIndex,
+                idMap,
+                diagnostics,
+                actionMappingContext,
+                actionMapperRegistry,
+                runtimeActionHandlerValidator);
             if (mappedAction != null)
                 actions.Add(mappedAction);
         }
@@ -145,7 +165,8 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         OctopusImportIdMap idMap,
         List<OctopusImportDiagnosticDto> diagnostics,
         OctopusImportActionMappingContext actionMappingContext,
-        IOctopusImportActionMapperRegistry actionMapperRegistry)
+        IOctopusImportActionMapperRegistry actionMapperRegistry,
+        IOctopusImportRuntimeActionHandlerValidator runtimeActionHandlerValidator)
     {
         var mappingResult = actionMapperRegistry.Map(action, actionMappingContext);
         diagnostics.AddRange(mappingResult.Diagnostics);
@@ -167,6 +188,8 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         AddUnsupportedVariableScopeDiagnostics(action, diagnostics);
         AddUnsupportedTenantDiagnostics(action, diagnostics);
         AddUnsupportedActionConditionDiagnostic(action, diagnostics);
+        if (runtimeActionHandlerValidator != null)
+            diagnostics.AddRange(runtimeActionHandlerValidator.Validate(action, model));
 
         return new ActionMapping(action, actionIndex, model);
     }

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusImportRuntimeActionHandlerValidatorTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/Actions/OctopusImportRuntimeActionHandlerValidatorTests.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+using Squid.Core.Services.DeploymentExecution.Handlers;
+using Squid.Core.Services.OctopusImport.Mapping.Actions;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Constants;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping.Actions;
+
+public class OctopusImportRuntimeActionHandlerValidatorTests
+{
+    [Fact]
+    public void Validate_WhenEnabledActionHasRuntimeHandler_ReturnsNoDiagnostics()
+    {
+        var handler = Mock.Of<IActionHandler>();
+        var registry = new Mock<IActionHandlerRegistry>();
+        registry
+            .Setup(r => r.Resolve(It.Is<DeploymentActionDto>(a =>
+                a.Name == "Run script"
+                && a.ActionType == SpecialVariables.ActionTypes.Script
+                && a.Properties.Single().PropertyName == SpecialVariables.Action.ScriptBody
+                && a.Properties.Single().PropertyValue == "echo hello"
+                && a.Environments.SequenceEqual(new[] { 101 })
+                && a.Channels.SequenceEqual(new[] { 201 }))))
+            .Returns(handler);
+        var validator = new OctopusImportRuntimeActionHandlerValidator(registry.Object);
+
+        var diagnostics = validator.Validate(SourceAction(), new CreateOrUpdateDeploymentActionModel
+        {
+            Name = "Run script",
+            ActionType = SpecialVariables.ActionTypes.Script,
+            IsDisabled = false,
+            Properties =
+            [
+                new ActionPropertyModel
+                {
+                    PropertyName = SpecialVariables.Action.ScriptBody,
+                    PropertyValue = "echo hello"
+                }
+            ],
+            Environments = [101],
+            Channels = [201]
+        });
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenEnabledActionHasNoRuntimeHandler_ReturnsBlocker()
+    {
+        var registry = new Mock<IActionHandlerRegistry>();
+        registry.Setup(r => r.Resolve(It.IsAny<DeploymentActionDto>())).Returns((IActionHandler)null);
+        var validator = new OctopusImportRuntimeActionHandlerValidator(registry.Object);
+
+        var diagnostics = validator.Validate(SourceAction(), new CreateOrUpdateDeploymentActionModel
+        {
+            Name = "Run script",
+            ActionType = "Squid.UnknownMappedAction"
+        });
+
+        diagnostics.Single().Severity.ShouldBe(OctopusImportCompatibilitySeverity.Blocker);
+        diagnostics.Single().Code.ShouldBe(OctopusImportActionMappingDiagnosticCodes.MissingRuntimeActionHandler);
+        diagnostics.Single().SourceId.ShouldBe("Actions-1");
+        diagnostics.Single().ResourceName.ShouldBe("Run script");
+    }
+
+    [Fact]
+    public void Validate_WhenMappedActionIsDisabled_DoesNotAskRuntimeRegistry()
+    {
+        var registry = new Mock<IActionHandlerRegistry>();
+        var validator = new OctopusImportRuntimeActionHandlerValidator(registry.Object);
+
+        var diagnostics = validator.Validate(SourceAction(), new CreateOrUpdateDeploymentActionModel
+        {
+            Name = "Unsupported placeholder",
+            ActionType = SpecialVariables.ActionTypes.Script,
+            IsDisabled = true
+        });
+
+        diagnostics.ShouldBeEmpty();
+        registry.Verify(r => r.Resolve(It.IsAny<DeploymentActionDto>()), Times.Never);
+    }
+
+    [Fact]
+    public void Validate_WhenMappedActionIsSkipped_DoesNotAskRuntimeRegistry()
+    {
+        var registry = new Mock<IActionHandlerRegistry>();
+        var validator = new OctopusImportRuntimeActionHandlerValidator(registry.Object);
+
+        var diagnostics = validator.Validate(SourceAction(), null);
+
+        diagnostics.ShouldBeEmpty();
+        registry.Verify(r => r.Resolve(It.IsAny<DeploymentActionDto>()), Times.Never);
+    }
+
+    private static OctopusDeploymentActionDto SourceAction()
+        => new()
+        {
+            Id = "Actions-1",
+            Name = "Run script",
+            ActionType = "Octopus.Script"
+        };
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapperTests.cs
@@ -1,10 +1,12 @@
 using System.Linq;
+using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Mapping;
 using Squid.Core.Services.OctopusImport.Mapping.Actions;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Process;
 
 namespace Squid.UnitTests.Services.OctopusImport.Mapping;
 
@@ -440,6 +442,96 @@ public class OctopusImportDeploymentProcessMapperTests
     }
 
     [Fact]
+    public void MapToCreateStepCommands_WhenEnabledMappedActionHasNoRuntimeHandler_AddsBlocker()
+    {
+        var mapper = new OctopusImportDeploymentProcessMapper(
+            new OctopusImportActionMapperRegistry([new OctopusScriptActionMapper()]),
+            new OctopusImportRuntimeActionHandlerValidator(new ActionHandlerRegistry([])));
+        var process = Process(new OctopusDeploymentStepDto
+        {
+            Id = "Steps-1",
+            Name = "Script",
+            Actions =
+            [
+                new OctopusDeploymentActionDto
+                {
+                    Id = "Actions-Script",
+                    Name = "Run script",
+                    ActionType = "Octopus.Script",
+                    Properties =
+                    {
+                        ["Octopus.Action.Script.ScriptBody"] = "echo hello"
+                    }
+                }
+            ]
+        });
+
+        var result = mapper.MapToCreateStepCommands(Resource(process), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportActionMappingDiagnosticCodes.MissingRuntimeActionHandler);
+    }
+
+    [Fact]
+    public void MapToCreateStepCommands_WhenEnabledMappedActionHasRuntimeHandler_DoesNotAddRuntimeBlocker()
+    {
+        var mapper = new OctopusImportDeploymentProcessMapper(
+            new OctopusImportActionMapperRegistry([new OctopusScriptActionMapper()]),
+            new OctopusImportRuntimeActionHandlerValidator(new ActionHandlerRegistry([RuntimeHandler(SpecialVariables.ActionTypes.Script)])));
+        var process = Process(new OctopusDeploymentStepDto
+        {
+            Id = "Steps-1",
+            Name = "Script",
+            Actions =
+            [
+                new OctopusDeploymentActionDto
+                {
+                    Id = "Actions-Script",
+                    Name = "Run script",
+                    ActionType = "Octopus.Script",
+                    Properties =
+                    {
+                        ["Octopus.Action.Script.ScriptBody"] = "echo hello"
+                    }
+                }
+            ]
+        });
+
+        var result = mapper.MapToCreateStepCommands(Resource(process), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Diagnostics.Select(d => d.Code).ShouldNotContain(OctopusImportActionMappingDiagnosticCodes.MissingRuntimeActionHandler);
+    }
+
+    [Fact]
+    public void MapToCreateStepCommands_WhenUnsupportedActionCreatesDisabledPlaceholder_DoesNotRequireRuntimeHandler()
+    {
+        var mapper = new OctopusImportDeploymentProcessMapper(
+            new OctopusImportActionMapperRegistry([]),
+            new OctopusImportRuntimeActionHandlerValidator(new ActionHandlerRegistry([])));
+        var process = Process(new OctopusDeploymentStepDto
+        {
+            Id = "Steps-1",
+            Name = "Unsupported",
+            Actions =
+            [
+                new OctopusDeploymentActionDto
+                {
+                    Id = "Actions-Unknown",
+                    Name = "Community step",
+                    ActionType = "Octopus.CustomCommunityStep"
+                }
+            ]
+        });
+
+        var result = mapper.MapToCreateStepCommands(Resource(process), IdMap(), 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportActionMappingDiagnosticCodes.UnsupportedActionPlaceholderCreated);
+        result.Diagnostics.Select(d => d.Code).ShouldNotContain(OctopusImportActionMappingDiagnosticCodes.MissingRuntimeActionHandler);
+    }
+
+    [Fact]
     public void MapToCreateStepCommands_WhenResourceIsNotDeploymentProcess_Throws()
     {
         Should.Throw<ArgumentException>(() => _mapper.MapToCreateStepCommands(
@@ -511,11 +603,20 @@ public class OctopusImportDeploymentProcessMapperTests
         [
             new OctopusKubernetesDeployContainersActionMapper(),
             new OctopusKubernetesDeployIngressActionMapper(),
-            new OctopusImportScriptActionMapper(),
-            new OctopusImportManualActionMapper(),
+            new OctopusScriptActionMapper(),
+            new OctopusManualActionMapper(),
             new OctopusImportIisActionMapper(),
             new OctopusImportWindowsServiceActionMapper(),
             new OctopusImportDeployWindowsServiceActionMapper(),
             new OctopusImportWindowsServiceDeployActionMapper()
         ];
+
+    private static IActionHandler RuntimeHandler(string actionType)
+    {
+        var handler = new Mock<IActionHandler>();
+        handler.Setup(h => h.ActionType).Returns(actionType);
+        handler.Setup(h => h.CanHandle(It.IsAny<DeploymentActionDto>()))
+            .Returns<DeploymentActionDto>(a => string.Equals(a?.ActionType, actionType, StringComparison.OrdinalIgnoreCase));
+        return handler.Object;
+    }
 }


### PR DESCRIPTION
## Summary

- Implemented Octopus import 5.8 runtime handler validation for enabled mapped actions.
- Added `IOctopusImportRuntimeActionHandlerValidator`, which projects mapped import actions to `DeploymentActionDto` and reuses runtime `IActionHandlerRegistry.Resolve`.
- Added blocker diagnostic `OctopusImport.Action.MissingRuntimeActionHandler` for enabled mapped actions with no runtime handler or failed `CanHandle`.
- Disabled unsupported placeholders and skipped unsupported actions are not runtime-handler blockers.
- Removed obsolete type-only script/manual mapper concrete classes to avoid duplicate DI registrations with the 5.4/5.5 concrete mappers.
- Updated `SESSION_MEMORY.md` and marked OpenSpec task 5.8 complete; no Chapter 6 work was started.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~OctopusImportRuntimeActionHandlerValidatorTests|FullyQualifiedName~OctopusImportDeploymentProcessMapperTests|FullyQualifiedName~OctopusImportActionMapperRegistryTests" --no-restore --no-build /m:1` passed: 23/23.