### PR TITLE
Required input markers for imported secrets

### DIFF
--- a/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMapper.cs
+++ b/src/Squid.Core/Services/OctopusImport/Mapping/OctopusImportVariableMapper.cs
@@ -49,6 +49,7 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
                 Variables = mapping.Variables
             },
             null,
+            mapping.RequiredInputs,
             mapping.Diagnostics);
     }
 
@@ -77,6 +78,7 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
                 SpaceId = destinationSpaceId,
                 Variables = mapping.Variables
             },
+            mapping.RequiredInputs,
             mapping.Diagnostics);
     }
 
@@ -102,8 +104,9 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
         var diagnostics = new List<OctopusImportDiagnosticDto>();
         var ownerType = MapOwnerType(variableSet, variableSetResource, diagnostics);
         var ownerId = MapOwnerId(variableSet, idMap, variableSetResource, diagnostics);
+        var requiredInputs = new List<OctopusImportRequiredInputDto>();
         var variables = variableSet.Variables
-            .Select((variable, index) => MapVariable(variable, index, idMap, diagnostics))
+            .Select((variable, index) => MapVariable(variableSet, variable, index, idMap, diagnostics, requiredInputs))
             .ToList();
 
         return new VariableSetCommandMapping(
@@ -112,6 +115,7 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
             ownerId,
             ownerType,
             variables,
+            requiredInputs,
             diagnostics);
     }
 
@@ -151,22 +155,26 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
     }
 
     private static VariableModel MapVariable(
+        OctopusVariableSetDto variableSet,
         OctopusVariableDto variable,
         int index,
         OctopusImportIdMap idMap,
-        List<OctopusImportDiagnosticDto> diagnostics)
+        List<OctopusImportDiagnosticDto> diagnostics,
+        List<OctopusImportRequiredInputDto> requiredInputs)
     {
         var variableType = MapVariableType(variable, diagnostics);
-        var isSensitive = variable.IsSensitive || IsType(variable.Type, "Sensitive");
+        var isSensitive = OctopusImportRequiredInputBuilder.IsSensitiveVariable(variable);
 
         if (isSensitive)
         {
+            var variableSourceId = OctopusImportRequiredInputBuilder.BuildVariableSourceId(variableSet.Id, variable.Id, index);
+            requiredInputs.Add(OctopusImportRequiredInputBuilder.ForSensitiveVariable(variableSourceId, variable));
             diagnostics.Add(Diagnostic(
                 OctopusImportCompatibilitySeverity.Warning,
                 OctopusImportVariableMappingDiagnosticCodes.SensitiveValueOmitted,
                 $"Sensitive Octopus variable '{variable.Name}' was mapped without its source value and must be supplied manually after import.",
                 OctopusResourceKind.Variable,
-                variable.Id,
+                variableSourceId,
                 variable.Name));
         }
 
@@ -371,12 +379,14 @@ public class OctopusImportVariableMapper : IOctopusImportVariableMapper
         int OwnerId,
         VariableSetOwnerType OwnerType,
         List<VariableModel> Variables,
+        IReadOnlyList<OctopusImportRequiredInputDto> RequiredInputs,
         IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics);
 }
 
 public sealed record OctopusImportVariableMappingResult(
     CreateVariableSetCommand CreateCommand,
     UpdateVariableSetCommand UpdateCommand,
+    IReadOnlyList<OctopusImportRequiredInputDto> RequiredInputs,
     IReadOnlyList<OctopusImportDiagnosticDto> Diagnostics)
 {
     public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewPlanner.cs
@@ -46,6 +46,9 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
         {
             GeneratedAt = DateTimeOffset.UtcNow,
             Resources = resources,
+            RequiredInputs = resources
+                .SelectMany(r => r.RequiredInputs)
+                .ToList(),
             Diagnostics = diagnostics
         };
     }
@@ -62,6 +65,8 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
             SourceName = resource.Name,
             OutcomeState = OctopusImportResourceOutcomeState.Pending
         };
