### PR TITLE
Manual configuration markers for external resource secrets

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportExternalResourceShellMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportExternalResourceShellMapper.cs
@@ -1,0 +1,364 @@
+using System.Globalization;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Commands.Deployments.Account;
+using Squid.Message.Enums;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.Deployments.Account;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public interface IOctopusImportExternalResourceShellMapper : IScopedDependency
+{
+    OctopusImportAccountShellMappingResult MapAccountToCreateCommand(
+        OctopusResourceNode accountResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId);
+
+    OctopusImportCertificateShellMappingResult MapCertificateToManualShell(
+        OctopusResourceNode certificateResource);
+
+    OctopusImportTargetShellMappingResult MapTargetToManualShell(
+        OctopusResourceNode targetResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId);
+}
+
+public sealed class OctopusImportExternalResourceShellMapper : IOctopusImportExternalResourceShellMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly IReadOnlySet<string> SafeEndpointMetadataNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "CommunicationStyle",
+        "ClusterUrl",
+        "Namespace",
+        "SkipTlsVerification",
+        "ProviderType",
+        "Uri",
+        "Host",
+        "Port",
+        "Fingerprint",
+        "Thumbprint",
+        "RemoteWorkingDirectory",
+        "AgentVersion",
+        "ReleaseName",
+        "HelmNamespace",
+        "ChartRef"
+    };
+
+    public OctopusImportAccountShellMappingResult MapAccountToCreateCommand(
+        OctopusResourceNode accountResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId)
+    {
+        ArgumentNullException.ThrowIfNull(accountResource);
+        ArgumentNullException.ThrowIfNull(idMap);
+
+        if (accountResource.Kind != OctopusResourceKind.Account)
+            throw new ArgumentException("Octopus account shell mapper requires an account resource.", nameof(accountResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var account = accountResource.GetSource<OctopusAccountDto>()
+            ?? throw new ArgumentException("Octopus account resource does not contain an OctopusAccountDto source.", nameof(accountResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var markers = new List<OctopusImportManualConfigurationMarker>();
+        var accountType = MapAccountType(account.AccountType, accountResource, diagnostics);
+        var environmentIds = MapEnvironmentIds(account.EnvironmentIds, idMap, accountResource, diagnostics);
+
+        if (OctopusImportManualConfiguration.HasJsonPayload(account.Credentials))
+        {
+            markers.Add(OctopusImportManualConfiguration.CreateMarker(
+                accountResource,
+                OctopusImportManualConfiguration.AccountCredentialsField,
+                OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted));
+
+            diagnostics.Add(OctopusImportManualConfiguration.Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted,
+                "Octopus account credentials were omitted from the Squid DeploymentAccount shell and must be configured manually after import.",
+                accountResource));
+        }
+
+        var createCommand = accountType == null
+            ? null
+            : new CreateDeploymentAccountCommand
+            {
+                SpaceId = destinationSpaceId,
+                Name = account.Name,
+                AccountType = accountType.Value,
+                Credentials = CreateEmptyCredentialsElement(accountType.Value),
+                EnvironmentIds = environmentIds
+            };
+
+        return new OctopusImportAccountShellMappingResult(createCommand, diagnostics, markers);
+    }
+
+    public OctopusImportCertificateShellMappingResult MapCertificateToManualShell(
+        OctopusResourceNode certificateResource)
+    {
+        ArgumentNullException.ThrowIfNull(certificateResource);
+
+        if (certificateResource.Kind != OctopusResourceKind.Certificate)
+            throw new ArgumentException("Octopus certificate shell mapper requires a certificate resource.", nameof(certificateResource));
+
+        var certificate = certificateResource.GetSource<OctopusCertificateDto>()
+            ?? throw new ArgumentException("Octopus certificate resource does not contain an OctopusCertificateDto source.", nameof(certificateResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var markers = new List<OctopusImportManualConfigurationMarker>();
+
+        if (certificate.HasPrivateKey || OctopusImportManualConfiguration.HasJsonPayload(certificate.CertificateData))
+        {
+            markers.Add(OctopusImportManualConfiguration.CreateMarker(
+                certificateResource,
+                OctopusImportManualConfiguration.CertificatePrivateMaterialField,
+                OctopusImportRedactionDiagnosticCodes.CertificatePrivateMaterialOmitted));
+
+            diagnostics.Add(OctopusImportManualConfiguration.Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportRedactionDiagnosticCodes.CertificatePrivateMaterialOmitted,
+                "Octopus certificate private material was omitted and the certificate must be recreated manually after import.",
+                certificateResource));
+        }
+
+        var shell = new OctopusImportCertificateShell(
+            certificate.Name,
+            certificate.Notes,
+            certificate.HasPrivateKey,
+            certificate.NotBefore,
+            certificate.NotAfter,
+            CannotExecuteUntilConfigured: markers.Any(m => m.IsRequired));
+
+        return new OctopusImportCertificateShellMappingResult(shell, diagnostics, markers);
+    }
+
+    public OctopusImportTargetShellMappingResult MapTargetToManualShell(
+        OctopusResourceNode targetResource,
+        OctopusImportIdMap idMap,
+        int destinationSpaceId)
+    {
+        ArgumentNullException.ThrowIfNull(targetResource);
+        ArgumentNullException.ThrowIfNull(idMap);
+
+        if (targetResource.Kind != OctopusResourceKind.Machine)
+            throw new ArgumentException("Octopus target shell mapper requires a machine resource.", nameof(targetResource));
+
+        if (destinationSpaceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(destinationSpaceId), destinationSpaceId, "Destination space id must be positive.");
+
+        var target = targetResource.GetSource<OctopusMachineDto>()
+            ?? throw new ArgumentException("Octopus target resource does not contain an OctopusMachineDto source.", nameof(targetResource));
+
+        var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var markers = new List<OctopusImportManualConfigurationMarker>();
+        var environmentIds = MapEnvironmentIds(target.EnvironmentIds, idMap, targetResource, diagnostics);
+        var endpointMetadata = BuildSafeEndpointMetadata(target.Endpoint);
+        var communicationStyle = endpointMetadata.TryGetValue("CommunicationStyle", out var style)
+            ? style
+            : null;
+
+        if (OctopusImportManualConfiguration.HasEndpointSecret(target.Endpoint))
+        {
+            markers.Add(OctopusImportManualConfiguration.CreateMarker(
+                targetResource,
+                OctopusImportManualConfiguration.EndpointSecretsField,
+                OctopusImportRedactionDiagnosticCodes.EndpointSecretOmitted,
+                metadata: new Dictionary<string, string>
+                {
+                    ["CommunicationStyle"] = communicationStyle
+                }));
+
+            diagnostics.Add(OctopusImportManualConfiguration.Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                OctopusImportRedactionDiagnosticCodes.EndpointSecretOmitted,
+                "Octopus target endpoint secrets were omitted and the deployment target must be configured manually after import.",
+                targetResource));
+        }
+
+        var shell = new OctopusImportTargetShell(
+            target.Name,
+            target.IsDisabled,
+            target.Roles ?? [],
+            environmentIds,
+            communicationStyle,
+            endpointMetadata,
+            CannotExecuteUntilConfigured: true);
+
+        return new OctopusImportTargetShellMappingResult(shell, diagnostics, markers);
+    }
+
+    private static AccountType? MapAccountType(
+        string sourceAccountType,
+        OctopusResourceNode accountResource,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        if (Enum.TryParse<AccountType>(sourceAccountType?.Trim(), ignoreCase: true, out var direct)
+            && direct != AccountType.None
+            && direct != AccountType.AzureSubscription)
+            return direct;
+
+        var normalized = Normalize(sourceAccountType);
+        var mapped = normalized switch
+        {
+            "usernamepassword" or "usernamepasswordaccount" => AccountType.UsernamePassword,
+            "sshkeypair" or "sshkeypairaccount" => AccountType.SshKeyPair,
+            "token" or "tokenaccount" => AccountType.Token,
+            "azureserviceprincipal" or "azureserviceprincipalaccount" => AccountType.AzureServicePrincipal,
+            "azureoidc" or "azureoidcaccount" => AccountType.AzureOidc,
+            "amazonwebservicesaccount" or "awsaccount" => AccountType.AmazonWebServicesAccount,
+            "amazonwebservicesroleaccount" or "awsroleaccount" => AccountType.AmazonWebServicesRoleAccount,
+            "amazonwebservicesoidcaccount" or "awsoidcaccount" => AccountType.AmazonWebServicesOidcAccount,
+            "clientcertificate" or "clientcertificateaccount" => AccountType.ClientCertificate,
+            "googlecloudaccount" or "gcpaccount" => AccountType.GoogleCloudAccount,
+            "openclawgateway" or "openclawgatewayaccount" => AccountType.OpenClawGateway,
+            _ => (AccountType?)null
+        };
+
+        if (mapped != null)
+            return mapped.Value;
+
+        diagnostics.Add(OctopusImportManualConfiguration.Diagnostic(
+            OctopusImportCompatibilitySeverity.Blocker,
+            "OctopusImport.Account.UnsupportedAccountType",
+            $"Octopus account type '{sourceAccountType}' is not supported by the current Squid import account shell mapper.",
+            accountResource));
+
+        return null;
+    }
+
+    private static List<int> MapEnvironmentIds(
+        IEnumerable<string> sourceEnvironmentIds,
+        OctopusImportIdMap idMap,
+        OctopusResourceNode resource,
+        List<OctopusImportDiagnosticDto> diagnostics)
+    {
+        var environmentIds = new List<int>();
+
+        foreach (var sourceEnvironmentId in sourceEnvironmentIds ?? [])
+        {
+            if (idMap.TryGetDestinationId(sourceEnvironmentId, OctopusResourceKind.Environment.ToString(), out var destinationEnvironmentId))
+            {
+                environmentIds.Add(destinationEnvironmentId);
+                continue;
+            }
+
+            diagnostics.Add(OctopusImportManualConfiguration.Diagnostic(
+                OctopusImportCompatibilitySeverity.Blocker,
+                "OctopusImport.ExternalResource.MissingEnvironmentMapping",
+                $"Octopus environment scope '{sourceEnvironmentId}' has not been mapped to a destination Squid environment.",
+                resource));
+        }
+
+        return environmentIds;
+    }
+
+    private static JsonElement CreateEmptyCredentialsElement(AccountType accountType)
+    {
+        object credentials = accountType switch
+        {
+            AccountType.Token => new TokenCredentials(),
+            AccountType.UsernamePassword => new UsernamePasswordCredentials(),
+            AccountType.ClientCertificate => new ClientCertificateCredentials(),
+            AccountType.AmazonWebServicesAccount => new AwsCredentials(),
+            AccountType.AmazonWebServicesRoleAccount => new AwsRoleCredentials(),
+            AccountType.SshKeyPair => new SshKeyPairCredentials(),
+            AccountType.AzureServicePrincipal => new AzureServicePrincipalCredentials(),
+            AccountType.AzureOidc => new AzureOidcCredentials(),
+            AccountType.GoogleCloudAccount => new GcpCredentials(),
+            AccountType.AmazonWebServicesOidcAccount => new AwsOidcCredentials(),
+            AccountType.OpenClawGateway => new OpenClawGatewayCredentials(),
+            _ => null
+        };
+
+        return credentials == null
+            ? JsonSerializer.SerializeToElement(new object(), JsonOptions)
+            : JsonSerializer.SerializeToElement(credentials, credentials.GetType(), JsonOptions);
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildSafeEndpointMetadata(JsonElement? endpoint)
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (endpoint is not { ValueKind: JsonValueKind.Object } value)
+            return metadata;
+
+        foreach (var property in value.EnumerateObject())
+        {
+            if (!SafeEndpointMetadataNames.Contains(property.Name))
+                continue;
+
+            var propertyValue = JsonScalarToString(property.Value);
+            if (string.IsNullOrWhiteSpace(propertyValue))
+                continue;
+
+            metadata[property.Name] = OctopusImportRedaction.RedactMetadataValue(property.Name, propertyValue);
+        }
+
+        return metadata;
+    }
+
+    private static string JsonScalarToString(JsonElement element)
+        => element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.ToString(),
+            JsonValueKind.True => bool.TrueString.ToLower(CultureInfo.InvariantCulture),
+            JsonValueKind.False => bool.FalseString.ToLower(CultureInfo.InvariantCulture),
+            _ => null
+        };
+
+    private static string Normalize(string value)
+        => string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : new string(value.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+}
+
+public sealed record OctopusImportAccountShellMappingResult(
+    CreateDeploymentAccountCommand CreateCommand,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics,
+    IReadOnlyList<OctopusImportManualConfigurationMarker> ManualConfigurationMarkers)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}
+
+public sealed record OctopusImportCertificateShell(
+    string Name,
+    string Notes,
+    bool SourceHasPrivateKey,
+    DateTimeOffset? NotBefore,
+    DateTimeOffset? NotAfter,
+    bool CannotExecuteUntilConfigured);
+
+public sealed record OctopusImportCertificateShellMappingResult(
+    OctopusImportCertificateShell Shell,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics,
+    IReadOnlyList<OctopusImportManualConfigurationMarker> ManualConfigurationMarkers)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}
+
+public sealed record OctopusImportTargetShell(
+    string Name,
+    bool SourceIsDisabled,
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<int> EnvironmentIds,
+    string CommunicationStyle,
+    IReadOnlyDictionary<string, string> EndpointMetadata,
+    bool CannotExecuteUntilConfigured);
+
+public sealed record OctopusImportTargetShellMappingResult(
+    OctopusImportTargetShell Shell,
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics,
+    IReadOnlyList<OctopusImportManualConfigurationMarker> ManualConfigurationMarkers)
+{
+    public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
+}

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportFeedMapper.cs
@@ -40,7 +40,8 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
                 SpaceId = destinationSpaceId
             },
             null,
