### PR TITLE
Central secret redaction service for Octopus import

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperRegistry.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMapperRegistry.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -12,7 +13,7 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
     internal const string PlaceholderSourceNameProperty = "Squid.Import.Octopus.SourceAction.Name";
     internal const string PlaceholderSourceSlugProperty = "Squid.Import.Octopus.SourceAction.Slug";
     internal const string PlaceholderSourceActionTypeProperty = "Squid.Import.Octopus.SourceAction.Type";
-    internal const string RedactedValue = "[redacted]";
+    internal const string RedactedValue = OctopusImportRedaction.RedactedValue;
 
     private readonly IReadOnlyDictionary<string, IOctopusImportActionMapper> _mappers;
 
@@ -41,7 +42,7 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
 
         if (!_mappers.TryGetValue(actionType, out var mapper))
         {
-            var redactedActionType = RedactMetadataValue(PlaceholderSourceActionTypeProperty, action.ActionType);
+            var redactedActionType = OctopusImportRedaction.RedactMetadataValue(PlaceholderSourceActionTypeProperty, action.ActionType);
             return Unsupported(
                 action,
                 OctopusImportActionMappingDiagnosticCodes.UnsupportedActionType,
@@ -95,15 +96,15 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
         string message,
         OctopusImportUnsupportedActionHandling handling)
     {
-        var redactedActionName = RedactMetadataValue(PlaceholderSourceNameProperty, action.Name);
-        var redactedSourceId = RedactMetadataValue(PlaceholderSourceIdProperty, action.Id);
+        var redactedActionName = OctopusImportRedaction.RedactMetadataValue(PlaceholderSourceNameProperty, action.Name);
+        var redactedSourceId = OctopusImportRedaction.RedactMetadataValue(PlaceholderSourceIdProperty, action.Id);
         var displayName = string.IsNullOrWhiteSpace(redactedActionName)
             ? "unsupported Octopus action"
             : redactedActionName;
 
         var diagnostics = new List<OctopusImportDiagnosticDto>
         {
-            new()
+            OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
             {
                 Severity = OctopusImportCompatibilitySeverity.Warning,
                 Code = code,
@@ -111,12 +112,12 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
                 ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
                 SourceId = redactedSourceId,
                 ResourceName = redactedActionName
-            }
+            })
         };
 
         if (handling == OctopusImportUnsupportedActionHandling.DisabledPlaceholder)
         {
-            diagnostics.Add(new OctopusImportDiagnosticDto
+            diagnostics.Add(OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
             {
                 Severity = OctopusImportCompatibilitySeverity.Warning,
                 Code = OctopusImportActionMappingDiagnosticCodes.UnsupportedActionPlaceholderCreated,
@@ -124,12 +125,12 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
                 ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
                 SourceId = redactedSourceId,
                 ResourceName = redactedActionName
-            });
+            }));
 
             return new OctopusImportActionMappingResult(CreateDisabledPlaceholder(action), diagnostics);
         }
 
-        diagnostics.Add(new OctopusImportDiagnosticDto
+        diagnostics.Add(OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = OctopusImportCompatibilitySeverity.Warning,
             Code = OctopusImportActionMappingDiagnosticCodes.UnsupportedActionSkipped,
@@ -137,7 +138,7 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
             ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
             SourceId = redactedSourceId,
             ResourceName = redactedActionName
-        });
+        }));
 
         return new OctopusImportActionMappingResult(null, diagnostics);
     }