+
+        AddRequiredInputs(result, resource);
 
         if (blockedSourceIds.Contains(resource.SourceId))
         {
@@ -107,6 +112,20 @@ public class OctopusImportPreviewPlanner : IOctopusImportPreviewPlanner
 
         ApplyConflictAction(result, resource, conflict);
         return result;
+    }
+
+    private static void AddRequiredInputs(
+        OctopusImportResourceResultDto result,
+        OctopusResourceNode resource)
+    {
+        if (resource.IsHistorical || resource.Kind != OctopusResourceKind.Variable)
+            return;
+
+        var variable = resource.GetSource<OctopusVariableDto>();
+        if (!OctopusImportRequiredInputBuilder.IsSensitiveVariable(variable))
+            return;
+
+        result.RequiredInputs.Add(OctopusImportRequiredInputBuilder.ForSensitiveVariable(resource.SourceId, variable));
     }
 
     private static void ApplyConflictAction(

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewValidator.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportPreviewValidator.cs
@@ -56,6 +56,11 @@ public class OctopusImportPreviewValidator : IOctopusImportPreviewValidator
 
         ValidateReferences(graph, selectedResources, allCurrentResources, result);
         ValidateReuse(conflictsBySourceId, previewResources, previewPlan.GeneratedAt, result);
+        result.RequiredInputs = previewPlan.RequiredInputs
+            .Concat(previewResources.Values.SelectMany(r => r.RequiredInputs))
+            .GroupBy(input => input.InputKey, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
 
         return result;
     }

--- a/src/Squid.Core/Services/OctopusImport/OctopusImportRequiredInputBuilder.cs
+++ b/src/Squid.Core/Services/OctopusImport/OctopusImportRequiredInputBuilder.cs
@@ -1,0 +1,71 @@
+using System.Security.Cryptography;
+using System.Text;
+using Squid.Core.Services.OctopusImport.Octopus;
+using Squid.Message.Enums.OctopusImport;
+using Squid.Message.Models.OctopusImport;
+
+namespace Squid.Core.Services.OctopusImport;
+
+public static class OctopusImportRequiredInputBuilder
+{
+    public const string RequiredSecretInputPrefix = "required-secret-input";
+
+    public static bool IsSensitiveVariable(OctopusVariableDto variable)
+        => variable != null
+           && (variable.IsSensitive || string.Equals(variable.Type?.Trim(), "Sensitive", StringComparison.OrdinalIgnoreCase));
+
+    public static OctopusImportRequiredInputDto ForSensitiveVariable(
+        string sourceId,
+        OctopusVariableDto variable)
+    {
+        ArgumentNullException.ThrowIfNull(variable);
+
+        return new OctopusImportRequiredInputDto
+        {
+            InputKey = BuildInputKey(OctopusImportRequiredInputKind.SensitiveVariableValue, sourceId, "Value"),
+            Kind = OctopusImportRequiredInputKind.SensitiveVariableValue,
+            SourceId = sourceId,
+            SourceType = OctopusResourceKind.Variable.ToString(),
+            Name = variable.Name,
+            FieldName = "Value",
+            ValueType = variable.Type,
+            HasSourceValue = !string.IsNullOrEmpty(variable.Value),
+            IsRequired = true,
+            SourceScopes = CloneScopes(variable.Scope)
+        };
+    }
+
+    public static string BuildVariableSourceId(string variableSetSourceId, string variableSourceId, int index)
+        => string.IsNullOrWhiteSpace(variableSourceId)
+            ? $"{variableSetSourceId}/variable-{index + 1}"
+            : variableSourceId;
+
+    private static string BuildInputKey(
+        OctopusImportRequiredInputKind kind,
+        string sourceId,
+        string fieldName)
+        => $"{RequiredSecretInputPrefix}:{kind}:{StableKeyPart(sourceId)}:{fieldName}";
+
+    private static string StableKeyPart(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value ?? string.Empty));
+        return Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+    }
+
+    private static Dictionary<string, List<string>> CloneScopes(Dictionary<string, List<string>> scopes)
+    {
+        if (scopes == null)
+            return [];
+
+        return scopes
+            .Where(scope => !string.IsNullOrWhiteSpace(scope.Key))
+            .OrderBy(scope => scope.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                scope => scope.Key,
+                scope => (scope.Value ?? [])
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Squid.Message/Enums/OctopusImport/OctopusImportRequiredInputKind.cs
+++ b/src/Squid.Message/Enums/OctopusImport/OctopusImportRequiredInputKind.cs
@@ -1,0 +1,6 @@
+namespace Squid.Message.Enums.OctopusImport;
+
+public enum OctopusImportRequiredInputKind
+{
+    SensitiveVariableValue
+}

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportPreviewPlanDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportPreviewPlanDto.cs
@@ -8,6 +8,8 @@ public class OctopusImportPreviewPlanDto
 
     public List<OctopusImportResourceResultDto> Resources { get; set; } = [];
 
+    public List<OctopusImportRequiredInputDto> RequiredInputs { get; set; } = [];
+
     public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];
 
     public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker)

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportRequiredInputDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportRequiredInputDto.cs
@@ -1,0 +1,26 @@
+using Squid.Message.Enums.OctopusImport;
+
+namespace Squid.Message.Models.OctopusImport;
+
+public class OctopusImportRequiredInputDto
+{
+    public string InputKey { get; set; }
+
+    public OctopusImportRequiredInputKind Kind { get; set; }
+
+    public string SourceId { get; set; }
+
+    public string SourceType { get; set; }
+
+    public string Name { get; set; }
+
+    public string FieldName { get; set; }
+
+    public string ValueType { get; set; }
+
+    public bool HasSourceValue { get; set; }
+
+    public bool IsRequired { get; set; }
+
+    public Dictionary<string, List<string>> SourceScopes { get; set; } = [];
+}

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportResourceResultDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportResourceResultDto.cs
@@ -16,5 +16,7 @@ public class OctopusImportResourceResultDto
 
     public int? DestinationId { get; set; }
 