-            mapping.Diagnostics);
+            mapping.Diagnostics,
+            mapping.ManualConfigurationMarkers);
     }
 
     public OctopusImportFeedMappingResult MapToUpdateCommand(
@@ -68,7 +69,8 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
                 PackageAcquisitionLocationOptions = [],
                 SpaceId = destinationSpaceId
             },
-            mapping.Diagnostics);
+            mapping.Diagnostics,
+            mapping.ManualConfigurationMarkers);
     }
 
     private static FeedCommandMapping Map(OctopusResourceNode feedResource, int destinationSpaceId)
@@ -85,10 +87,16 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
             ?? throw new ArgumentException("Octopus feed resource does not contain an OctopusFeedDto source.", nameof(feedResource));
 
         var diagnostics = new List<OctopusImportDiagnosticDto>();
+        var markers = new List<OctopusImportManualConfigurationMarker>();
         var mappedFeedType = MapFeedType(feed, feedResource, diagnostics);
 
         if (!string.IsNullOrWhiteSpace(feed.Username) || !string.IsNullOrWhiteSpace(feed.Password))
         {
+            markers.Add(OctopusImportManualConfiguration.CreateMarker(
+                feedResource,
+                OctopusImportManualConfiguration.FeedCredentialsField,
+                OctopusImportRedactionDiagnosticCodes.FeedCredentialsOmitted));
+
             diagnostics.Add(Diagnostic(
                 OctopusImportCompatibilitySeverity.Warning,
                 OctopusImportFeedMappingDiagnosticCodes.CredentialsOmitted,
@@ -96,13 +104,17 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
                 feedResource));
         }
 