@@ -145,9 +146,9 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
     private static CreateOrUpdateDeploymentActionModel CreateDisabledPlaceholder(OctopusDeploymentActionDto action)
         => new()
         {
-            Name = string.IsNullOrWhiteSpace(RedactMetadataValue(PlaceholderSourceNameProperty, action.Name))
+            Name = string.IsNullOrWhiteSpace(OctopusImportRedaction.RedactMetadataValue(PlaceholderSourceNameProperty, action.Name))
                 ? "Unsupported Octopus action"
-                : RedactMetadataValue(PlaceholderSourceNameProperty, action.Name),
+                : OctopusImportRedaction.RedactMetadataValue(PlaceholderSourceNameProperty, action.Name),
             ActionType = SpecialVariables.ActionTypes.Script,
             IsDisabled = true,
             IsRequired = action.IsRequired,
@@ -165,26 +166,6 @@ public class OctopusImportActionMapperRegistry : IOctopusImportActionMapperRegis
         => new()
         {
             PropertyName = propertyName,
-            PropertyValue = RedactMetadataValue(propertyName, value)
+            PropertyValue = OctopusImportRedaction.RedactMetadataValue(propertyName, value)
         };
-
-    internal static string RedactMetadataValue(string propertyName, string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return string.Empty;
-
-        return LooksSensitive(propertyName) || LooksSensitive(value)
-            ? RedactedValue
-            : value.Trim();
-    }
-
-    private static bool LooksSensitive(string value)
-        => value.Contains("password", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("secret", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("token", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("credential", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("certificate", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("pfx", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("privatekey", StringComparison.OrdinalIgnoreCase)
-           || value.Contains("private-key", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportActionMappingDiagnosticCodes.cs
@@ -1,3 +1,5 @@
+using Squid.Core.Services.OctopusImport;
+
 namespace Squid.Core.Services.OctopusImport.Mapping.Actions;
 
 public static class OctopusImportActionMappingDiagnosticCodes
@@ -10,7 +12,7 @@ public static class OctopusImportActionMappingDiagnosticCodes
     public const string UnsupportedActionPlaceholderCreated = "OctopusImport.Action.UnsupportedActionPlaceholderCreated";
     public const string MissingRuntimeActionHandler = "OctopusImport.Action.MissingRuntimeActionHandler";
     public const string ActionPropertiesOmitted = "OctopusImport.Action.PropertiesOmitted";
-    public const string SensitiveActionPropertyValueOmitted = "OctopusImport.Action.SensitivePropertyValueOmitted";
+    public const string SensitiveActionPropertyValueOmitted = OctopusImportRedactionDiagnosticCodes.SensitiveActionPropertyValueOmitted;
     public const string UnsupportedScriptSyntax = "OctopusImport.Action.Script.UnsupportedSyntax";
     public const string MissingPackageFeedMapping = "OctopusImport.Action.Script.MissingPackageFeedMapping";
     public const string MultiplePackageReferencesUnsupported = "OctopusImport.Action.Script.MultiplePackageReferencesUnsupported";

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportBuiltInActionMappers.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportBuiltInActionMappers.cs
@@ -1,5 +1,6 @@
 using Squid.Core.Services.DeploymentExecution;
 using Squid.Core.Services.DeploymentExecution.Tentacle.Handlers;
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -294,7 +295,7 @@ internal static class OctopusImportActionMapperHelper
         string code,
         string message,
         OctopusDeploymentActionDto action)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -302,5 +303,5 @@ internal static class OctopusImportActionMapperHelper
             ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
             SourceId = action.Id,
             ResourceName = action.Name
-        };
+        });
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportKubernetesActionMapperSupport.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportKubernetesActionMapperSupport.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Squid.Core.Services.DeploymentExecution.Kubernetes;
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -263,7 +264,7 @@ internal static class OctopusImportKubernetesActionMapperSupport
         string code,
         string message,
         OctopusDeploymentActionDto action)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -271,5 +272,5 @@ internal static class OctopusImportKubernetesActionMapperSupport
             ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
             SourceId = action.Id,
             ResourceName = action.Name
-        };
+        });
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportRuntimeActionHandlerValidator.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusImportRuntimeActionHandlerValidator.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.DeploymentExecution.Handlers;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Enums.OctopusImport;
@@ -38,7 +39,7 @@ public sealed class OctopusImportRuntimeActionHandlerValidator : IOctopusImportR
 
         return
         [
-            new OctopusImportDiagnosticDto
+            OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
             {
                 Severity = OctopusImportCompatibilitySeverity.Blocker,
                 Code = OctopusImportActionMappingDiagnosticCodes.MissingRuntimeActionHandler,
@@ -46,7 +47,7 @@ public sealed class OctopusImportRuntimeActionHandlerValidator : IOctopusImportR
                 ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
                 SourceId = sourceAction.Id,
                 ResourceName = sourceAction.Name
-            }
+            })
         ];
     }
 

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusManualActionMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusManualActionMapper.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -122,7 +123,7 @@ public sealed class OctopusManualActionMapper : IOctopusImportActionMapper
         string code,
         string message,
         OctopusDeploymentActionDto action)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -130,5 +131,5 @@ public sealed class OctopusManualActionMapper : IOctopusImportActionMapper
             ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
             SourceId = action.Id,
             ResourceName = action.Name
-        };
+        });
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusScriptActionMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/Actions/OctopusScriptActionMapper.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Constants;
 using Squid.Message.Enums.OctopusImport;
@@ -177,7 +178,7 @@ public sealed class OctopusScriptActionMapper : IOctopusImportActionMapper
         string code,
         string message,
         OctopusDeploymentActionDto action)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -185,7 +186,7 @@ public sealed class OctopusScriptActionMapper : IOctopusImportActionMapper
             ResourceType = OctopusResourceKind.DeploymentAction.ToString(),
             SourceId = action.Id,
             ResourceName = action.Name
-        };
+        });
 
     private sealed record PackageReference(string PackageId, string FeedId, string Version);
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportDeploymentProcessMapper.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Mapping.Actions;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Commands.Deployments.Process.Step;
@@ -419,7 +420,7 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
         OctopusResourceKind resourceKind,
         string sourceId,
         string resourceName)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -427,7 +428,7 @@ public class OctopusImportDeploymentProcessMapper : IOctopusImportDeploymentProc
             ResourceType = resourceKind.ToString(),
             SourceId = sourceId,
             ResourceName = resourceName
-        };
+        });
 
     private sealed record ActionMapping(
         OctopusDeploymentActionDto SourceAction,

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs
@@ -1,3 +1,4 @@
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Commands.Deployments.ExternalFeed;
 using Squid.Message.Enums.OctopusImport;
@@ -100,7 +101,7 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
             feed.FeedUri,
             feed.Name,
             feed.Slug,
-            BuildProperties(feed),
+            OctopusImportRedaction.RedactProperties(BuildProperties(feed)),
             diagnostics);
     }
 
@@ -167,7 +168,7 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
         string code,
         string message,
         OctopusResourceNode resource)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -175,7 +176,7 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
             ResourceType = resource.Kind.ToString(),
             SourceId = resource.SourceId,
             ResourceName = resource.Name