+    public List<OctopusImportRequiredInputDto> RequiredInputs { get; set; } = [];
+
     public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];
 }

--- a/src/Squid.Message/Models/OctopusImport/OctopusImportValidationResultDto.cs
+++ b/src/Squid.Message/Models/OctopusImport/OctopusImportValidationResultDto.cs
@@ -4,6 +4,8 @@ namespace Squid.Message.Models.OctopusImport;
 
 public class OctopusImportValidationResultDto
 {
+    public List<OctopusImportRequiredInputDto> RequiredInputs { get; set; } = [];
+
     public List<OctopusImportDiagnosticDto> Diagnostics { get; set; } = [];
 
     public bool HasBlockers => Diagnostics.Any(d => d.Severity == OctopusImportCompatibilitySeverity.Blocker);

--- a/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportVariableMapperTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/Mapping/OctopusImportVariableMapperTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text.Json;
 using Squid.Core.Services.OctopusImport;
 using Squid.Core.Services.OctopusImport.Mapping;
 using Squid.Core.Services.OctopusImport.Octopus;
@@ -121,8 +122,46 @@ public class OctopusImportVariableMapperTests
         result.CreateCommand.Variables[0].Type.ShouldBe(VariableType.Password);
         result.CreateCommand.Variables[0].IsSensitive.ShouldBeTrue();
         result.CreateCommand.Variables[0].Value.ShouldBe(string.Empty);
+        var requiredInput = result.RequiredInputs.Single();
+        requiredInput.InputKey.ShouldStartWith("required-secret-input:SensitiveVariableValue:");
+        requiredInput.InputKey.ShouldEndWith(":Value");
+        requiredInput.Kind.ShouldBe(OctopusImportRequiredInputKind.SensitiveVariableValue);
+        requiredInput.SourceId.ShouldBe("Variables-Secret");
+        requiredInput.SourceType.ShouldBe(OctopusResourceKind.Variable.ToString());
+        requiredInput.Name.ShouldBe("ApiKey");
+        requiredInput.FieldName.ShouldBe("Value");
+        requiredInput.ValueType.ShouldBe("Sensitive");
+        requiredInput.HasSourceValue.ShouldBeTrue();
+        requiredInput.IsRequired.ShouldBeTrue();
         result.Diagnostics.Select(d => d.Code).ShouldContain(OctopusImportVariableMappingDiagnosticCodes.SensitiveValueOmitted);
         result.Diagnostics.All(d => d.Message.Contains("encrypted-source-secret", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
+        JsonSerializer.Serialize(result.RequiredInputs).ToLowerInvariant().ShouldNotContain("encrypted-source-secret");
+    }
+
+    [Fact]
+    public void MapToCreateCommand_WhenSensitiveVariableHasScopes_RequiredInputPreservesSourceScopeMetadata()
+    {
+        var variableSet = VariableSet(new OctopusVariableDto
+        {
+            Id = "Variables-ScopedSecret",
+            Name = "DatabasePassword",
+            Value = "scoped-source-secret",
+            IsSensitive = true,
+            Scope =
+            {
+                ["Environment"] = ["Environments-2", "Environments-1"],
+                ["Role"] = ["web"]
+            }
+        });
+
+        var result = _mapper.MapToCreateCommand(Resource(variableSet), IdMap(), 7);
+
+        var requiredInput = result.RequiredInputs.Single();
+        requiredInput.HasSourceValue.ShouldBeTrue();
+        requiredInput.SourceScopes["Environment"].ShouldBe(["Environments-1", "Environments-2"]);
+        requiredInput.SourceScopes["Role"].ShouldBe(["web"]);
+        result.CreateCommand.Variables.Single().Value.ShouldBe(string.Empty);
+        JsonSerializer.Serialize(result).ToLowerInvariant().ShouldNotContain("scoped-source-secret");
     }
 
     [Theory]

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewPlannerTests.cs
@@ -24,6 +24,51 @@ public class OctopusImportPreviewPlannerTests
     }
 
     [Fact]
+    public void BuildPreviewPlan_WhenCurrentSensitiveVariableIsSelected_AddsRequiredInputMarker()
+    {
+        var variable = new OctopusVariableDto
+        {
+            Id = "Variables-Secret",
+            Name = "ApiKey",
+            Type = "Sensitive",
+            IsSensitive = true,
+            Value = "preview-source-secret",
+            Scope = { ["Environment"] = ["Environments-1"] }
+        };
+        var resource = Node("Variables-Secret", OctopusResourceKind.Variable, "ApiKey", source: variable);
+
+        var preview = _planner.BuildPreviewPlan(Plan([resource]), NoConflicts());
+
+        var resourceResult = preview.Resources.Single();
+        var requiredInput = resourceResult.RequiredInputs.Single();
+        preview.RequiredInputs.Single().InputKey.ShouldBe(requiredInput.InputKey);
+        requiredInput.Kind.ShouldBe(OctopusImportRequiredInputKind.SensitiveVariableValue);
+        requiredInput.Name.ShouldBe("ApiKey");
+        requiredInput.ValueType.ShouldBe("Sensitive");
+        requiredInput.HasSourceValue.ShouldBeTrue();
+        requiredInput.SourceScopes["Environment"].ShouldBe(["Environments-1"]);
+    }
+
+    [Fact]
+    public void BuildPreviewPlan_WhenHistoricalSensitiveVariableIsOutOfScope_DoesNotRequireInput()
+    {
+        var variable = new OctopusVariableDto
+        {
+            Id = "Variables-Secret",
+            Name = "ApiKey",
+            Type = "Sensitive",
+            IsSensitive = true,
+            Value = "historical-source-secret"
+        };
+        var resource = Node("Variables-Secret", OctopusResourceKind.Variable, "ApiKey", isHistorical: true, source: variable);
+
+        var preview = _planner.BuildPreviewPlan(Plan([], outOfScopeResources: [resource]), NoConflicts());
+
+        preview.RequiredInputs.ShouldBeEmpty();
+        preview.Resources.Single().RequiredInputs.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void BuildPreviewPlan_WhenSharedResourceHasOneConflict_ProposesReuseExisting()
     {
         var resource = Node("Feeds-1", OctopusResourceKind.Feed, "Docker");
@@ -195,7 +240,8 @@ public class OctopusImportPreviewPlannerTests
         string sourceId,
         OctopusResourceKind kind,
         string name,
-        bool isHistorical = false)
+        bool isHistorical = false,
+        object source = null)
         => new(
             sourceId,
             name,
@@ -205,5 +251,5 @@ public class OctopusImportPreviewPlannerTests
             "Projects-1",
             null,
             isHistorical,
-            new object());
+            source ?? new object());
 }

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewValidatorTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportPreviewValidatorTests.cs
@@ -186,6 +186,31 @@ public class OctopusImportPreviewValidatorTests
         result.Diagnostics.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void Validate_PreservesRequiredInputMarkersFromPreview()