+        var properties = OctopusImportRedaction.RedactProperties(BuildProperties(feed));
+        OctopusImportManualConfiguration.AddMarkerProperties(properties, feedResource, markers);
+
         return new FeedCommandMapping(
             mappedFeedType,
             feed.FeedUri,
             feed.Name,
             feed.Slug,
-            OctopusImportRedaction.RedactProperties(BuildProperties(feed)),
-            diagnostics);
+            properties,
+            diagnostics,
+            markers);
     }
 
     private static string MapFeedType(
@@ -184,13 +196,15 @@ public class OctopusImportFeedMapper : IOctopusImportFeedMapper
         string Name,
         string Slug,
         Dictionary<string, string> Properties,
-        IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics);
+        IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics,
+        IReadOnlyList<OctopusImportManualConfigurationMarker> ManualConfigurationMarkers);
 }
 
 public sealed record OctopusImportFeedMappingResult(
     CreateExternalFeedCommand CreateCommand,
     UpdateExternalFeedCommand UpdateCommand,
-    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
+    IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics,
+    IReadOnlyList<OctopusImportManualConfigurationMarker> ManualConfigurationMarkers)
 {
     public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);
 }

--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportManualConfigurationMarker.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportManualConfigurationMarker.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport.Mapping;
+
+public sealed record OctopusImportManualConfigurationMarker(
+    string ResourceType,
+    string SourceId,
+    string SourceName,
+    string FieldName,
+    string ReasonCode,
+    bool IsRequired,
+    IReadOnlyDictionary<string, string> Metadata);
+
+public static class OctopusImportManualConfiguration
+{
+    public const string RequiredPropertyName = "Squid.Import.ManualConfiguration.Required";
+    public const string FieldsPropertyName = "Squid.Import.ManualConfiguration.Fields";
+    public const string ReasonsPropertyName = "Squid.Import.ManualConfiguration.Reasons";
+    public const string SourceIdPropertyName = "Squid.Import.Octopus.SourceId";
+    public const string SourceTypePropertyName = "Squid.Import.Octopus.SourceType";
+    public const string SourceNamePropertyName = "Squid.Import.Octopus.SourceName";
+
+    public const string FeedCredentialsField = "Credentials";
+    public const string AccountCredentialsField = "Credentials";
+    public const string CertificatePrivateMaterialField = "CertificatePrivateMaterial";
+    public const string EndpointSecretsField = "EndpointSecrets";
+
+    public static OctopusImportManualConfigurationMarker CreateMarker(
+        OctopusResourceNode resource,
+        string fieldName,
+        string reasonCode,
+        bool isRequired = true,
+        IReadOnlyDictionary<string, string> metadata = null)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return new OctopusImportManualConfigurationMarker(
+            resource.Kind.ToString(),
+            OctopusImportRedaction.RedactMetadataValue("SourceId", resource.SourceId),
+            OctopusImportRedaction.RedactMetadataValue("SourceName", resource.Name),
+            fieldName?.Trim() ?? string.Empty,
+            reasonCode,
+            isRequired,
+            OctopusImportRedaction.RedactProperties(metadata ?? new Dictionary<string, string>()));
+    }
+
+    public static void AddMarkerProperties(
+        Dictionary<string, string> properties,
+        OctopusResourceNode resource,
+        IReadOnlyList<OctopusImportManualConfigurationMarker> markers)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (markers == null || markers.Count == 0)
+            return;
+
+        properties[RequiredPropertyName] = markers.Any(m => m.IsRequired).ToString().ToLowerInvariant();
+        properties[FieldsPropertyName] = string.Join(",", markers.Select(m => m.FieldName).Distinct(StringComparer.OrdinalIgnoreCase));
+        properties[ReasonsPropertyName] = string.Join(",", markers.Select(m => m.ReasonCode).Distinct(StringComparer.OrdinalIgnoreCase));
+        properties[SourceIdPropertyName] = OctopusImportRedaction.RedactMetadataValue(SourceIdPropertyName, resource.SourceId);
+        properties[SourceTypePropertyName] = resource.Kind.ToString();
+        properties[SourceNamePropertyName] = OctopusImportRedaction.RedactMetadataValue(SourceNamePropertyName, resource.Name);
+    }
+
+    public static OctopusImportDiagnosticDto Diagnostic(
+        OctopusImportCompatibilitySeverity severity,
+        string code,
+        string message,
+        OctopusResourceNode resource)
+        => OctopusImportRedaction.RedactDiagnostic(new OctopusImportDiagnosticDto
+        {
+            Severity = severity,
+            Code = code,
+            Message = message,
+            ResourceType = resource.Kind.ToString(),
+            SourceId = resource.SourceId,
+            ResourceName = resource.Name
+        });
+
+    public static IReadOnlyList<OctopusImportManualConfigurationMarker> BuildRequiredMarkers(OctopusResourceNode resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return resource.Kind switch
+        {
+            OctopusResourceKind.Feed when FeedHasCredentials(resource.GetSource<OctopusFeedDto>()) =>
+            [
+                CreateMarker(resource, FeedCredentialsField, OctopusImportRedactionDiagnosticCodes.FeedCredentialsOmitted)
+            ],
+            OctopusResourceKind.Account when HasJsonPayload(resource.GetSource<OctopusAccountDto>()?.Credentials) =>
+            [
+                CreateMarker(resource, AccountCredentialsField, OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted)
+            ],
+            OctopusResourceKind.Certificate when CertificateHasPrivateMaterial(resource.GetSource<OctopusCertificateDto>()) =>
+            [
+                CreateMarker(resource, CertificatePrivateMaterialField, OctopusImportRedactionDiagnosticCodes.CertificatePrivateMaterialOmitted)
+            ],
+            OctopusResourceKind.Machine when HasEndpointSecret(resource.GetSource<OctopusMachineDto>()?.Endpoint) =>
+            [
+                CreateMarker(resource, EndpointSecretsField, OctopusImportRedactionDiagnosticCodes.EndpointSecretOmitted)
+            ],
+            _ => []
+        };
+    }
+
+    public static IReadOnlyList<OctopusImportDiagnosticDto> BuildRequiredConfigurationDiagnostics(OctopusResourceNode resource)
+        => BuildRequiredMarkers(resource)
+            .Select(marker => Diagnostic(
+                OctopusImportCompatibilitySeverity.Warning,
+                marker.ReasonCode,
+                MessageFor(marker),
+                resource))
+            .ToList();
+
+    public static bool HasJsonPayload(JsonElement? element)
+        => element is { } value && HasJsonPayload(value);
+
+    public static bool HasEndpointSecret(JsonElement? endpoint)
+        => endpoint is { } value && HasEndpointSecret(value, null);
+
+    private static bool FeedHasCredentials(OctopusFeedDto feed)
+        => !string.IsNullOrWhiteSpace(feed?.Username) || !string.IsNullOrWhiteSpace(feed?.Password);
+
+    private static bool CertificateHasPrivateMaterial(OctopusCertificateDto certificate)
+        => certificate is { HasPrivateKey: true } || HasJsonPayload(certificate?.CertificateData);
+
+    private static bool HasJsonPayload(JsonElement element)
+        => element.ValueKind switch
+        {
+            JsonValueKind.Undefined or JsonValueKind.Null => false,
+            JsonValueKind.Object => element.EnumerateObject().Any(),
+            JsonValueKind.Array => element.EnumerateArray().Any(),
+            JsonValueKind.String => !string.IsNullOrWhiteSpace(element.GetString()),
+            _ => true
+        };
+
+    private static bool HasEndpointSecret(JsonElement element, string propertyName)
+    {
+        if (!string.IsNullOrWhiteSpace(propertyName)
+            && (IsSensitiveEndpointContainerName(propertyName)
+                || OctopusImportRedaction.ShouldRedactPropertyValue(propertyName)))
+            return true;
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => element.EnumerateObject().Any(property => HasEndpointSecret(property.Value, property.Name)),
+            JsonValueKind.Array => element.EnumerateArray().Any(child => HasEndpointSecret(child, propertyName)),
+            JsonValueKind.String => OctopusImportRedaction.ShouldRedactPropertyValue(propertyName, element.GetString()),
+            _ => false
+        };
+    }
+
+    private static bool IsSensitiveEndpointContainerName(string propertyName)
+        => string.Equals(propertyName, "SubscriptionId", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "ProviderConfig", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "Credentials", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "Credential", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "CertificateData", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "ClientCertificateData", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "ClientCertificateKeyData", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "PrivateKey", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "PrivateKeyFile", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "PrivateKeyPassphrase", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "ProxyPassword", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "InlineGatewayToken", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(propertyName, "InlineHooksToken", StringComparison.OrdinalIgnoreCase);
+
+    private static string MessageFor(OctopusImportManualConfigurationMarker marker)
+        => marker.ReasonCode switch
+        {
+            OctopusImportRedactionDiagnosticCodes.FeedCredentialsOmitted =>
+                "Octopus feed credentials were omitted from the import shell and must be configured manually after import.",
+            OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted =>
+                "Octopus account credentials were omitted from the import shell and must be configured manually after import.",
+            OctopusImportRedactionDiagnosticCodes.CertificatePrivateMaterialOmitted =>
+                "Octopus certificate private material was omitted and the certificate must be recreated manually after import.",
+            OctopusImportRedactionDiagnosticCodes.EndpointSecretOmitted =>
+                "Octopus target endpoint secrets were omitted and the deployment target must be configured manually after import.",
+            _ => "Octopus source data was omitted and must be configured manually after import."
+        };
+}

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
@@ -1,4 +1,5 @@
 using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Core.Services.OctopusImport.Mapping;
 using Squid.Message.Enums.OctopusImport;
 using Squid.Message.Models.OctopusImport;
 