-        };
+        });
 
     private sealed record FeedCommandMapping(
         string FeedType,

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMappingDiagnosticCodes.cs
@@ -1,7 +1,9 @@
+using Squid.Core.Services.OctopusImport;
+
 namespace Squid.Core.Services.OctopusImport.Mapping;
 
 public static class OctopusImportFeedMappingDiagnosticCodes
 {
-    public const string CredentialsOmitted = "octopus.mapping.feed.credentials_omitted";
+    public const string CredentialsOmitted = OctopusImportRedactionDiagnosticCodes.FeedCredentialsOmitted;
     public const string UnsupportedFeedType = "octopus.mapping.feed.unsupported_feed_type";
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportLifecycleMapper.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Enums.Deployments;
 using Squid.Message.Enums.OctopusImport;
@@ -266,7 +267,7 @@ public class OctopusImportLifecycleMapper : IOctopusImportLifecycleMapper
         string phaseName,
         string message)
     {
-        diagnostics.Add(new OctopusImportDiagnosticDto
+        diagnostics.Add(OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = OctopusImportCompatibilitySeverity.Warning,
             Code = diagnosticCode,
@@ -276,7 +277,7 @@ public class OctopusImportLifecycleMapper : IOctopusImportLifecycleMapper
             ResourceType = resource.Kind.ToString(),
             SourceId = resource.SourceId,
             ResourceName = resource.Name
-        });
+        }));
     }
 
     private static bool? ReadBoolean(IReadOnlyDictionary<string, JsonElement> properties, params string[] names)

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportProjectMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportProjectMapper.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Enums.OctopusImport;
 using Squid.Message.Models.Deployments.Project;
@@ -178,7 +179,7 @@ public class OctopusImportProjectMapper : IOctopusImportProjectMapper
         string code,
         string message,
         OctopusResourceNode resource)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -186,7 +187,7 @@ public class OctopusImportProjectMapper : IOctopusImportProjectMapper
             ResourceType = resource.Kind.ToString(),
             SourceId = resource.SourceId,
             ResourceName = resource.Name
-        };
+        });
 
     private sealed class OctopusProjectImportMetadata
     {

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMapper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Commands.Deployments.Variable;
 using Squid.Message.Enums;
@@ -354,7 +355,7 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
         OctopusResourceKind resourceKind,
         string sourceId,
         string resourceName)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -362,7 +363,7 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
             ResourceType = resourceKind.ToString(),
             SourceId = sourceId,
             ResourceName = resourceName
-        };
+        });
 
     private sealed record VariableSetCommandMapping(
         string Name,

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMappingDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMappingDiagnosticCodes.cs
@@ -1,10 +1,12 @@
+using Squid.Core.Services.OctopusImport;
+
 namespace Squid.Core.Services.OctopusImport.Mapping;
 
 public static class OctopusImportVariableMappingDiagnosticCodes
 {
     public const string MissingProjectMapping = "OctopusImport.Variable.MissingProjectMapping";
     public const string UnsupportedVariableSetOwnerType = "OctopusImport.Variable.UnsupportedVariableSetOwnerType";
-    public const string SensitiveValueOmitted = "OctopusImport.Variable.SensitiveValueOmitted";
+    public const string SensitiveValueOmitted = OctopusImportRedactionDiagnosticCodes.SensitiveVariableValueOmitted;
     public const string UnsupportedVariableType = "OctopusImport.Variable.UnsupportedVariableType";
     public const string PromptDisplaySettingsOmitted = "OctopusImport.Variable.PromptDisplaySettingsOmitted";
     public const string MissingScopeMapping = "OctopusImport.Variable.MissingScopeMapping";

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
@@ -147,7 +147,7 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
     }
 
     private static OctopusImportDiagnosticDto MapDependencyDiagnostic(OctopusInputExtractionDiagnostic diagnostic)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = diagnostic.Severity,
             Code = string.IsNullOrWhiteSpace(diagnostic.Code)
@@ -156,14 +156,14 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
             Message = diagnostic.Message,
             SourceId = diagnostic.SourceId,
             ResourceType = diagnostic.DocumentKind?.ToString()
-        };
+        });
 
     private static OctopusImportDiagnosticDto Diagnostic(
         OctopusImportCompatibilitySeverity severity,
         string code,
         string message,
         OctopusResourceNode resource)
-        => new()
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = severity,
             Code = code,
@@ -171,7 +171,7 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
             ResourceType = resource.Kind.ToString(),
             SourceId = resource.SourceId,
             ResourceName = resource.Name
-        };
+        });
 
     private static bool IsOutOfScope(OctopusResourceKind kind)
         => kind is OctopusResourceKind.Release

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewValidator.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewValidator.cs
@@ -146,7 +146,7 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
 
             if (previewGeneratedAt != default && match.Destination.LastModifiedDate > previewGeneratedAt)
             {
-                result.Diagnostics.Add(new OctopusImportDiagnosticDto
+                result.Diagnostics.Add(OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
                 {
                     Severity = OctopusImportCompatibilitySeverity.Blocker,
                     Code = OctopusImportPreviewDiagnosticCodes.StalePreviewPlan,
@@ -154,7 +154,7 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
                     SourceId = previewResource.SourceId,
                     ResourceType = previewResource.SourceType,
                     ResourceName = previewResource.SourceName
-                });
+                }));
             }
         }
     }