+    {
+        var variable = Node("Variables-Secret", OctopusResourceKind.Variable, "ApiKey");
+        var preview = Preview([variable]);
+        preview.Resources.Single().RequiredInputs.Add(new OctopusImportRequiredInputDto
+        {
+            InputKey = "required-secret-input:SensitiveVariableValue:variable-value:Value",
+            Kind = OctopusImportRequiredInputKind.SensitiveVariableValue,
+            SourceId = variable.SourceId,
+            SourceType = variable.Kind.ToString(),
+            Name = variable.Name,
+            FieldName = "Value",
+            ValueType = "Sensitive",
+            HasSourceValue = true,
+            IsRequired = true
+        });
+        preview.RequiredInputs = preview.Resources.SelectMany(r => r.RequiredInputs).ToList();
+
+        var result = _validator.Validate(Graph([variable]), Plan([variable]), NoConflicts(), preview);
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.RequiredInputs.Single().InputKey.ShouldBe("required-secret-input:SensitiveVariableValue:variable-value:Value");
+    }
+
     private static OctopusResourceGraph Graph(
         IReadOnlyList<OctopusResourceNode> resources,
         IReadOnlyList<OctopusResourceReference> references = null)

--- a/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportRedactionTests.cs
+++ b/tests/Squid.UnitTests/Services/OctopusImport/OctopusImportRedactionTests.cs
@@ -181,6 +181,37 @@ public class OctopusImportRedactionTests
         redacted.ShouldContain("https://worker.example");
     }
 