@@ -84,6 +85,7 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
                 OctopusImportPreviewDiagnosticCodes.ResourceOutOfScope,
                 $"Octopus {resource.Kind} resource is outside the initial current-configuration import scope.",
                 resource));
+            AddManualConfigurationDiagnostics(result, resource);
             return result;
         }
 
@@ -96,16 +98,19 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
                 OctopusImportPreviewDiagnosticCodes.ResourceUnsupported,
                 $"Octopus {resource.Kind} resources are detected but are not imported by the current preview planner.",
                 resource));
+            AddManualConfigurationDiagnostics(result, resource);
             return result;
         }
 
         if (!conflictsBySourceId.TryGetValue(resource.SourceId, out var conflict))
         {
             result.PreviewAction = OctopusImportPreviewAction.Create;
+            AddManualConfigurationDiagnostics(result, resource);
             return result;
         }
 
         ApplyConflictAction(result, resource, conflict);
+        AddManualConfigurationDiagnostics(result, resource);
         return result;
     }
 
@@ -172,6 +177,14 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
             SourceId = resource.SourceId,
             ResourceName = resource.Name
         });
+
+    private static void AddManualConfigurationDiagnostics(
+        OctopusImportResourceResultDto result,
+        OctopusResourceNode resource)
+    {
+        foreach (var diagnostic in OctopusImportManualConfiguration.BuildRequiredConfigurationDiagnostics(resource))
+            result.Diagnostics.Add(diagnostic);
+    }
 
     private static bool IsOutOfScope(OctopusResourceKind kind)
         => kind is OctopusResourceKind.Release

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportExternalResourceShellMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportExternalResourceShellMapperTests.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using System.Text.Json;
+using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums;
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.UnitTests.Services.OctopusImport.Mapping;
+
+public class OctopusImportExternalResourceShellMapperTests
+{
+    private readonly OctopusImportExternalResourceShellMapper _mapper = new();
+
+    [Fact]
+    public void MapAccountToCreateCommand_CreatesEmptyCredentialShellAndManualMarker()
+    {
+        var account = new OctopusAccountDto
+        {
+            Id = "Accounts-1",
+            Name = "AWS prod",
+            AccountType = "AmazonWebServicesAccount",
+            EnvironmentIds = ["Environments-1"],
+            Credentials = Json("""
+                {
+                  "AccessKey": "source-access-key",
+                  "SecretKey": "source-secret-key"
+                }
+                """)
+        };
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource(new OctopusEnvironmentDto
+        {
+            Id = "Environments-1",
+            Name = "Production"
+        }, OctopusResourceKind.Environment), 21);
+
+        var result = _mapper.MapAccountToCreateCommand(Resource(account, OctopusResourceKind.Account), idMap, 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.CreateCommand.ShouldNotBeNull();
+        result.CreateCommand.SpaceId.ShouldBe(7);
+        result.CreateCommand.Name.ShouldBe("AWS prod");
+        result.CreateCommand.AccountType.ShouldBe(AccountType.AmazonWebServicesAccount);
+        result.CreateCommand.EnvironmentIds.ShouldBe([21]);
+        result.CreateCommand.Credentials.Value.GetRawText().ShouldNotContain("source-access-key");
+        result.CreateCommand.Credentials.Value.GetRawText().ShouldNotContain("source-secret-key");
+        result.ManualConfigurationMarkers.Single().ReasonCode.ShouldBe(OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted);
+        result.Diagnostics.Single().Message.ShouldNotContain("source-secret-key");
+    }
+
+    [Fact]
+    public void MapCertificateToManualShell_DoesNotCreateCertificateDataAndMarksPrivateMaterial()
+    {
+        var certificate = new OctopusCertificateDto
+        {
+            Id = "Certificates-1",
+            Name = "TLS cert",
+            Notes = "Imported shell",
+            HasPrivateKey = true,
+            NotBefore = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+            NotAfter = DateTimeOffset.Parse("2027-01-01T00:00:00Z"),
+            CertificateData = Json("""{ "Pfx": "certificate-source-secret" }""")
+        };
+
+        var result = _mapper.MapCertificateToManualShell(Resource(certificate, OctopusResourceKind.Certificate));
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Shell.Name.ShouldBe("TLS cert");
+        result.Shell.SourceHasPrivateKey.ShouldBeTrue();
+        result.Shell.CannotExecuteUntilConfigured.ShouldBeTrue();
+        result.ManualConfigurationMarkers.Single().FieldName.ShouldBe(OctopusImportManualConfiguration.CertificatePrivateMaterialField);
+        result.Diagnostics.Single().Code.ShouldBe(OctopusImportRedactionDiagnosticCodes.CertificatePrivateMaterialOmitted);
+        result.Diagnostics.Single().Message.ShouldNotContain("certificate-source-secret");
+    }
+
+    [Fact]
+    public void MapTargetToManualShell_PreservesSafeEndpointMetadataAndOmitsEndpointSecrets()
+    {
+        var target = new OctopusMachineDto
+        {
+            Id = "Machines-1",
+            Name = "EKS target",
+            Roles = ["aws-eks-us"],
+            EnvironmentIds = ["Environments-1"],
+            Endpoint = Json("""
+                {
+                  "CommunicationStyle": "KubernetesApi",
+                  "ClusterUrl": "https://cluster.example",
+                  "Namespace": "production",
+                  "ProviderType": "AwsEks",
+                  "ProviderConfig": { "SecretKey": "endpoint-source-secret" },
+                  "SubscriptionId": "subscription-source-secret"
+                }
+                """)
+        };
+        var idMap = new OctopusImportIdMap();
+        idMap.AddReused(Resource(new OctopusEnvironmentDto
+        {
+            Id = "Environments-1",
+            Name = "Production"
+        }, OctopusResourceKind.Environment), 21);
+
+        var result = _mapper.MapTargetToManualShell(Resource(target, OctopusResourceKind.Machine), idMap, 7);
+
+        result.HasBlockers.ShouldBeFalse();
+        result.Shell.Name.ShouldBe("EKS target");
+        result.Shell.Roles.ShouldBe(["aws-eks-us"]);
+        result.Shell.EnvironmentIds.ShouldBe([21]);
+        result.Shell.CommunicationStyle.ShouldBe("KubernetesApi");
+        result.Shell.EndpointMetadata["ClusterUrl"].ShouldBe("https://cluster.example");
+        result.Shell.EndpointMetadata["Namespace"].ShouldBe("production");
+        result.Shell.EndpointMetadata.ContainsKey("ProviderConfig").ShouldBeFalse();
+        result.Shell.EndpointMetadata.ContainsKey("SubscriptionId").ShouldBeFalse();
+        result.Shell.CannotExecuteUntilConfigured.ShouldBeTrue();
+        result.ManualConfigurationMarkers.Single().ReasonCode.ShouldBe(OctopusImportRedactionDiagnosticCodes.EndpointSecretOmitted);
+        result.Diagnostics.Single().Message.ShouldNotContain("endpoint-source-secret");
+    }
+
+    [Fact]
+    public void MapAccountToCreateCommand_WhenEnvironmentMappingIsMissing_AddsBlocker()
+    {
+        var account = new OctopusAccountDto
+        {
+            Id = "Accounts-1",
+            Name = "Token account",
+            AccountType = "Token",
+            EnvironmentIds = ["Environments-Missing"],
+            Credentials = Json("""{ "Token": "source-token" }""")
+        };
+
+        var result = _mapper.MapAccountToCreateCommand(Resource(account, OctopusResourceKind.Account), new OctopusImportIdMap(), 7);
+
+        result.HasBlockers.ShouldBeTrue();
+        result.Diagnostics.Select(d => d.Code).ShouldContain("OctopusImport.ExternalResource.MissingEnvironmentMapping");
+        result.Diagnostics.All(d => d.Message.Contains("source-token", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
+    }
+
+    private static JsonElement Json(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static OctopusResourceNode Resource<T>(T source, OctopusResourceKind kind)
+        where T : OctopusDocumentDto
+        => new(
+            source.Id,
+            source.Name,
+            kind,
+            DocumentKind(kind),
+            $"{source.Id}.json",
+            null,
+            null,
+            false,
+            source);
+
+    private static OctopusDocumentKind DocumentKind(OctopusResourceKind kind)
+        => kind switch
+        {
+            OctopusResourceKind.Environment => OctopusDocumentKind.Environment,
+            OctopusResourceKind.Account => OctopusDocumentKind.Account,
+            OctopusResourceKind.Certificate => OctopusDocumentKind.Certificate,
+            OctopusResourceKind.Machine => OctopusDocumentKind.Machine,
+            _ => OctopusDocumentKind.Unknown
+        };
+}

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportFeedMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportFeedMapperTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Mapping;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Enums.OctopusImport;
@@ -61,6 +62,9 @@ public class OctopusImportFeedMapperTests
 
         result.CreateCommand.Username.ShouldBeNull();
         result.CreateCommand.Password.ShouldBeNull();
+        result.CreateCommand.Properties[OctopusImportManualConfiguration.RequiredPropertyName].ShouldBe("true");
+        result.CreateCommand.Properties[OctopusImportManualConfiguration.FieldsPropertyName].ShouldBe(OctopusImportManualConfiguration.FeedCredentialsField);
+        result.ManualConfigurationMarkers.Single().ReasonCode.ShouldBe(OctopusImportRedactionDiagnosticCodes.FeedCredentialsOmitted);
         result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportFeedMappingDiagnosticCodes.CredentialsOmitted);
         result.Diagnostics.All(d => d.Message.Contains("encrypted-source-secret", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
     }

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Squid.Core.Services.OctopusImport;
+using Squid.Core.Services.OctopusImport.Mapping;
 using Squid.Core.Services.OctopusImport.Octopus;
 using Squid.Message.Enums.OctopusImport;
 
@@ -127,6 +128,50 @@ public class OctopusImportPreviewPlannerTests
     }
 
     [Fact]
+    public void BuildPreviewPlan_AddsManualConfigurationDiagnosticsForExternalResourceSecrets()
+    {
+        var feed = Node(new OctopusFeedDto
+        {
+            Id = "Feeds-1",
+            Name = "Docker",
+            Username = "feed-user",
+            Password = "feed-source-secret"
+        }, OctopusResourceKind.Feed);
+        var account = Node(new OctopusAccountDto
+        {
+            Id = "Accounts-1",
+            Name = "AWS",
+            Credentials = Json("""{ "SecretKey": "account-source-secret" }""")
+        }, OctopusResourceKind.Account);
+        var certificate = Node(new OctopusCertificateDto
+        {
+            Id = "Certificates-1",
+            Name = "TLS",
+            HasPrivateKey = true,
+            CertificateData = Json("""{ "Pfx": "certificate-source-secret" }""")
+        }, OctopusResourceKind.Certificate);
+        var target = Node(new OctopusMachineDto
+        {
+            Id = "Machines-1",
+            Name = "Kubernetes target",
+            Endpoint = Json("""{ "ProviderConfig": { "Token": "endpoint-source-secret" } }""")
+        }, OctopusResourceKind.Machine);
+
+        var preview = _planner.BuildPreviewPlan(Plan([feed, account, certificate, target]), NoConflicts());
+
+        preview.Resources.Single(r => r.SourceId == "Feeds-1").Diagnostics.Select(d => d.Code)
+            .ShouldContain(OctopusImportRedactionDiagnosticCodes.FeedCredentialsOmitted);
+        preview.Resources.Single(r => r.SourceId == "Accounts-1").Diagnostics.Select(d => d.Code)
+            .ShouldContain(OctopusImportRedactionDiagnosticCodes.AccountCredentialsOmitted);
+        preview.Resources.Single(r => r.SourceId == "Certificates-1").Diagnostics.Select(d => d.Code)
+            .ShouldContain(OctopusImportRedactionDiagnosticCodes.CertificatePrivateMaterialOmitted);
+        preview.Resources.Single(r => r.SourceId == "Machines-1").Diagnostics.Select(d => d.Code)
+            .ShouldContain(OctopusImportRedactionDiagnosticCodes.EndpointSecretOmitted);
+        preview.Resources.SelectMany(r => r.Diagnostics).All(d =>
+            !d.Message.Contains("source-secret", StringComparison.OrdinalIgnoreCase)).ShouldBeTrue();
+    }
+
+    [Fact]
     public void BuildPreviewPlan_WhenDependencyPlanHasResourceBlocker_ProposesBlocked()
     {
         var project = Node("Projects-1", OctopusResourceKind.Project, "Project");
@@ -206,4 +251,33 @@ public class OctopusImportPreviewPlannerTests
             null,
             isHistorical,
             new object());
+
+    private static OctopusResourceNode Node<T>(T source, OctopusResourceKind kind, bool isHistorical = false)
+        where T : OctopusDocumentDto
+        => new(
+            source.Id,
+            source.Name,
+            kind,
+            DocumentKind(kind),
+            $"{source.Id}.json",
+            "Projects-1",
+            null,
+            isHistorical,
+            source);
+
+    private static System.Text.Json.JsonElement Json(string json)
+    {
+        using var document = System.Text.Json.JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static OctopusDocumentKind DocumentKind(OctopusResourceKind kind)
+        => kind switch
+        {
+            OctopusResourceKind.Feed => OctopusDocumentKind.Feed,
+            OctopusResourceKind.Account => OctopusDocumentKind.Account,
+            OctopusResourceKind.Certificate => OctopusDocumentKind.Certificate,
+            OctopusResourceKind.Machine => OctopusDocumentKind.Machine,
+            _ => OctopusDocumentKind.Project
+        };
 }


### PR DESCRIPTION
## Summary

- Implemented OpenSpec 6.3 on branch `codex/octopus-import-external-secret-shells`.
- Added import-only manual configuration markers and shell mapping for Feed, Account, Certificate, and Target resources in [OctopusImportManualConfigurationMarker.cs](/Users/mindy/Documents/repo/octopus-import-resource-shells/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportManualConfigurationMarker.cs) and [OctopusImportExternalResourceShellMapper.cs](/Users/mindy/Documents/repo/octopus-import-resource-shells/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportExternalResourceShellMapper.cs).
- Extended Feed mapping so credentials remain omitted, safe manual configuration marker properties are added, and markers are returned from mapping results.
- Extended preview planning so Feed/Account/Certificate/Target secret omissions emit redacted manual-configuration diagnostics without changing public import DTO contracts.
- Added focused tests for feed markers, account empty credential shells, certificate manual shells, target endpoint secret omission, preview diagnostics, and non-leakage.
- Updated `SESSION_MEMORY.md` and marked OpenSpec task `6.3` complete; did not implement 6.2, 6.4, 6.5, 6.6, or confirmation orchestration.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~OctopusImportFeedMapperTests|FullyQualifiedName~OctopusImportExternalResourceShellMapperTests|FullyQualifiedName~OctopusImportPreviewPlannerTests|FullyQualifiedName~OctopusImportRedactionTests" --no-restore` passed 30/30.
- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter FullyQualifiedName~Services.OctopusImport --no-restore -p:UseSharedCompilation=false -m:1 -v quiet` passed 222/222.
- [x] `git diff --check` passed.