@@ -181,7 +181,7 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
         OctopusImportValidationResultDto result,
         OctopusImportResourceResultDto previewResource)
     {
-        result.Diagnostics.Add(new OctopusImportDiagnosticDto
+        result.Diagnostics.Add(OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = OctopusImportCompatibilitySeverity.Blocker,
             Code = OctopusImportPreviewDiagnosticCodes.IncompatibleSharedResourceReuse,
@@ -189,7 +189,7 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
             SourceId = previewResource.SourceId,
             ResourceType = previewResource.SourceType,
             ResourceName = previewResource.SourceName
-        });
+        }));
     }
 
     private static void AddReferenceDiagnostic(
@@ -198,7 +198,7 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
         string code,
         string message)
     {
-        result.Diagnostics.Add(new OctopusImportDiagnosticDto
+        result.Diagnostics.Add(OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
         {
             Severity = OctopusImportCompatibilitySeverity.Blocker,
             Code = code,
@@ -206,6 +206,6 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
             SourceId = source.SourceId,
             ResourceType = source.Kind.ToString(),
             ResourceName = source.Name
-        });
+        }));
     }
 }

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportRedaction.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportRedaction.cs
@@ -1,0 +1,342 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public interface IOctopusImportRedactionService : IScopedDependency
+{
+    bool ShouldRedactPropertyValue(string propertyName, string value = null);
+
+    string RedactMetadataValue(string propertyName, string value);
+
+    Dictionary<string, string> RedactProperties(IReadOnlyDictionary<string, string> properties);
+
+    string RedactJson(string json);
+
+    T RedactDto<T>(T value) where T : class;
+
+    OctopusImportDiagnosticDto RedactDiagnostic(OctopusImportDiagnosticDto diagnostic);
+
+    OctopusInputExtractionDiagnostic RedactDiagnostic(OctopusInputExtractionDiagnostic diagnostic);
+}
+
+public class OctopusImportRedactionService : IOctopusImportRedactionService
+{
+    public bool ShouldRedactPropertyValue(string propertyName, string value = null)
+        => OctopusImportRedaction.ShouldRedactPropertyValue(propertyName, value);
+
+    public string RedactMetadataValue(string propertyName, string value)
+        => OctopusImportRedaction.RedactMetadataValue(propertyName, value);
+
+    public Dictionary<string, string> RedactProperties(IReadOnlyDictionary<string, string> properties)
+        => OctopusImportRedaction.RedactProperties(properties);
+
+    public string RedactJson(string json)
+        => OctopusImportRedaction.RedactJson(json);
+
+    public T RedactDto<T>(T value) where T : class
+        => OctopusImportRedaction.RedactDto(value);
+
+    public OctopusImportDiagnosticDto RedactDiagnostic(OctopusImportDiagnosticDto diagnostic)
+        => OctopusImportRedaction.RedactDiagnostic(diagnostic);
+
+    public OctopusInputExtractionDiagnostic RedactDiagnostic(OctopusInputExtractionDiagnostic diagnostic)
+        => OctopusImportRedaction.RedactDiagnostic(diagnostic);
+}
+
+public static class OctopusImportRedaction
+{
+    public const string RedactedValue = "[redacted]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static readonly string[] SensitiveNameFragments =
+    [
+        "password",
+        "passphrase",
+        "secret",
+        "token",
+        "credential",
+        "apikey",
+        "api-key",
+        "api key",
+        "username",
+        "user name",
+        "accesskey",
+        "access-key",
+        "clientsecret",
+        "client-secret",
+        "privatekey",
+        "private-key",
+        "private key",
+        "pfx",
+        "certificateData",
+        "certificate-data",
+        "certificate data"
+    ];
+
+    private static readonly string[] SensitiveValueFragments =
+    [
+        "password",
+        "passphrase",
+        "secret",
+        "token",
+        "credential",
+        "apikey",
+        "api-key",
+        "api key",
+        "accesskey",
+        "access-key",
+        "clientsecret",
+        "client-secret",
+        "privatekey",
+        "private-key",
+        "private key",
+        "pfx"
+    ];
+
+    private static readonly Regex QuotedSensitiveValuePattern = new("'([^']*)'", RegexOptions.Compiled);
+
+    private static readonly Regex AssignmentSecretPattern =
+        new(@"(?i)\b(password|passphrase|secret|token|credential|api[-_ ]?key|access[-_ ]?key|client[-_ ]?secret|private[-_ ]?key|pfx)\b\s*[:=]\s*[^,\s}""]+", RegexOptions.Compiled);
+
+    private static readonly Regex AuthorizationSecretPattern =
+        new("(?i)\\b(bearer|basic)\\s+[a-z0-9._~+/=-]+", RegexOptions.Compiled);
+
+    public static bool ShouldRedactPropertyValue(string propertyName, string value = null)
+        => IsSensitiveName(propertyName)
+           || LooksSensitiveAssignment(value)
+           || LooksSensitiveAuthorizationValue(value);
+
+    public static string RedactMetadataValue(string propertyName, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        return ShouldRedactPropertyValue(propertyName, value)
+               || LooksSensitiveValue(value)
+            ? RedactedValue
+            : value.Trim();
+    }
+
+    public static Dictionary<string, string> RedactProperties(IReadOnlyDictionary<string, string> properties)
+    {
+        if (properties == null)
+            return [];
+
+        var redacted = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (key, value) in properties)
+        {
+            redacted[key] = ShouldRedactPropertyValue(key, value)
+                ? RedactedValue
+                : value;
+        }
+
+        return redacted;
+    }
+
+    public static string RedactJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return json;
+
+        try
+        {
+            var node = JsonNode.Parse(json);
+            var redacted = RedactNode(node, null, false);
+            return redacted?.ToJsonString(JsonOptions) ?? json;
+        }
+        catch (JsonException)
+        {
+            return LooksSensitiveValue(json) ? RedactedValue : json;
+        }
+    }
+
+    public static JsonElement RedactJsonElement(JsonElement element)
+    {
+        var redactedJson = RedactJson(element.GetRawText());
+        using var document = JsonDocument.Parse(redactedJson);
+        return document.RootElement.Clone();
+    }
+
+    public static T RedactDto<T>(T value) where T : class
+    {
+        if (value == null)
+            return null;
+
+        var json = JsonSerializer.Serialize(value, JsonOptions);
+        return JsonSerializer.Deserialize<T>(RedactJson(json), JsonOptions);
+    }
+
+    public static OctopusImportDiagnosticDto RedactDiagnostic(OctopusImportDiagnosticDto diagnostic)
+    {
+        if (diagnostic == null)
+            return null;
+
+        return new OctopusImportDiagnosticDto
+        {
+            Severity = diagnostic.Severity,
+            Code = diagnostic.Code,
+            Message = RedactDiagnosticText(diagnostic.Message),
+            ResourceType = diagnostic.ResourceType,
+            SourceId = RedactMetadataValue("SourceId", diagnostic.SourceId),
+            ResourceName = RedactMetadataValue("ResourceName", diagnostic.ResourceName)
+        };
+    }
+
+    public static OctopusInputExtractionDiagnostic RedactDiagnostic(OctopusInputExtractionDiagnostic diagnostic)
+    {
+        if (diagnostic == null)
+            return null;
+
+        return new OctopusInputExtractionDiagnostic(
+            diagnostic.Severity,
+            diagnostic.Code,
+            RedactDiagnosticText(diagnostic.Message),
+            RedactMetadataValue("SourcePath", diagnostic.SourcePath),
+            RedactMetadataValue("SourceId", diagnostic.SourceId),
+            diagnostic.DocumentKind);
+    }
+
+    private static JsonNode RedactNode(JsonNode node, string propertyName, bool forceRedact)
+    {
+        if (node == null)
+            return null;
+
+        if (node is JsonValue value)
+            return RedactValue(value, propertyName, forceRedact);
+
+        if (node is JsonArray array)
+        {
+            var redactedArray = new JsonArray();
+            foreach (var child in array)
+                redactedArray.Add(RedactNode(child, propertyName, forceRedact));
+
+            return redactedArray;
+        }
+
+        var obj = node.AsObject();
+        var redactedObject = new JsonObject();
+        var isSensitiveVariable = IsSensitiveVariableObject(obj);
+
+        foreach (var (childName, childNode) in obj)
+        {
+            var childForceRedact = forceRedact || IsSensitiveContainerName(childName);
+
+            if (isSensitiveVariable && string.Equals(childName, "Value", StringComparison.OrdinalIgnoreCase))
+            {
+                redactedObject[childName] = RedactedValue;
+                continue;
+            }
+
+            redactedObject[childName] = RedactNode(childNode, childName, childForceRedact);
+        }
+
+        return redactedObject;
+    }
+
+    private static JsonNode RedactValue(JsonValue value, string propertyName, bool forceRedact)
+    {
+        if (!value.TryGetValue<string>(out var stringValue))
+            return value.DeepClone();
+
+        return forceRedact || ShouldRedactPropertyValue(propertyName, stringValue)
+               || (IsRedactableMetadataName(propertyName) && LooksSensitiveValue(stringValue))
+            ? RedactedValue
+            : stringValue;
+    }
+
+    private static bool IsRedactableMetadataName(string propertyName)
+        => string.Equals(propertyName, "ResourceName", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "SourceName", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSensitiveVariableObject(JsonObject obj)
+    {
+        var isSensitive = TryGetBoolean(obj, "IsSensitive") == true;
+        var isSensitiveType = string.Equals(TryGetString(obj, "Type"), "Sensitive", StringComparison.OrdinalIgnoreCase);
+
+        return isSensitive || isSensitiveType;
+    }
+
+    private static bool IsSensitiveContainerName(string propertyName)
+        => IsSensitiveName(propertyName)
+           || string.Equals(propertyName, "Credentials", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "CertificateData", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSensitiveName(string value)
+        => ContainsAny(value, SensitiveNameFragments);
+
+    private static bool LooksSensitiveValue(string value)
+        => ContainsAny(value, SensitiveValueFragments);
+
+    private static bool LooksSensitiveAssignment(string value)
+        => !string.IsNullOrWhiteSpace(value) && AssignmentSecretPattern.IsMatch(value);
+
+    private static bool LooksSensitiveAuthorizationValue(string value)
+        => !string.IsNullOrWhiteSpace(value) && AuthorizationSecretPattern.IsMatch(value);
+
+    private static bool ContainsAny(string value, IEnumerable<string> fragments)
+        => !string.IsNullOrWhiteSpace(value)
+           && fragments.Any(fragment => value.Contains(fragment, StringComparison.OrdinalIgnoreCase));
+
+    private static bool? TryGetBoolean(JsonObject obj, string propertyName)
+    {
+        return TryGetProperty(obj, propertyName) is { } node && node is JsonValue value && value.TryGetValue<bool>(out var result)
+            ? result
+            : null;
+    }
+
+    private static string TryGetString(JsonObject obj, string propertyName)
+    {
+        return TryGetProperty(obj, propertyName) is { } node && node is JsonValue value && value.TryGetValue<string>(out var result)
+            ? result
+            : null;
+    }
+
+    private static JsonNode TryGetProperty(JsonObject obj, string propertyName)
+    {
+        foreach (var (key, value) in obj)
+        {
+            if (string.Equals(key, propertyName, StringComparison.OrdinalIgnoreCase))
+                return value;
+        }
+
+        return null;
+    }
+
+    private static string RedactDiagnosticText(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return value;
+
+        var redacted = QuotedSensitiveValuePattern.Replace(value, match =>
+        {
+            var quoted = match.Groups[1].Value;
+            return LooksSensitiveValue(quoted) ? $"'{RedactedValue}'" : match.Value;
+        });
+
+        redacted = AssignmentSecretPattern.Replace(redacted, match =>
+        {
+            var separatorIndex = match.Value.IndexOfAny([':', '=']);
+            return separatorIndex < 0
+                ? RedactedValue
+                : match.Value[..(separatorIndex + 1)] + RedactedValue;
+        });
+
+        return AuthorizationSecretPattern.Replace(redacted, match =>
+        {
+            var scheme = match.Groups[1].Value;
+            return $"{scheme} {RedactedValue}";
+        });
+    }
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportRedactionDiagnosticCodes.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportRedactionDiagnosticCodes.cs
@@ -1,0 +1,12 @@
+namespace Squid.Core.Services.OctopusImport;
+
+public static class OctopusImportRedactionDiagnosticCodes
+{
+    public const string SensitiveVariableValueOmitted = "OctopusImport.Redaction.SensitiveVariableValueOmitted";
+    public const string FeedCredentialsOmitted = "OctopusImport.Redaction.FeedCredentialsOmitted";
+    public const string AccountCredentialsOmitted = "OctopusImport.Redaction.AccountCredentialsOmitted";
+    public const string CertificatePrivateMaterialOmitted = "OctopusImport.Redaction.CertificatePrivateMaterialOmitted";
+    public const string EndpointSecretOmitted = "OctopusImport.Redaction.EndpointSecretOmitted";
+    public const string SensitiveActionPropertyValueOmitted = "OctopusImport.Redaction.SensitiveActionPropertyValueOmitted";
+    public const string SuspiciousPropertyValueRedacted = "OctopusImport.Redaction.SuspiciousPropertyValueRedacted";
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportSessionService.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportSessionService.cs
@@ -72,7 +72,7 @@ public class OctopusImportSessionService : IOctopusImportSessionService
             DestinationSpaceId = destinationSpaceId,
             OwnerUserId = ownerUserId,
             State = OctopusImportSessionState.Uploaded.ToString(),
-            SourceSummaryJson = Serialize(sourceSummary ?? new OctopusImportSourceSummaryDto()),
+            SourceSummaryJson = Serialize(OctopusImportRedaction.RedactDto(sourceSummary ?? new OctopusImportSourceSummaryDto())),
             DataVersion = Guid.NewGuid().ToByteArray(),
             ExpiresAt = expiresAt,
             LastStateChangedAt = now
@@ -108,8 +108,12 @@ public class OctopusImportSessionService : IOctopusImportSessionService
 
         session.State = newState.ToString();
         session.LastStateChangedAt = DateTimeOffset.UtcNow;
-        session.RedactedNormalizedDataJson = redactedNormalizedDataJson ?? session.RedactedNormalizedDataJson;
-        session.ValidatedPlanJson = validatedPlanJson ?? session.ValidatedPlanJson;
+        session.RedactedNormalizedDataJson = redactedNormalizedDataJson == null
+            ? session.RedactedNormalizedDataJson
+            : OctopusImportRedaction.RedactJson(redactedNormalizedDataJson);
+        session.ValidatedPlanJson = validatedPlanJson == null
+            ? session.ValidatedPlanJson
+            : OctopusImportRedaction.RedactJson(validatedPlanJson);
 
         if (OctopusImportSessionStateMachine.IsTerminal(newState))
             session.CompletedAt = session.LastStateChangedAt;
@@ -152,7 +156,7 @@ public class OctopusImportSessionService : IOctopusImportSessionService
         result.CompletedAt = completedAt;
 
         session.State = terminalState.ToString();
-        session.ResultJson = Serialize(result);
+        session.ResultJson = Serialize(OctopusImportRedaction.RedactDto(result));
         session.CompletedAt = completedAt;
         session.LastStateChangedAt = completedAt;
 
@@ -195,8 +199,8 @@ public class OctopusImportSessionService : IOctopusImportSessionService
             DestinationSpaceId = session.DestinationSpaceId,
             OwnerUserId = session.OwnerUserId,
             State = ParseState(session.State),
-            SourceSummary = Deserialize<OctopusImportSourceSummaryDto>(session.SourceSummaryJson),
-            Result = Deserialize<OctopusImportSessionResultDto>(session.ResultJson),
+            SourceSummary = OctopusImportRedaction.RedactDto(Deserialize<OctopusImportSourceSummaryDto>(session.SourceSummaryJson)),
+            Result = OctopusImportRedaction.RedactDto(Deserialize<OctopusImportSessionResultDto>(session.ResultJson)),
             ExpiresAt = session.ExpiresAt,
             CompletedAt = session.CompletedAt,
             LastStateChangedAt = session.LastStateChangedAt

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportRedactionTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportRedactionTests.cs
@@ -1,0 +1,192 @@
+using System.Linq;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport;
+
+public class OctopusImportRedactionTests
+{
+    [Fact]
+    public void RedactDto_RemovesSensitiveVariableValuesButPreservesStructure()
+    {
+        var variableSet = new OctopusVariableSetDto
+        {
+            Id = "variableset-Projects-1",
+            OwnerId = "Projects-1",
+            Variables =
+            [
+                new OctopusVariableDto
+                {
+                    Id = "Variables-Secret",
+                    Name = "ApiKey",
+                    Type = "Sensitive",
+                    IsSensitive = true,
+                    Value = "super-secret-variable-value",
+                    Scope = { ["Environment"] = ["Environments-1"] }
+                },
+                new OctopusVariableDto
+                {
+                    Id = "Variables-Plain",
+                    Name = "Namespace",
+                    Type = "String",
+                    Value = "next-chat"
+                }
+            ]
+        };
+
+        var redacted = OctopusImportRedaction.RedactDto(variableSet);
+
+        redacted.Id.ShouldBe(variableSet.Id);
+        redacted.Variables[0].Name.ShouldBe("ApiKey");
+        redacted.Variables[0].Value.ShouldBe(OctopusImportRedaction.RedactedValue);
+        redacted.Variables[0].Scope["Environment"].Single().ShouldBe("Environments-1");
+        redacted.Variables[1].Value.ShouldBe("next-chat");
+        Serialized(redacted).ShouldNotContain("super-secret-variable-value");
+    }
+
+    [Fact]
+    public void RedactDto_RemovesFeedCredentials()
+    {
+        var feed = new OctopusFeedDto
+        {
+            Id = "Feeds-1",
+            Name = "Docker",
+            FeedUri = "https://registry.example",
+            Username = "feed-user",
+            Password = "feed-password-secret"
+        };
+
+        var redacted = OctopusImportRedaction.RedactDto(feed);
+
+        redacted.FeedUri.ShouldBe("https://registry.example");
+        redacted.Username.ShouldBe(OctopusImportRedaction.RedactedValue);
+        redacted.Password.ShouldBe(OctopusImportRedaction.RedactedValue);
+        Serialized(redacted).ShouldNotContain("feed-user");
+        Serialized(redacted).ShouldNotContain("feed-password-secret");
+    }
+
+    [Fact]
+    public void RedactDto_RemovesAccountCredentialsCertificateMaterialAndEndpointSecrets()
+    {
+        var account = new OctopusAccountDto
+        {
+            Id = "Accounts-1",
+            Name = "AWS",
+            Credentials = Json("""
+            {
+              "AccessKey": "AKIA-SOURCE",
+              "SecretKey": "aws-source-secret"
+            }
+            """)
+        };
+        var certificate = new OctopusCertificateDto
+        {
+            Id = "Certificates-1",
+            Name = "TLS",
+            HasPrivateKey = true,
+            CertificateData = Json("""
+            {
+              "HasPrivateKey": true,
+              "PrivateKey": "private-key-material",
+              "Password": "pfx-password"
+            }
+            """)
+        };
+        var machine = new OctopusMachineDto
+        {
+            Id = "Machines-1",
+            Name = "worker",
+            Endpoint = Json("""
+            {
+              "Uri": "https://worker.example",
+              "Thumbprint": "non-secret-thumbprint",
+              "BearerToken": "endpoint-token-value"
+            }
+            """)
+        };
+
+        var accountJson = Serialized(OctopusImportRedaction.RedactDto(account));
+        var certificateJson = Serialized(OctopusImportRedaction.RedactDto(certificate));
+        var machineJson = Serialized(OctopusImportRedaction.RedactDto(machine));
+
+        accountJson.ShouldNotContain("AKIA-SOURCE");
+        accountJson.ShouldNotContain("aws-source-secret");
+        certificateJson.ShouldContain("Certificates-1");
+        certificateJson.ShouldNotContain("private-key-material");
+        certificateJson.ShouldNotContain("pfx-password");
+        machineJson.ShouldContain("https://worker.example");
+        machineJson.ShouldNotContain("endpoint-token-value");
+    }
+
+    [Fact]
+    public void RedactProperties_RemovesSuspiciousActionPropertyValues()
+    {
+        var redacted = OctopusImportRedaction.RedactProperties(new Dictionary<string, string>
+        {
+            ["Octopus.Action.Custom.Password"] = "literal-password",
+            ["Octopus.Action.Custom.Url"] = "https://service.example",
+            ["Octopus.Action.Custom.Header"] = "Authorization=Bearer source-token"
+        });
+
+        redacted["Octopus.Action.Custom.Password"].ShouldBe(OctopusImportRedaction.RedactedValue);
+        redacted["Octopus.Action.Custom.Url"].ShouldBe("https://service.example");
+        redacted["Octopus.Action.Custom.Header"].ShouldBe(OctopusImportRedaction.RedactedValue);
+    }
+
+    [Fact]
+    public void RedactDiagnostic_RemovesSensitiveDiagnosticAndLogText()
+    {
+        var diagnostic = new OctopusImportDiagnosticDto
+        {
+            Severity = OctopusImportCompatibilitySeverity.Warning,
+            Code = OctopusImportRedactionDiagnosticCodes.SuspiciousPropertyValueRedacted,
+            Message = "Import failed with Authorization=Bearer source-token and password=plain-secret.",
+            ResourceType = "DeploymentAction",
+            SourceId = "Actions-1",
+            ResourceName = "Rotate password secret"
+        };
+
+        var redacted = OctopusImportRedaction.RedactDiagnostic(diagnostic);
+        var redactedJson = Serialized(redacted);
+
+        redactedJson.ShouldNotContain("source-token");
+        redactedJson.ShouldNotContain("plain-secret");
+        redacted.ResourceName.ShouldBe(OctopusImportRedaction.RedactedValue);
+        redacted.SourceId.ShouldBe("Actions-1");
+    }
+
+    [Fact]
+    public void RedactJson_RemovesNestedSensitiveJsonValues()
+    {
+        var redacted = OctopusImportRedaction.RedactJson("""
+        {
+          "Variables": [
+            { "Name": "ApiKey", "Type": "Sensitive", "IsSensitive": true, "Value": "json-variable-secret" },
+            { "Name": "Namespace", "Type": "String", "Value": "next-chat" }
+          ],
+          "Credentials": { "ClientSecret": "json-client-secret" },
+          "Endpoint": { "Uri": "https://worker.example", "BearerToken": "json-endpoint-token" },
+          "Properties": { "Octopus.Action.Custom.Secret": "json-property-secret" }
+        }
+        """);
+
+        redacted.ShouldNotContain("json-variable-secret");
+        redacted.ShouldNotContain("json-client-secret");
+        redacted.ShouldNotContain("json-endpoint-token");
+        redacted.ShouldNotContain("json-property-secret");
+        redacted.ShouldContain("next-chat");
+        redacted.ShouldContain("https://worker.example");
+    }
+
+    private static JsonElement Json(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static string Serialized<T>(T value)
+        => JsonSerializer.Serialize(value);
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportSessionServiceTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportSessionServiceTests.cs
@@ -119,6 +119,38 @@ public class OctopusImportSessionServiceTests
     }
 
     [Fact]
+    public async Task UpdatePayloadAndTransitionAsync_RedactsPersistedPayloadJson()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = NewSession(sessionId, OctopusImportSessionState.Uploaded);
+
+        _dataProvider
+            .Setup(p => p.GetSessionAsync(sessionId, 42, 7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        await _service.UpdatePayloadAndTransitionAsync(
+            sessionId,
+            7,
+            OctopusImportSessionState.Uploaded,
+            OctopusImportSessionState.Extracted,
+            redactedNormalizedDataJson: """
+            {
+              "variables": [{ "name": "ApiKey", "type": "Sensitive", "isSensitive": true, "value": "session-variable-secret" }],
+              "account": { "credentials": { "secretKey": "session-account-secret" } },
+              "machine": { "endpoint": { "uri": "https://worker.example", "bearerToken": "session-endpoint-token" } }
+            }
+            """,
+            validatedPlanJson: """{"properties":{"Octopus.Action.Custom.Password":"session-property-secret"}}""",
+            ct: CancellationToken.None);
+
+        session.RedactedNormalizedDataJson.ShouldNotContain("session-variable-secret");
+        session.RedactedNormalizedDataJson.ShouldNotContain("session-account-secret");
+        session.RedactedNormalizedDataJson.ShouldNotContain("session-endpoint-token");
+        session.RedactedNormalizedDataJson.ShouldContain("https://worker.example");
+        session.ValidatedPlanJson.ShouldNotContain("session-property-secret");
+    }
+
+    [Fact]
     public async Task TryStartConfirmationAsync_UsesAtomicValidatedToImportingAdmission()
     {
         var sessionId = Guid.NewGuid();
@@ -171,6 +203,42 @@ public class OctopusImportSessionServiceTests
         result.Result.Succeeded.ShouldBeTrue();
         result.Result.Resources.Count.ShouldBe(1);
         _dataProvider.Verify(p => p.UpdateSessionAsync(session, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordResultAsync_RedactsPersistedDiagnostics()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = NewSession(sessionId, OctopusImportSessionState.Importing);
+
+        _dataProvider
+            .Setup(p => p.GetSessionAsync(sessionId, 42, 7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        await _service.RecordResultAsync(
+            sessionId,
+            7,
+            OctopusImportSessionState.Failed,
+            new OctopusImportSessionResultDto
+            {
+                Diagnostics =
+                [
+                    new OctopusImportDiagnosticDto
+                    {
+                        Severity = OctopusImportCompatibilitySeverity.Warning,
+                        Code = OctopusImportRedactionDiagnosticCodes.SuspiciousPropertyValueRedacted,
+                        Message = "Failed with token=result-token-secret.",
+                        ResourceType = "DeploymentAction",
+                        SourceId = "Actions-1",
+                        ResourceName = "Rotate password secret"
+                    }
+                ]
+            },
+            CancellationToken.None);
+
+        session.ResultJson.ShouldNotContain("result-token-secret");
+        session.ResultJson.ShouldNotContain("Rotate password secret");
+        session.ResultJson.ShouldContain(OctopusImportRedaction.RedactedValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Implemented OpenSpec 6.1 on branch `codex/central-import-secret-redaction`.
- Added central redaction contract/helper/service and diagnostic codes in `/Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/OctopusImportRedaction.cs` and `/Users/mindy/Documents/repo/Squid/src/Squid.Core/Services/OctopusImport/OctopusImportRedactionDiagnosticCodes.cs`.
- Migrated scattered Octopus Import diagnostic/placeholder redaction paths to the central helper, including action mapping, preview/validation, process/project/lifecycle/feed/variable mapping, runtime action validation, and session persistence.
- Hardened `OctopusImportSessionService` so normalized payload JSON, validated plan JSON, source summaries, and terminal results are redacted before storage/return.
- Added focused unit coverage for sensitive variables, feed credentials, account credentials, certificate private material, endpoint secrets, suspicious properties, diagnostics/log-like text, and session JSON persistence.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter OctopusImport --no-restore -v:q` passed: 217/217 tests.
- [x] `git diff --check` passed.
- [x] Confirmed sandboxed `dotnet test` fails due MSBuild named-pipe `SocketException (13): Permission denied`; reran with escalated permissions successfully.