+    [Fact]
+    public void RedactDto_PreservesRequiredInputMarkersWithoutSourceValues()
+    {
+        var requiredInput = OctopusImportRequiredInputBuilder.ForSensitiveVariable(
+            "Variables-Secret",
+            new OctopusVariableDto
+            {
+                Id = "Variables-Secret",
+                Name = "ApiKey",
+                Type = "Sensitive",
+                IsSensitive = true,
+                Value = "marker-source-secret",
+                Scope = { ["Environment"] = ["Environments-1"] }
+            });
+        var preview = new OctopusImportPreviewPlanDto
+        {
+            RequiredInputs = [requiredInput]
+        };
+
+        var redacted = OctopusImportRedaction.RedactDto(preview);
+
+        var redactedInput = redacted.RequiredInputs.Single();
+        redactedInput.InputKey.ShouldStartWith("required-secret-input:SensitiveVariableValue:");
+        redactedInput.InputKey.ShouldEndWith(":Value");
+        redactedInput.SourceId.ShouldBe("Variables-Secret");
+        redactedInput.Name.ShouldBe("ApiKey");
+        redactedInput.HasSourceValue.ShouldBeTrue();
+        Serialized(redacted).ShouldNotContain(OctopusImportRedaction.RedactedValue);
+        Serialized(redacted).ShouldNotContain("marker-source-secret");
+    }
+
     private static JsonElement Json(string json)
     {
         using var document = JsonDocument.Parse(json);


### PR DESCRIPTION
## Summary

- Implemented OpenSpec 6.2 on branch `codex/octopus-import-secret-input-6-2`.
- Added Octopus-import-only required input structures: `OctopusImportRequiredInputDto`, `OctopusImportRequiredInputKind`, and `OctopusImportRequiredInputBuilder`.
- Sensitive variables still map to `VariableType.Password` with empty values, and now emit `required-secret-input` markers with source ID, type, scope, and value-presence metadata only.
- Added `RequiredInputs` to Octopus import preview/resource/validation DTOs because existing import responses had no structured required-input surface; the general Squid variable command contract was not changed.
- Reused the 6.1 central redaction helpers and diagnostics; no duplicate redaction logic was added.
- Updated OpenSpec task 6.2 and `SESSION_MEMORY.md`; did not implement 6.3, 6.4, 6.5, 6.6, confirmation, or API behavior.

## Test plan

- [x] `dotnet test tests/Squid.UnitTests/Squid.UnitTests.csproj --filter "FullyQualifiedName~OctopusImport"` passed: 222/222.
- [x] `openspec validate add-octopus-import --strict` passed.
- [x] `git diff --check` passed.
- [x] Checked sensitive value handling via tests and search: source secret values are not emitted through required-input DTOs, diagnostics, or production code; no OctopusImport structured logging path was added.
- [ ] Full repository test suite not run; validation was scoped to OctopusImport-related tests.